### PR TITLE
AC-857: document intentional Python/TS subsystem asymmetries

### DIFF
--- a/autocontext/src/autocontext/control_plane/__init__.py
+++ b/autocontext/src/autocontext/control_plane/__init__.py
@@ -1,1 +1,7 @@
-"""autocontext control-plane Python parity surface (AC-728)."""
+"""autocontext control-plane Python parity surface (AC-728).
+
+Intentionally thin: the full control plane lives in ts/src/control-plane/
+(runtime, contract, promotion, registry, and CLI layers). This package
+holds only the Python-side contract probes and change-proposal harness
+needed to keep the two runtimes aligned.
+"""

--- a/autocontext/src/autocontext/harness/__init__.py
+++ b/autocontext/src/autocontext/harness/__init__.py
@@ -1,1 +1,7 @@
 # autocontext.harness — domain-agnostic infrastructure primitives
+#
+# Scope: generic pipeline, scoring, mutation, and orchestration primitives
+# (core, pipeline, scoring, mutations, orchestration, meta, optimizer, repl,
+# audit, cost, evaluation, adapt, validation, storage) shared across
+# scenarios, not scenario-specific logic. Currently Python-only: no ts/
+# mirror exists for this package.

--- a/autocontext/src/autocontext/hermes/__init__.py
+++ b/autocontext/src/autocontext/hermes/__init__.py
@@ -1,9 +1,10 @@
 """Hermes Agent integration helpers.
 
-Scope: read-only integration with NousResearch's Hermes agent and its
-Curator subsystem (inspect, ingest, export-skill, train-advisor; see
-docs/hermes-positioning.md). Currently Python-only: no ts/ mirror exists
-for this package.
+Scope: integration with NousResearch's Hermes agent and its Curator
+subsystem (inspect, ingest, export-skill, train-advisor; see
+docs/hermes-positioning.md). Read-only against Hermes/Curator state,
+though export-skill writes a local skill file when an output path is
+supplied. Currently Python-only: no ts/ mirror exists for this package.
 
 Naming note: unrelated to the "hermes" OpenAI-compatible provider gateway
 in ts/src/providers/provider-factory.ts, which just points at a

--- a/autocontext/src/autocontext/hermes/__init__.py
+++ b/autocontext/src/autocontext/hermes/__init__.py
@@ -1,4 +1,14 @@
-"""Hermes Agent integration helpers."""
+"""Hermes Agent integration helpers.
+
+Scope: read-only integration with NousResearch's Hermes agent and its
+Curator subsystem (inspect, ingest, export-skill, train-advisor; see
+docs/hermes-positioning.md). Currently Python-only: no ts/ mirror exists
+for this package.
+
+Naming note: unrelated to the "hermes" OpenAI-compatible provider gateway
+in ts/src/providers/provider-factory.ts, which just points at a
+Hermes-3-Llama model endpoint.
+"""
 
 from autocontext.hermes.inspection import CuratorInventory, CuratorRunSummary, HermesInventory, HermesSkill, inspect_hermes_home
 from autocontext.hermes.skill import AUTOCONTEXT_HERMES_SKILL_NAME, render_autocontext_skill

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -5,7 +5,10 @@ import { ClaudeCLIRuntime } from "../runtimes/claude-cli.js";
 import { CodexCLIRuntime, CodexCLIConfig } from "../runtimes/codex-cli.js";
 import { PiCLIRuntime, PiCLIConfig } from "../runtimes/pi-cli.js";
 import { PiPersistentRPCRuntime, PiRPCRuntime, PiRPCConfig } from "../runtimes/pi-rpc.js";
-import { RuntimeBridgeProvider, type RuntimeBridgeProviderOpts } from "../agents/provider-bridge.js";
+import {
+  RuntimeBridgeProvider,
+  type RuntimeBridgeProviderOpts,
+} from "../agents/provider-bridge.js";
 import type { AgentRuntime } from "../runtimes/base.js";
 import { SUPPORTED_PROVIDER_TYPES } from "./supported-provider-types.js";
 import type { RuntimeCommandGrant } from "../runtimes/workspace-env.js";
@@ -219,6 +222,9 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
   }
 
   if (type === "hermes") {
+    // Naming collision only: this is an OpenAI-compatible gateway pointed at a
+    // Hermes-3-Llama model. Unrelated to autocontext.hermes (Python), which
+    // integrates with NousResearch's Hermes agent Curator subsystem.
     const inner = createOpenAICompatibleProvider({
       apiKey: opts.apiKey ?? "no-key",
       baseUrl: opts.baseUrl ?? "http://localhost:8080/v1",

--- a/ts/src/traces/README.md
+++ b/ts/src/traces/README.md
@@ -1,0 +1,20 @@
+# traces/
+
+Public trace schema, data-plane curation, dataset adapters/discovery,
+distillation pipeline, redaction, and sharing/publishing workflows.
+
+Maps to these Python homes:
+
+- `production_traces/` (contract, taxonomy, emit, redaction/validate):
+  `public-schema*.ts`, `redaction*.ts`, `trace-ingest-workflow.ts`
+- `sharing/` (attestation, bundle, manifest, publishers, review):
+  `publishers*.ts`, `publishing-workflow.ts`, `export-*-workflow.ts`
+- `training/autoresearch/` (data selection, augmentation, distillation):
+  `distillation-*.ts`, `dataset-*.ts`
+
+Distinct from `ts/src/production-traces/`, which is the direct TS mirror
+of `production_traces/` (contract, ingest, redaction, dataset, cli
+layers). This directory predates that split and covers the broader
+surface above; see `docs/knowledge-production-trace-boundary-map.md` for
+the "leave behavior where it already works" rule that keeps both
+directories shipping rather than merging them.


### PR DESCRIPTION
## Summary
Five short scope notes so contributors do not mistake intentional single-language subsystems for missing work:

- `harness/__init__.py` and `hermes/__init__.py`: descriptive notes (currently Python-only; no design doc claims intent, so worded descriptively).
- `control_plane/__init__.py`: intentionally thin; the full control plane lives in `ts/src/control-plane/` (cites docs/core-control-package-split.md).
- `ts/src/providers/provider-factory.ts`: one-line note that its "hermes" provider gateway is an unrelated naming collision with the Python hermes subsystem.
- `ts/src/traces/README.md` (new): maps its responsibilities to the Python homes (production_traces/, sharing/, training/autoresearch/), citing docs/knowledge-production-trace-boundary-map.md.

Docs only, no code changes. Citations were verified against the actual design docs during review. Part 4 of 4 of the quality sweep.