### PR TITLE
fix: resync README whats-new block (unbreaks CI test job on main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Everything is filesystem-first: inspect it, diff it, replay it, export it, or fe
 Python owns the full control-plane package; TypeScript owns several operator-facing surfaces, the TUI, and Node runtime adapters. Start with [autocontext/README.md](autocontext/README.md) or [ts/README.md](ts/README.md).
 
 <!-- autocontext-whats-new:start -->
-
 ## What's New in 0.10.0
 
 - **Scaled training plans** add default-off CUDA/TRL profiles for 7B QLoRA RLVR and sharded 32B/72B distillation across Python and TypeScript.


### PR DESCRIPTION
## Summary
Main's `test` job is red: the AC-846 README trim (99c4be2f) left a stray blank line after `<!-- autocontext-whats-new:start -->`, failing `test_banner_sync.py::test_root_readme_whats_new_stays_synced` and `test_release_surface_manifest.py::test_release_manifest_syncs_public_surfaces` on main and on every PR based on it (currently #1149, #1150, #1151, #1152).

One-line fix generated by the canonical `scripts/sync_release_surfaces.py`; both tests verified passing locally afterward.

Merge this first, then re-run checks on the four quality-sweep PRs to clear their inherited failures.