### PR TITLE
AC-864: decompose run_generation into named phase helpers

### DIFF
--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json as _json
 import logging
 from collections.abc import Callable, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +15,12 @@ from autocontext.agents.competitor import CompetitorRunner
 from autocontext.agents.curator import KnowledgeCurator
 from autocontext.agents.llm_client import DeferredMLXClient, LanguageModelClient, build_client_from_settings
 from autocontext.agents.model_router import ModelRouter, TierConfig
+from autocontext.agents.orchestrator_helpers import (
+    assemble_agent_outputs,
+    run_analyst_coach_architect,
+    run_competitor_phase,
+    run_translator_phase,
+)
 from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
 from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext
 from autocontext.agents.role_runtime_overrides import apply_role_overrides, settings_for_budgeted_role_call
@@ -538,162 +543,56 @@ class AgentOrchestrator:
             if on_role_event:
                 on_role_event(role, status)
 
-        # --- Competitor phase ---
-        competitor_model = (
-            self.resolve_model(
-                "competitor",
-                generation=generation_index,
-                scenario_name=scenario_name,
-            )
-            or self.competitor.model
-        )
-        use_competitor_rlm = (
-            self.settings.rlm_enabled
-            and self.settings.rlm_competitor_enabled
-            and self._rlm_loader is not None
-            and self.settings.agent_provider != "agent_sdk"
+        raw_text, competitor_exec = run_competitor_phase(
+            self,
+            prompts,
+            generation_index,
+            tool_context,
+            run_id,
+            scenario_name,
+            strategy_interface,
+            scenario_rules,
+            current_strategy,
+            generation_deadline,
+            _notify,
         )
 
-        if use_competitor_rlm:
-            _notify("competitor", "started")
-            raw_text, competitor_exec = self._run_rlm_competitor(
-                run_id,
-                scenario_name,
-                generation_index,
-                model=competitor_model,
-                strategy_interface=strategy_interface,
-                scenario_rules=scenario_rules,
-                current_strategy=current_strategy,
-            )
-            _notify("competitor", "completed")
-        else:
-            _notify("competitor", "started")
-            competitor_prompt = prompts.competitor
-            if self.settings.code_strategies_enabled:
-                from autocontext.prompts.templates import code_strategy_competitor_suffix
+        strategy, translator_exec = run_translator_phase(
+            self,
+            raw_text,
+            strategy_interface,
+            generation_index,
+            scenario_name,
+            generation_deadline,
+            _notify,
+        )
 
-                competitor_prompt += code_strategy_competitor_suffix(strategy_interface)
-            with self._use_role_runtime(
-                "competitor",
-                self.competitor,
-                generation=generation_index,
-                scenario_name=scenario_name,
-                generation_deadline=generation_deadline,
-            ):
-                raw_text, competitor_exec = self.competitor.run(competitor_prompt, tool_context=tool_context)
-            _notify("competitor", "completed")
-
-        _notify("translator", "started")
-        with self._use_role_runtime(
-            "translator",
-            self.translator,
-            generation=generation_index,
-            scenario_name=scenario_name,
-            generation_deadline=generation_deadline,
-        ):
-            if self.settings.code_strategies_enabled:
-                strategy, translator_exec = self.translator.translate_code(raw_text)
-            else:
-                strategy, translator_exec = self.translator.translate(raw_text, strategy_interface)
-        _notify("translator", "completed")
         architect_prompt = prompts.architect
         if generation_index % self.settings.architect_every_n_gens != 0:
             architect_prompt += _ARCHITECT_CADENCE_SKIP
 
-        if self.settings.rlm_enabled and self._rlm_loader is not None and self.settings.agent_provider != "agent_sdk":
-            _notify("analyst", "started")
-            _notify("architect", "started")
-            analyst_exec, architect_exec = self._run_rlm_roles(
-                run_id,
-                scenario_name,
-                generation_index,
-                strategy,
-                architect_prompt,
-                scenario_rules=scenario_rules,
-            )
-            _notify("analyst", "completed")
-            _notify("architect", "completed")
-            _notify("coach", "started")
-            enriched_coach_prompt = self._enrich_coach_prompt(prompts.coach, analyst_exec.content)
-            with ThreadPoolExecutor(max_workers=1) as pool:
-                with self._use_role_runtime(
-                    "coach",
-                    self.coach,
-                    generation=generation_index,
-                    scenario_name=scenario_name,
-                    generation_deadline=generation_deadline,
-                ):
-                    coach_future = pool.submit(self.coach.run, enriched_coach_prompt)
-                    coach_exec = coach_future.result()
-            _notify("coach", "completed")
-        else:
-            # Analyst runs first; its output enriches the coach prompt
-            _notify("analyst", "started")
-            with self._use_role_runtime(
-                "analyst",
-                self.analyst,
-                generation=generation_index,
-                scenario_name=scenario_name,
-                generation_deadline=generation_deadline,
-            ):
-                analyst_exec = self.analyst.run(prompts.analyst)
-            _notify("analyst", "completed")
-            enriched_coach_prompt = self._enrich_coach_prompt(prompts.coach, analyst_exec.content)
-            _notify("coach", "started")
-            _notify("architect", "started")
-            with (
-                self._use_role_runtime(
-                    "coach",
-                    self.coach,
-                    generation=generation_index,
-                    scenario_name=scenario_name,
-                    generation_deadline=generation_deadline,
-                ),
-                self._use_role_runtime(
-                    "architect",
-                    self.architect,
-                    generation=generation_index,
-                    scenario_name=scenario_name,
-                    generation_deadline=generation_deadline,
-                ),
-            ):
-                with ThreadPoolExecutor(max_workers=2) as pool:
-                    coach_future = pool.submit(self.coach.run, enriched_coach_prompt)
-                    architect_future = pool.submit(self.architect.run, architect_prompt)
-                    coach_exec = coach_future.result()
-                    _notify("coach", "completed")
-                    architect_exec = architect_future.result()
-                    _notify("architect", "completed")
+        analyst_exec, coach_exec, architect_exec = run_analyst_coach_architect(
+            self,
+            prompts,
+            run_id,
+            scenario_name,
+            generation_index,
+            strategy,
+            architect_prompt,
+            scenario_rules,
+            generation_deadline,
+            _notify,
+        )
 
-        tools = parse_architect_tool_specs(architect_exec.content)
-        harness_specs = parse_architect_harness_specs(architect_exec.content)
-        coach_playbook, coach_lessons, coach_hints = parse_coach_sections(coach_exec.content)
-
-        # Parse typed contracts
-        competitor_typed = parse_competitor_output(
+        return assemble_agent_outputs(
+            self,
             raw_text,
             strategy,
-            is_code_strategy=self.settings.code_strategies_enabled,
-        )
-        analyst_typed = parse_analyst_output(analyst_exec.content)
-        coach_typed = parse_coach_output(coach_exec.content)
-        architect_typed = parse_architect_output(architect_exec.content)
-
-        return AgentOutputs(
-            strategy=strategy,
-            analysis_markdown=analyst_exec.content,
-            coach_markdown=coach_exec.content,
-            coach_playbook=coach_playbook,
-            coach_lessons=coach_lessons,
-            coach_competitor_hints=coach_hints,
-            architect_markdown=architect_exec.content,
-            architect_tools=tools,
-            architect_harness_specs=harness_specs,
-            role_executions=[competitor_exec, translator_exec, analyst_exec, coach_exec, architect_exec],
-            competitor_output=competitor_typed,
-            analyst_output=analyst_typed,
-            coach_output=coach_typed,
-            architect_output=architect_typed,
+            competitor_exec,
+            translator_exec,
+            analyst_exec,
+            coach_exec,
+            architect_exec,
         )
 
     def _run_via_pipeline(

--- a/autocontext/src/autocontext/agents/orchestrator_helpers.py
+++ b/autocontext/src/autocontext/agents/orchestrator_helpers.py
@@ -1,0 +1,241 @@
+"""Orchestrator generation-phase helpers (AC-864).
+
+Free functions extracted from AgentOrchestrator.run_generation, mirroring the
+loop/stage_helpers/ extraction pattern: each takes the orchestrator instance
+as its first argument plus the same explicit parameters run_generation used
+to thread through the call. Kept in a separate module because
+agents/orchestrator.py sits at its grandfathered module-size cap.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+from autocontext.agents.architect import parse_architect_harness_specs, parse_architect_tool_specs
+from autocontext.agents.coach import parse_coach_sections
+from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
+from autocontext.agents.types import AgentOutputs, RoleExecution
+
+if TYPE_CHECKING:
+    from autocontext.agents.orchestrator import AgentOrchestrator
+    from autocontext.prompts.templates import PromptBundle
+
+NotifyFn = Callable[[str, str], None]
+
+
+def run_competitor_phase(
+    orchestrator: AgentOrchestrator,
+    prompts: PromptBundle,
+    generation_index: int,
+    tool_context: str,
+    run_id: str,
+    scenario_name: str,
+    strategy_interface: str,
+    scenario_rules: str,
+    current_strategy: dict[str, Any] | None,
+    generation_deadline: float | None,
+    notify: NotifyFn,
+) -> tuple[str, RoleExecution]:
+    """Run the Competitor role, choosing RLM vs direct execution."""
+    settings = orchestrator.settings
+    competitor_model = (
+        orchestrator.resolve_model(
+            "competitor",
+            generation=generation_index,
+            scenario_name=scenario_name,
+        )
+        or orchestrator.competitor.model
+    )
+    use_competitor_rlm = (
+        settings.rlm_enabled
+        and settings.rlm_competitor_enabled
+        and orchestrator._rlm_loader is not None
+        and settings.agent_provider != "agent_sdk"
+    )
+
+    if use_competitor_rlm:
+        notify("competitor", "started")
+        raw_text, competitor_exec = orchestrator._run_rlm_competitor(
+            run_id,
+            scenario_name,
+            generation_index,
+            model=competitor_model,
+            strategy_interface=strategy_interface,
+            scenario_rules=scenario_rules,
+            current_strategy=current_strategy,
+        )
+        notify("competitor", "completed")
+    else:
+        notify("competitor", "started")
+        competitor_prompt = prompts.competitor
+        if settings.code_strategies_enabled:
+            from autocontext.prompts.templates import code_strategy_competitor_suffix
+
+            competitor_prompt += code_strategy_competitor_suffix(strategy_interface)
+        with orchestrator._use_role_runtime(
+            "competitor",
+            orchestrator.competitor,
+            generation=generation_index,
+            scenario_name=scenario_name,
+            generation_deadline=generation_deadline,
+        ):
+            raw_text, competitor_exec = orchestrator.competitor.run(competitor_prompt, tool_context=tool_context)
+        notify("competitor", "completed")
+
+    return raw_text, competitor_exec
+
+
+def run_translator_phase(
+    orchestrator: AgentOrchestrator,
+    raw_text: str,
+    strategy_interface: str,
+    generation_index: int,
+    scenario_name: str,
+    generation_deadline: float | None,
+    notify: NotifyFn,
+) -> tuple[dict[str, Any], RoleExecution]:
+    """Run the Translator role against the Competitor's raw output."""
+    settings = orchestrator.settings
+    notify("translator", "started")
+    with orchestrator._use_role_runtime(
+        "translator",
+        orchestrator.translator,
+        generation=generation_index,
+        scenario_name=scenario_name,
+        generation_deadline=generation_deadline,
+    ):
+        if settings.code_strategies_enabled:
+            strategy, translator_exec = orchestrator.translator.translate_code(raw_text)
+        else:
+            strategy, translator_exec = orchestrator.translator.translate(raw_text, strategy_interface)
+    notify("translator", "completed")
+    return strategy, translator_exec
+
+
+def run_analyst_coach_architect(
+    orchestrator: AgentOrchestrator,
+    prompts: PromptBundle,
+    run_id: str,
+    scenario_name: str,
+    generation_index: int,
+    strategy: dict[str, Any],
+    architect_prompt: str,
+    scenario_rules: str,
+    generation_deadline: float | None,
+    notify: NotifyFn,
+) -> tuple[RoleExecution, RoleExecution, RoleExecution]:
+    """Run Analyst, Coach, and Architect, choosing RLM vs threaded execution.
+
+    Returns (analyst_exec, coach_exec, architect_exec).
+    """
+    settings = orchestrator.settings
+    if settings.rlm_enabled and orchestrator._rlm_loader is not None and settings.agent_provider != "agent_sdk":
+        notify("analyst", "started")
+        notify("architect", "started")
+        analyst_exec, architect_exec = orchestrator._run_rlm_roles(
+            run_id,
+            scenario_name,
+            generation_index,
+            strategy,
+            architect_prompt,
+            scenario_rules=scenario_rules,
+        )
+        notify("analyst", "completed")
+        notify("architect", "completed")
+        notify("coach", "started")
+        enriched_coach_prompt = orchestrator._enrich_coach_prompt(prompts.coach, analyst_exec.content)
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            with orchestrator._use_role_runtime(
+                "coach",
+                orchestrator.coach,
+                generation=generation_index,
+                scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
+            ):
+                coach_future = pool.submit(orchestrator.coach.run, enriched_coach_prompt)
+                coach_exec = coach_future.result()
+        notify("coach", "completed")
+    else:
+        # Analyst runs first; its output enriches the coach prompt
+        notify("analyst", "started")
+        with orchestrator._use_role_runtime(
+            "analyst",
+            orchestrator.analyst,
+            generation=generation_index,
+            scenario_name=scenario_name,
+            generation_deadline=generation_deadline,
+        ):
+            analyst_exec = orchestrator.analyst.run(prompts.analyst)
+        notify("analyst", "completed")
+        enriched_coach_prompt = orchestrator._enrich_coach_prompt(prompts.coach, analyst_exec.content)
+        notify("coach", "started")
+        notify("architect", "started")
+        with (
+            orchestrator._use_role_runtime(
+                "coach",
+                orchestrator.coach,
+                generation=generation_index,
+                scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
+            ),
+            orchestrator._use_role_runtime(
+                "architect",
+                orchestrator.architect,
+                generation=generation_index,
+                scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
+            ),
+        ):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                coach_future = pool.submit(orchestrator.coach.run, enriched_coach_prompt)
+                architect_future = pool.submit(orchestrator.architect.run, architect_prompt)
+                coach_exec = coach_future.result()
+                notify("coach", "completed")
+                architect_exec = architect_future.result()
+                notify("architect", "completed")
+
+    return analyst_exec, coach_exec, architect_exec
+
+
+def assemble_agent_outputs(
+    orchestrator: AgentOrchestrator,
+    raw_text: str,
+    strategy: dict[str, Any],
+    competitor_exec: RoleExecution,
+    translator_exec: RoleExecution,
+    analyst_exec: RoleExecution,
+    coach_exec: RoleExecution,
+    architect_exec: RoleExecution,
+) -> AgentOutputs:
+    """Parse role outputs and assemble the AgentOutputs for this generation."""
+    tools = parse_architect_tool_specs(architect_exec.content)
+    harness_specs = parse_architect_harness_specs(architect_exec.content)
+    coach_playbook, coach_lessons, coach_hints = parse_coach_sections(coach_exec.content)
+
+    competitor_typed = parse_competitor_output(
+        raw_text,
+        strategy,
+        is_code_strategy=orchestrator.settings.code_strategies_enabled,
+    )
+    analyst_typed = parse_analyst_output(analyst_exec.content)
+    coach_typed = parse_coach_output(coach_exec.content)
+    architect_typed = parse_architect_output(architect_exec.content)
+
+    return AgentOutputs(
+        strategy=strategy,
+        analysis_markdown=analyst_exec.content,
+        coach_markdown=coach_exec.content,
+        coach_playbook=coach_playbook,
+        coach_lessons=coach_lessons,
+        coach_competitor_hints=coach_hints,
+        architect_markdown=architect_exec.content,
+        architect_tools=tools,
+        architect_harness_specs=harness_specs,
+        role_executions=[competitor_exec, translator_exec, analyst_exec, coach_exec, architect_exec],
+        competitor_output=competitor_typed,
+        analyst_output=analyst_typed,
+        coach_output=coach_typed,
+        architect_output=architect_typed,
+    )


### PR DESCRIPTION
## Summary

- `AgentOrchestrator.run_generation` (~187 lines) mixed four branching phases in one function: pipeline-engine vs legacy codepath, RLM vs direct competitor execution, code-strategy vs JSON translation, and RLM-threaded vs 2-worker-`ThreadPoolExecutor` analyst/coach/architect execution.
- Extracted each phase into a named helper (`run_competitor_phase`, `run_translator_phase`, `run_analyst_coach_architect`, `assemble_agent_outputs`) in a new `agents/orchestrator_helpers.py` module, so `run_generation` now reads as a flat sequence of phase calls.
- Relocated to a sibling module (rather than class-local methods, per the task's escape clause) because `orchestrator.py` was at 999/1000 of its grandfathered module-size cap with no headroom for new method signatures; it's now 898 lines.
- Behavior-preserving: every extracted body is a verbatim relocation of the original code (only `self.` -> `orchestrator.` and the `_notify` closure -> an explicit `notify` parameter changed); no control-flow restructuring.

## Test plan

- [x] Covering tests (14 files exercising `AgentOrchestrator`/`run_generation`): 252 passed before and after, identical.
- [x] `tests/test_module_size_limits.py` passes (no `GRANDFATHERED` bump needed).
- [x] `uv run --frozen ruff check src tests`: clean.
- [x] `uv run --frozen mypy src`: clean, 666 source files.
- [x] Full suite (`uv run --frozen pytest -q`): 2 pre-existing failures in `tests/test_custom_scenario_name_resolution.py` (unrelated `evidence_requirement` custom-scenario validation), confirmed present on unmodified `main` via `git stash` + re-run; all other tests pass.