### PR TITLE
AC-862: resolve readPlaybook asymmetry in server routes

### DIFF
--- a/ts/src/server/routes/run-list-routes.ts
+++ b/ts/src/server/routes/run-list-routes.ts
@@ -3,8 +3,9 @@
  *
  * Both share the executeRunSimulationReadRequest dispatcher and its
  * RunSimulationReadDeps. The playbook route is the one call site with a
- * real readPlaybook implementation; the others keep the null-returning
- * stub (see AC-852 task report for the tracked asymmetry).
+ * real readPlaybook implementation; the run routes below dispatch route
+ * literals that never reach the playbook case, so their shared runSimDeps
+ * omits readPlaybook entirely (AC-862; it is optional on the deps type).
  */
 
 import {

--- a/ts/src/server/routes/scenario-simulation-routes.ts
+++ b/ts/src/server/routes/scenario-simulation-routes.ts
@@ -1,8 +1,9 @@
 /**
  * /api/scenarios and /api/simulations routes (AC-852).
  *
- * Shares the executeRunSimulationReadRequest dispatcher with run-list-routes;
- * all four call sites here use the null-returning readPlaybook stub.
+ * Shares the executeRunSimulationReadRequest dispatcher with run-list-routes.
+ * None of the four routes here dispatch the "playbook" case, so their
+ * shared runSimDeps omits readPlaybook (AC-862; optional on the deps type).
  */
 
 import {

--- a/ts/src/server/run-simulation-read-workflow.ts
+++ b/ts/src/server/run-simulation-read-workflow.ts
@@ -32,7 +32,13 @@ export interface RunSimulationApi {
 
 export interface RunSimulationReadDeps {
   openStore: () => RunReadStore;
-  readPlaybook: (scenario: string, roots: { runsRoot: string; knowledgeRoot: string }) => string | null;
+  // Only the "playbook" route reads this (AC-862): every other route's
+  // request kind is a fixed literal that never reaches the playbook case,
+  // so callers that never dispatch "playbook" may omit it.
+  readPlaybook?: (
+    scenario: string,
+    roots: { runsRoot: string; knowledgeRoot: string },
+  ) => string | null;
   loadReplayArtifactResponse: typeof loadReplayArtifactResponse;
 }
 
@@ -120,10 +126,12 @@ export function executeRunSimulationReadRequest(opts: {
         status: 200,
         body: {
           scenario: opts.scenario,
-          content: opts.deps.readPlaybook(opts.scenario!, {
-            runsRoot: opts.runManager.getRunsRoot(),
-            knowledgeRoot: opts.runManager.getKnowledgeRoot(),
-          }),
+          content: opts.deps.readPlaybook
+            ? opts.deps.readPlaybook(opts.scenario!, {
+                runsRoot: opts.runManager.getRunsRoot(),
+                knowledgeRoot: opts.runManager.getKnowledgeRoot(),
+              })
+            : null,
         },
       };
     case "scenarios":

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -292,14 +292,13 @@ export class InteractiveServer {
       readJsonBody: () => this.#readJsonBody(req),
     };
 
-    // Shared executeRunSimulationReadRequest deps (AC-852): the playbook
-    // route is the one call site with a real readPlaybook implementation;
-    // every other run/scenario/simulation route keeps the null-returning
-    // stub the original code used (see AC-852 task report for the tracked
-    // asymmetry: this refactor does not wire new capability).
+    // Shared executeRunSimulationReadRequest deps (AC-852). readPlaybook is
+    // optional (AC-862): only the "playbook" route reads it, and every other
+    // run/scenario/simulation route dispatches a fixed route literal that
+    // never reaches that case, so readPlaybook is dropped here as a dead
+    // parameter (see AC-862 task report for the investigation).
     const runSimDeps: RunSimulationReadDeps = {
       openStore,
-      readPlaybook: () => null,
       loadReplayArtifactResponse,
     };
     const playbookDeps: RunSimulationReadDeps = {

--- a/ts/tests/run-simulation-read-workflow.test.ts
+++ b/ts/tests/run-simulation-read-workflow.test.ts
@@ -15,32 +15,46 @@ describe("run and simulation read workflow", () => {
     try {
       const replayDir = join(dir, "run_1", "generations", "gen_1", "replays");
       mkdirSync(replayDir, { recursive: true });
-      writeFileSync(join(replayDir, "replay.json"), JSON.stringify({ scenario: "grid_ctf" }), "utf-8");
+      writeFileSync(
+        join(replayDir, "replay.json"),
+        JSON.stringify({ scenario: "grid_ctf" }),
+        "utf-8",
+      );
 
-      expect(loadReplayArtifactResponse({
-        runsRoot: dir,
-        runId: "run_1",
-        generation: 1,
-      })).toEqual({
+      expect(
+        loadReplayArtifactResponse({
+          runsRoot: dir,
+          runId: "run_1",
+          generation: 1,
+        }),
+      ).toEqual({
         status: 200,
         body: { scenario: "grid_ctf" },
       });
 
-      expect(loadReplayArtifactResponse({
-        runsRoot: dir,
-        runId: "run_1",
-        generation: 99,
-      })).toEqual({
+      expect(
+        loadReplayArtifactResponse({
+          runsRoot: dir,
+          runId: "run_1",
+          generation: 99,
+        }),
+      ).toEqual({
         status: 404,
         body: { error: expect.stringContaining("No replay files found under") },
       });
 
-      writeFileSync(join(replayDir, "broken.json"), JSON.stringify(["not", "an", "object"]), "utf-8");
-      expect(loadReplayArtifactResponse({
-        runsRoot: dir,
-        runId: "run_1",
-        generation: 1,
-      })).toEqual({
+      writeFileSync(
+        join(replayDir, "broken.json"),
+        JSON.stringify(["not", "an", "object"]),
+        "utf-8",
+      );
+      expect(
+        loadReplayArtifactResponse({
+          runsRoot: dir,
+          runId: "run_1",
+          generation: 1,
+        }),
+      ).toEqual({
         status: 500,
         body: { error: "Replay payload is not a JSON object" },
       });
@@ -57,49 +71,57 @@ describe("run and simulation read workflow", () => {
       close: vi.fn(),
     };
 
-    expect(executeRunSimulationReadRequest({
-      route: "runs_list",
-      runManager: {
-        getRunsRoot: () => "/tmp/runs",
-        getKnowledgeRoot: () => "/tmp/knowledge",
-        getEnvironmentInfo: () => ({ scenarios: [{ name: "grid_ctf", description: "Capture the flag" }] }),
-      },
-      simulationApi: {
-        listSimulations: vi.fn(),
-        getSimulation: vi.fn(),
-        getDashboardData: vi.fn(),
-      },
-      deps: {
-        openStore: () => store,
-        readPlaybook: vi.fn(() => "playbook"),
-        loadReplayArtifactResponse: vi.fn(),
-      },
-    })).toEqual({
+    expect(
+      executeRunSimulationReadRequest({
+        route: "runs_list",
+        runManager: {
+          getRunsRoot: () => "/tmp/runs",
+          getKnowledgeRoot: () => "/tmp/knowledge",
+          getEnvironmentInfo: () => ({
+            scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],
+          }),
+        },
+        simulationApi: {
+          listSimulations: vi.fn(),
+          getSimulation: vi.fn(),
+          getDashboardData: vi.fn(),
+        },
+        deps: {
+          openStore: () => store,
+          readPlaybook: vi.fn(() => "playbook"),
+          loadReplayArtifactResponse: vi.fn(),
+        },
+      }),
+    ).toEqual({
       status: 200,
       body: [{ run_id: "run_1" }],
     });
     expect(store.close).toHaveBeenCalledOnce();
 
     store.close.mockClear();
-    expect(executeRunSimulationReadRequest({
-      route: "run_status",
-      runId: "run_1",
-      runManager: {
-        getRunsRoot: () => "/tmp/runs",
-        getKnowledgeRoot: () => "/tmp/knowledge",
-        getEnvironmentInfo: () => ({ scenarios: [{ name: "grid_ctf", description: "Capture the flag" }] }),
-      },
-      simulationApi: {
-        listSimulations: vi.fn(),
-        getSimulation: vi.fn(),
-        getDashboardData: vi.fn(),
-      },
-      deps: {
-        openStore: () => store,
-        readPlaybook: vi.fn(() => "playbook"),
-        loadReplayArtifactResponse: vi.fn(),
-      },
-    })).toEqual({
+    expect(
+      executeRunSimulationReadRequest({
+        route: "run_status",
+        runId: "run_1",
+        runManager: {
+          getRunsRoot: () => "/tmp/runs",
+          getKnowledgeRoot: () => "/tmp/knowledge",
+          getEnvironmentInfo: () => ({
+            scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],
+          }),
+        },
+        simulationApi: {
+          listSimulations: vi.fn(),
+          getSimulation: vi.fn(),
+          getDashboardData: vi.fn(),
+        },
+        deps: {
+          openStore: () => store,
+          readPlaybook: vi.fn(() => "playbook"),
+          loadReplayArtifactResponse: vi.fn(),
+        },
+      }),
+    ).toEqual({
       status: 200,
       body: [{ generation: 1 }],
     });
@@ -109,103 +131,177 @@ describe("run and simulation read workflow", () => {
   it("routes playbook, scenarios, and simulation reads with 404s for missing simulations", () => {
     const simulationApi = {
       listSimulations: vi.fn(() => [{ name: "live_sim" }]),
-      getSimulation: vi.fn((name: string) => name === "live_sim" ? { name } : null),
-      getDashboardData: vi.fn((name: string) => name === "live_sim" ? { name, overallScore: 0.82 } : null),
+      getSimulation: vi.fn((name: string) => (name === "live_sim" ? { name } : null)),
+      getDashboardData: vi.fn((name: string) =>
+        name === "live_sim" ? { name, overallScore: 0.82 } : null,
+      ),
     };
 
-    expect(executeRunSimulationReadRequest({
-      route: "playbook",
-      scenario: "grid_ctf",
-      runManager: {
-        getRunsRoot: () => "/tmp/runs",
-        getKnowledgeRoot: () => "/tmp/knowledge",
-        getEnvironmentInfo: () => ({ scenarios: [{ name: "grid_ctf", description: "Capture the flag" }] }),
-      },
-      simulationApi,
-      deps: {
-        openStore: vi.fn(),
-        readPlaybook: vi.fn(() => "## Playbook"),
-        loadReplayArtifactResponse: vi.fn(),
-      },
-    })).toEqual({
+    expect(
+      executeRunSimulationReadRequest({
+        route: "playbook",
+        scenario: "grid_ctf",
+        runManager: {
+          getRunsRoot: () => "/tmp/runs",
+          getKnowledgeRoot: () => "/tmp/knowledge",
+          getEnvironmentInfo: () => ({
+            scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],
+          }),
+        },
+        simulationApi,
+        deps: {
+          openStore: vi.fn(),
+          readPlaybook: vi.fn(() => "## Playbook"),
+          loadReplayArtifactResponse: vi.fn(),
+        },
+      }),
+    ).toEqual({
       status: 200,
       body: { scenario: "grid_ctf", content: "## Playbook" },
     });
 
-    expect(executeRunSimulationReadRequest({
-      route: "scenarios",
-      runManager: {
-        getRunsRoot: () => "/tmp/runs",
-        getKnowledgeRoot: () => "/tmp/knowledge",
-        getEnvironmentInfo: () => ({ scenarios: [{ name: "grid_ctf", description: "Capture the flag" }] }),
-      },
-      simulationApi,
-      deps: {
-        openStore: vi.fn(),
-        readPlaybook: vi.fn(),
-        loadReplayArtifactResponse: vi.fn(),
-      },
-    })).toEqual({
+    expect(
+      executeRunSimulationReadRequest({
+        route: "scenarios",
+        runManager: {
+          getRunsRoot: () => "/tmp/runs",
+          getKnowledgeRoot: () => "/tmp/knowledge",
+          getEnvironmentInfo: () => ({
+            scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],
+          }),
+        },
+        simulationApi,
+        deps: {
+          openStore: vi.fn(),
+          readPlaybook: vi.fn(),
+          loadReplayArtifactResponse: vi.fn(),
+        },
+      }),
+    ).toEqual({
       status: 200,
       body: [{ name: "grid_ctf", description: "Capture the flag" }],
     });
 
-    expect(executeRunSimulationReadRequest({
-      route: "simulations_list",
-      runManager: {
-        getRunsRoot: () => "/tmp/runs",
-        getKnowledgeRoot: () => "/tmp/knowledge",
-        getEnvironmentInfo: () => ({ scenarios: [] }),
-      },
-      simulationApi,
-      deps: {
-        openStore: vi.fn(),
-        readPlaybook: vi.fn(),
-        loadReplayArtifactResponse: vi.fn(),
-      },
-    })).toEqual({
+    expect(
+      executeRunSimulationReadRequest({
+        route: "simulations_list",
+        runManager: {
+          getRunsRoot: () => "/tmp/runs",
+          getKnowledgeRoot: () => "/tmp/knowledge",
+          getEnvironmentInfo: () => ({ scenarios: [] }),
+        },
+        simulationApi,
+        deps: {
+          openStore: vi.fn(),
+          readPlaybook: vi.fn(),
+          loadReplayArtifactResponse: vi.fn(),
+        },
+      }),
+    ).toEqual({
       status: 200,
       body: [{ name: "live_sim" }],
     });
 
-    expect(executeRunSimulationReadRequest({
-      route: "simulation_detail",
-      simulationName: "missing",
-      rawSimulationName: "missing",
-      runManager: {
-        getRunsRoot: () => "/tmp/runs",
-        getKnowledgeRoot: () => "/tmp/knowledge",
-        getEnvironmentInfo: () => ({ scenarios: [] }),
-      },
-      simulationApi,
-      deps: {
-        openStore: vi.fn(),
-        readPlaybook: vi.fn(),
-        loadReplayArtifactResponse: vi.fn(),
-      },
-    })).toEqual({
+    expect(
+      executeRunSimulationReadRequest({
+        route: "simulation_detail",
+        simulationName: "missing",
+        rawSimulationName: "missing",
+        runManager: {
+          getRunsRoot: () => "/tmp/runs",
+          getKnowledgeRoot: () => "/tmp/knowledge",
+          getEnvironmentInfo: () => ({ scenarios: [] }),
+        },
+        simulationApi,
+        deps: {
+          openStore: vi.fn(),
+          readPlaybook: vi.fn(),
+          loadReplayArtifactResponse: vi.fn(),
+        },
+      }),
+    ).toEqual({
       status: 404,
       body: { error: "Simulation 'missing' not found" },
     });
 
-    expect(executeRunSimulationReadRequest({
-      route: "simulation_dashboard",
-      simulationName: "live_sim",
-      rawSimulationName: "live_sim",
-      runManager: {
-        getRunsRoot: () => "/tmp/runs",
-        getKnowledgeRoot: () => "/tmp/knowledge",
-        getEnvironmentInfo: () => ({ scenarios: [] }),
-      },
-      simulationApi,
-      deps: {
-        openStore: vi.fn(),
-        readPlaybook: vi.fn(),
-        loadReplayArtifactResponse: vi.fn(),
-      },
-    })).toEqual({
+    expect(
+      executeRunSimulationReadRequest({
+        route: "simulation_dashboard",
+        simulationName: "live_sim",
+        rawSimulationName: "live_sim",
+        runManager: {
+          getRunsRoot: () => "/tmp/runs",
+          getKnowledgeRoot: () => "/tmp/knowledge",
+          getEnvironmentInfo: () => ({ scenarios: [] }),
+        },
+        simulationApi,
+        deps: {
+          openStore: vi.fn(),
+          readPlaybook: vi.fn(),
+          loadReplayArtifactResponse: vi.fn(),
+        },
+      }),
+    ).toEqual({
       status: 200,
       body: { name: "live_sim", overallScore: 0.82 },
     });
+  });
+
+  it("routes that never dispatch the playbook case work without readPlaybook in deps (AC-862)", () => {
+    const store = {
+      listRuns: vi.fn(() => [{ run_id: "run_1" }]),
+      getRun: vi.fn(() => ({ run_id: "run_1" })),
+      getGenerations: vi.fn(() => [{ generation: 1 }]),
+      close: vi.fn(),
+    };
+    const simulationApi = {
+      listSimulations: vi.fn(() => [{ name: "live_sim" }]),
+      getSimulation: vi.fn(),
+      getDashboardData: vi.fn(),
+    };
+    const runManager = {
+      getRunsRoot: () => "/tmp/runs",
+      getKnowledgeRoot: () => "/tmp/knowledge",
+      getEnvironmentInfo: () => ({
+        scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],
+      }),
+    };
+    // No readPlaybook field at all: proves the parameter is genuinely
+    // optional for every route except "playbook", matching the shared
+    // runSimDeps object built in ws-server.ts.
+    const deps = {
+      openStore: () => store,
+      loadReplayArtifactResponse: vi.fn(),
+    };
+
+    expect(
+      executeRunSimulationReadRequest({
+        route: "runs_list",
+        runManager,
+        simulationApi,
+        deps,
+      }),
+    ).toEqual({ status: 200, body: [{ run_id: "run_1" }] });
+
+    expect(
+      executeRunSimulationReadRequest({
+        route: "scenarios",
+        runManager,
+        simulationApi,
+        deps,
+      }),
+    ).toEqual({
+      status: 200,
+      body: [{ name: "grid_ctf", description: "Capture the flag" }],
+    });
+
+    expect(
+      executeRunSimulationReadRequest({
+        route: "simulations_list",
+        runManager,
+        simulationApi,
+        deps,
+      }),
+    ).toEqual({ status: 200, body: [{ name: "live_sim" }] });
   });
 });


### PR DESCRIPTION
## Summary

Investigated the 8 `executeRunSimulationReadRequest` call sites where 7 pass `readPlaybook: () => null` and only `/api/knowledge/playbook/:scenario` uses the real ArtifactStore implementation.

**Investigation findings:**

`executeRunSimulationReadRequest` (ts/src/server/run-simulation-read-workflow.ts) is a `switch (opts.route)` dispatcher. `opts.deps.readPlaybook` is read only inside the `"playbook"` case. Every call site passes a compile-time route literal:

- run-list-routes.ts: `"runs_list"`, `"run_replay"`, `"run_status"` (via shared `runSimDeps`), and `"playbook"` (via the separate `playbookDeps`, which has the real implementation)
- scenario-simulation-routes.ts: `"scenarios"`, `"simulations_list"`, `"simulation_detail"`, `"simulation_dashboard"` (all via `runSimDeps`)

None of the 7 `runSimDeps`-backed literals is ever `"playbook"`, so `deps.readPlaybook` at those sites is structurally unreachable, not a missing capability. Grepped `ts/tests/`, TUI, and dashboard code for any consumer that reads playbook content off those 7 endpoints or handles its absence; found none — the only consumer of playbook data is the dedicated `/api/knowledge/playbook/:scenario` route, which already gets the real implementation via `playbookDeps`.

**Decision rule fired: DROP** (request kinds can never invoke `readPlaybook` — dead parameter).

## Changes

- `RunSimulationReadDeps.readPlaybook` made optional; the `"playbook"` case guards on its presence (falls back to `null`, matching prior behavior).
- Removed the no-op `readPlaybook: () => null` stub from the shared `runSimDeps` object in `ws-server.ts`. `playbookDeps` (real ArtifactStore-backed implementation) is untouched.
- Updated stale header comments in `run-list-routes.ts` and `scenario-simulation-routes.ts` that described the old null-stub asymmetry.
- Added a test in `run-simulation-read-workflow.test.ts` proving non-playbook routes work with `deps` that omit `readPlaybook` entirely, locking in the dropped-parameter contract.

Behavior is byte-identical for all 8 routes: null was already the observed behavior for the 7 sites, and the playbook route still calls the real implementation.

## Test plan

- [x] `npx tsc --noEmit` clean (baseline and after)
- [x] `npm run lint` clean (baseline and after)
- [x] `npx vitest run --maxWorkers=1 tests/run-simulation-read-workflow.test.ts tests/http-api.test.ts`: baseline 71 passed / 2 pre-existing failures (`/api/knowledge/solve` job endpoints, unrelated to readPlaybook) → after: 72 passed (+1 new test) / same 2 pre-existing failures
- [x] Verified other failures seen in a broader server-test sweep (`server-protocol.test.ts` WS timeouts, `mission-dashboard.test.ts` checkpoint 500) are pre-existing on `origin/main` by stashing and re-running — unrelated to this change