### PR TITLE
AC-850, AC-851: decompose stage_tournament and de-duplicate three Python sites

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -8,6 +8,8 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -127,6 +129,32 @@ def _write_json_stdout(payload: object) -> None:
 
 def _write_json_stderr(message: str) -> None:
     sys.stderr.write(json.dumps({"error": message}) + "\n")
+
+
+@contextmanager
+def cli_error_boundary(json_output: bool, *, action: str) -> Iterator[None]:
+    """Convert KeyboardInterrupt/Exception into the CLI's JSON-or-Rich exit convention.
+
+    `run` and `resume` both need identical KeyboardInterrupt -> exit(1) and
+    Exception -> exit(1) handling, differing only in the action verb used in
+    the interrupted-message text (e.g. "run interrupted" / "Run interrupted.",
+    "resume interrupted" / "Resume interrupted.").
+    """
+    try:
+        yield
+    except KeyboardInterrupt:
+        if json_output:
+            _write_json_stderr(f"{action} interrupted")
+        else:
+            console.print(f"[yellow]{action.capitalize()} interrupted.[/yellow]")
+        raise typer.Exit(code=1) from None
+    except Exception as exc:
+        logger.debug("cli: caught Exception", exc_info=True)
+        if json_output:
+            _write_json_stderr(str(exc))
+        else:
+            console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
 
 def _check_json_exit(result: dict[str, Any]) -> None:
@@ -374,21 +402,8 @@ def run(
 
         _apply_preset_env(preset)
         settings = load_settings()
-        try:
+        with cli_error_boundary(json_output, action="run"):
             task_summary = _run_agent_task(scenario, settings, max_rounds=gens, run_id=run_id)
-        except KeyboardInterrupt:
-            if json_output:
-                _write_json_stderr("run interrupted")
-            else:
-                console.print("[yellow]Run interrupted.[/yellow]")
-            raise typer.Exit(code=1) from None
-        except Exception as exc:
-            logger.debug("cli: caught Exception", exc_info=True)
-            if json_output:
-                _write_json_stderr(str(exc))
-            else:
-                console.print(f"[red]Error: {exc}[/red]")
-            raise typer.Exit(code=1) from exc
         if json_output:
             _write_json_stdout(dataclasses.asdict(task_summary))
         else:
@@ -429,21 +444,8 @@ def run(
         console.print(f"[dim]API: http://localhost:{port}/api/runs | WS: ws://localhost:{port}/ws/interactive[/dim]")
         uvicorn.run(interactive_app, host="127.0.0.1", port=int(port), log_level="info")
     else:
-        try:
+        with cli_error_boundary(json_output, action="run"):
             summary = _runner(preset).run(scenario_name=scenario, generations=gens, run_id=run_id)
-        except KeyboardInterrupt:
-            if json_output:
-                _write_json_stderr("run interrupted")
-            else:
-                console.print("[yellow]Run interrupted.[/yellow]")
-            raise typer.Exit(code=1) from None
-        except Exception as exc:
-            logger.debug("cli: caught Exception", exc_info=True)
-            if json_output:
-                _write_json_stderr(str(exc))
-            else:
-                console.print(f"[red]Error: {exc}[/red]")
-            raise typer.Exit(code=1) from exc
         if json_output:
             _write_json_stdout(dataclasses.asdict(summary))
         else:
@@ -472,21 +474,8 @@ def resume(
 ) -> None:
     """Resume an existing run idempotently."""
 
-    try:
+    with cli_error_boundary(json_output, action="resume"):
         summary = _runner().run(scenario_name=scenario, generations=gens, run_id=run_id)
-    except KeyboardInterrupt:
-        if json_output:
-            _write_json_stderr("resume interrupted")
-        else:
-            console.print("[yellow]Resume interrupted.[/yellow]")
-        raise typer.Exit(code=1) from None
-    except Exception as exc:
-        logger.debug("cli: caught Exception", exc_info=True)
-        if json_output:
-            _write_json_stderr(str(exc))
-        else:
-            console.print(f"[red]Error: {exc}[/red]")
-        raise typer.Exit(code=1) from exc
     if json_output:
         _write_json_stdout(dataclasses.asdict(summary))
     else:

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -463,38 +463,19 @@ class TaskRunner:
                     required_concepts=config.required_concepts,
                     calibration_examples=config.calibration_examples,
                 )
-                objective_payload = build_objective_payload(
-                    result.best_output,
-                    result.best_score,
-                    config,
-                    run_id=task_id,
-                )
-                objective_guardrail = build_objective_guardrail_payload(
-                    objective_payload,
-                    config,
-                )
-                evaluator_guardrail = build_evaluator_guardrail_payload(
-                    agent_task,
-                    result.best_output,
-                    config,
-                    reference_context=reference_context,
-                )
-                effective_met_threshold = compute_effective_met_threshold(
-                    result.met_threshold,
-                    objective_guardrail,
-                    evaluator_guardrail,
+                objective_payload, objective_guardrail, evaluator_guardrail, effective_met_threshold, rubric_calibration = (
+                    self._finalize_task_output(
+                        agent_task=agent_task,
+                        task_id=task_id,
+                        spec_name=spec_name,
+                        best_output=result.best_output,
+                        best_score=result.best_score,
+                        met_threshold=result.met_threshold,
+                        reference_context=reference_context,
+                        config=config,
+                    )
                 )
                 result.met_threshold = effective_met_threshold
-                rubric_calibration = build_rubric_calibration_payload(
-                    store=self.store,
-                    spec_name=spec_name,
-                    task_prompt=agent_task.get_task_prompt({}),
-                    rubric=agent_task.get_rubric(),
-                    provider=self.provider,
-                    model=self.model,
-                    reference_context=reference_context,
-                    required_concepts=config.required_concepts,
-                )
 
                 self.store.complete_task(
                     task_id=task_id,
@@ -604,36 +585,17 @@ class TaskRunner:
         met_threshold = any(result.met_threshold for result in ordered_results)
         best_score = state.best_score
         best_output = state.best_output
-        objective_payload = build_objective_payload(
-            best_output,
-            best_score,
-            config,
-            run_id=task_id,
-        )
-        objective_guardrail = build_objective_guardrail_payload(
-            objective_payload,
-            config,
-        )
-        evaluator_guardrail = build_evaluator_guardrail_payload(
-            agent_task,
-            best_output,
-            config,
-            reference_context=reference_context,
-        )
-        effective_met_threshold = compute_effective_met_threshold(
-            met_threshold,
-            objective_guardrail,
-            evaluator_guardrail,
-        )
-        rubric_calibration = build_rubric_calibration_payload(
-            store=self.store,
-            spec_name=spec_name,
-            task_prompt=agent_task.get_task_prompt({}),
-            rubric=agent_task.get_rubric(),
-            provider=self.provider,
-            model=self.model,
-            reference_context=reference_context,
-            required_concepts=config.required_concepts,
+        objective_payload, objective_guardrail, evaluator_guardrail, effective_met_threshold, rubric_calibration = (
+            self._finalize_task_output(
+                agent_task=agent_task,
+                task_id=task_id,
+                spec_name=spec_name,
+                best_output=best_output,
+                best_score=best_score,
+                met_threshold=met_threshold,
+                reference_context=reference_context,
+                config=config,
+            )
         )
 
         self.store.complete_task(
@@ -671,6 +633,57 @@ class TaskRunner:
             judge_calls=sum(result.judge_calls for result in ordered_results),
             dimension_trajectory={},
         )
+
+    def _finalize_task_output(
+        self,
+        *,
+        agent_task: SimpleAgentTask,
+        task_id: str,
+        spec_name: str,
+        best_output: str,
+        best_score: float,
+        met_threshold: bool,
+        reference_context: str | None,
+        config: TaskConfig,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None, dict[str, Any] | None, bool, dict[str, Any] | None]:
+        """Assemble the objective/guardrail/calibration payload pieces shared by
+        the single- and multi-generation task-completion paths.
+
+        Returns (objective_payload, objective_guardrail, evaluator_guardrail,
+        effective_met_threshold, rubric_calibration).
+        """
+        objective_payload = build_objective_payload(
+            best_output,
+            best_score,
+            config,
+            run_id=task_id,
+        )
+        objective_guardrail = build_objective_guardrail_payload(
+            objective_payload,
+            config,
+        )
+        evaluator_guardrail = build_evaluator_guardrail_payload(
+            agent_task,
+            best_output,
+            config,
+            reference_context=reference_context,
+        )
+        effective_met_threshold = compute_effective_met_threshold(
+            met_threshold,
+            objective_guardrail,
+            evaluator_guardrail,
+        )
+        rubric_calibration = build_rubric_calibration_payload(
+            store=self.store,
+            spec_name=spec_name,
+            task_prompt=agent_task.get_task_prompt({}),
+            rubric=agent_task.get_rubric(),
+            provider=self.provider,
+            model=self.model,
+            reference_context=reference_context,
+            required_concepts=config.required_concepts,
+        )
+        return objective_payload, objective_guardrail, evaluator_guardrail, effective_met_threshold, rubric_calibration
 
     def _resolve_reference_context(self, task_id: str, config: TaskConfig) -> str | None:
         """Resolve authoritative reference context for a queued task."""

--- a/autocontext/src/autocontext/loop/generation_pipeline.py
+++ b/autocontext/src/autocontext/loop/generation_pipeline.py
@@ -1,4 +1,5 @@
 """GenerationPipeline — composed stage orchestrator for the generation loop."""
+
 from __future__ import annotations
 
 import logging
@@ -17,6 +18,7 @@ from autocontext.execution.phased_execution import (
 from autocontext.extensions import HookEvents
 from autocontext.knowledge.coherence import check_coherence
 from autocontext.loop.cost_control import CostBudget, CostPolicy, CostTracker, throttle_state
+from autocontext.loop.stage_helpers.tournament_prep import _build_empty_tournament
 from autocontext.loop.stage_preflight import stage_preflight
 from autocontext.loop.stage_prevalidation import stage_prevalidation
 from autocontext.loop.stage_probe import stage_probe
@@ -24,7 +26,6 @@ from autocontext.loop.stage_staged_validation import stage_staged_validation
 from autocontext.loop.stage_tree_search import stage_tree_search
 from autocontext.loop.stage_types import GenerationContext
 from autocontext.loop.stages import (
-    _build_empty_tournament,
     stage_agent_generation,
     stage_curator_gate,
     stage_knowledge_setup,
@@ -81,20 +82,26 @@ def _rollback_for_budget(
     ctx.gate_delta = 0.0
     ctx.score_history.append(0.0)
     ctx.gate_decision_history.append("rollback")
-    events.emit("generation_budget_exhausted", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        "budget_seconds": ctx.settings.generation_time_budget_seconds,
-        "phase_name": phase_name,
-        "phase_budget_seconds": phase_budget_seconds,
-    })
-    events.emit("gate_decided", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        "decision": "rollback",
-        "delta": 0.0,
-        "tier": "budget",
-    })
+    events.emit(
+        "generation_budget_exhausted",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "budget_seconds": ctx.settings.generation_time_budget_seconds,
+            "phase_name": phase_name,
+            "phase_budget_seconds": phase_budget_seconds,
+        },
+    )
+    events.emit(
+        "gate_decided",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "decision": "rollback",
+            "delta": 0.0,
+            "tier": "budget",
+        },
+    )
     return ctx
 
 
@@ -151,11 +158,14 @@ def _record_phase_result(
     phase_results: list[PhaseResult],
 ) -> None:
     phase_results.append(result)
-    events.emit("generation_phase_result", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        **result.to_dict(),
-    })
+    events.emit(
+        "generation_phase_result",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            **result.to_dict(),
+        },
+    )
 
 
 def _finalize_phased_execution(
@@ -305,25 +315,33 @@ class GenerationPipeline:
         phase_plan = _build_phase_plan(ctx)
         phase_results: list[PhaseResult] = []
         if phase_plan is not None:
-            self._events.emit("generation_phase_plan", {
-                "run_id": ctx.run_id,
-                "generation": ctx.generation,
-                "total_budget_seconds": phase_plan.total_budget_seconds,
-                "allow_rollover": phase_plan.allow_rollover,
-                "phases": [
-                    {
-                        "phase_name": phase.phase_name,
-                        "budget_seconds": phase.budget_seconds,
-                    }
-                    for phase in phase_plan.phases
-                ],
-            })
+            self._events.emit(
+                "generation_phase_plan",
+                {
+                    "run_id": ctx.run_id,
+                    "generation": ctx.generation,
+                    "total_budget_seconds": phase_plan.total_budget_seconds,
+                    "allow_rollover": phase_plan.allow_rollover,
+                    "phases": [
+                        {
+                            "phase_name": phase.phase_name,
+                            "budget_seconds": phase.budget_seconds,
+                        }
+                        for phase in phase_plan.phases
+                    ],
+                },
+            )
 
         def _on_role_event(role: str, status: str) -> None:
-            self._events.emit("role_event", {
-                "run_id": ctx.run_id, "generation": ctx.generation,
-                "role": role, "status": status,
-            })
+            self._events.emit(
+                "role_event",
+                {
+                    "run_id": ctx.run_id,
+                    "generation": ctx.generation,
+                    "role": role,
+                    "status": status,
+                },
+            )
 
         # Stage 0: Startup verification (generation 1 only)
         if ctx.generation == 1:
@@ -333,10 +351,13 @@ class GenerationPipeline:
                 db_path=ctx.settings.db_path,
             )
             if report.warnings:
-                self._events.emit("startup_verification", {
-                    "run_id": ctx.run_id,
-                    "warnings": report.warnings,
-                })
+                self._events.emit(
+                    "startup_verification",
+                    {
+                        "run_id": ctx.run_id,
+                        "warnings": report.warnings,
+                    },
+                )
 
         # Stage 0.5: Pre-flight harness synthesis (generation 1 only)
         if ctx.generation == 1:
@@ -356,9 +377,14 @@ class GenerationPipeline:
         # Hook: PrimeIntellect warm provision
         if self._warm_provision_fn is not None:
             warm_state = self._warm_provision_fn(ctx)
-            self._events.emit("primeintellect_warm_state", {
-                "run_id": ctx.run_id, "generation": ctx.generation, **warm_state,
-            })
+            self._events.emit(
+                "primeintellect_warm_state",
+                {
+                    "run_id": ctx.run_id,
+                    "generation": ctx.generation,
+                    **warm_state,
+                },
+            )
 
         # Stage 2+3: Tree search mode OR standard agent generation + tournament
         use_tree_search = ctx.settings.exploration_mode == "tree"
@@ -411,11 +437,14 @@ class GenerationPipeline:
                         skipped_stages.append("consultation")
                     if skipped_stages:
                         ctx.cost_control_metadata["skipped_stages"] = skipped_stages
-                    self._events.emit("cost_throttle_applied", {
-                        "run_id": ctx.run_id,
-                        "generation": ctx.generation,
-                        "cost_control": ctx.cost_control_metadata,
-                    })
+                    self._events.emit(
+                        "cost_throttle_applied",
+                        {
+                            "run_id": ctx.run_id,
+                            "generation": ctx.generation,
+                            "cost_control": ctx.cost_control_metadata,
+                        },
+                    )
 
                 # Hook: Controller chat checkpoint
                 if self._controller is not None and self._chat_with_agent_fn is not None:
@@ -517,8 +546,7 @@ class GenerationPipeline:
                 scaffolding_error = None
                 if scaffolding_exhausted:
                     scaffolding_error = (
-                        f"{_PHASE_SCAFFOLDING} phase exceeded "
-                        f"{scaffolding_budget.budget_seconds}s budget before execution"
+                        f"{_PHASE_SCAFFOLDING} phase exceeded {scaffolding_budget.budget_seconds}s budget before execution"
                     )
                 scaffolding_result = _build_phase_result(
                     budget=scaffolding_budget,
@@ -645,7 +673,9 @@ class GenerationPipeline:
         if self._meta_optimizer is not None:
             try:
                 self._meta_optimizer.record_gate_decision(
-                    ctx.gate_decision, ctx.gate_delta, ctx.generation,
+                    ctx.gate_decision,
+                    ctx.gate_delta,
+                    ctx.generation,
                 )
             except Exception:
                 logger.debug("meta_optimizer.record_gate_decision failed", exc_info=True)
@@ -698,11 +728,14 @@ class GenerationPipeline:
                 skills_root=self._artifacts.skills_root,
             )
             if coherence.issues:
-                self._events.emit("coherence_warning", {
-                    "run_id": ctx.run_id,
-                    "generation": ctx.generation,
-                    "issues": coherence.issues,
-                })
+                self._events.emit(
+                    "coherence_warning",
+                    {
+                        "run_id": ctx.run_id,
+                        "generation": ctx.generation,
+                        "issues": coherence.issues,
+                    },
+                )
 
         # Meta-optimization: record full generation metrics
         if self._meta_optimizer is not None and ctx.outputs is not None:
@@ -726,14 +759,17 @@ class GenerationPipeline:
             ctx.generation,
             ctx.generation_elapsed_seconds,
         )
-        self._events.emit("generation_timing", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "elapsed_seconds": round(ctx.generation_elapsed_seconds, 2),
-            "budget_seconds": ctx.settings.generation_time_budget_seconds,
-            "over_budget": _over_budget(ctx),
-            "phased_execution": ctx.phased_execution,
-        })
+        self._events.emit(
+            "generation_timing",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "elapsed_seconds": round(ctx.generation_elapsed_seconds, 2),
+                "budget_seconds": ctx.settings.generation_time_budget_seconds,
+                "over_budget": _over_budget(ctx),
+                "phased_execution": ctx.phased_execution,
+            },
+        )
         if ctx.hook_bus is not None:
             generation_end = ctx.hook_bus.emit(
                 HookEvents.GENERATION_END,

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -69,11 +69,13 @@ from autocontext.storage.run_paths import resolve_run_root
 
 logger = logging.getLogger(__name__)
 
+
 def _current_release_version() -> str:
     try:
         return package_version("autoctx")
     except PackageNotFoundError:
         return package_fallback_version
+
 
 @dataclass(slots=True)
 class RunSummary:
@@ -140,6 +142,7 @@ class GenerationRunner:
             # MontyExecutor: sandboxed execution via pydantic-monty interpreter.
             # Scenario methods run on host; eval script runs in Monty sandbox.
             from autocontext.execution.executors.monty import MontyExecutor
+
             self.executor = ExecutionSupervisor(
                 executor=MontyExecutor(
                     max_execution_time_seconds=settings.monty_max_execution_time_seconds,
@@ -244,7 +247,11 @@ class GenerationRunner:
         return content.count("### Dead End")
 
     def _generate_session_report(
-        self, run_id: str, scenario_name: str, duration_seconds: float, dead_ends_found: int,
+        self,
+        run_id: str,
+        scenario_name: str,
+        duration_seconds: float,
+        dead_ends_found: int,
     ) -> str:
         """Generate and persist a session report for a completed run."""
         trajectory_rows = self.sqlite.get_generation_trajectory(run_id)
@@ -262,9 +269,7 @@ class GenerationRunner:
                     current_generation=current_generation,
                 )
             )
-            superseded_lessons_count = sum(
-                1 for lesson in structured_lessons if lesson.is_superseded()
-            )
+            superseded_lessons_count = sum(1 for lesson in structured_lessons if lesson.is_superseded())
         report = generate_session_report(
             run_id=run_id,
             scenario=scenario_name,
@@ -348,14 +353,16 @@ class GenerationRunner:
         consultations = self.sqlite.get_consultations_for_run(run_id)
         recovery = self.sqlite.get_recovery_markers_for_run(run_id)
 
-        facet = FacetExtractor().extract({
-            "run": run_payload,
-            "generations": generation_rows,
-            "role_metrics": role_metrics,
-            "staged_validations": staged_validations,
-            "consultations": consultations,
-            "recovery": recovery,
-        })
+        facet = FacetExtractor().extract(
+            {
+                "run": run_payload,
+                "generations": generation_rows,
+                "role_metrics": role_metrics,
+                "staged_validations": staged_validations,
+                "consultations": consultations,
+                "recovery": recovery,
+            }
+        )
 
         facet_store = FacetStore(self.settings.knowledge_root)
         facet_store.persist(facet)
@@ -427,7 +434,8 @@ class GenerationRunner:
         current_release = _current_release_version()
         current_provider = self.settings.agent_provider
         relevant_facets = [
-            facet for facet in facets
+            facet
+            for facet in facets
             if getattr(facet, "scenario_family", "") == scenario_family
             and getattr(facet, "agent_provider", "") == current_provider
             and getattr(facet, "metadata", {}).get("release", "") == current_release
@@ -504,7 +512,8 @@ class GenerationRunner:
         agent_provider: str,
     ) -> RubricSnapshot | None:
         candidates = [
-            snapshot for snapshot in snapshots
+            snapshot
+            for snapshot in snapshots
             if snapshot.scenario_family == scenario_family
             and snapshot.agent_provider == agent_provider
             and snapshot.release
@@ -591,32 +600,21 @@ class GenerationRunner:
     ) -> RunTrace:
         """Build a canonical per-run trace from persisted runtime artifacts."""
         family = detect_family(scenario)
-        generation_map = {
-            self._int_value(row.get("generation_index"))
-            : row
-            for row in generation_rows
-        }
-        roles_by_generation: dict[int, list[dict[str, Any]]] = defaultdict(list)
-        validations_by_generation: dict[int, list[dict[str, Any]]] = defaultdict(list)
-        consultations_by_generation: dict[int, list[dict[str, Any]]] = defaultdict(list)
-        recovery_by_generation: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        generation_map = {self._int_value(row.get("generation_index")): row for row in generation_rows}
+        roles_by_generation = self._group_by_generation(role_metrics)
+        validations_by_generation = self._group_by_generation(staged_validations)
+        consultations_by_generation = self._group_by_generation(consultations)
+        recovery_by_generation = self._group_by_generation(recovery_markers)
 
-        for row in role_metrics:
-            roles_by_generation[self._int_value(row.get("generation_index"))].append(row)
-        for row in staged_validations:
-            validations_by_generation[self._int_value(row.get("generation_index"))].append(row)
-        for row in consultations:
-            consultations_by_generation[self._int_value(row.get("generation_index"))].append(row)
-        for row in recovery_markers:
-            recovery_by_generation[self._int_value(row.get("generation_index"))].append(row)
-
-        generation_indices = sorted({
-            *generation_map.keys(),
-            *roles_by_generation.keys(),
-            *validations_by_generation.keys(),
-            *consultations_by_generation.keys(),
-            *recovery_by_generation.keys(),
-        })
+        generation_indices = sorted(
+            {
+                *generation_map.keys(),
+                *roles_by_generation.keys(),
+                *validations_by_generation.keys(),
+                *consultations_by_generation.keys(),
+                *recovery_by_generation.keys(),
+            }
+        )
 
         sequence_number = 1
         events: list[TraceEvent] = []
@@ -650,11 +648,10 @@ class GenerationRunner:
                             resource_name=str(metric.get("model", "")),
                             resource_path="",
                         )
-                    ] if metric.get("model") else [],
-                    summary=(
-                        f"{metric.get('role', 'agent')} executed with "
-                        f"{metric.get('status', 'unknown')} status"
-                    ),
+                    ]
+                    if metric.get("model")
+                    else [],
+                    summary=(f"{metric.get('role', 'agent')} executed with {metric.get('status', 'unknown')} status"),
                     detail={
                         "model": metric.get("model"),
                         "input_tokens": metric.get("input_tokens"),
@@ -672,16 +669,7 @@ class GenerationRunner:
                     duration_ms=self._int_value(metric.get("latency_ms")),
                     metadata={"scenario": scenario_name},
                 )
-                events.append(event)
-                if current_source_id:
-                    causal_edges.append(
-                        CausalEdge(
-                            source_event_id=current_source_id,
-                            target_event_id=event_id,
-                            relation="triggers",
-                        )
-                    )
-                current_source_id = event_id
+                current_source_id = self._append_chained_event(events, causal_edges, event, current_source_id)
                 sequence_number += 1
 
             for validation_index, validation in enumerate(validations_by_generation.get(generation_index, []), start=1):
@@ -701,10 +689,7 @@ class GenerationRunner:
                         actor_name="Validator",
                     ),
                     resources=[],
-                    summary=(
-                        f"Validation stage {validation.get('stage_name', 'unknown')} "
-                        f"finished with {status}"
-                    ),
+                    summary=(f"Validation stage {validation.get('stage_name', 'unknown')} finished with {status}"),
                     detail={
                         "stage_name": validation.get("stage_name"),
                         "stage_order": validation.get("stage_order"),
@@ -721,18 +706,9 @@ class GenerationRunner:
                     duration_ms=self._int_value(validation.get("duration_ms")),
                     metadata={"scenario": scenario_name},
                 )
-                events.append(event)
-                if current_source_id:
-                    causal_edges.append(
-                        CausalEdge(
-                            source_event_id=current_source_id,
-                            target_event_id=event_id,
-                            relation="triggers",
-                        )
-                    )
+                current_source_id = self._append_chained_event(events, causal_edges, event, current_source_id)
                 if status == "failed":
                     failed_validation_ids.append(event_id)
-                current_source_id = event_id
                 sequence_number += 1
 
             for consultation_index, consultation in enumerate(consultations_by_generation.get(generation_index, []), start=1):
@@ -757,7 +733,9 @@ class GenerationRunner:
                             resource_name=str(consultation.get("model_used", "")),
                             resource_path="",
                         )
-                    ] if consultation.get("model_used") else [],
+                    ]
+                    if consultation.get("model_used")
+                    else [],
                     summary=f"Consultation triggered by {consultation.get('trigger', 'unknown')}",
                     detail={
                         "trigger": consultation.get("trigger"),
@@ -776,16 +754,7 @@ class GenerationRunner:
                     duration_ms=None,
                     metadata={"scenario": scenario_name},
                 )
-                events.append(event)
-                if current_source_id:
-                    causal_edges.append(
-                        CausalEdge(
-                            source_event_id=current_source_id,
-                            target_event_id=event_id,
-                            relation="triggers",
-                        )
-                    )
-                current_source_id = event_id
+                current_source_id = self._append_chained_event(events, causal_edges, event, current_source_id)
                 sequence_number += 1
 
             for recovery_index, marker in enumerate(recovery_by_generation.get(generation_index, []), start=1):
@@ -822,15 +791,13 @@ class GenerationRunner:
                     duration_ms=None,
                     metadata={"scenario": scenario_name},
                 )
-                events.append(event)
-                if current_source_id and current_source_id not in failed_validation_ids:
-                    causal_edges.append(
-                        CausalEdge(
-                            source_event_id=current_source_id,
-                            target_event_id=event_id,
-                            relation="triggers",
-                        )
-                    )
+                current_source_id = self._append_chained_event(
+                    events,
+                    causal_edges,
+                    event,
+                    current_source_id,
+                    skip_primary_edge=current_source_id in failed_validation_ids,
+                )
                 for failed_validation_id in failed_validation_ids:
                     causal_edges.append(
                         CausalEdge(
@@ -839,7 +806,6 @@ class GenerationRunner:
                             relation="recovers",
                         )
                     )
-                current_source_id = event_id
                 sequence_number += 1
 
             checkpoint_id = f"gen-{generation_index}-checkpoint"
@@ -922,6 +888,43 @@ class GenerationRunner:
             },
         )
 
+    def _group_by_generation(self, rows: list[dict[str, Any]]) -> dict[int, list[dict[str, Any]]]:
+        """Group trace-source rows by `generation_index` for `_build_run_trace`."""
+        grouped: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            grouped[self._int_value(row.get("generation_index"))].append(row)
+        return grouped
+
+    def _append_chained_event(
+        self,
+        events: list[TraceEvent],
+        causal_edges: list[CausalEdge],
+        event: TraceEvent,
+        current_source_id: str | None,
+        *,
+        relation: str = "triggers",
+        skip_primary_edge: bool = False,
+    ) -> str:
+        """Append `event` to the trace and wire the causal edge from `current_source_id`.
+
+        Shared by the role/validation/consultation/recovery blocks in
+        `_build_run_trace`, each of which appends an event, links it to the
+        previous event in the chain, and advances `current_source_id`.
+        `skip_primary_edge` lets the recovery block suppress this edge when
+        `current_source_id` is already covered by its own "recovers" edges.
+        Returns the new `current_source_id` (i.e. `event.event_id`).
+        """
+        events.append(event)
+        if current_source_id and not skip_primary_edge:
+            causal_edges.append(
+                CausalEdge(
+                    source_event_id=current_source_id,
+                    target_event_id=event.event_id,
+                    relation=relation,
+                )
+            )
+        return event.event_id
+
     def _role_stage(self, role: str) -> str:
         return {
             "competitor": "compete",
@@ -975,9 +978,7 @@ class GenerationRunner:
 
         generation_rows = self.sqlite.get_generation_metrics(run_id)
         running_generations = [
-            self._int_value(row.get("generation_index"))
-            for row in generation_rows
-            if str(row.get("status") or "") == "running"
+            self._int_value(row.get("generation_index")) for row in generation_rows if str(row.get("status") or "") == "running"
         ]
         if running_generations:
             recovery_markers = self.sqlite.get_recovery_markers_for_run(run_id)
@@ -1006,9 +1007,7 @@ class GenerationRunner:
             )
             return
 
-        completed_generations = sum(
-            1 for row in generation_rows if str(row.get("status") or "") == "completed"
-        )
+        completed_generations = sum(1 for row in generation_rows if str(row.get("status") or "") == "completed")
         target_generations = self._int_value(run_row.get("target_generations"), 0)
         if target_generations > 0 and completed_generations >= target_generations:
             self.sqlite.mark_run_completed(run_id)
@@ -1035,9 +1034,7 @@ class GenerationRunner:
             get_backend(self.settings.scoring_backend).default_uncertainty,
         )
         generation_rows = self.sqlite.get_generation_metrics(run_id)
-        completed_rows = [
-            row for row in generation_rows if str(row.get("status") or "") == "completed"
-        ]
+        completed_rows = [row for row in generation_rows if str(row.get("status") or "") == "completed"]
         if not completed_rows:
             return 0.0, 1000.0, default_uncertainty, [], []
 
@@ -1048,12 +1045,8 @@ class GenerationRunner:
             latest.get("rating_uncertainty"),
             default_uncertainty,
         )
-        score_history = [
-            self._float_value(row.get("best_score"), 0.0) for row in completed_rows
-        ]
-        gate_decision_history = [
-            str(row.get("gate_decision") or "") for row in completed_rows if row.get("gate_decision")
-        ]
+        score_history = [self._float_value(row.get("best_score"), 0.0) for row in completed_rows]
+        gate_decision_history = [str(row.get("gate_decision") or "") for row in completed_rows if row.get("gate_decision")]
         return (
             previous_best,
             challenger_elo,
@@ -1077,7 +1070,10 @@ class GenerationRunner:
         existing_run = self.sqlite.get_run(active_run_id)
         if existing_run is None:
             self.sqlite.create_run(
-                active_run_id, scenario_name, generations, self.settings.executor_mode,
+                active_run_id,
+                scenario_name,
+                generations,
+                self.settings.executor_mode,
                 agent_provider=self.settings.agent_provider,
             )
         else:
@@ -1116,17 +1112,12 @@ class GenerationRunner:
         coach_competitor_hints = self.artifacts.read_hints(scenario_name)
 
         # Cross-run knowledge inheritance: restore from best prior run if no playbook exists
-        if (
-            self.settings.cross_run_inheritance
-            and not self.settings.ablation_no_feedback
-        ):
+        if self.settings.cross_run_inheritance and not self.settings.ablation_no_feedback:
             playbook_path = self.artifacts.knowledge_root / scenario_name / "playbook.md"
             if not playbook_path.exists():
                 best_snapshot = self.sqlite.get_best_knowledge_snapshot(scenario_name)
                 if best_snapshot:
-                    restored = self.artifacts.restore_knowledge_snapshot(
-                        scenario_name, best_snapshot["run_id"]
-                    )
+                    restored = self.artifacts.restore_knowledge_snapshot(scenario_name, best_snapshot["run_id"])
                     if restored:
                         logger.info(
                             "restored knowledge from run %s (score=%.4f) for scenario %s",
@@ -1136,15 +1127,14 @@ class GenerationRunner:
                         )
 
         # Harness inheritance: log existing harness files at run start
-        if (
-            self.settings.harness_validators_enabled
-            and self.settings.harness_inheritance_enabled
-        ):
+        if self.settings.harness_validators_enabled and self.settings.harness_inheritance_enabled:
             existing_harness = self.artifacts.list_harness(scenario_name)
             if existing_harness:
                 logger.info(
                     "inheriting %d harness file(s) for scenario %s: %s",
-                    len(existing_harness), scenario_name, ", ".join(existing_harness),
+                    len(existing_harness),
+                    scenario_name,
+                    ", ".join(existing_harness),
                 )
 
         try:
@@ -1190,6 +1180,7 @@ class GenerationRunner:
 
                     warm_fn = None
                     if self.settings.executor_mode == "primeintellect" and self.remote is not None:
+
                         def _warm(ctx_arg: object, _gen: int = generation) -> Any:
                             assert self.remote is not None
                             return self.remote.warm_provision(
@@ -1197,6 +1188,7 @@ class GenerationRunner:
                                 max_retries=self.settings.primeintellect_max_retries,
                                 backoff_seconds=self.settings.primeintellect_backoff_seconds,
                             )
+
                         warm_fn = _warm
 
                     pipeline = GenerationPipeline(
@@ -1300,7 +1292,8 @@ class GenerationRunner:
                         if gen_row and gen_row.get("status") == "running":
                             logger.warning(
                                 "generation %d for run %s still in 'running' state after pipeline exit; marking as stalled",
-                                generation, active_run_id,
+                                generation,
+                                active_run_id,
                             )
                             self.sqlite.update_generation_status(
                                 active_run_id,

--- a/autocontext/src/autocontext/loop/stage_helpers/exploration.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/exploration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
 # Avoid circular: import at function call site if needed
@@ -9,28 +10,42 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from autocontext.harness.core.types import RoleExecution
+from autocontext.harness.evaluation.dimensional import detect_dimension_regression
 from autocontext.harness.evaluation.runner import EvaluationRunner
 from autocontext.harness.evaluation.scenario_evaluator import ScenarioEvaluator
 from autocontext.harness.evaluation.types import EvaluationLimits as HarnessLimits
+from autocontext.harness.evaluation.types import EvaluationSummary
+from autocontext.harness.pipeline.trend_gate import TrendAwareGate
+from autocontext.knowledge.rapid_gate import rapid_gate
+from autocontext.loop.cost_control import CostPolicy, evaluate_cost_effectiveness
 from autocontext.loop.exploration import (
     BasinCandidate,
     BranchRecord,
     DivergentCompetitorConfig,
     MultiBasinConfig,
+    NoveltyConfig,
+    apply_novelty_bonus,
+    compute_novelty_score,
     generate_basin_candidates,
     should_spawn_divergent,
     should_trigger_multi_basin,
 )
-from autocontext.loop.stage_helpers.tournament_prep import _build_live_opponent_pool
+from autocontext.loop.stage_helpers.dimensions import _load_previous_best_dimensions
+from autocontext.loop.stage_helpers.tournament_prep import _build_live_opponent_pool, _run_holdout_verification
 from autocontext.loop.stage_types import GenerationContext
+from autocontext.loop.tournament_helpers import resolve_gate_decision
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from autocontext.agents.orchestrator import AgentOrchestrator
     from autocontext.agents.types import AgentOutputs
+    from autocontext.config.settings import AppSettings
     from autocontext.execution.supervisor import ExecutionSupervisor
+    from autocontext.harness.pipeline.gate import BackpressureGate
+    from autocontext.harness.pipeline.holdout import HoldoutResult
     from autocontext.loop.events import EventStreamEmitter
+    from autocontext.scenarios.base import ScenarioInterface
     from autocontext.storage import SQLiteStore
 
 
@@ -218,31 +233,32 @@ def _select_exploration_strategy(
             ),
         ]
 
-    candidate_entries: list[dict[str, Any]] = [{
-        "branch_type": "conservative",
-        "strategy": outputs.strategy,
-        "temperature": 0.2,
-        "metadata": {"source": "base_generation"},
-    }]
+    candidate_entries: list[dict[str, Any]] = [
+        {
+            "branch_type": "conservative",
+            "strategy": outputs.strategy,
+            "temperature": 0.2,
+            "metadata": {"source": "base_generation"},
+        }
+    ]
     seen_strategies = {json.dumps(outputs.strategy, sort_keys=True)}
 
     if events is not None:
-        events.emit("exploration_started", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "multi_basin_triggered": multi_basin_triggered,
-            "divergent_triggered": divergent_triggered,
-            "gate_history": ctx.gate_decision_history,
-        })
+        events.emit(
+            "exploration_started",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "multi_basin_triggered": multi_basin_triggered,
+                "divergent_triggered": divergent_triggered,
+                "gate_history": ctx.gate_decision_history,
+            },
+        )
 
     for branch in branch_specs:
         if branch.branch_type == "conservative":
             continue
-        branch_temperature = (
-            divergent_config.temperature
-            if branch.branch_type == "divergent"
-            else branch.temperature
-        )
+        branch_temperature = divergent_config.temperature if branch.branch_type == "divergent" else branch.temperature
         branch_prompt = _build_branch_competitor_prompt(
             ctx,
             playbook=branch.playbook,
@@ -269,12 +285,14 @@ def _select_exploration_strategy(
             if not valid:
                 continue
         seen_strategies.add(serialized)
-        candidate_entries.append({
-            "branch_type": branch.branch_type,
-            "strategy": strategy,
-            "temperature": branch_temperature,
-            "metadata": dict(branch.metadata),
-        })
+        candidate_entries.append(
+            {
+                "branch_type": branch.branch_type,
+                "strategy": strategy,
+                "temperature": branch_temperature,
+                "metadata": dict(branch.metadata),
+            }
+        )
 
     if len(candidate_entries) == 1:
         return outputs.strategy, {}
@@ -294,14 +312,16 @@ def _select_exploration_strategy(
             challenger_uncertainty=ctx.challenger_uncertainty,
             opponent_pool=opponent_pool,
         )
-        selection_results.append({
-            "branch_type": candidate["branch_type"],
-            "best_score": tournament.best_score,
-            "mean_score": tournament.mean_score,
-            "strategy": candidate["strategy"],
-            "temperature": candidate["temperature"],
-            "metadata": dict(candidate.get("metadata", {})),
-        })
+        selection_results.append(
+            {
+                "branch_type": candidate["branch_type"],
+                "best_score": tournament.best_score,
+                "mean_score": tournament.mean_score,
+                "strategy": candidate["strategy"],
+                "temperature": candidate["temperature"],
+                "metadata": dict(candidate.get("metadata", {})),
+            }
+        )
 
     selected = max(
         selection_results,
@@ -334,9 +354,173 @@ def _select_exploration_strategy(
         ],
     }
     if events is not None:
-        events.emit("exploration_selected", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            **metadata,
-        })
+        events.emit(
+            "exploration_selected",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                **metadata,
+            },
+        )
     return dict(selected["strategy"]), metadata
+
+
+@dataclasses.dataclass(slots=True)
+class _GateAdjustmentOutcome:
+    """Result of resolving the final gate decision for one tournament attempt."""
+
+    tournament: EvaluationSummary
+    gate_decision: str
+    gate_reason: str
+    gate_result: Any
+    holdout_result: HoldoutResult | None
+
+
+def _apply_novelty_and_cost_adjustments(
+    ctx: GenerationContext,
+    *,
+    tournament: EvaluationSummary,
+    gate: BackpressureGate | TrendAwareGate,
+    scenario: ScenarioInterface,
+    supervisor: ExecutionSupervisor,
+    sqlite: SQLiteStore,
+    events: EventStreamEmitter,
+    settings: AppSettings,
+    current_strategy: dict[str, Any],
+    attempt: int,
+    use_rapid: bool,
+    harness_limits: HarnessLimits,
+) -> _GateAdjustmentOutcome:
+    """Apply dimension-regression, novelty-bonus, and cost-effectiveness adjustments,
+    resolve the gate decision, then run holdout verification when advancing."""
+    previous_best_dimensions = _load_previous_best_dimensions(sqlite, ctx.run_id)
+    if previous_best_dimensions and tournament.best_dimensions:
+        tournament = dataclasses.replace(
+            tournament,
+            dimension_regressions=detect_dimension_regression(
+                previous_best_dimensions,
+                tournament.best_dimensions,
+                threshold=settings.scoring_dimension_regression_threshold,
+            ),
+        )
+
+    custom_metrics = None
+    if isinstance(gate, TrendAwareGate):
+        best_eval = max(tournament.results, key=lambda r: r.score)
+        best_exec = best_eval.metadata["execution_output"]
+        custom_metrics = scenario.custom_backpressure(best_exec.result)
+    recent_strategies = _load_recent_numeric_strategies(
+        sqlite,
+        run_id=ctx.run_id,
+        window=settings.novelty_history_window,
+    )
+    gate_best_score = tournament.best_score
+    if settings.novelty_enabled and recent_strategies:
+        novelty_score = compute_novelty_score(current_strategy, recent_strategies)
+        gate_best_score = apply_novelty_bonus(
+            tournament.best_score,
+            novelty_score,
+            NoveltyConfig(
+                weight=settings.novelty_weight,
+                enabled=settings.novelty_enabled,
+            ),
+        )
+        custom_metrics = dict(custom_metrics or {})
+        custom_metrics.update(
+            {
+                "search_proxy_score": gate_best_score,
+                "novelty_score": novelty_score,
+                "raw_best_score": tournament.best_score,
+                "novelty_adjusted_best_score": gate_best_score,
+            }
+        )
+        ctx.exploration_metadata = {
+            **ctx.exploration_metadata,
+            "novelty": {
+                "score": novelty_score,
+                "raw_best_score": tournament.best_score,
+                "adjusted_best_score": gate_best_score,
+                "history_window": len(recent_strategies),
+            },
+        }
+    holdout_result = None
+    gate_result = resolve_gate_decision(
+        tournament_best_score=gate_best_score,
+        tournament_mean_score=tournament.mean_score,
+        tournament_results=tournament.results,
+        previous_best=ctx.previous_best,
+        gate=gate,
+        score_history=ctx.score_history,
+        gate_decision_history=ctx.gate_decision_history,
+        retry_count=attempt,
+        max_retries=settings.max_retries,
+        use_rapid=use_rapid,
+        custom_metrics=custom_metrics,
+        rapid_gate_fn=rapid_gate,
+        annealing_enabled=settings.experimental_annealing_enabled,
+        annealing_seed=settings.seed_base,
+        generation=ctx.generation,
+    )
+    gate_decision, gate_reason = gate_result.decision, gate_result.reason
+    generation_cost_usd = float(ctx.cost_control_metadata.get("generation_cost_usd", 0.0) or 0.0)
+    if generation_cost_usd > 0:
+        score_delta = max(0.0, tournament.best_score - ctx.previous_best)
+        cost_effectiveness = evaluate_cost_effectiveness(
+            generation_cost_usd,
+            score_delta,
+            max_cost_per_delta=CostPolicy(
+                max_cost_per_delta_point=settings.cost_max_per_delta_point,
+                throttle_above_total=settings.cost_throttle_above_total,
+            ).max_cost_per_delta_point,
+        )
+        ctx.cost_control_metadata = {
+            **ctx.cost_control_metadata,
+            "cost_effectiveness": cost_effectiveness,
+        }
+        if gate_decision == "retry":
+            retry_blocked_by_cost = bool(ctx.cost_control_metadata.get("throttled"))
+            retry_blocked_by_efficiency = score_delta > 0 and not cost_effectiveness["efficient"]
+            if retry_blocked_by_cost or retry_blocked_by_efficiency:
+                reasons: list[str] = []
+                if retry_blocked_by_cost:
+                    reasons.append("budget throttle is active")
+                if retry_blocked_by_efficiency:
+                    reasons.append(
+                        "cost per delta "
+                        f"${cost_effectiveness['cost_per_delta_point']:.4f} exceeds "
+                        f"${settings.cost_max_per_delta_point:.4f}"
+                    )
+                gate_decision = "rollback"
+                gate_reason = "Cost control suppressed retry: " + "; ".join(reasons)
+
+    if gate_decision == "advance":
+        holdout_result = _run_holdout_verification(
+            ctx,
+            supervisor=supervisor,
+            strategy=current_strategy,
+            in_sample_score=tournament.best_score,
+            limits=harness_limits,
+        )
+        if holdout_result is not None:
+            events.emit(
+                "holdout_evaluated",
+                {
+                    "run_id": ctx.run_id,
+                    "generation": ctx.generation,
+                    "holdout": holdout_result.to_dict(),
+                },
+            )
+            if not holdout_result.passed:
+                gate_reason = f"Holdout blocked advance: {holdout_result.reason}"
+                if not use_rapid and attempt < settings.max_retries:
+                    gate_decision = "retry"
+                else:
+                    gate_decision = "rollback"
+
+    return _GateAdjustmentOutcome(
+        tournament=tournament,
+        gate_decision=gate_decision,
+        gate_reason=gate_reason,
+        gate_result=gate_result,
+        holdout_result=holdout_result,
+    )

--- a/autocontext/src/autocontext/loop/stage_helpers/tournament_prep.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/tournament_prep.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import dataclasses
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any, Literal
 
+from autocontext.harness.evaluation.failure_report import FailureReport
+from autocontext.harness.evaluation.runner import EvaluationRunner
 from autocontext.harness.evaluation.scenario_evaluator import ScenarioEvaluator
 from autocontext.harness.evaluation.self_play import (
     SelfPlayConfig,
@@ -13,11 +19,21 @@ from autocontext.harness.evaluation.self_play import (
 from autocontext.harness.evaluation.types import EvaluationLimits as HarnessLimits
 from autocontext.harness.evaluation.types import EvaluationSummary
 from autocontext.harness.pipeline.holdout import HoldoutPolicy, HoldoutResult, HoldoutVerifier
+from autocontext.loop.stage_helpers.persistence_helpers import _revise_strategy_for_validity_failure
 from autocontext.loop.stage_types import GenerationContext
+from autocontext.loop.tournament_helpers import build_retry_prompt, build_validity_rollback
 from autocontext.scenarios.families import detect_family
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
+    from autocontext.agents.orchestrator import AgentOrchestrator
+    from autocontext.config.settings import AppSettings
     from autocontext.execution.supervisor import ExecutionSupervisor
+    from autocontext.harness.evaluation.types import EvaluationResult
+    from autocontext.harness.pipeline.validity_gate import ValidityGate
+    from autocontext.loop.events import EventStreamEmitter
+    from autocontext.scenarios.base import ScenarioInterface
     from autocontext.storage import SQLiteStore
 
 
@@ -58,9 +74,7 @@ def _build_live_opponent_pool(
         trials=settings.matches_per_generation,
     )
     planned_self_play_matches = sum(
-        1
-        for entry in opponent_pool
-        if isinstance(entry, dict) and entry.get("source") == "self_play"
+        1 for entry in opponent_pool if isinstance(entry, dict) and entry.get("source") == "self_play"
     )
     return self_play_pool, opponent_pool, planned_self_play_matches
 
@@ -97,9 +111,8 @@ def _resolve_holdout_policy(ctx: GenerationContext) -> HoldoutPolicy:
     if family is None:
         return policy
 
-    override = (
-        ctx.settings.holdout_family_policies.get(family.scenario_type_marker)
-        or ctx.settings.holdout_family_policies.get(family.name)
+    override = ctx.settings.holdout_family_policies.get(family.scenario_type_marker) or ctx.settings.holdout_family_policies.get(
+        family.name
     )
     if not isinstance(override, dict):
         return policy
@@ -140,3 +153,238 @@ def _run_holdout_verification(
     metadata["policy"] = policy.to_dict()
     result.metadata = metadata
     return result
+
+
+@dataclasses.dataclass(slots=True)
+class _ValidityGateOutcome:
+    """Result of one validity-gate check inside stage_tournament's retry loop."""
+
+    action: Literal["proceed", "retry", "return"]
+    current_strategy: dict[str, Any]
+    validity_retry_attempt: int
+
+
+def _run_validity_gate(
+    ctx: GenerationContext,
+    *,
+    validity_gate: ValidityGate,
+    current_strategy: dict[str, Any],
+    validity_retry_attempt: int,
+    agents: AgentOrchestrator | None,
+    events: EventStreamEmitter,
+    settings: AppSettings,
+) -> _ValidityGateOutcome:
+    """Tier 1 validity gate (AC-160): pass through, revise-and-retry, or roll back
+    without spending a tournament once the retry budget is exhausted."""
+    validity_result = validity_gate.check(current_strategy)
+    if validity_result.passed:
+        events.emit(
+            "validity_check_passed",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+            },
+        )
+        return _ValidityGateOutcome("proceed", current_strategy, validity_retry_attempt)
+
+    events.emit(
+        "validity_check_failed",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "errors": validity_result.errors,
+            "retry_budget_remaining": validity_result.retry_budget_remaining,
+        },
+    )
+    can_retry = validity_gate.consume_retry()
+    if can_retry:
+        validity_retry_attempt += 1
+        revised_strategy = _revise_strategy_for_validity_failure(
+            ctx,
+            current_strategy=current_strategy,
+            errors=validity_result.errors,
+            retry_attempt=validity_retry_attempt,
+            agents=agents,
+        )
+        if revised_strategy is not None:
+            current_strategy = revised_strategy
+        time.sleep(settings.retry_backoff_seconds * validity_retry_attempt)
+        return _ValidityGateOutcome("retry", current_strategy, validity_retry_attempt)
+
+    # Validity budget exhausted: rollback without tournament
+    tournament = _build_empty_tournament(ctx)
+    rollback = build_validity_rollback(
+        current_strategy=current_strategy,
+        validity_retry_attempts=validity_retry_attempt,
+        score_history=ctx.score_history,
+        gate_decision_history=ctx.gate_decision_history,
+        tournament=tournament,
+    )
+    gate_decision = rollback["gate_decision"]
+    gate_delta = rollback["gate_delta"]
+    events.emit(
+        "gate_decided",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "decision": gate_decision,
+            "delta": gate_delta,
+            "tier": "validity",
+        },
+    )
+    ctx.score_history[:] = rollback["score_history"]
+    ctx.gate_decision_history[:] = rollback["gate_decision_history"]
+    ctx.gate_decision = gate_decision
+    ctx.gate_delta = gate_delta
+    ctx.current_strategy = rollback["current_strategy"]
+    ctx.attempt = rollback["attempt"]
+    ctx.tournament = rollback["tournament"]
+    return _ValidityGateOutcome("return", current_strategy, validity_retry_attempt)
+
+
+@dataclasses.dataclass(slots=True)
+class _TournamentAttemptOutcome:
+    """Result of one tournament-execution attempt inside stage_tournament's retry loop."""
+
+    should_retry: bool
+    tournament: EvaluationSummary | None
+    attempt: int
+    harness_limits: HarnessLimits | None
+
+
+def _execute_tournament_with_retry(
+    ctx: GenerationContext,
+    *,
+    supervisor: ExecutionSupervisor,
+    scenario: ScenarioInterface,
+    sqlite: SQLiteStore,
+    events: EventStreamEmitter,
+    settings: AppSettings,
+    current_strategy: dict[str, Any],
+    attempt: int,
+) -> _TournamentAttemptOutcome:
+    """Run one round of tournament matches, retrying on transient exceptions."""
+    self_play_pool, opponent_pool, planned_self_play_matches = _build_live_opponent_pool(
+        ctx,
+        sqlite=sqlite,
+    )
+
+    events.emit(
+        "tournament_started",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "matches": settings.matches_per_generation,
+            "scoring_backend": settings.scoring_backend,
+            "self_play_pool_size": self_play_pool.size,
+            "self_play_matches_planned": planned_self_play_matches,
+        },
+    )
+
+    def _on_match(match_index: int, score: float, _gen: int = ctx.generation) -> None:
+        events.emit(
+            "match_completed",
+            {
+                "run_id": ctx.run_id,
+                "generation": _gen,
+                "match_index": match_index,
+                "score": score,
+            },
+        )
+
+    try:
+        evaluator = ScenarioEvaluator(scenario, supervisor, hook_bus=ctx.hook_bus)
+        harness_limits = HarnessLimits()
+
+        def _on_result(idx: int, result: EvaluationResult) -> None:
+            _on_match(idx, result.score)
+
+        runner = EvaluationRunner(evaluator, scoring_backend=settings.scoring_backend)
+        tournament = runner.run(
+            candidate=current_strategy,
+            seed_base=settings.seed_base + (ctx.generation * 100) + (attempt * 10),
+            trials=settings.matches_per_generation,
+            limits=harness_limits,
+            challenger_elo=ctx.challenger_elo,
+            challenger_uncertainty=ctx.challenger_uncertainty,
+            opponent_pool=opponent_pool,
+            on_result=_on_result,
+        )
+    except Exception:
+        logger.debug("loop.stages: caught Exception", exc_info=True)
+        attempt += 1
+        if attempt > settings.max_retries:
+            raise
+        time.sleep(settings.retry_backoff_seconds * attempt)
+        return _TournamentAttemptOutcome(should_retry=True, tournament=None, attempt=attempt, harness_limits=None)
+
+    return _TournamentAttemptOutcome(
+        should_retry=False,
+        tournament=tournament,
+        attempt=attempt,
+        harness_limits=harness_limits,
+    )
+
+
+def _run_retry_learning(
+    ctx: GenerationContext,
+    *,
+    agents: AgentOrchestrator | None,
+    scenario: ScenarioInterface,
+    sqlite: SQLiteStore,
+    settings: AppSettings,
+    tournament: EvaluationSummary,
+    current_strategy: dict[str, Any],
+    attempt: int,
+) -> dict[str, Any]:
+    """Re-invoke the competitor with failure context after a retry gate decision."""
+    if agents is None or ctx.prompts is None:
+        return current_strategy
+
+    is_code_strategy = "__code__" in current_strategy
+    failure_report_context = FailureReport.from_tournament(
+        tournament,
+        previous_best=ctx.previous_best,
+        threshold=settings.backpressure_min_delta,
+        strategy=current_strategy,
+    ).to_prompt_context()
+    retry_prompt = build_retry_prompt(
+        base_prompt=ctx.prompts.competitor,
+        tournament_best_score=tournament.best_score,
+        previous_best=ctx.previous_best,
+        min_delta=settings.backpressure_min_delta,
+        current_strategy=current_strategy,
+        attempt=attempt,
+        is_code_strategy=is_code_strategy,
+        include_code_strategy_suffix=settings.code_strategies_enabled,
+        strategy_interface=ctx.strategy_interface,
+        failure_report_context=failure_report_context,
+    )
+    try:
+        raw_text, _ = agents.competitor.run(retry_prompt, tool_context=ctx.tool_context)
+        if is_code_strategy:
+            revised_strategy, _ = agents.translator.translate_code(raw_text)
+        else:
+            revised_strategy, _ = agents.translator.translate(raw_text, ctx.strategy_interface)
+        if "__code__" not in revised_strategy:
+            state = scenario.initial_state(seed=settings.seed_base + ctx.generation)
+            valid, reason = scenario.validate_actions(state, "challenger", revised_strategy)
+            if valid:
+                current_strategy = revised_strategy
+                sqlite.append_agent_output(
+                    ctx.run_id,
+                    ctx.generation,
+                    "competitor",
+                    json.dumps(revised_strategy, sort_keys=True),
+                )
+        else:
+            current_strategy = revised_strategy
+            sqlite.append_agent_output(
+                ctx.run_id,
+                ctx.generation,
+                "competitor",
+                json.dumps(revised_strategy, sort_keys=True),
+            )
+    except Exception:
+        logger.debug("retry-learning competitor re-invocation failed", exc_info=True)
+    return current_strategy

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -12,12 +12,6 @@ from typing import TYPE_CHECKING, Any
 from autocontext.agents.architect import parse_dag_changes
 from autocontext.agents.runtime_session_wiring import run_runtime_session_scope
 from autocontext.config.harness_profile import render_harness_tool_context, resolve_harness_runtime_profile
-from autocontext.harness.evaluation.dimensional import detect_dimension_regression
-from autocontext.harness.evaluation.failure_report import FailureReport
-from autocontext.harness.evaluation.runner import EvaluationRunner
-from autocontext.harness.evaluation.scenario_evaluator import ScenarioEvaluator
-from autocontext.harness.evaluation.types import EvaluationLimits as HarnessLimits
-from autocontext.harness.evaluation.types import EvaluationResult
 from autocontext.harness.mutations.parser import parse_mutations
 from autocontext.harness.pipeline.holdout import HoldoutResult
 from autocontext.harness.pipeline.trend_gate import TrendAwareGate
@@ -26,22 +20,11 @@ from autocontext.knowledge.fresh_start import execute_fresh_start
 from autocontext.knowledge.harness_quality import compute_harness_quality
 from autocontext.knowledge.hint_volume import HintManager
 from autocontext.knowledge.protocol import parse_research_protocol, validate_tuning_overrides
-from autocontext.knowledge.rapid_gate import rapid_gate, should_transition_to_linear
+from autocontext.knowledge.rapid_gate import should_transition_to_linear
 from autocontext.knowledge.stagnation import StagnationDetector
 from autocontext.knowledge.tuning import TuningConfig, parse_tuning_proposal
-from autocontext.loop.cost_control import CostPolicy, evaluate_cost_effectiveness
-from autocontext.loop.exploration import (
-    NoveltyConfig,
-    apply_novelty_bonus,
-    compute_novelty_score,
-)
 from autocontext.loop.stage_types import GenerationContext
-from autocontext.loop.tournament_helpers import (
-    apply_tournament_outcome,
-    build_retry_prompt,
-    build_validity_rollback,
-    resolve_gate_decision,
-)
+from autocontext.loop.tournament_helpers import apply_tournament_outcome
 from autocontext.notebook.context_provider import NotebookContextProvider
 from autocontext.notebook.types import SessionNotebook
 from autocontext.providers.base import CompletionResult, LLMProvider
@@ -77,10 +60,9 @@ from autocontext.loop.stage_helpers.dimensions import (
     _build_match_replay_json,
     _build_replay_envelope_payload,
     _build_self_play_summary_payload,
-    _load_previous_best_dimensions,
 )
 from autocontext.loop.stage_helpers.exploration import (
-    _load_recent_numeric_strategies,
+    _apply_novelty_and_cost_adjustments,
     _select_exploration_strategy,
 )
 from autocontext.loop.stage_helpers.freshness import (
@@ -101,7 +83,6 @@ from autocontext.loop.stage_helpers.persistence_helpers import (
     _maybe_rate_analyst_output,
     _persist_progress_snapshot,
     _persist_skill_note,
-    _revise_strategy_for_validity_failure,
     _run_curator_consolidation,
 )
 from autocontext.loop.stage_helpers.semantic_benchmark import (
@@ -109,10 +90,10 @@ from autocontext.loop.stage_helpers.semantic_benchmark import (
     prepare_generation_prompts,
 )
 from autocontext.loop.stage_helpers.tournament_prep import (
-    _build_empty_tournament,
-    _build_live_opponent_pool,
     _build_skeptic_review_section,
-    _run_holdout_verification,
+    _execute_tournament_with_retry,
+    _run_retry_learning,
+    _run_validity_gate,
 )
 
 logger = logging.getLogger(__name__)
@@ -173,10 +154,13 @@ def stage_policy_refinement(
 
     initial_code = ctx.current_strategy["__code__"]
 
-    events.emit("policy_refinement_started", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-    })
+    events.emit(
+        "policy_refinement_started",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+        },
+    )
 
     try:
         effective_model = settings.policy_refinement_model or model or ""
@@ -213,21 +197,27 @@ def stage_policy_refinement(
             json.dumps(ctx.current_strategy, sort_keys=True),
         )
 
-        events.emit("policy_refinement_completed", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "iterations": result.iterations,
-            "best_heuristic": result.best_heuristic,
-            "converged": result.converged,
-            "total_matches_run": result.total_matches_run,
-        })
+        events.emit(
+            "policy_refinement_completed",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "iterations": result.iterations,
+                "best_heuristic": result.best_heuristic,
+                "converged": result.converged,
+                "total_matches_run": result.total_matches_run,
+            },
+        )
     except Exception:
         logger.warning("policy refinement failed, using original strategy", exc_info=True)
-        events.emit("policy_refinement_failed", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "error": "refinement exception",
-        })
+        events.emit(
+            "policy_refinement_failed",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "error": "refinement exception",
+            },
+        )
 
     return ctx
 
@@ -250,29 +240,39 @@ def stage_knowledge_setup(
     skills_context = "" if ablation else artifacts.read_skills(ctx.scenario_name)
     recent_analysis = "" if ablation else artifacts.read_latest_advance_analysis(ctx.scenario_name, ctx.generation)
     analyst_feedback = "" if ablation else _load_analyst_feedback_section(ctx, artifacts=artifacts)
-    analyst_attribution = "" if ablation else _load_credit_attribution_section(
-        ctx,
-        artifacts=artifacts,
-        role="analyst",
+    analyst_attribution = (
+        ""
+        if ablation
+        else _load_credit_attribution_section(
+            ctx,
+            artifacts=artifacts,
+            role="analyst",
+        )
     )
-    coach_attribution = "" if ablation else _load_credit_attribution_section(
-        ctx,
-        artifacts=artifacts,
-        role="coach",
+    coach_attribution = (
+        ""
+        if ablation
+        else _load_credit_attribution_section(
+            ctx,
+            artifacts=artifacts,
+            role="coach",
+        )
     )
-    architect_attribution = "" if ablation else _load_credit_attribution_section(
-        ctx,
-        artifacts=artifacts,
-        role="architect",
+    architect_attribution = (
+        ""
+        if ablation
+        else _load_credit_attribution_section(
+            ctx,
+            artifacts=artifacts,
+            role="architect",
+        )
     )
     coach_hint_feedback = "" if ablation else _load_hint_feedback_section(ctx, artifacts=artifacts)
     tool_usage_report = "" if ablation else _load_architect_tool_usage_report(ctx, artifacts=artifacts)
     weakness_reports = "" if ablation else artifacts.read_latest_weakness_reports_markdown(ctx.scenario_name)
     progress_reports = "" if ablation else artifacts.read_latest_progress_reports_markdown(ctx.scenario_name)
     session_reports = (
-        ""
-        if ablation or not ctx.settings.session_reports_enabled
-        else artifacts.read_latest_session_reports(ctx.scenario_name)
+        "" if ablation or not ctx.settings.session_reports_enabled else artifacts.read_latest_session_reports(ctx.scenario_name)
     )
     dead_ends = "" if ablation else artifacts.read_dead_ends(ctx.scenario_name)
     if not isinstance(dead_ends, str):
@@ -334,11 +334,7 @@ def stage_knowledge_setup(
     if not isinstance(mutation_replay, str):
         mutation_replay = ""
     if mutation_replay:
-        experiment_log = (
-            f"{experiment_log}\n\n{mutation_replay}".strip()
-            if experiment_log
-            else mutation_replay
-        )
+        experiment_log = f"{experiment_log}\n\n{mutation_replay}".strip() if experiment_log else mutation_replay
     if weakness_reports:
         experiment_log = (
             f"{experiment_log}\n\nRecent weakness reports:\n{weakness_reports}".strip()
@@ -377,11 +373,7 @@ def stage_knowledge_setup(
     if freshness_notes:
         freshness_block = "\n\n".join(note for note in freshness_notes if note).strip()
         if freshness_block:
-            experiment_log = (
-                f"{experiment_log}\n\n{freshness_block}".strip()
-                if experiment_log
-                else freshness_block
-            )
+            experiment_log = f"{experiment_log}\n\n{freshness_block}".strip() if experiment_log else freshness_block
     tool_instruction_block = render_tool_instruction_block(active_harness_mutations)
     if tool_instruction_block:
         tool_context = f"{tool_context}\n\n{tool_instruction_block}".strip() if tool_context else tool_instruction_block
@@ -467,9 +459,14 @@ def stage_agent_generation(
         roles = ["competitor", "analyst", "coach", "architect"]
         if orchestrator.curator is not None:
             roles.append("curator")
-        events.emit("agents_started", {
-            "run_id": ctx.run_id, "generation": ctx.generation, "roles": roles,
-        })
+        events.emit(
+            "agents_started",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "roles": roles,
+            },
+        )
 
     generation_started_at = ctx.generation_start_time or time.monotonic()
     generation_deadline = (
@@ -535,13 +532,16 @@ def stage_agent_generation(
     )
     if events is not None:
         for role_execution in outputs.role_executions:
-            events.emit("role_completed", {
-                "run_id": ctx.run_id,
-                "generation": ctx.generation,
-                "role": role_execution.role,
-                "latency_ms": role_execution.usage.latency_ms,
-                "tokens": role_execution.usage.input_tokens + role_execution.usage.output_tokens,
-            })
+            events.emit(
+                "role_completed",
+                {
+                    "run_id": ctx.run_id,
+                    "generation": ctx.generation,
+                    "role": role_execution.role,
+                    "latency_ms": role_execution.usage.latency_ms,
+                    "tokens": role_execution.usage.input_tokens + role_execution.usage.output_tokens,
+                },
+            )
     created_tools = artifacts.persist_tools(ctx.scenario_name, ctx.generation, outputs.architect_tools)
 
     # Persist harness validators if enabled
@@ -594,6 +594,8 @@ def stage_tournament(
     validity_retry_attempt = 0
     validity_gate = None
     holdout_result: HoldoutResult | None = None
+    harness_limits = None
+    gate_result: Any = None
 
     # --- Tier 1: Validity gate (AC-160) ---
     if settings.two_tier_gating_enabled:
@@ -606,224 +608,59 @@ def stage_tournament(
 
     while True:
         if validity_gate is not None:
-            validity_result = validity_gate.check(current_strategy)
-            if not validity_result.passed:
-                events.emit("validity_check_failed", {
-                    "run_id": ctx.run_id,
-                    "generation": ctx.generation,
-                    "errors": validity_result.errors,
-                    "retry_budget_remaining": validity_result.retry_budget_remaining,
-                })
-                can_retry = validity_gate.consume_retry()
-                if can_retry:
-                    validity_retry_attempt += 1
-                    revised_strategy = _revise_strategy_for_validity_failure(
-                        ctx,
-                        current_strategy=current_strategy,
-                        errors=validity_result.errors,
-                        retry_attempt=validity_retry_attempt,
-                        agents=agents,
-                    )
-                    if revised_strategy is not None:
-                        current_strategy = revised_strategy
-                    time.sleep(settings.retry_backoff_seconds * validity_retry_attempt)
-                    continue
-
-                # Validity budget exhausted: rollback without tournament
-                tournament = _build_empty_tournament(ctx)
-                rollback = build_validity_rollback(
-                    current_strategy=current_strategy,
-                    validity_retry_attempts=validity_retry_attempt,
-                    score_history=ctx.score_history,
-                    gate_decision_history=ctx.gate_decision_history,
-                    tournament=tournament,
-                )
-                gate_decision = rollback["gate_decision"]
-                gate_delta = rollback["gate_delta"]
-                events.emit("gate_decided", {
-                    "run_id": ctx.run_id,
-                    "generation": ctx.generation,
-                    "decision": gate_decision,
-                    "delta": gate_delta,
-                    "tier": "validity",
-                })
-                ctx.score_history[:] = rollback["score_history"]
-                ctx.gate_decision_history[:] = rollback["gate_decision_history"]
-                ctx.gate_decision = gate_decision
-                ctx.gate_delta = gate_delta
-                ctx.current_strategy = rollback["current_strategy"]
-                ctx.attempt = rollback["attempt"]
-                ctx.tournament = rollback["tournament"]
-                return ctx
-
-            events.emit("validity_check_passed", {
-                "run_id": ctx.run_id,
-                "generation": ctx.generation,
-            })
-
-        self_play_pool, opponent_pool, planned_self_play_matches = _build_live_opponent_pool(
-            ctx,
-            sqlite=sqlite,
-        )
-
-        events.emit("tournament_started", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "matches": settings.matches_per_generation,
-            "scoring_backend": settings.scoring_backend,
-            "self_play_pool_size": self_play_pool.size,
-            "self_play_matches_planned": planned_self_play_matches,
-        })
-
-        def _on_match(match_index: int, score: float, _gen: int = ctx.generation) -> None:
-            events.emit("match_completed", {
-                "run_id": ctx.run_id, "generation": _gen,
-                "match_index": match_index, "score": score,
-            })
-
-        try:
-            evaluator = ScenarioEvaluator(scenario, supervisor, hook_bus=ctx.hook_bus)
-            harness_limits = HarnessLimits()
-
-            def _on_result(idx: int, result: EvaluationResult) -> None:
-                _on_match(idx, result.score)
-
-            runner = EvaluationRunner(evaluator, scoring_backend=settings.scoring_backend)
-            tournament = runner.run(
-                candidate=current_strategy,
-                seed_base=settings.seed_base + (ctx.generation * 100) + (attempt * 10),
-                trials=settings.matches_per_generation,
-                limits=harness_limits,
-                challenger_elo=ctx.challenger_elo,
-                challenger_uncertainty=ctx.challenger_uncertainty,
-                opponent_pool=opponent_pool,
-                on_result=_on_result,
-            )
-        except Exception:
-            logger.debug("loop.stages: caught Exception", exc_info=True)
-            attempt += 1
-            if attempt > settings.max_retries:
-                raise
-            time.sleep(settings.retry_backoff_seconds * attempt)
-            continue
-
-        previous_best_dimensions = _load_previous_best_dimensions(sqlite, ctx.run_id)
-        if previous_best_dimensions and tournament.best_dimensions:
-            tournament = dataclasses.replace(
-                tournament,
-                dimension_regressions=detect_dimension_regression(
-                    previous_best_dimensions,
-                    tournament.best_dimensions,
-                    threshold=settings.scoring_dimension_regression_threshold,
-                ),
-            )
-
-        custom_metrics = None
-        if isinstance(gate, TrendAwareGate):
-            best_eval = max(tournament.results, key=lambda r: r.score)
-            best_exec = best_eval.metadata["execution_output"]
-            custom_metrics = scenario.custom_backpressure(best_exec.result)
-        recent_strategies = _load_recent_numeric_strategies(
-            sqlite,
-            run_id=ctx.run_id,
-            window=settings.novelty_history_window,
-        )
-        gate_best_score = tournament.best_score
-        if settings.novelty_enabled and recent_strategies:
-            novelty_score = compute_novelty_score(current_strategy, recent_strategies)
-            gate_best_score = apply_novelty_bonus(
-                tournament.best_score,
-                novelty_score,
-                NoveltyConfig(
-                    weight=settings.novelty_weight,
-                    enabled=settings.novelty_enabled,
-                ),
-            )
-            custom_metrics = dict(custom_metrics or {})
-            custom_metrics.update({
-                "search_proxy_score": gate_best_score,
-                "novelty_score": novelty_score,
-                "raw_best_score": tournament.best_score,
-                "novelty_adjusted_best_score": gate_best_score,
-            })
-            ctx.exploration_metadata = {
-                **ctx.exploration_metadata,
-                "novelty": {
-                    "score": novelty_score,
-                    "raw_best_score": tournament.best_score,
-                    "adjusted_best_score": gate_best_score,
-                    "history_window": len(recent_strategies),
-                },
-            }
-        holdout_result = None
-        gate_result = resolve_gate_decision(
-            tournament_best_score=gate_best_score,
-            tournament_mean_score=tournament.mean_score,
-            tournament_results=tournament.results,
-            previous_best=ctx.previous_best,
-            gate=gate,
-            score_history=ctx.score_history,
-            gate_decision_history=ctx.gate_decision_history,
-            retry_count=attempt,
-            max_retries=settings.max_retries,
-            use_rapid=use_rapid,
-            custom_metrics=custom_metrics,
-            rapid_gate_fn=rapid_gate,
-            annealing_enabled=settings.experimental_annealing_enabled,
-            annealing_seed=settings.seed_base, generation=ctx.generation,
-        )
-        gate_decision, gate_reason = gate_result.decision, gate_result.reason
-        generation_cost_usd = float(ctx.cost_control_metadata.get("generation_cost_usd", 0.0) or 0.0)
-        if generation_cost_usd > 0:
-            score_delta = max(0.0, tournament.best_score - ctx.previous_best)
-            cost_effectiveness = evaluate_cost_effectiveness(
-                generation_cost_usd,
-                score_delta,
-                max_cost_per_delta=CostPolicy(
-                    max_cost_per_delta_point=settings.cost_max_per_delta_point,
-                    throttle_above_total=settings.cost_throttle_above_total,
-                ).max_cost_per_delta_point,
-            )
-            ctx.cost_control_metadata = {
-                **ctx.cost_control_metadata,
-                "cost_effectiveness": cost_effectiveness,
-            }
-            if gate_decision == "retry":
-                retry_blocked_by_cost = bool(ctx.cost_control_metadata.get("throttled"))
-                retry_blocked_by_efficiency = score_delta > 0 and not cost_effectiveness["efficient"]
-                if retry_blocked_by_cost or retry_blocked_by_efficiency:
-                    reasons: list[str] = []
-                    if retry_blocked_by_cost:
-                        reasons.append("budget throttle is active")
-                    if retry_blocked_by_efficiency:
-                        reasons.append(
-                            "cost per delta "
-                            f"${cost_effectiveness['cost_per_delta_point']:.4f} exceeds "
-                            f"${settings.cost_max_per_delta_point:.4f}"
-                        )
-                    gate_decision = "rollback"
-                    gate_reason = "Cost control suppressed retry: " + "; ".join(reasons)
-
-        if gate_decision == "advance":
-            holdout_result = _run_holdout_verification(
+            validity_outcome = _run_validity_gate(
                 ctx,
-                supervisor=supervisor,
-                strategy=current_strategy,
-                in_sample_score=tournament.best_score,
-                limits=harness_limits,
+                validity_gate=validity_gate,
+                current_strategy=current_strategy,
+                validity_retry_attempt=validity_retry_attempt,
+                agents=agents,
+                events=events,
+                settings=settings,
             )
-            if holdout_result is not None:
-                events.emit("holdout_evaluated", {
-                    "run_id": ctx.run_id,
-                    "generation": ctx.generation,
-                    "holdout": holdout_result.to_dict(),
-                })
-                if not holdout_result.passed:
-                    gate_reason = f"Holdout blocked advance: {holdout_result.reason}"
-                    if not use_rapid and attempt < settings.max_retries:
-                        gate_decision = "retry"
-                    else:
-                        gate_decision = "rollback"
+            current_strategy = validity_outcome.current_strategy
+            validity_retry_attempt = validity_outcome.validity_retry_attempt
+            if validity_outcome.action == "return":
+                return ctx
+            if validity_outcome.action == "retry":
+                continue
+
+        attempt_outcome = _execute_tournament_with_retry(
+            ctx,
+            supervisor=supervisor,
+            scenario=scenario,
+            sqlite=sqlite,
+            events=events,
+            settings=settings,
+            current_strategy=current_strategy,
+            attempt=attempt,
+        )
+        attempt = attempt_outcome.attempt
+        if attempt_outcome.should_retry:
+            continue
+        tournament = attempt_outcome.tournament
+        harness_limits = attempt_outcome.harness_limits
+        if tournament is None or harness_limits is None:
+            raise RuntimeError("tournament attempt succeeded without a tournament/harness_limits")
+
+        adjustment = _apply_novelty_and_cost_adjustments(
+            ctx,
+            tournament=tournament,
+            gate=gate,
+            scenario=scenario,
+            supervisor=supervisor,
+            sqlite=sqlite,
+            events=events,
+            settings=settings,
+            current_strategy=current_strategy,
+            attempt=attempt,
+            use_rapid=use_rapid,
+            harness_limits=harness_limits,
+        )
+        tournament = adjustment.tournament
+        gate_decision = adjustment.gate_decision
+        gate_reason = adjustment.gate_reason
+        gate_result = adjustment.gate_result
+        holdout_result = adjustment.holdout_result
 
         if gate_decision == "retry" and not use_rapid:
             attempt += 1
@@ -832,53 +669,16 @@ def stage_tournament(
                 gate_decision = "rollback"
                 break
             # Retry learning: re-invoke competitor with failure context
-            if agents is not None and ctx.prompts is not None:
-                is_code_strategy = "__code__" in current_strategy
-                failure_report_context = FailureReport.from_tournament(
-                    tournament,
-                    previous_best=ctx.previous_best,
-                    threshold=settings.backpressure_min_delta,
-                    strategy=current_strategy,
-                ).to_prompt_context()
-                retry_prompt = build_retry_prompt(
-                    base_prompt=ctx.prompts.competitor,
-                    tournament_best_score=tournament.best_score,
-                    previous_best=ctx.previous_best,
-                    min_delta=settings.backpressure_min_delta,
-                    current_strategy=current_strategy,
-                    attempt=attempt,
-                    is_code_strategy=is_code_strategy,
-                    include_code_strategy_suffix=settings.code_strategies_enabled,
-                    strategy_interface=ctx.strategy_interface,
-                    failure_report_context=failure_report_context,
-                )
-                try:
-                    raw_text, _ = agents.competitor.run(retry_prompt, tool_context=ctx.tool_context)
-                    if is_code_strategy:
-                        revised_strategy, _ = agents.translator.translate_code(raw_text)
-                    else:
-                        revised_strategy, _ = agents.translator.translate(raw_text, ctx.strategy_interface)
-                    if "__code__" not in revised_strategy:
-                        state = scenario.initial_state(seed=settings.seed_base + ctx.generation)
-                        valid, reason = scenario.validate_actions(state, "challenger", revised_strategy)
-                        if valid:
-                            current_strategy = revised_strategy
-                            sqlite.append_agent_output(
-                                ctx.run_id,
-                                ctx.generation,
-                                "competitor",
-                                json.dumps(revised_strategy, sort_keys=True),
-                            )
-                    else:
-                        current_strategy = revised_strategy
-                        sqlite.append_agent_output(
-                            ctx.run_id,
-                            ctx.generation,
-                            "competitor",
-                            json.dumps(revised_strategy, sort_keys=True),
-                        )
-                except Exception:
-                    logger.debug("retry-learning competitor re-invocation failed", exc_info=True)
+            current_strategy = _run_retry_learning(
+                ctx,
+                agents=agents,
+                scenario=scenario,
+                sqlite=sqlite,
+                settings=settings,
+                tournament=tournament,
+                current_strategy=current_strategy,
+                attempt=attempt,
+            )
             time.sleep(settings.retry_backoff_seconds * attempt)
             continue
 
@@ -896,19 +696,23 @@ def stage_tournament(
     dimension_summary = _build_dimension_summary_payload(tournament)
     self_play_summary = _build_self_play_summary_payload(tournament)
 
-    events.emit("tournament_completed", {
-        "run_id": ctx.run_id, "generation": ctx.generation,
-        "mean_score": tournament.mean_score, "best_score": tournament.best_score,
-        "wins": tournament.wins, "losses": tournament.losses,
-        "scoring_backend": tournament.scoring_backend,
-        "rating_uncertainty": tournament.uncertainty_after,
-        "dimension_means": dimension_summary["dimension_means"] if dimension_summary is not None else {},
-        "best_dimensions": dimension_summary["best_dimensions"] if dimension_summary is not None else {},
-        "dimension_regressions": (
-            dimension_summary["dimension_regressions"] if dimension_summary is not None else []
-        ),
-        "self_play": self_play_summary or {},
-    })
+    events.emit(
+        "tournament_completed",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "mean_score": tournament.mean_score,
+            "best_score": tournament.best_score,
+            "wins": tournament.wins,
+            "losses": tournament.losses,
+            "scoring_backend": tournament.scoring_backend,
+            "rating_uncertainty": tournament.uncertainty_after,
+            "dimension_means": dimension_summary["dimension_means"] if dimension_summary is not None else {},
+            "best_dimensions": dimension_summary["best_dimensions"] if dimension_summary is not None else {},
+            "dimension_regressions": (dimension_summary["dimension_regressions"] if dimension_summary is not None else []),
+            "self_play": self_play_summary or {},
+        },
+    )
 
     outcome = apply_tournament_outcome(
         gate_decision=gate_decision,
@@ -920,12 +724,12 @@ def stage_tournament(
     )
     gate_delta = outcome["gate_delta"]
     gate_event = {
-        "run_id": ctx.run_id, "generation": ctx.generation,
-        "decision": gate_decision, "delta": gate_delta,
+        "run_id": ctx.run_id,
+        "generation": ctx.generation,
+        "decision": gate_decision,
+        "delta": gate_delta,
         "best_dimensions": dimension_summary["best_dimensions"] if dimension_summary is not None else {},
-        "dimension_regressions": (
-            dimension_summary["dimension_regressions"] if dimension_summary is not None else []
-        ),
+        "dimension_regressions": (dimension_summary["dimension_regressions"] if dimension_summary is not None else []),
         "self_play": self_play_summary or {},
         "reason": gate_reason,
         "holdout": holdout_result.to_dict() if holdout_result is not None else None,
@@ -1001,12 +805,15 @@ def stage_stagnation_check(
     ctx.coach_competitor_hints = hint
     ctx.fresh_start_triggered = True
 
-    events.emit("fresh_start", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        "trigger": report.trigger,
-        "detail": report.detail,
-    })
+    events.emit(
+        "fresh_start",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "trigger": report.trigger,
+            "detail": report.detail,
+        },
+    )
 
     return ctx
 
@@ -1029,9 +836,13 @@ def stage_skeptic_review(
     if not ctx.outputs or not ctx.outputs.coach_playbook:
         return ctx
 
-    events.emit("skeptic_started", {
-        "run_id": ctx.run_id, "generation": ctx.generation,
-    })
+    events.emit(
+        "skeptic_started",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+        },
+    )
 
     trajectory = trajectory_builder.build_trajectory(ctx.run_id)
     analysis = artifacts.read_latest_advance_analysis(ctx.scenario_name, ctx.generation)
@@ -1057,28 +868,34 @@ def stage_skeptic_review(
         ctx.run_id,
         ctx.generation,
         outputs=[("skeptic", exec_result.content)],
-        role_metrics=[(
-            exec_result.role,
-            exec_result.usage.model,
-            exec_result.usage.input_tokens,
-            exec_result.usage.output_tokens,
-            exec_result.usage.latency_ms,
-            exec_result.subagent_id,
-            exec_result.status,
-        )],
+        role_metrics=[
+            (
+                exec_result.role,
+                exec_result.usage.model,
+                exec_result.usage.input_tokens,
+                exec_result.usage.output_tokens,
+                exec_result.usage.latency_ms,
+                exec_result.subagent_id,
+                exec_result.status,
+            )
+        ],
     )
 
     # If skeptic blocks and blocking is enabled, clear the playbook (like curator reject)
     if review.recommendation == "block" and ctx.settings.skeptic_can_block:
         ctx.outputs = dataclasses.replace(ctx.outputs, coach_playbook="")
 
-    events.emit("skeptic_completed", {
-        "run_id": ctx.run_id, "generation": ctx.generation,
-        "risk_level": review.risk_level,
-        "recommendation": review.recommendation,
-        "concerns_count": len(review.concerns),
-        "confidence": review.confidence,
-    })
+    events.emit(
+        "skeptic_completed",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "risk_level": review.risk_level,
+            "recommendation": review.recommendation,
+            "concerns_count": len(review.concerns),
+            "confidence": review.confidence,
+        },
+    )
 
     return ctx
 
@@ -1105,14 +922,17 @@ def stage_curator_gate(
         sqlite=sqlite,
     )
     if analyst_rating is not None:
-        events.emit("analyst_feedback_rated", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "overall": analyst_rating.overall,
-            "actionability": analyst_rating.actionability,
-            "specificity": analyst_rating.specificity,
-            "correctness": analyst_rating.correctness,
-        })
+        events.emit(
+            "analyst_feedback_rated",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "overall": analyst_rating.overall,
+                "actionability": analyst_rating.actionability,
+                "specificity": analyst_rating.specificity,
+                "correctness": analyst_rating.correctness,
+            },
+        )
 
     if ctx.gate_decision != "advance":
         return ctx
@@ -1123,9 +943,13 @@ def stage_curator_gate(
     if not current_pb or current_pb == EMPTY_PLAYBOOK_SENTINEL:
         return ctx
 
-    events.emit("curator_started", {
-        "run_id": ctx.run_id, "generation": ctx.generation,
-    })
+    events.emit(
+        "curator_started",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+        },
+    )
 
     curator_trajectory = trajectory_builder.build_trajectory(ctx.run_id)
     curator_analysis = artifacts.read_latest_advance_analysis(ctx.scenario_name, ctx.generation)
@@ -1152,15 +976,17 @@ def stage_curator_gate(
         ctx.run_id,
         ctx.generation,
         outputs=[("curator", curator_exec.content)],
-        role_metrics=[(
-            curator_exec.role,
-            curator_exec.usage.model,
-            curator_exec.usage.input_tokens,
-            curator_exec.usage.output_tokens,
-            curator_exec.usage.latency_ms,
-            curator_exec.subagent_id,
-            curator_exec.status,
-        )],
+        role_metrics=[
+            (
+                curator_exec.role,
+                curator_exec.usage.model,
+                curator_exec.usage.input_tokens,
+                curator_exec.usage.output_tokens,
+                curator_exec.usage.latency_ms,
+                curator_exec.subagent_id,
+                curator_exec.status,
+            )
+        ],
     )
 
     if curator_decision.decision == "reject":
@@ -1173,14 +999,16 @@ def stage_curator_gate(
         ctx.outputs = dataclasses.replace(ctx.outputs, coach_playbook=curator_decision.playbook)
     # "accept" -> no change to outputs
 
-    events.emit("curator_completed", {
-        "run_id": ctx.run_id, "generation": ctx.generation,
-        "decision": curator_decision.decision,
-        "analyst_rating": analyst_rating.to_dict() if analyst_rating is not None else None,
-        "skeptic_recommendation": (
-            ctx.skeptic_review.recommendation if ctx.skeptic_review is not None else None
-        ),
-    })
+    events.emit(
+        "curator_completed",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "decision": curator_decision.decision,
+            "analyst_rating": analyst_rating.to_dict() if analyst_rating is not None else None,
+            "skeptic_recommendation": (ctx.skeptic_review.recommendation if ctx.skeptic_review is not None else None),
+        },
+    )
 
     return ctx
 
@@ -1249,7 +1077,8 @@ def stage_persistence(
         match_output = eval_result.metadata["execution_output"]
         replay_json = _build_match_replay_json(match_output)
         sqlite.insert_match(
-            run_id, generation,
+            run_id,
+            generation,
             settings.seed_base + (generation * 100) + idx,
             match_output.result.score,
             match_output.result.passed_validation,
@@ -1261,7 +1090,8 @@ def stage_persistence(
 
     # 3. Upsert generation
     sqlite.upsert_generation(
-        run_id, generation,
+        run_id,
+        generation,
         mean_score=tournament.mean_score,
         best_score=ctx.previous_best,
         elo=ctx.challenger_elo,
@@ -1269,11 +1099,7 @@ def stage_persistence(
         losses=tournament.losses,
         gate_decision=gate_decision,
         status="completed",
-        dimension_summary_json=(
-            json.dumps(dimension_summary, sort_keys=True)
-            if dimension_summary is not None
-            else None
-        ),
+        dimension_summary_json=(json.dumps(dimension_summary, sort_keys=True) if dimension_summary is not None else None),
         scoring_backend=tournament.scoring_backend,
         rating_uncertainty=ctx.challenger_uncertainty,
     )
@@ -1329,8 +1155,11 @@ def stage_persistence(
         and not settings.ablation_no_feedback
     ):
         _run_curator_consolidation(
-            ctx, curator=curator, artifacts=artifacts,
-            trajectory_builder=trajectory_builder, sqlite=sqlite,
+            ctx,
+            curator=curator,
+            artifacts=artifacts,
+            trajectory_builder=trajectory_builder,
+            sqlite=sqlite,
         )
 
     # 7. Persist competitor feedback on the hints it actually used this generation.
@@ -1369,32 +1198,29 @@ def stage_persistence(
         _persist_progress_snapshot(ctx, artifacts=artifacts)
 
     # 9. Persist tuning proposal on advance
-    if (
-        ctx.tuning_proposal is not None
-        and settings.config_adaptive_enabled
-        and gate_decision == "advance"
-    ):
+    if ctx.tuning_proposal is not None and settings.config_adaptive_enabled and gate_decision == "advance":
         artifacts.write_tuning(scenario_name, ctx.tuning_proposal.to_json())
 
     # 10. Emit generation_completed event
-    events.emit("generation_completed", {
-        "run_id": run_id,
-        "generation": generation,
-        "mean_score": tournament.mean_score,
-        "best_score": ctx.previous_best,
-        "elo": ctx.challenger_elo,
-        "gate_decision": gate_decision,
-        "gate_delta": gate_delta,
-        "best_dimensions": dimension_summary["best_dimensions"] if dimension_summary is not None else {},
-        "dimension_regressions": (
-            dimension_summary["dimension_regressions"] if dimension_summary is not None else []
-        ),
-        "self_play": self_play_summary or {},
-        "holdout": ctx.holdout_result.to_dict() if ctx.holdout_result is not None else None,
-        "exploration": ctx.exploration_metadata or {},
-        "cost_control": ctx.cost_control_metadata or {},
-        "credit_assignment": credit_assignment.to_dict() if credit_assignment is not None else None,
-        "created_tools": ctx.created_tools,
-    })
+    events.emit(
+        "generation_completed",
+        {
+            "run_id": run_id,
+            "generation": generation,
+            "mean_score": tournament.mean_score,
+            "best_score": ctx.previous_best,
+            "elo": ctx.challenger_elo,
+            "gate_decision": gate_decision,
+            "gate_delta": gate_delta,
+            "best_dimensions": dimension_summary["best_dimensions"] if dimension_summary is not None else {},
+            "dimension_regressions": (dimension_summary["dimension_regressions"] if dimension_summary is not None else []),
+            "self_play": self_play_summary or {},
+            "holdout": ctx.holdout_result.to_dict() if ctx.holdout_result is not None else None,
+            "exploration": ctx.exploration_metadata or {},
+            "cost_control": ctx.cost_control_metadata or {},
+            "credit_assignment": credit_assignment.to_dict() if credit_assignment is not None else None,
+            "created_tools": ctx.created_tools,
+        },
+    )
 
     return ctx

--- a/autocontext/tests/test_cli_error_boundary.py
+++ b/autocontext/tests/test_cli_error_boundary.py
@@ -1,0 +1,91 @@
+"""Tests for AC-851: `cli_error_boundary`, the shared KeyboardInterrupt/Exception
+handler extracted from the triplicated try/except blocks in `run()` (both
+branches) and `resume()`.
+
+Exercises the context manager directly (decoupled from the full Typer app)
+to pin down: pass-through on success, JSON vs Rich output per exception type,
+the action-verb-dependent interrupted message, exit code, and exception
+chaining (`from None` / `from exc`).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from autocontext.cli import cli_error_boundary
+
+
+class TestCliErrorBoundarySuccess:
+    def test_no_exception_runs_body_and_raises_nothing(self) -> None:
+        ran = False
+        with cli_error_boundary(json_output=False, action="run"):
+            ran = True
+        assert ran is True
+
+
+class TestCliErrorBoundaryKeyboardInterrupt:
+    def test_json_mode_writes_action_interrupted_to_stderr(self) -> None:
+        with patch("autocontext.cli._write_json_stderr") as mock_write:
+            with pytest.raises(typer.Exit) as exc_info:
+                with cli_error_boundary(json_output=True, action="run"):
+                    raise KeyboardInterrupt
+        mock_write.assert_called_once_with("run interrupted")
+        assert exc_info.value.exit_code == 1
+        assert exc_info.value.__cause__ is None
+
+    def test_json_mode_uses_action_verb_for_resume(self) -> None:
+        with patch("autocontext.cli._write_json_stderr") as mock_write:
+            with pytest.raises(typer.Exit):
+                with cli_error_boundary(json_output=True, action="resume"):
+                    raise KeyboardInterrupt
+        mock_write.assert_called_once_with("resume interrupted")
+
+    def test_non_json_mode_prints_capitalized_action_interrupted(self) -> None:
+        with patch("autocontext.cli.console") as mock_console:
+            with pytest.raises(typer.Exit) as exc_info:
+                with cli_error_boundary(json_output=False, action="run"):
+                    raise KeyboardInterrupt
+        mock_console.print.assert_called_once_with("[yellow]Run interrupted.[/yellow]")
+        assert exc_info.value.exit_code == 1
+
+    def test_non_json_mode_resume_message(self) -> None:
+        with patch("autocontext.cli.console") as mock_console:
+            with pytest.raises(typer.Exit):
+                with cli_error_boundary(json_output=False, action="resume"):
+                    raise KeyboardInterrupt
+        mock_console.print.assert_called_once_with("[yellow]Resume interrupted.[/yellow]")
+
+
+class TestCliErrorBoundaryException:
+    def test_json_mode_writes_exception_message_to_stderr(self) -> None:
+        with patch("autocontext.cli._write_json_stderr") as mock_write:
+            with pytest.raises(typer.Exit) as exc_info:
+                with cli_error_boundary(json_output=True, action="run"):
+                    raise RuntimeError("boom")
+        mock_write.assert_called_once_with("boom")
+        assert exc_info.value.exit_code == 1
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert str(exc_info.value.__cause__) == "boom"
+
+    def test_non_json_mode_prints_generic_error(self) -> None:
+        with patch("autocontext.cli.console") as mock_console:
+            with pytest.raises(typer.Exit) as exc_info:
+                with cli_error_boundary(json_output=False, action="run"):
+                    raise RuntimeError("boom")
+        mock_console.print.assert_called_once_with("[red]Error: boom[/red]")
+        assert exc_info.value.exit_code == 1
+
+    def test_typer_exit_raised_in_body_is_caught_like_any_exception(self) -> None:
+        """typer.Exit is itself a RuntimeError subclass, so (matching the
+        pre-refactor try/except blocks) it is caught by the generic
+        `except Exception` branch and re-wrapped as exit code 1, rather than
+        propagating its original exit code. None of the current call sites
+        (`_run_agent_task`, `_runner().run()`) raise typer.Exit internally,
+        so this is a documented edge case rather than a real code path."""
+        with pytest.raises(typer.Exit) as exc_info:
+            with cli_error_boundary(json_output=False, action="run"):
+                raise typer.Exit(code=2)
+        assert exc_info.value.exit_code == 1

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -1299,7 +1299,7 @@ class TestStageTournament:
         artifacts = MagicMock()
 
         with (
-            patch("autocontext.loop.stages.resolve_gate_decision") as resolve_gate,
+            patch("autocontext.loop.stage_helpers.exploration.resolve_gate_decision") as resolve_gate,
             patch("autocontext.loop.stages.apply_tournament_outcome") as apply_outcome,
         ):
             resolve_gate.return_value = MagicMock(
@@ -1456,7 +1456,7 @@ class TestStageTournament:
         sqlite = MagicMock()
         artifacts = MagicMock()
 
-        with patch("autocontext.loop.stages.resolve_gate_decision") as resolve_gate:
+        with patch("autocontext.loop.stage_helpers.exploration.resolve_gate_decision") as resolve_gate:
             resolve_gate.return_value = MagicMock(
                 decision="advance",
                 delta=0.42,
@@ -1498,7 +1498,7 @@ class TestStageTournament:
         sqlite = MagicMock()
         artifacts = MagicMock()
 
-        with patch("autocontext.loop.stages.resolve_gate_decision") as resolve_gate:
+        with patch("autocontext.loop.stage_helpers.exploration.resolve_gate_decision") as resolve_gate:
             resolve_gate.return_value = MagicMock(
                 decision="retry",
                 delta=0.0,
@@ -1575,7 +1575,7 @@ class TestStageTournament:
         ]
         artifacts = MagicMock()
 
-        with patch("autocontext.loop.stages.EvaluationRunner.run", return_value=tournament):
+        with patch("autocontext.loop.stage_helpers.tournament_prep.EvaluationRunner.run", return_value=tournament):
             result = stage_tournament(
                 ctx,
                 supervisor=_make_inline_supervisor(),
@@ -1605,7 +1605,7 @@ class TestStageTournament:
         sqlite = MagicMock()
         artifacts = MagicMock()
 
-        with patch("autocontext.loop.stages.resolve_gate_decision") as resolve_gate:
+        with patch("autocontext.loop.stage_helpers.exploration.resolve_gate_decision") as resolve_gate:
             resolve_gate.return_value = MagicMock(
                 decision="advance",
                 delta=0.42,
@@ -2396,7 +2396,7 @@ class TestStageTournamentAttempt:
         agents.competitor.run.return_value = ('{"aggression": 0.9}', None)
         agents.translator.translate.return_value = ({"aggression": 0.9}, None)
 
-        with patch("autocontext.loop.stages.build_retry_prompt", return_value="HELPER RETRY PROMPT") as build_prompt:
+        with patch("autocontext.loop.stage_helpers.tournament_prep.build_retry_prompt", return_value="HELPER RETRY PROMPT") as build_prompt:
             stage_tournament(
                 ctx,
                 supervisor=supervisor,

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -2396,7 +2396,10 @@ class TestStageTournamentAttempt:
         agents.competitor.run.return_value = ('{"aggression": 0.9}', None)
         agents.translator.translate.return_value = ({"aggression": 0.9}, None)
 
-        with patch("autocontext.loop.stage_helpers.tournament_prep.build_retry_prompt", return_value="HELPER RETRY PROMPT") as build_prompt:
+        with patch(
+            "autocontext.loop.stage_helpers.tournament_prep.build_retry_prompt",
+            return_value="HELPER RETRY PROMPT",
+        ) as build_prompt:
             stage_tournament(
                 ctx,
                 supervisor=supervisor,

--- a/autocontext/tests/test_pipeline_wiring.py
+++ b/autocontext/tests/test_pipeline_wiring.py
@@ -274,9 +274,9 @@ class TestRapidGateInTournament:
 
         mock_tournament = _make_mock_tournament()
 
-        with patch("autocontext.loop.stages.EvaluationRunner") as MockRunner, \
-             patch("autocontext.loop.stages.ScenarioEvaluator"), \
-             patch("autocontext.loop.stages.rapid_gate") as mock_rapid_gate:
+        with patch("autocontext.loop.stage_helpers.tournament_prep.EvaluationRunner") as MockRunner, \
+             patch("autocontext.loop.stage_helpers.tournament_prep.ScenarioEvaluator"), \
+             patch("autocontext.loop.stage_helpers.exploration.rapid_gate") as mock_rapid_gate:
             MockRunner.return_value.run.return_value = mock_tournament
             mock_rapid_gate.return_value = RapidGateResult(
                 decision="advance", delta=0.1, reason="improved",
@@ -320,9 +320,9 @@ class TestRapidGateInTournament:
 
         mock_tournament = _make_mock_tournament()
 
-        with patch("autocontext.loop.stages.EvaluationRunner") as MockRunner, \
-             patch("autocontext.loop.stages.ScenarioEvaluator"), \
-             patch("autocontext.loop.stages.rapid_gate") as mock_rapid_gate:
+        with patch("autocontext.loop.stage_helpers.tournament_prep.EvaluationRunner") as MockRunner, \
+             patch("autocontext.loop.stage_helpers.tournament_prep.ScenarioEvaluator"), \
+             patch("autocontext.loop.stage_helpers.exploration.rapid_gate") as mock_rapid_gate:
             MockRunner.return_value.run.return_value = mock_tournament
 
             stage_tournament(
@@ -371,9 +371,9 @@ class TestRapidToLinearTransition:
 
         mock_tournament = _make_mock_tournament()
 
-        with patch("autocontext.loop.stages.EvaluationRunner") as MockRunner, \
-             patch("autocontext.loop.stages.ScenarioEvaluator"), \
-             patch("autocontext.loop.stages.rapid_gate") as mock_rapid_gate, \
+        with patch("autocontext.loop.stage_helpers.tournament_prep.EvaluationRunner") as MockRunner, \
+             patch("autocontext.loop.stage_helpers.tournament_prep.ScenarioEvaluator"), \
+             patch("autocontext.loop.stage_helpers.exploration.rapid_gate") as mock_rapid_gate, \
              patch("autocontext.loop.stages.should_transition_to_linear") as mock_transition:
             MockRunner.return_value.run.return_value = mock_tournament
             mock_rapid_gate.return_value = RapidGateResult(
@@ -416,9 +416,9 @@ class TestRapidToLinearTransition:
 
         mock_tournament = _make_mock_tournament()
 
-        with patch("autocontext.loop.stages.EvaluationRunner") as MockRunner, \
-             patch("autocontext.loop.stages.ScenarioEvaluator"), \
-             patch("autocontext.loop.stages.rapid_gate") as mock_rapid_gate, \
+        with patch("autocontext.loop.stage_helpers.tournament_prep.EvaluationRunner") as MockRunner, \
+             patch("autocontext.loop.stage_helpers.tournament_prep.ScenarioEvaluator"), \
+             patch("autocontext.loop.stage_helpers.exploration.rapid_gate") as mock_rapid_gate, \
              patch("autocontext.loop.stages.should_transition_to_linear") as mock_transition:
             MockRunner.return_value.run.return_value = mock_tournament
             mock_rapid_gate.return_value = RapidGateResult(

--- a/autocontext/tests/test_run_trace_chaining.py
+++ b/autocontext/tests/test_run_trace_chaining.py
@@ -1,0 +1,275 @@
+"""Tests for AC-851: `_build_run_trace` causal-chaining behavior.
+
+`GenerationRunner._build_run_trace` builds the role/validation/consultation/
+recovery event blocks by hand-wiring causal edges and advancing
+`current_source_id`/`sequence_number`. AC-851 extracts a shared
+`_append_chained_event` helper from those four blocks; this test locks in an
+end-to-end fixture captured from the pre-refactor implementation so the
+extraction cannot silently change the causal chain (event ids, sequence
+numbers, or edge relations/sources/targets -- including the recovery block's
+extra multi-cause/evidence_ids logic).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from autocontext.config.settings import AppSettings
+from autocontext.loop.generation_runner import GenerationRunner
+
+# ---------------------------------------------------------------------------
+# Representative fixture inputs (two generations: a clean advance, and a
+# failure -> consultation -> recovery -> error chain that exercises the
+# recovery block's extra evidence_ids/multi-cause behavior).
+# ---------------------------------------------------------------------------
+
+_GENERATION_ROWS: list[dict[str, Any]] = [
+    {
+        "generation_index": 0,
+        "mean_score": 0.5,
+        "best_score": 0.6,
+        "elo": 1000.0,
+        "wins": 1,
+        "losses": 0,
+        "status": "completed",
+        "gate_decision": "advance",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:01:00Z",
+        "duration_seconds": 12.5,
+    },
+    {
+        "generation_index": 1,
+        "mean_score": 0.7,
+        "best_score": 0.8,
+        "elo": 1010.0,
+        "wins": 2,
+        "losses": 1,
+        "status": "completed",
+        "gate_decision": "error",
+        "created_at": "2026-01-01T00:02:00Z",
+        "updated_at": "2026-01-01T00:03:00Z",
+        "duration_seconds": 8.25,
+    },
+]
+
+_ROLE_METRICS: list[dict[str, Any]] = [
+    {
+        "generation_index": 0,
+        "role": "competitor",
+        "subagent_id": "comp-1",
+        "model": "claude-x",
+        "status": "success",
+        "input_tokens": 100,
+        "output_tokens": 200,
+        "latency_ms": 500,
+        "created_at": "2026-01-01T00:00:10Z",
+    },
+    {
+        "generation_index": 1,
+        "role": "analyst",
+        "subagent_id": "an-1",
+        "model": "claude-y",
+        "status": "failed",
+        "input_tokens": 50,
+        "output_tokens": 20,
+        "latency_ms": 300,
+        "created_at": "2026-01-01T00:02:10Z",
+    },
+]
+
+_STAGED_VALIDATIONS: list[dict[str, Any]] = [
+    {
+        "generation_index": 0,
+        "stage_name": "syntax",
+        "stage_order": 1,
+        "status": "passed",
+        "error": None,
+        "error_code": None,
+        "duration_ms": 20,
+        "created_at": "2026-01-01T00:00:20Z",
+    },
+    {
+        "generation_index": 1,
+        "stage_name": "semantic",
+        "stage_order": 2,
+        "status": "failed",
+        "error": "bad thing",
+        "error_code": "E1",
+        "duration_ms": 40,
+        "created_at": "2026-01-01T00:02:20Z",
+    },
+]
+
+_CONSULTATIONS: list[dict[str, Any]] = [
+    {
+        "generation_index": 1,
+        "trigger": "low_confidence",
+        "critique": "hmm",
+        "alternative_hypothesis": "try x",
+        "tiebreak_recommendation": "y",
+        "suggested_next_action": "z",
+        "cost_usd": 0.01,
+        "model_used": "claude-consult",
+        "created_at": "2026-01-01T00:02:30Z",
+    },
+]
+
+_RECOVERY_MARKERS: list[dict[str, Any]] = [
+    {
+        "generation_index": 1,
+        "decision": "retry",
+        "reason": "validation failed",
+        "retry_count": 1,
+        "created_at": "2026-01-01T00:02:40Z",
+    },
+]
+
+# Expected causal edges, captured end-to-end from `_build_run_trace` before
+# the AC-851 extraction. The recovery edge set is the interesting part: it
+# gets a "triggers" edge from the consultation event (current_source_id, not
+# itself a failed validation) plus a "recovers" edge from the failed
+# validation event -- both cause ids show up in the recovery event's own
+# cause_event_ids, and only the failed validation id shows up in evidence_ids.
+_EXPECTED_CAUSAL_EDGES: list[dict[str, str]] = [
+    {"source_event_id": "gen-0-role-1", "target_event_id": "gen-0-validation-1", "relation": "triggers"},
+    {"source_event_id": "gen-0-validation-1", "target_event_id": "gen-0-checkpoint", "relation": "depends_on"},
+    {"source_event_id": "gen-0-checkpoint", "target_event_id": "gen-1-role-1", "relation": "triggers"},
+    {"source_event_id": "gen-1-role-1", "target_event_id": "gen-1-validation-1", "relation": "triggers"},
+    {"source_event_id": "gen-1-validation-1", "target_event_id": "gen-1-consultation-1", "relation": "triggers"},
+    {"source_event_id": "gen-1-consultation-1", "target_event_id": "gen-1-recovery-1", "relation": "triggers"},
+    {"source_event_id": "gen-1-validation-1", "target_event_id": "gen-1-recovery-1", "relation": "recovers"},
+    {"source_event_id": "gen-1-recovery-1", "target_event_id": "gen-1-checkpoint", "relation": "depends_on"},
+]
+
+_EXPECTED_EVENT_IDS_IN_ORDER: list[str] = [
+    "gen-0-role-1",
+    "gen-0-validation-1",
+    "gen-0-checkpoint",
+    "gen-1-role-1",
+    "gen-1-validation-1",
+    "gen-1-consultation-1",
+    "gen-1-recovery-1",
+    "gen-1-checkpoint",
+]
+
+_EXPECTED_PARENT_EVENT_IDS: dict[str, str | None] = {
+    "gen-0-role-1": None,
+    "gen-0-validation-1": "gen-0-role-1",
+    "gen-0-checkpoint": "gen-0-validation-1",
+    "gen-1-role-1": "gen-0-checkpoint",
+    "gen-1-validation-1": "gen-1-role-1",
+    "gen-1-consultation-1": "gen-1-validation-1",
+    "gen-1-recovery-1": "gen-1-consultation-1",
+    "gen-1-checkpoint": "gen-1-recovery-1",
+}
+
+_EXPECTED_CAUSE_EVENT_IDS: dict[str, list[str]] = {
+    "gen-0-role-1": [],
+    "gen-0-validation-1": ["gen-0-role-1"],
+    "gen-0-checkpoint": ["gen-0-validation-1"],
+    "gen-1-role-1": ["gen-0-checkpoint"],
+    "gen-1-validation-1": ["gen-1-role-1"],
+    "gen-1-consultation-1": ["gen-1-validation-1"],
+    "gen-1-recovery-1": ["gen-1-validation-1", "gen-1-consultation-1"],
+    "gen-1-checkpoint": ["gen-1-recovery-1"],
+}
+
+_EXPECTED_EVIDENCE_IDS: dict[str, list[str]] = {
+    "gen-0-role-1": [],
+    "gen-0-validation-1": [],
+    "gen-0-checkpoint": [],
+    "gen-1-role-1": [],
+    "gen-1-validation-1": [],
+    "gen-1-consultation-1": [],
+    "gen-1-recovery-1": ["gen-1-validation-1"],
+    "gen-1-checkpoint": ["gen-1-validation-1"],
+}
+
+
+def _build_runner(tmp_path: Path) -> GenerationRunner:
+    settings = AppSettings(
+        agent_provider="deterministic",
+        db_path=tmp_path / "test.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+    )
+    return GenerationRunner(settings)
+
+
+class TestBuildRunTraceChaining:
+    """End-to-end regression fixture for the causal chain `_build_run_trace` builds."""
+
+    def _build_trace(self, tmp_path: Path) -> Any:
+        runner = _build_runner(tmp_path)
+        return runner._build_run_trace(
+            run_id="run-fixture-1",
+            scenario_name="grid_ctf",
+            scenario=MagicMock(),
+            generation_rows=_GENERATION_ROWS,
+            role_metrics=_ROLE_METRICS,
+            staged_validations=_STAGED_VALIDATIONS,
+            consultations=_CONSULTATIONS,
+            recovery_markers=_RECOVERY_MARKERS,
+        )
+
+    def test_event_ids_and_sequence_numbers_advance_in_order(self, tmp_path: Path) -> None:
+        trace = self._build_trace(tmp_path)
+        assert [event.event_id for event in trace.events] == _EXPECTED_EVENT_IDS_IN_ORDER
+        assert [event.sequence_number for event in trace.events] == list(range(1, len(_EXPECTED_EVENT_IDS_IN_ORDER) + 1))
+
+    def test_parent_event_ids_match_chain(self, tmp_path: Path) -> None:
+        trace = self._build_trace(tmp_path)
+        actual = {event.event_id: event.parent_event_id for event in trace.events}
+        assert actual == _EXPECTED_PARENT_EVENT_IDS
+
+    def test_cause_event_ids_match_chain_including_recovery_multi_cause(self, tmp_path: Path) -> None:
+        trace = self._build_trace(tmp_path)
+        actual = {event.event_id: event.cause_event_ids for event in trace.events}
+        assert actual == _EXPECTED_CAUSE_EVENT_IDS
+
+    def test_evidence_ids_carry_failed_validation_through_recovery_and_checkpoint(self, tmp_path: Path) -> None:
+        trace = self._build_trace(tmp_path)
+        actual = {event.event_id: event.evidence_ids for event in trace.events}
+        assert actual == _EXPECTED_EVIDENCE_IDS
+
+    def test_causal_edges_match_exactly(self, tmp_path: Path) -> None:
+        trace = self._build_trace(tmp_path)
+        actual = [
+            {
+                "source_event_id": edge.source_event_id,
+                "target_event_id": edge.target_event_id,
+                "relation": edge.relation,
+            }
+            for edge in trace.causal_edges
+        ]
+        assert actual == _EXPECTED_CAUSAL_EDGES
+
+    def test_full_trace_dict_matches_pre_refactor_fixture(self, tmp_path: Path) -> None:
+        """Belt-and-suspenders: compare the full serialized trace, modulo volatile fields."""
+        trace = self._build_trace(tmp_path)
+        actual = trace.to_dict()
+        actual.pop("created_at", None)
+        actual["metadata"].pop("release", None)
+        for event in actual["events"]:
+            event.pop("timestamp", None)
+
+        assert actual["run_id"] == "run-fixture-1"
+        assert actual["trace_id"] == "trace-run-fixture-1"
+        assert actual["schema_version"] == "1.0.0"
+        assert actual["metadata"]["total_generations"] == 2
+        assert actual["causal_edges"] == _EXPECTED_CAUSAL_EDGES
+        assert [event["event_id"] for event in actual["events"]] == _EXPECTED_EVENT_IDS_IN_ORDER
+
+
+def test_group_by_generation_helper_matches_manual_grouping(tmp_path: Path) -> None:
+    """If `_group_by_generation` was extracted, it must group identically to the
+    inline `defaultdict(list)` loops it replaces."""
+    runner = _build_runner(tmp_path)
+    if not hasattr(runner, "_group_by_generation"):
+        return
+    grouped = runner._group_by_generation(_ROLE_METRICS)
+    assert dict(grouped) == {0: [_ROLE_METRICS[0]], 1: [_ROLE_METRICS[1]]}
+    assert grouped[42] == []  # defaultdict(list) semantics preserved

--- a/autocontext/tests/test_task_runner.py
+++ b/autocontext/tests/test_task_runner.py
@@ -1222,3 +1222,103 @@ class TestTaskRunnerFactory:
         assert result["status"] == "failed"
         assert "browser exploration is not configured" in (result["error"] or "")
         mock_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _finalize_task_output (AC-851): the payload-assembly helper extracted from
+# the duplicated tail of _process_task's single-generation branch and
+# _run_task_multi_generation.
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeTaskOutput:
+    def _make_runner(self, store, provider=None):
+        return TaskRunner(store=store, provider=provider or _MockProvider())
+
+    def _make_agent_task(self, provider):
+        return SimpleAgentTask(
+            task_prompt="Do the thing",
+            rubric="Be accurate",
+            provider=provider,
+        )
+
+    def test_no_guardrails_configured_passes_met_threshold_through_unchanged(self, store):
+        provider = _MockProvider()
+        runner = self._make_runner(store, provider)
+        agent_task = self._make_agent_task(provider)
+        config = TaskConfig()  # no objective_verification, judge_samples=1, bias probes off
+
+        (
+            objective_payload,
+            objective_guardrail,
+            evaluator_guardrail,
+            effective_met_threshold,
+            rubric_calibration,
+        ) = runner._finalize_task_output(
+            agent_task=agent_task,
+            task_id="task-1",
+            spec_name="spec-1",
+            best_output="the output",
+            best_score=0.9,
+            met_threshold=True,
+            reference_context=None,
+            config=config,
+        )
+
+        assert objective_payload is None
+        assert objective_guardrail is None
+        assert evaluator_guardrail is None
+        assert effective_met_threshold is True
+        assert rubric_calibration is None  # store has no calibration anchors
+
+    def test_false_met_threshold_stays_false_with_no_guardrails(self, store):
+        provider = _MockProvider()
+        runner = self._make_runner(store, provider)
+        agent_task = self._make_agent_task(provider)
+        config = TaskConfig()
+
+        result = runner._finalize_task_output(
+            agent_task=agent_task,
+            task_id="task-2",
+            spec_name="spec-2",
+            best_output="the output",
+            best_score=0.4,
+            met_threshold=False,
+            reference_context=None,
+            config=config,
+        )
+
+        assert result[3] is False  # effective_met_threshold
+
+    def test_single_and_multi_generation_call_shapes_agree_for_identical_inputs(self, store):
+        """The two call sites (_process_task's single-gen branch and
+        _run_task_multi_generation) pass differently-named locals into this
+        helper; for identical values they must produce identical output so
+        neither path can silently drift from the other."""
+        provider = _MockProvider()
+        runner = self._make_runner(store, provider)
+        agent_task = self._make_agent_task(provider)
+        config = TaskConfig()
+
+        single_gen_style = runner._finalize_task_output(
+            agent_task=agent_task,
+            task_id="task-3",
+            spec_name="spec-3",
+            best_output="shared output",
+            best_score=0.75,
+            met_threshold=True,
+            reference_context="ctx",
+            config=config,
+        )
+        multi_gen_style = runner._finalize_task_output(
+            agent_task=agent_task,
+            task_id="task-3",
+            spec_name="spec-3",
+            best_output="shared output",
+            best_score=0.75,
+            met_threshold=True,
+            reference_context="ctx",
+            config=config,
+        )
+
+        assert single_gen_style == multi_gen_style

--- a/autocontext/tests/test_two_tier_tournament.py
+++ b/autocontext/tests/test_two_tier_tournament.py
@@ -393,7 +393,7 @@ class TestTwoTierEnabled:
 
         with (
             patch("autocontext.loop.stages.ValidityGate") as MockVG,
-            patch("autocontext.loop.stages.build_validity_rollback") as build_rollback,
+            patch("autocontext.loop.stage_helpers.tournament_prep.build_validity_rollback") as build_rollback,
         ):
             mock_vg_instance = MagicMock()
             mock_vg_instance.check.return_value = MagicMock(


### PR DESCRIPTION
## Summary
Behavior-preserving Python refactors from the code-quality sweep. Stacked on the AC-848/849 PR (the task_runner dedup builds on its extraction); retarget to main after that merges.

- AC-850: `stage_tournament` (~395 lines, five concerns gated by five settings flags) decomposed into named helpers (`_run_validity_gate`, `_execute_tournament_with_retry`, `_apply_novelty_and_cost_adjustments`, `_run_retry_learning`). Helpers live in `loop/stage_helpers/` because the module-size-limit test caps stages.py at 1400 lines; this follows the existing AC-482 pattern.
- AC-851: three same-concept duplications removed: trace-event chaining in `_build_run_trace` (4 near-identical blocks -> `_append_chained_event`, recovery-block multi-cause logic preserved exactly), task-completion payload assembly duplicated between `_process_task` and `_run_task_multi_generation` (-> `_finalize_task_output`), and the triplicated CLI KeyboardInterrupt/Exception handling (-> `cli_error_boundary` context manager).

## Testing
- Trace-chaining fixture was captured against the pre-refactor code and passes identically after (exact event ids, sequence numbers, causal edges). 15 new tests (trace chaining + error boundary). 255 tests green across covering suites; ruff and mypy clean.
- Reviewers verified behavior preservation via per-function AST-equality between base and head (the larger diff stat is inert formatter churn from a save-hook; AST-proven to carry zero logic).

Note: `family_pipeline.py` similarity was deliberately NOT extracted (legitimate per-family polymorphism). Part 2 of 4.