### PR TITLE
AC-855: introduce branded id types (RunId, ScenarioName) with first-slice migration

### DIFF
--- a/ts/root-export-allowlist.json
+++ b/ts/root-export-allowlist.json
@@ -1,6 +1,7 @@
 {
   "modules": [
     "./types/index.js",
+    "./domain/ids.js",
     "./providers/index.js",
     "./judge/index.js",
     "./storage/index.js",

--- a/ts/src/cli/benchmark-command-workflow.ts
+++ b/ts/src/cli/benchmark-command-workflow.ts
@@ -1,3 +1,5 @@
+import { asRunId } from "../domain/ids.js";
+
 export const BENCHMARK_HELP_TEXT = `autoctx benchmark — Run benchmark (multiple runs, aggregate stats)
 
 Usage: autoctx benchmark [options]
@@ -105,7 +107,7 @@ export async function executeBenchmarkCommandWorkflow<
           runsRoot: opts.runsRoot,
           knowledgeRoot: opts.knowledgeRoot,
         });
-        const result = await runner.run(`bench_${now()}_${i}`, opts.plan.numGens);
+        const result = await runner.run(asRunId(`bench_${now()}_${i}`), opts.plan.numGens);
         scores.push(result.bestScore);
       } finally {
         store.close();

--- a/ts/src/cli/run-command-workflow.ts
+++ b/ts/src/cli/run-command-workflow.ts
@@ -1,3 +1,4 @@
+import { asRunId } from "../domain/ids.js";
 import type { HookBus } from "../extensions/index.js";
 
 export const RUN_HELP_TEXT = `autoctx run — Run the generation loop for a scenario
@@ -122,11 +123,13 @@ export interface AgentTaskRunStore {
   close(): void;
 }
 
-export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends {
-  defaultProvider: unknown;
-  defaultConfig: { providerType: string };
-  close?: () => void;
-}>(opts: {
+export async function executeAgentTaskRunCommandWorkflow<
+  TProviderBundle extends {
+    defaultProvider: unknown;
+    defaultConfig: { providerType: string };
+    close?: () => void;
+  },
+>(opts: {
   plan: RunCommandPlan;
   providerBundle: TProviderBundle;
   spec: Record<string, unknown>;
@@ -138,15 +141,20 @@ export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends
 }): Promise<RunCommandResult> {
   const provider = opts.providerBundle.defaultConfig.providerType;
   const migrationsDir = opts.migrationsDir;
-  const store = opts.createStore && opts.dbPath && opts.migrationsDir
-    ? opts.createStore(opts.dbPath)
-    : null;
+  const store =
+    opts.createStore && opts.dbPath && opts.migrationsDir ? opts.createStore(opts.dbPath) : null;
 
   try {
     if (store && migrationsDir) {
       store.migrate(migrationsDir);
     }
-    store?.createRun(opts.plan.runId, opts.plan.scenarioName, opts.plan.gens, "agent_task", provider);
+    store?.createRun(
+      opts.plan.runId,
+      opts.plan.scenarioName,
+      opts.plan.gens,
+      "agent_task",
+      provider,
+    );
 
     const result = await opts.executeAgentTaskSolve({
       provider: opts.providerBundle.defaultProvider,
@@ -246,12 +254,17 @@ export async function executeRunCommandWorkflow<
     close?: () => void;
   },
   TStore extends { migrate(path: string): void; close(): void },
-  TRunner extends { run(runId: string, gens: number): Promise<{
-    runId: string;
-    generationsCompleted: number;
-    bestScore: number;
-    currentElo: number;
-  }> },
+  TRunner extends {
+    run(
+      runId: string,
+      gens: number,
+    ): Promise<{
+      runId: string;
+      generationsCompleted: number;
+      bestScore: number;
+      currentElo: number;
+    }>;
+  },
   TScenario,
 >(opts: {
   dbPath: string;
@@ -264,43 +277,47 @@ export async function executeRunCommandWorkflow<
   ScenarioClass: new () => TScenario;
   assertFamilyContract: (scenario: TScenario, family: "game", label: string) => void;
   createStore: (dbPath: string) => TStore;
-  createRunner: (opts: {
-    provider: TProviderBundle["defaultProvider"];
-    roleProviders: TProviderBundle["roleProviders"];
-    roleModels: TProviderBundle["roleModels"];
-    scenario: TScenario;
-    store: TStore;
-    runsRoot: string;
-    knowledgeRoot: string;
-    matchesPerGeneration: number;
-    maxRetries: number;
-    minDelta: number;
-    playbookMaxVersions: number;
-    contextBudgetTokens: number;
-    curatorEnabled: boolean;
-    curatorConsolidateEveryNGens: number;
-    softHintsEnabled: boolean;
-    hintStyle: string;
-    skillMaxLessons: number;
-    deadEndTrackingEnabled: boolean;
-    deadEndMaxEntries: number;
-    stagnationResetEnabled: boolean;
-    stagnationRollbackThreshold: number;
-    stagnationPlateauWindow: number;
-    stagnationPlateauEpsilon: number;
-    stagnationDistillTopLessons: number;
-    explorationMode: unknown;
-    seedBase?: number;
-    experimentalAnnealingEnabled?: boolean;
-    experimentalLevyScoutEnabled?: boolean;
-    levyScoutAlpha?: number;
-    levyScoutScale?: number;
-    explorationCollapseGuard?: boolean;
-    explorationCollapseAutoMitigation?: boolean;
-    notifyWebhookUrl: unknown;
-    notifyOn: unknown;
-    runtimeSession?: TProviderBundle["runtimeSession"];
-  } | Record<string, unknown>) => TRunner;
+  createRunner: (
+    opts:
+      | {
+          provider: TProviderBundle["defaultProvider"];
+          roleProviders: TProviderBundle["roleProviders"];
+          roleModels: TProviderBundle["roleModels"];
+          scenario: TScenario;
+          store: TStore;
+          runsRoot: string;
+          knowledgeRoot: string;
+          matchesPerGeneration: number;
+          maxRetries: number;
+          minDelta: number;
+          playbookMaxVersions: number;
+          contextBudgetTokens: number;
+          curatorEnabled: boolean;
+          curatorConsolidateEveryNGens: number;
+          softHintsEnabled: boolean;
+          hintStyle: string;
+          skillMaxLessons: number;
+          deadEndTrackingEnabled: boolean;
+          deadEndMaxEntries: number;
+          stagnationResetEnabled: boolean;
+          stagnationRollbackThreshold: number;
+          stagnationPlateauWindow: number;
+          stagnationPlateauEpsilon: number;
+          stagnationDistillTopLessons: number;
+          explorationMode: unknown;
+          seedBase?: number;
+          experimentalAnnealingEnabled?: boolean;
+          experimentalLevyScoutEnabled?: boolean;
+          levyScoutAlpha?: number;
+          levyScoutScale?: number;
+          explorationCollapseGuard?: boolean;
+          explorationCollapseAutoMitigation?: boolean;
+          notifyWebhookUrl: unknown;
+          notifyOn: unknown;
+          runtimeSession?: TProviderBundle["runtimeSession"];
+        }
+      | Record<string, unknown>,
+  ) => TRunner;
 }): Promise<RunCommandResult> {
   const scenario = new opts.ScenarioClass();
   opts.assertFamilyContract(scenario, "game", `scenario '${opts.plan.scenarioName}'`);
@@ -345,7 +362,7 @@ export async function executeRunCommandWorkflow<
       notifyOn: opts.settings.notifyOn,
       runtimeSession: opts.providerBundle.runtimeSession,
     });
-    const result = await runner.run(opts.plan.runId, opts.plan.gens);
+    const result = await runner.run(asRunId(opts.plan.runId), opts.plan.gens);
     const provider = opts.providerBundle.defaultConfig.providerType;
     return {
       ...result,

--- a/ts/src/domain/ids.ts
+++ b/ts/src/domain/ids.ts
@@ -1,0 +1,75 @@
+/**
+ * Branded id types (AC-855).
+ *
+ * `runId: string` and `scenario: string` are structurally indistinguishable
+ * from every other string in the codebase, so nothing stops a scenario name
+ * from being passed where a run id is expected (or vice versa). Branding
+ * gives each identifier a distinct nominal type at compile time while
+ * remaining a plain `string` at runtime (zero behavior change, no
+ * serialization concerns).
+ *
+ * Discipline: convert at the boundary, carry the brand internally.
+ *   - HTTP route parsing, DB reads, and CLI arg parsing are boundaries —
+ *     call `asRunId` / `asScenarioName` / `asDbPath` once, immediately after
+ *     the raw string is obtained.
+ *   - Everything downstream that has been migrated to a branded parameter
+ *     type carries the brand; no further casts are needed because a branded
+ *     type is a structural subtype of `string` (it can be passed anywhere a
+ *     `string` is expected, including into modules that have not yet been
+ *     migrated).
+ *   - `unbrand` is an identity passthrough for the rare case where code
+ *     needs the underlying `string` type explicitly (e.g. a generic
+ *     `Record<string, unknown>` key). It performs no validation or
+ *     transformation — it exists purely to document the intent at the call
+ *     site instead of reaching for an `as string` cast.
+ */
+
+declare const brand: unique symbol;
+type Brand<T, B> = T & { readonly [brand]: B };
+
+export type RunId = Brand<string, "RunId">;
+export type ScenarioName = Brand<string, "ScenarioName">;
+export type DbPath = Brand<string, "DbPath">;
+
+/**
+ * Construct a `RunId` from a raw string. Throws if the value is empty or
+ * all-whitespace — a run id is always caller- or ULID-supplied and should
+ * never be blank.
+ */
+export function asRunId(value: string): RunId {
+  if (value.trim().length === 0) {
+    throw new Error("RunId must be a non-empty string");
+  }
+  return value as RunId;
+}
+
+/**
+ * Construct a `ScenarioName` from a raw string. Throws if the value is
+ * empty or all-whitespace.
+ */
+export function asScenarioName(value: string): ScenarioName {
+  if (value.trim().length === 0) {
+    throw new Error("ScenarioName must be a non-empty string");
+  }
+  return value as ScenarioName;
+}
+
+/**
+ * Construct a `DbPath` from a raw string. Throws if the value is empty or
+ * all-whitespace.
+ */
+export function asDbPath(value: string): DbPath {
+  if (value.trim().length === 0) {
+    throw new Error("DbPath must be a non-empty string");
+  }
+  return value as DbPath;
+}
+
+/**
+ * Identity passthrough that documents "I am deliberately dropping the
+ * brand here" at the call site, instead of an unexplained `as string`.
+ * Performs no runtime transformation.
+ */
+export function unbrand(value: RunId | ScenarioName | DbPath): string {
+  return value;
+}

--- a/ts/src/domain/ids.ts
+++ b/ts/src/domain/ids.ts
@@ -9,7 +9,7 @@
  * serialization concerns).
  *
  * Discipline: convert at the boundary, carry the brand internally.
- *   - HTTP route parsing, DB reads, and CLI arg parsing are boundaries —
+ *   - HTTP route parsing, DB reads, and CLI arg parsing are boundaries:
  *     call `asRunId` / `asScenarioName` / `asDbPath` once, immediately after
  *     the raw string is obtained.
  *   - Everything downstream that has been migrated to a branded parameter
@@ -20,8 +20,16 @@
  *   - `unbrand` is an identity passthrough for the rare case where code
  *     needs the underlying `string` type explicitly (e.g. a generic
  *     `Record<string, unknown>` key). It performs no validation or
- *     transformation — it exists purely to document the intent at the call
+ *     transformation, it exists purely to document the intent at the call
  *     site instead of reaching for an `as string` cast.
+ *
+ * Validation is deliberately byte-empty-only (`value.length === 0`), not
+ * whitespace-trimmed. Several downstream consumers (e.g. `cockpit-api.ts`'s
+ * `contextSelection`) trim internally and turn a whitespace-only id into a
+ * specific 404/422, and callers rely on that HTTP-layer behavior. A
+ * trim-based check here would throw before that code ever runs, replacing
+ * a handled 4xx with an unhandled 500. These constructors exist to add a
+ * type boundary, not to change what counts as a valid id.
  */
 
 declare const brand: unique symbol;
@@ -32,34 +40,36 @@ export type ScenarioName = Brand<string, "ScenarioName">;
 export type DbPath = Brand<string, "DbPath">;
 
 /**
- * Construct a `RunId` from a raw string. Throws if the value is empty or
- * all-whitespace — a run id is always caller- or ULID-supplied and should
- * never be blank.
+ * Construct a `RunId` from a raw string. Throws only if the value is
+ * byte-empty (see the module doc comment for why this doesn't also reject
+ * whitespace-only input).
  */
 export function asRunId(value: string): RunId {
-  if (value.trim().length === 0) {
+  if (value.length === 0) {
     throw new Error("RunId must be a non-empty string");
   }
   return value as RunId;
 }
 
 /**
- * Construct a `ScenarioName` from a raw string. Throws if the value is
- * empty or all-whitespace.
+ * Construct a `ScenarioName` from a raw string. Throws only if the value is
+ * byte-empty (see the module doc comment for why this doesn't also reject
+ * whitespace-only input).
  */
 export function asScenarioName(value: string): ScenarioName {
-  if (value.trim().length === 0) {
+  if (value.length === 0) {
     throw new Error("ScenarioName must be a non-empty string");
   }
   return value as ScenarioName;
 }
 
 /**
- * Construct a `DbPath` from a raw string. Throws if the value is empty or
- * all-whitespace.
+ * Construct a `DbPath` from a raw string. Throws only if the value is
+ * byte-empty (see the module doc comment for why this doesn't also reject
+ * whitespace-only input).
  */
 export function asDbPath(value: string): DbPath {
-  if (value.trim().length === 0) {
+  if (value.length === 0) {
     throw new Error("DbPath must be a non-empty string");
   }
   return value as DbPath;

--- a/ts/src/execution/sandbox.ts
+++ b/ts/src/execution/sandbox.ts
@@ -4,6 +4,7 @@
  */
 
 import { ArtifactStore } from "../knowledge/artifact-store.js";
+import { asRunId } from "../domain/ids.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
 import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
 import type { LLMProvider } from "../types/index.js";
@@ -76,7 +77,7 @@ export class SandboxManager {
     if (sandbox.status === "destroyed") throw new Error(`Sandbox ${sandboxId} is destroyed`);
 
     sandbox.status = "running";
-    const runId = `${sandboxId}_run_${Date.now()}`;
+    const runId = asRunId(`${sandboxId}_run_${Date.now()}`);
     sandbox.runId = runId;
 
     try {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./types/index.js";
+export * from "./domain/ids.js";
 export * from "./providers/index.js";
 export * from "./judge/index.js";
 export * from "./storage/index.js";

--- a/ts/src/knowledge/built-in-game-solve-execution.ts
+++ b/ts/src/knowledge/built-in-game-solve-execution.ts
@@ -2,6 +2,7 @@ import type { LLMProvider } from "../types/index.js";
 import type { SQLiteStore } from "../storage/index.js";
 import type { ScenarioInterface } from "../scenarios/game-interface.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
+import { asRunId } from "../domain/ids.js";
 import { ArtifactStore } from "./artifact-store.js";
 import { exportStrategyPackage } from "./package.js";
 
@@ -13,7 +14,9 @@ export interface BuiltInGameSolveExecutionResult {
 type ScenarioClass = new () => ScenarioInterface;
 
 export interface BuiltInGameSolveDeps {
-  resolveScenarioClass?: (scenarioName: string) => Promise<ScenarioClass | undefined> | ScenarioClass | undefined;
+  resolveScenarioClass?: (
+    scenarioName: string,
+  ) => Promise<ScenarioClass | undefined> | ScenarioClass | undefined;
   createRunner?: (opts: {
     provider: LLMProvider;
     scenario: ScenarioInterface;
@@ -32,7 +35,9 @@ export interface BuiltInGameSolveDeps {
   }) => Record<string, unknown>;
 }
 
-async function defaultResolveScenarioClass(scenarioName: string): Promise<ScenarioClass | undefined> {
+async function defaultResolveScenarioClass(
+  scenarioName: string,
+): Promise<ScenarioClass | undefined> {
   const { SCENARIO_REGISTRY } = await import("../scenarios/registry.js");
   return SCENARIO_REGISTRY[scenarioName] as ScenarioClass | undefined;
 }
@@ -47,7 +52,9 @@ async function defaultCreateRunner(opts: {
   maxRetries: number;
   minDelta: number;
   generationTimeBudgetSeconds?: number | null;
-}): Promise<{ run(runId: string, generations: number): Promise<{ generationsCompleted: number }> }> {
+}): Promise<{
+  run(runId: string, generations: number): Promise<{ generationsCompleted: number }>;
+}> {
   const { GenerationRunner } = await import("../loop/generation-runner.js");
   return new GenerationRunner(opts);
 }
@@ -63,7 +70,9 @@ export async function executeBuiltInGameSolve(opts: {
   generationTimeBudgetSeconds?: number | null;
   deps?: BuiltInGameSolveDeps;
 }): Promise<BuiltInGameSolveExecutionResult> {
-  const ScenarioClass = await (opts.deps?.resolveScenarioClass ?? defaultResolveScenarioClass)(opts.scenarioName);
+  const ScenarioClass = await (opts.deps?.resolveScenarioClass ?? defaultResolveScenarioClass)(
+    opts.scenarioName,
+  );
   if (!ScenarioClass) {
     throw new Error(`Game scenario '${opts.scenarioName}' not found in SCENARIO_REGISTRY`);
   }
@@ -82,7 +91,7 @@ export async function executeBuiltInGameSolve(opts: {
     generationTimeBudgetSeconds: opts.generationTimeBudgetSeconds,
   });
 
-  const runId = `solve_${opts.scenarioName}_${opts.jobId}`;
+  const runId = asRunId(`solve_${opts.scenarioName}_${opts.jobId}`);
   const runResult = await runner.run(runId, opts.generations);
   const artifacts = new ArtifactStore({
     runsRoot: opts.runsRoot,

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -11,6 +11,7 @@
  */
 
 import type { CompletionResult, LLMProvider } from "../types/index.js";
+import type { RunId } from "../domain/ids.js";
 import type { ScenarioInterface } from "../scenarios/game-interface.js";
 import type { SQLiteStore } from "../storage/index.js";
 import { TournamentRunner } from "../execution/tournament.js";
@@ -133,7 +134,7 @@ export interface GenerationRunnerOpts {
 }
 
 export interface RunResult {
-  runId: string;
+  runId: RunId;
   generationsCompleted: number;
   bestScore: number;
   currentElo: number;
@@ -254,7 +255,7 @@ export class GenerationRunner {
     this.#runtimeSession = opts.runtimeSession;
   }
 
-  async run(runId: string, generations: number): Promise<RunResult> {
+  async run(runId: RunId, generations: number): Promise<RunResult> {
     this.emitHook(HookEvents.RUN_START, {
       run_id: runId,
       scenario: this.#scenario.name,
@@ -284,7 +285,7 @@ export class GenerationRunner {
   }
 
   private async runGeneration(
-    runId: string,
+    runId: RunId,
     orchestration: GenerationLoopOrchestration,
   ): Promise<GenerationLoopOrchestration> {
     await this.#controller?.waitIfPaused();
@@ -357,7 +358,7 @@ export class GenerationRunner {
 
   private async runGenerationAttempt(
     attemptOrchestration: GenerationAttemptOrchestration,
-    runId: string,
+    runId: RunId,
     generation: number,
   ): Promise<{
     attemptOrchestration: GenerationAttemptOrchestration;
@@ -411,7 +412,7 @@ export class GenerationRunner {
   }
 
   private async finalizeSuccessfulRun(
-    runId: string,
+    runId: RunId,
     orchestration: GenerationLoopOrchestration,
   ): Promise<RunResult> {
     this.#store.updateRunStatus(runId, "completed");
@@ -450,7 +451,7 @@ export class GenerationRunner {
   }
 
   private async handleRunFailure(
-    runId: string,
+    runId: RunId,
     orchestration: GenerationLoopOrchestration,
     error: unknown,
   ): Promise<never> {
@@ -477,7 +478,7 @@ export class GenerationRunner {
     throw error;
   }
 
-  private buildCompetitorPrompt(runId: string, generation: number): string {
+  private buildCompetitorPrompt(runId: RunId, generation: number): string {
     const consumedHint = consumeFreshStartHint(this.#runState!);
     this.#runState = consumedHint.state;
     const freshStartHint = consumedHint.hint;
@@ -519,7 +520,7 @@ export class GenerationRunner {
   }
 
   private applyContextComponentsHook(
-    runId: string,
+    runId: RunId,
     generation: number,
     role: string,
     components: Record<string, string>,
@@ -535,7 +536,7 @@ export class GenerationRunner {
   }
 
   private compactPromptComponentsForRun(
-    runId: string,
+    runId: RunId,
     generation: number,
     components: Record<string, string>,
   ): Record<string, string> {
@@ -581,7 +582,7 @@ export class GenerationRunner {
 
   private buildSupportPrompt(
     role: "analyst" | "coach",
-    runId: string,
+    runId: RunId,
     generation: number,
     attempt: GenerationAttempt,
   ): string {
@@ -612,7 +613,7 @@ export class GenerationRunner {
   }
 
   private buildCuratorPrompt(
-    runId: string,
+    runId: RunId,
     currentPlaybook: string,
     proposedPlaybook: string,
     attempt: GenerationAttempt,
@@ -659,7 +660,7 @@ export class GenerationRunner {
   }
 
   private async runSupportRoles(
-    runId: string,
+    runId: RunId,
     gen: number,
     attempt: GenerationAttempt,
   ): Promise<void> {
@@ -763,7 +764,7 @@ export class GenerationRunner {
     }
   }
 
-  private async runCuratorConsolidation(runId: string, gen: number): Promise<void> {
+  private async runCuratorConsolidation(runId: RunId, gen: number): Promise<void> {
     if (this.#requirePlaybookApproval) return;
     const playbook = this.#artifactStore.readPlaybook(this.#scenario.name);
     if (!playbook || playbook === EMPTY_PLAYBOOK_SENTINEL) return;
@@ -803,7 +804,7 @@ export class GenerationRunner {
   }
 
   private async applyAdvancedFeatures(
-    runId: string,
+    runId: RunId,
     gen: number,
     attempt: GenerationAttempt,
     previousBestForGeneration: number,
@@ -842,7 +843,7 @@ export class GenerationRunner {
     this.persistExplorationCollapseGuard(runId, gen);
   }
 
-  private persistExplorationCollapseGuard(runId: string, gen: number): void {
+  private persistExplorationCollapseGuard(runId: RunId, gen: number): void {
     if (!this.#explorationCollapseGuard) return;
     const playbook = this.#artifactStore.readPlaybook(this.#scenario.name).trim();
     if (!playbook || playbook === EMPTY_PLAYBOOK_SENTINEL) return;
@@ -874,7 +875,7 @@ export class GenerationRunner {
 
   private async notify(
     type: EventType,
-    runId: string,
+    runId: RunId,
     score: number,
     extras: {
       previousBest?: number;
@@ -901,7 +902,7 @@ export class GenerationRunner {
   }
 
   private applyContextHook(
-    runId: string,
+    runId: RunId,
     generation: number,
     roles: Record<string, string>,
   ): Record<string, string> {
@@ -928,7 +929,7 @@ export class GenerationRunner {
   }
 
   private emitRoleCompleted(
-    runId: string,
+    runId: RunId,
     generation: number,
     role: "competitor" | "analyst" | "coach" | "curator",
     startedAt: number,

--- a/ts/src/mcp/run-management-tools.ts
+++ b/ts/src/mcp/run-management-tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { LLMProvider } from "../types/index.js";
+import { asRunId } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { GenerationRunner } from "../loop/generation-runner.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
@@ -232,7 +233,7 @@ export function registerRunManagementTools(
         return jsonText(buildRunScenarioUnknownPayload(args.scenario));
       }
 
-      const runId = args.runId ?? internals.createRunId();
+      const runId = asRunId(args.runId ?? internals.createRunId());
       const scenario = new ScenarioClass();
       internals.assertFamilyContract(scenario, "game", `scenario '${args.scenario}'`);
       const runner = internals.createRunner({

--- a/ts/src/server/routes/cockpit-routes.ts
+++ b/ts/src/server/routes/cockpit-routes.ts
@@ -6,6 +6,7 @@ import type { BackgroundSessionApiRoutes } from "../background-session-api.js";
 import type { CockpitApiRoutes } from "../cockpit-api.js";
 import type { RuntimeSessionApiRoutes } from "../runtime-session-api.js";
 import type { TraceGateReviewApiRoutes } from "../trace-gate-review-api.js";
+import { asRunId } from "../../domain/ids.js";
 import type { HttpRouteContext } from "./http-route-context.js";
 
 export async function tryCockpitRoutes(
@@ -124,7 +125,7 @@ export async function tryCockpitRoutes(
   );
   if (ctx.method === "GET" && cockpitRunRuntimeSessionTimelineMatch) {
     const [, rawRunId] = cockpitRunRuntimeSessionTimelineMatch;
-    const response = runtimeSessionApi.getTimelineByRunId(decodeURIComponent(rawRunId!));
+    const response = runtimeSessionApi.getTimelineByRunId(asRunId(decodeURIComponent(rawRunId!)));
     ctx.json(response.status, response.body);
     return true;
   }
@@ -134,7 +135,7 @@ export async function tryCockpitRoutes(
   );
   if (ctx.method === "GET" && cockpitRunRuntimeSessionMatch) {
     const [, rawRunId] = cockpitRunRuntimeSessionMatch;
-    const response = runtimeSessionApi.getByRunId(decodeURIComponent(rawRunId!));
+    const response = runtimeSessionApi.getByRunId(asRunId(decodeURIComponent(rawRunId!)));
     ctx.json(response.status, response.body);
     return true;
   }
@@ -142,7 +143,7 @@ export async function tryCockpitRoutes(
   const cockpitTraceGateReviewMatch = ctx.url.match(/^\/api\/cockpit\/runs\/([^/]+)\/trace-gates$/);
   if (ctx.method === "GET" && cockpitTraceGateReviewMatch) {
     const [, rawRunId] = cockpitTraceGateReviewMatch;
-    const response = traceGateReviewApi.getByRunId(decodeURIComponent(rawRunId!));
+    const response = traceGateReviewApi.getByRunId(asRunId(decodeURIComponent(rawRunId!)));
     ctx.json(response.status, response.body);
     return true;
   }
@@ -152,7 +153,7 @@ export async function tryCockpitRoutes(
   );
   if (ctx.method === "GET" && cockpitContextSelectionMatch) {
     const [, rawRunId] = cockpitContextSelectionMatch;
-    const response = cockpitApi.contextSelection(decodeURIComponent(rawRunId!));
+    const response = cockpitApi.contextSelection(asRunId(decodeURIComponent(rawRunId!)));
     ctx.json(response.status, response.body);
     return true;
   }
@@ -163,7 +164,7 @@ export async function tryCockpitRoutes(
   if (ctx.method === "GET" && cockpitCompareMatch) {
     const [, rawRunId, rawGenA, rawGenB] = cockpitCompareMatch;
     const response = cockpitApi.compareGenerations(
-      decodeURIComponent(rawRunId!),
+      asRunId(decodeURIComponent(rawRunId!)),
       Number.parseInt(rawGenA!, 10),
       Number.parseInt(rawGenB!, 10),
     );
@@ -176,7 +177,7 @@ export async function tryCockpitRoutes(
   );
   if (ctx.method === "GET" && cockpitRunResourceMatch) {
     const [, rawRunId, resource] = cockpitRunResourceMatch;
-    const runId = decodeURIComponent(rawRunId!);
+    const runId = asRunId(decodeURIComponent(rawRunId!));
     const response =
       resource === "status"
         ? cockpitApi.runStatus(runId)
@@ -193,7 +194,7 @@ export async function tryCockpitRoutes(
   if (ctx.method === "POST" && cockpitConsultMatch) {
     const [, rawRunId] = cockpitConsultMatch;
     const response = await cockpitApi.requestConsultation(
-      decodeURIComponent(rawRunId!),
+      asRunId(decodeURIComponent(rawRunId!)),
       await ctx.readJsonBody(),
     );
     ctx.json(response.status, response.body);
@@ -203,7 +204,7 @@ export async function tryCockpitRoutes(
   const cockpitWriteupMatch = ctx.url.match(/^\/api\/cockpit\/writeup\/([^/]+)$/);
   if (ctx.method === "GET" && cockpitWriteupMatch) {
     const [, rawRunId] = cockpitWriteupMatch;
-    const response = cockpitApi.writeup(decodeURIComponent(rawRunId!));
+    const response = cockpitApi.writeup(asRunId(decodeURIComponent(rawRunId!)));
     ctx.json(response.status, response.body);
     return true;
   }

--- a/ts/src/server/routes/knowledge-routes.ts
+++ b/ts/src/server/routes/knowledge-routes.ts
@@ -4,6 +4,7 @@
  */
 
 import type { KnowledgeApiRoutes } from "../knowledge-api.js";
+import { asScenarioName } from "../../domain/ids.js";
 import type { HttpRouteContext } from "./http-route-context.js";
 
 export async function tryKnowledgeRoutes(
@@ -21,7 +22,7 @@ export async function tryKnowledgeRoutes(
   const knowledgeExportMatch = ctx.url.match(/^\/api\/knowledge\/export\/([^/]+)$/);
   if (ctx.method === "GET" && knowledgeExportMatch) {
     const [, rawScenario] = knowledgeExportMatch;
-    const response = knowledgeApi.exportScenario(decodeURIComponent(rawScenario!));
+    const response = knowledgeApi.exportScenario(asScenarioName(decodeURIComponent(rawScenario!)));
     ctx.json(response.status, response.body);
     return true;
   }
@@ -51,21 +52,25 @@ export async function tryKnowledgeRoutes(
   const pendingPlaybookMatch = ctx.url.match(/^\/api\/knowledge\/([^/]+)\/playbook\/pending$/);
   if (ctx.method === "GET" && pendingPlaybookMatch) {
     const [, rawScenario] = pendingPlaybookMatch;
-    const response = knowledgeApi.pendingPlaybook(decodeURIComponent(rawScenario!));
+    const response = knowledgeApi.pendingPlaybook(asScenarioName(decodeURIComponent(rawScenario!)));
     ctx.json(response.status, response.body);
     return true;
   }
   const approvePlaybookMatch = ctx.url.match(/^\/api\/knowledge\/([^/]+)\/playbook\/approve$/);
   if (ctx.method === "POST" && approvePlaybookMatch) {
     const [, rawScenario] = approvePlaybookMatch;
-    const response = knowledgeApi.approvePendingPlaybook(decodeURIComponent(rawScenario!));
+    const response = knowledgeApi.approvePendingPlaybook(
+      asScenarioName(decodeURIComponent(rawScenario!)),
+    );
     ctx.json(response.status, response.body);
     return true;
   }
   const rejectPlaybookMatch = ctx.url.match(/^\/api\/knowledge\/([^/]+)\/playbook\/reject$/);
   if (ctx.method === "POST" && rejectPlaybookMatch) {
     const [, rawScenario] = rejectPlaybookMatch;
-    const response = knowledgeApi.rejectPendingPlaybook(decodeURIComponent(rawScenario!));
+    const response = knowledgeApi.rejectPendingPlaybook(
+      asScenarioName(decodeURIComponent(rawScenario!)),
+    );
     ctx.json(response.status, response.body);
     return true;
   }
@@ -74,7 +79,7 @@ export async function tryKnowledgeRoutes(
   const lessonLifecycleMatch = ctx.url.match(/^\/api\/knowledge\/([^/]+)\/lifecycle$/);
   if (ctx.method === "GET" && lessonLifecycleMatch) {
     const [, rawScenario] = lessonLifecycleMatch;
-    const response = knowledgeApi.lessonLifecycle(decodeURIComponent(rawScenario!));
+    const response = knowledgeApi.lessonLifecycle(asScenarioName(decodeURIComponent(rawScenario!)));
     ctx.json(response.status, response.body);
     return true;
   }
@@ -85,7 +90,7 @@ export async function tryKnowledgeRoutes(
   );
   if (ctx.method === "POST" && lessonActionMatch) {
     const [, rawScenario, rawLessonId, action] = lessonActionMatch;
-    const scenario = decodeURIComponent(rawScenario!);
+    const scenario = asScenarioName(decodeURIComponent(rawScenario!));
     const lessonId = decodeURIComponent(rawLessonId!);
     const response =
       action === "approve"

--- a/ts/src/server/routes/openclaw-routes.ts
+++ b/ts/src/server/routes/openclaw-routes.ts
@@ -3,6 +3,7 @@
  */
 
 import type { OpenClawApiRoutes } from "../openclaw-api.js";
+import { asScenarioName } from "../../domain/ids.js";
 import type { HttpRouteContext } from "./http-route-context.js";
 
 export async function tryOpenClawRoutes(
@@ -104,7 +105,9 @@ export async function tryOpenClawRoutes(
   );
   if (ctx.method === "GET" && openClawScenarioArtifactsMatch) {
     const [, rawScenarioName] = openClawScenarioArtifactsMatch;
-    const response = openClawApi.discoveryScenarioArtifacts(decodeURIComponent(rawScenarioName!));
+    const response = openClawApi.discoveryScenarioArtifacts(
+      asScenarioName(decodeURIComponent(rawScenarioName!)),
+    );
     ctx.json(response.status, response.body);
     return true;
   }
@@ -113,7 +116,9 @@ export async function tryOpenClawRoutes(
   const openClawScenarioMatch = ctx.url.match(/^\/api\/openclaw\/discovery\/scenario\/([^/]+)$/);
   if (ctx.method === "GET" && openClawScenarioMatch) {
     const [, rawScenarioName] = openClawScenarioMatch;
-    const response = openClawApi.discoveryScenario(decodeURIComponent(rawScenarioName!));
+    const response = openClawApi.discoveryScenario(
+      asScenarioName(decodeURIComponent(rawScenarioName!)),
+    );
     ctx.json(response.status, response.body);
     return true;
   }

--- a/ts/src/server/routes/run-list-routes.ts
+++ b/ts/src/server/routes/run-list-routes.ts
@@ -13,6 +13,7 @@ import {
   type RunSimulationReadDeps,
   type RunSimulationReadRunManager,
 } from "../run-simulation-read-workflow.js";
+import { asRunId, asScenarioName } from "../../domain/ids.js";
 import type { HttpRouteContext } from "./http-route-context.js";
 
 export async function tryRunListRoutes(
@@ -41,10 +42,11 @@ export async function tryRunListRoutes(
   // GET /api/runs/:id/replay/:gen
   const replayMatch = ctx.url.match(/^\/api\/runs\/([^/]+)\/replay\/(\d+)$/);
   if (replayMatch) {
-    const [, runId, genStr] = replayMatch;
+    const [, rawRunId, genStr] = replayMatch;
+    const runId = asRunId(rawRunId!);
     const response = executeRunSimulationReadRequest({
       route: "run_replay",
-      runId: runId!,
+      runId,
       generation: parseInt(genStr!, 10),
       runManager,
       simulationApi,
@@ -57,10 +59,11 @@ export async function tryRunListRoutes(
   // GET /api/runs/:id/status
   const statusMatch = ctx.url.match(/^\/api\/runs\/([^/]+)\/status$/);
   if (statusMatch) {
-    const [, runId] = statusMatch;
+    const [, rawRunId] = statusMatch;
+    const runId = asRunId(rawRunId!);
     const response = executeRunSimulationReadRequest({
       route: "run_status",
-      runId: runId!,
+      runId,
       runManager,
       simulationApi,
       deps: runSimDeps,
@@ -72,10 +75,11 @@ export async function tryRunListRoutes(
   // GET /api/knowledge/playbook/:scenario
   const playbookMatch = ctx.url.match(/^\/api\/knowledge\/playbook\/([^/]+)$/);
   if (playbookMatch) {
-    const [, scenario] = playbookMatch;
+    const [, rawScenario] = playbookMatch;
+    const scenario = asScenarioName(rawScenario!);
     const response = executeRunSimulationReadRequest({
       route: "playbook",
-      scenario: scenario!,
+      scenario,
       runManager,
       simulationApi,
       deps: playbookDeps,

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 
 import type { AppSettings } from "../config/index.js";
+import { asRunId } from "../domain/ids.js";
 import type { LoopController } from "../loop/controller.js";
 import type { EventStreamEmitter } from "../loop/events.js";
 import { GenerationRunner } from "../loop/generation-runner.js";
@@ -18,16 +19,16 @@ import { SQLiteStore } from "../storage/index.js";
 export type RunStartPlan =
   | { kind: "builtin_game"; scenarioName: string }
   | {
-    kind: "agent_task_custom";
-    scenarioName: string;
-    entry: CustomScenarioEntry;
-  }
+      kind: "agent_task_custom";
+      scenarioName: string;
+      entry: CustomScenarioEntry;
+    }
   | {
-    kind: "generated_custom";
-    scenarioName: string;
-    entry: CustomScenarioEntry;
-    family: ScenarioFamilyName;
-  };
+      kind: "generated_custom";
+      scenarioName: string;
+      entry: CustomScenarioEntry;
+      family: ScenarioFamilyName;
+    };
 
 export function resolveRunStartPlan(opts: {
   scenario: string;
@@ -42,7 +43,9 @@ export function resolveRunStartPlan(opts: {
   const customScenario = opts.customScenario;
   const family = opts.customScenarioFamily ?? null;
   if (!customScenario) {
-    throw new Error(`Unknown scenario: ${opts.scenario}. Available: ${opts.builtinScenarioNames.join(", ")}`);
+    throw new Error(
+      `Unknown scenario: ${opts.scenario}. Available: ${opts.builtinScenarioNames.join(", ")}`,
+    );
   }
   if (family === "agent_task" || customScenario.type === "agent_task") {
     return {
@@ -55,7 +58,7 @@ export function resolveRunStartPlan(opts: {
   if (!customScenario.hasGeneratedSource || !family) {
     throw new Error(
       `Scenario '${opts.scenario}' is a saved custom ${customScenario.type ?? "unknown"} scenario. ` +
-      "It is discoverable in the TS control plane, but /run currently supports only built-in game, saved agent-task, and generated custom scenarios.",
+        "It is discoverable in the TS control plane, but /run currently supports only built-in game, saved agent-task, and generated custom scenarios.",
     );
   }
 
@@ -73,8 +76,8 @@ export function resolveBuiltInGameScenario(opts: {
   scenarioName: string;
   resolveScenarioClass?: (scenarioName: string) => ScenarioClass | undefined;
 }): ScenarioInterface {
-  const ScenarioClass = opts.resolveScenarioClass?.(opts.scenarioName)
-    ?? SCENARIO_REGISTRY[opts.scenarioName];
+  const ScenarioClass =
+    opts.resolveScenarioClass?.(opts.scenarioName) ?? SCENARIO_REGISTRY[opts.scenarioName];
   if (!ScenarioClass) {
     throw new Error(`Unknown scenario: ${opts.scenarioName}`);
   }
@@ -117,10 +120,12 @@ export async function executeBuiltInGameStartRun(opts: {
   scenario?: ScenarioInterface;
   deps?: BuiltInGameStartRunDeps;
 }): Promise<void> {
-  const scenarioInstance = opts.scenario ?? resolveBuiltInGameScenario({
-    scenarioName: opts.scenarioName,
-    resolveScenarioClass: opts.deps?.resolveScenarioClass,
-  });
+  const scenarioInstance =
+    opts.scenario ??
+    resolveBuiltInGameScenario({
+      scenarioName: opts.scenarioName,
+      resolveScenarioClass: opts.deps?.resolveScenarioClass,
+    });
 
   const store = opts.deps?.createStore?.(opts.opts.dbPath) ?? new SQLiteStore(opts.opts.dbPath);
   store.migrate(opts.opts.migrationsDir);
@@ -130,81 +135,83 @@ export async function executeBuiltInGameStartRun(opts: {
   });
 
   try {
-    const runner = opts.deps?.createRunner?.({
-      provider: opts.providerBundle.defaultProvider,
-      roleProviders: opts.providerBundle.roleProviders,
-      roleModels: opts.providerBundle.roleModels,
-      scenario: scenarioInstance,
-      store: store as SQLiteStore,
-      runsRoot: opts.opts.runsRoot,
-      knowledgeRoot: opts.opts.knowledgeRoot,
-      matchesPerGeneration: opts.settings.matchesPerGeneration,
-      maxRetries: opts.settings.maxRetries,
-      minDelta: opts.settings.backpressureMinDelta,
-      playbookMaxVersions: opts.settings.playbookMaxVersions,
-      requirePlaybookApproval: opts.requirePlaybookApproval ?? false,
-      contextBudgetTokens: opts.settings.contextBudgetTokens,
-      curatorEnabled: opts.settings.curatorEnabled,
-      curatorConsolidateEveryNGens: opts.settings.curatorConsolidateEveryNGens,
-      softHintsEnabled: opts.settings.softHintsEnabled,
-      hintStyle: opts.settings.hintStyle,
-      skillMaxLessons: opts.settings.skillMaxLessons,
-      deadEndTrackingEnabled: opts.settings.deadEndTrackingEnabled,
-      deadEndMaxEntries: opts.settings.deadEndMaxEntries,
-      stagnationResetEnabled: opts.settings.stagnationResetEnabled,
-      stagnationRollbackThreshold: opts.settings.stagnationRollbackThreshold,
-      stagnationPlateauWindow: opts.settings.stagnationPlateauWindow,
-      stagnationPlateauEpsilon: opts.settings.stagnationPlateauEpsilon,
-      stagnationDistillTopLessons: opts.settings.stagnationDistillTopLessons,
-      explorationMode: opts.settings.explorationMode,
-      explorationCollapseGuard: opts.settings.explorationCollapseGuard,
-      explorationCollapseAutoMitigation: opts.settings.explorationCollapseAutoMitigation,
-      notifyWebhookUrl: opts.settings.notifyWebhookUrl,
-      notifyOn: opts.settings.notifyOn,
-      controller: opts.controller,
-      events: opts.events,
-      hookBus,
-      loadedExtensions,
-      runtimeSession: opts.providerBundle.runtimeSession,
-    }) ?? new GenerationRunner({
-      provider: opts.providerBundle.defaultProvider,
-      roleProviders: opts.providerBundle.roleProviders,
-      roleModels: opts.providerBundle.roleModels,
-      scenario: scenarioInstance,
-      store: store as SQLiteStore,
-      runsRoot: opts.opts.runsRoot,
-      knowledgeRoot: opts.opts.knowledgeRoot,
-      matchesPerGeneration: opts.settings.matchesPerGeneration,
-      maxRetries: opts.settings.maxRetries,
-      minDelta: opts.settings.backpressureMinDelta,
-      playbookMaxVersions: opts.settings.playbookMaxVersions,
-      requirePlaybookApproval: opts.requirePlaybookApproval ?? false,
-      contextBudgetTokens: opts.settings.contextBudgetTokens,
-      curatorEnabled: opts.settings.curatorEnabled,
-      curatorConsolidateEveryNGens: opts.settings.curatorConsolidateEveryNGens,
-      softHintsEnabled: opts.settings.softHintsEnabled,
-      hintStyle: opts.settings.hintStyle,
-      skillMaxLessons: opts.settings.skillMaxLessons,
-      deadEndTrackingEnabled: opts.settings.deadEndTrackingEnabled,
-      deadEndMaxEntries: opts.settings.deadEndMaxEntries,
-      stagnationResetEnabled: opts.settings.stagnationResetEnabled,
-      stagnationRollbackThreshold: opts.settings.stagnationRollbackThreshold,
-      stagnationPlateauWindow: opts.settings.stagnationPlateauWindow,
-      stagnationPlateauEpsilon: opts.settings.stagnationPlateauEpsilon,
-      stagnationDistillTopLessons: opts.settings.stagnationDistillTopLessons,
-      explorationMode: opts.settings.explorationMode,
-      explorationCollapseGuard: opts.settings.explorationCollapseGuard,
-      explorationCollapseAutoMitigation: opts.settings.explorationCollapseAutoMitigation,
-      notifyWebhookUrl: opts.settings.notifyWebhookUrl,
-      notifyOn: opts.settings.notifyOn,
-      controller: opts.controller,
-      events: opts.events,
-      hookBus,
-      loadedExtensions,
-      runtimeSession: opts.providerBundle.runtimeSession,
-    });
+    const runner =
+      opts.deps?.createRunner?.({
+        provider: opts.providerBundle.defaultProvider,
+        roleProviders: opts.providerBundle.roleProviders,
+        roleModels: opts.providerBundle.roleModels,
+        scenario: scenarioInstance,
+        store: store as SQLiteStore,
+        runsRoot: opts.opts.runsRoot,
+        knowledgeRoot: opts.opts.knowledgeRoot,
+        matchesPerGeneration: opts.settings.matchesPerGeneration,
+        maxRetries: opts.settings.maxRetries,
+        minDelta: opts.settings.backpressureMinDelta,
+        playbookMaxVersions: opts.settings.playbookMaxVersions,
+        requirePlaybookApproval: opts.requirePlaybookApproval ?? false,
+        contextBudgetTokens: opts.settings.contextBudgetTokens,
+        curatorEnabled: opts.settings.curatorEnabled,
+        curatorConsolidateEveryNGens: opts.settings.curatorConsolidateEveryNGens,
+        softHintsEnabled: opts.settings.softHintsEnabled,
+        hintStyle: opts.settings.hintStyle,
+        skillMaxLessons: opts.settings.skillMaxLessons,
+        deadEndTrackingEnabled: opts.settings.deadEndTrackingEnabled,
+        deadEndMaxEntries: opts.settings.deadEndMaxEntries,
+        stagnationResetEnabled: opts.settings.stagnationResetEnabled,
+        stagnationRollbackThreshold: opts.settings.stagnationRollbackThreshold,
+        stagnationPlateauWindow: opts.settings.stagnationPlateauWindow,
+        stagnationPlateauEpsilon: opts.settings.stagnationPlateauEpsilon,
+        stagnationDistillTopLessons: opts.settings.stagnationDistillTopLessons,
+        explorationMode: opts.settings.explorationMode,
+        explorationCollapseGuard: opts.settings.explorationCollapseGuard,
+        explorationCollapseAutoMitigation: opts.settings.explorationCollapseAutoMitigation,
+        notifyWebhookUrl: opts.settings.notifyWebhookUrl,
+        notifyOn: opts.settings.notifyOn,
+        controller: opts.controller,
+        events: opts.events,
+        hookBus,
+        loadedExtensions,
+        runtimeSession: opts.providerBundle.runtimeSession,
+      }) ??
+      new GenerationRunner({
+        provider: opts.providerBundle.defaultProvider,
+        roleProviders: opts.providerBundle.roleProviders,
+        roleModels: opts.providerBundle.roleModels,
+        scenario: scenarioInstance,
+        store: store as SQLiteStore,
+        runsRoot: opts.opts.runsRoot,
+        knowledgeRoot: opts.opts.knowledgeRoot,
+        matchesPerGeneration: opts.settings.matchesPerGeneration,
+        maxRetries: opts.settings.maxRetries,
+        minDelta: opts.settings.backpressureMinDelta,
+        playbookMaxVersions: opts.settings.playbookMaxVersions,
+        requirePlaybookApproval: opts.requirePlaybookApproval ?? false,
+        contextBudgetTokens: opts.settings.contextBudgetTokens,
+        curatorEnabled: opts.settings.curatorEnabled,
+        curatorConsolidateEveryNGens: opts.settings.curatorConsolidateEveryNGens,
+        softHintsEnabled: opts.settings.softHintsEnabled,
+        hintStyle: opts.settings.hintStyle,
+        skillMaxLessons: opts.settings.skillMaxLessons,
+        deadEndTrackingEnabled: opts.settings.deadEndTrackingEnabled,
+        deadEndMaxEntries: opts.settings.deadEndMaxEntries,
+        stagnationResetEnabled: opts.settings.stagnationResetEnabled,
+        stagnationRollbackThreshold: opts.settings.stagnationRollbackThreshold,
+        stagnationPlateauWindow: opts.settings.stagnationPlateauWindow,
+        stagnationPlateauEpsilon: opts.settings.stagnationPlateauEpsilon,
+        stagnationDistillTopLessons: opts.settings.stagnationDistillTopLessons,
+        explorationMode: opts.settings.explorationMode,
+        explorationCollapseGuard: opts.settings.explorationCollapseGuard,
+        explorationCollapseAutoMitigation: opts.settings.explorationCollapseAutoMitigation,
+        notifyWebhookUrl: opts.settings.notifyWebhookUrl,
+        notifyOn: opts.settings.notifyOn,
+        controller: opts.controller,
+        events: opts.events,
+        hookBus,
+        loadedExtensions,
+        runtimeSession: opts.providerBundle.runtimeSession,
+      });
 
-    await runner.run(opts.runId, opts.generations);
+    await runner.run(asRunId(opts.runId), opts.generations);
   } finally {
     store.close();
     opts.providerBundle.close?.();
@@ -238,9 +245,9 @@ export async function executeAgentTaskCustomStartRun(opts: {
   const executeTask = opts.deps?.executeAgentTaskSolve ?? executeAgentTaskSolve;
   const { hookBus, loadedExtensions } = opts.settings
     ? await initializeHookBus({
-      extensions: opts.settings.extensions,
-      failFast: opts.settings.extensionFailFast,
-    })
+        extensions: opts.settings.extensions,
+        failFast: opts.settings.extensionFailFast,
+      })
     : { hookBus: null, loadedExtensions: [] };
 
   emitHook(hookBus, HookEvents.RUN_START, {

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -22,7 +22,10 @@ async function fetchJson(url: string): Promise<{ status: number; body: unknown }
   return { status: res.status, body };
 }
 
-async function postJson(url: string, body: Record<string, unknown>): Promise<{ status: number; body: unknown }> {
+async function postJson(
+  url: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; body: unknown }> {
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -42,7 +45,10 @@ function readStringProperty(value: unknown, key: string): string {
   return descriptor.value;
 }
 
-async function putJson(url: string, body: Record<string, unknown>): Promise<{ status: number; body: unknown }> {
+async function putJson(
+  url: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; body: unknown }> {
   const res = await fetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -51,7 +57,10 @@ async function putJson(url: string, body: Record<string, unknown>): Promise<{ st
   return { status: res.status, body: await res.json() };
 }
 
-async function patchJson(url: string, body: Record<string, unknown>): Promise<{ status: number; body: unknown }> {
+async function patchJson(
+  url: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; body: unknown }> {
   const res = await fetch(url, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
@@ -77,7 +86,7 @@ async function createTestServer(dir: string) {
   store.createRun("test-run-1", "grid_ctf", 3, "local");
   store.upsertGeneration("test-run-1", 1, {
     meanScore: 0.65,
-    bestScore: 0.70,
+    bestScore: 0.7,
     elo: 1050,
     wins: 3,
     losses: 2,
@@ -86,7 +95,7 @@ async function createTestServer(dir: string) {
   });
   store.recordMatch("test-run-1", 1, {
     seed: 42,
-    score: 0.70,
+    score: 0.7,
     passedValidation: true,
     validationErrors: "",
     winner: "challenger",
@@ -98,13 +107,17 @@ async function createTestServer(dir: string) {
   mkdirSync(replayDir, { recursive: true });
   writeFileSync(
     join(replayDir, "grid_ctf_1.json"),
-    JSON.stringify({
-      scenario: "grid_ctf",
-      seed: 42,
-      narrative: "Blue team secured the center route.",
-      timeline: [{ turn: 1, action: "advance" }],
-      matches: [{ seed: 42, score: 0.7, winner: "challenger" }],
-    }, null, 2),
+    JSON.stringify(
+      {
+        scenario: "grid_ctf",
+        seed: 42,
+        narrative: "Blue team secured the center route.",
+        timeline: [{ turn: 1, action: "advance" }],
+        matches: [{ seed: 42, score: 0.7, winner: "challenger" }],
+      },
+      null,
+      2,
+    ),
     "utf-8",
   );
 
@@ -129,89 +142,107 @@ async function createTestServer(dir: string) {
   mkdirSync(progressDir, { recursive: true });
   writeFileSync(
     join(progressDir, "test-run-1.json"),
-    JSON.stringify({
-      run_id: "test-run-1",
-      scenario: "grid_ctf",
-      total_generations: 1,
-      advances: 1,
-      rollbacks: 0,
-      retries: 0,
-      progress: {
-        raw_score: 0.7,
-        normalized_score: 0.7,
-        score_floor: 0,
-        score_ceiling: 1,
-        pct_of_ceiling: 70,
+    JSON.stringify(
+      {
+        run_id: "test-run-1",
+        scenario: "grid_ctf",
+        total_generations: 1,
+        advances: 1,
+        rollbacks: 0,
+        retries: 0,
+        progress: {
+          raw_score: 0.7,
+          normalized_score: 0.7,
+          score_floor: 0,
+          score_ceiling: 1,
+          pct_of_ceiling: 70,
+        },
+        cost: {
+          total_input_tokens: 20000,
+          total_output_tokens: 10000,
+          total_tokens: 30000,
+          total_cost_usd: 0.15,
+        },
       },
-      cost: {
-        total_input_tokens: 20000,
-        total_output_tokens: 10000,
-        total_tokens: 30000,
-        total_cost_usd: 0.15,
-      },
-    }, null, 2),
+      null,
+      2,
+    ),
     "utf-8",
   );
   const weaknessDir = join(scenarioKnowledgeDir, "weakness_reports");
   mkdirSync(weaknessDir, { recursive: true });
   writeFileSync(
     join(weaknessDir, "test-run-1.json"),
-    JSON.stringify({
-      run_id: "test-run-1",
-      scenario: "grid_ctf",
-      total_generations: 1,
-      weaknesses: [{
-        category: "validation_failure",
-        severity: "medium",
-        affected_generations: [1],
-        description: "Parse failure on generation 1",
-        evidence: { count: 1 },
-        frequency: 1,
-      }],
-    }, null, 2),
+    JSON.stringify(
+      {
+        run_id: "test-run-1",
+        scenario: "grid_ctf",
+        total_generations: 1,
+        weaknesses: [
+          {
+            category: "validation_failure",
+            severity: "medium",
+            affected_generations: [1],
+            description: "Parse failure on generation 1",
+            evidence: { count: 1 },
+            frequency: 1,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
     "utf-8",
   );
   const facetDir = join(dir, "knowledge", "analytics", "facets");
   mkdirSync(facetDir, { recursive: true });
   writeFileSync(
     join(facetDir, "test-run-1.json"),
-    JSON.stringify({
-      run_id: "test-run-1",
-      scenario: "grid_ctf",
-      scenario_family: "game",
-      agent_provider: "deterministic",
-      executor_mode: "local",
-      total_generations: 1,
-      advances: 1,
-      retries: 0,
-      rollbacks: 0,
-      best_score: 0.7,
-      best_elo: 1050,
-      total_duration_seconds: 12,
-      total_tokens: 30000,
-      total_cost_usd: 0.15,
-      tool_invocations: 2,
-      validation_failures: 1,
-      consultation_count: 0,
-      consultation_cost_usd: 0,
-      friction_signals: [{
-        signal_type: "validation_failure",
-        severity: "medium",
-        generation_index: 1,
-        description: "Parse failure on generation 1",
-        evidence: ["ev-1"],
-        recoverable: true,
-      }],
-      delight_signals: [{
-        signal_type: "strong_improvement",
-        generation_index: 1,
-        description: "Center route improved quickly",
-        evidence: ["ev-2"],
-      }],
-      events: [],
-      metadata: {},
-      created_at: "2026-04-25T00:00:00Z",
-    }, null, 2),
+    JSON.stringify(
+      {
+        run_id: "test-run-1",
+        scenario: "grid_ctf",
+        scenario_family: "game",
+        agent_provider: "deterministic",
+        executor_mode: "local",
+        total_generations: 1,
+        advances: 1,
+        retries: 0,
+        rollbacks: 0,
+        best_score: 0.7,
+        best_elo: 1050,
+        total_duration_seconds: 12,
+        total_tokens: 30000,
+        total_cost_usd: 0.15,
+        tool_invocations: 2,
+        validation_failures: 1,
+        consultation_count: 0,
+        consultation_cost_usd: 0,
+        friction_signals: [
+          {
+            signal_type: "validation_failure",
+            severity: "medium",
+            generation_index: 1,
+            description: "Parse failure on generation 1",
+            evidence: ["ev-1"],
+            recoverable: true,
+          },
+        ],
+        delight_signals: [
+          {
+            signal_type: "strong_improvement",
+            generation_index: 1,
+            description: "Center route improved quickly",
+            evidence: ["ev-2"],
+          },
+        ],
+        events: [],
+        metadata: {},
+        created_at: "2026-04-25T00:00:00Z",
+      },
+      null,
+      2,
+    ),
     "utf-8",
   );
 
@@ -219,13 +250,17 @@ async function createTestServer(dir: string) {
   mkdirSync(customDir, { recursive: true });
   writeFileSync(
     join(customDir, "agent_task_spec.json"),
-    JSON.stringify({
-      task_prompt: "Summarize the control-plane state.",
-      judge_rubric: "Prefer concise and accurate summaries.",
-      output_format: "free_text",
-      max_rounds: 1,
-      quality_threshold: 0.9,
-    }, null, 2),
+    JSON.stringify(
+      {
+        task_prompt: "Summarize the control-plane state.",
+        judge_rubric: "Prefer concise and accurate summaries.",
+        output_format: "free_text",
+        max_rounds: 1,
+        quality_threshold: 0.9,
+      },
+      null,
+      2,
+    ),
     "utf-8",
   );
 
@@ -260,11 +295,8 @@ afterEach(async () => {
 });
 
 async function persistRuntimeSession(dir: string): Promise<void> {
-  const {
-    RuntimeSessionEventLog,
-    RuntimeSessionEventStore,
-    RuntimeSessionEventType,
-  } = await import("../src/session/runtime-events.js");
+  const { RuntimeSessionEventLog, RuntimeSessionEventStore, RuntimeSessionEventType } =
+    await import("../src/session/runtime-events.js");
   const eventStore = new RuntimeSessionEventStore(join(dir, "test.db"));
   const log = RuntimeSessionEventLog.create({
     sessionId: "run:test-run-1:runtime",
@@ -297,45 +329,51 @@ function persistContextSelectionDecision(dir: string): void {
   mkdirSync(contextDir, { recursive: true });
   writeFileSync(
     join(contextDir, "gen_1_generation_prompt_context.json"),
-    JSON.stringify({
-      schema_version: 1,
-      run_id: "test-run-1",
-      scenario_name: "grid_ctf",
-      generation: 1,
-      stage: "generation_prompt_context",
-      created_at: "2026-01-02T03:04:05.000Z",
-      metadata: {
-        context_budget_telemetry: {
-          input_token_estimate: 120,
-          output_token_estimate: 20,
-          dedupe_hit_count: 1,
-          component_cap_hit_count: 2,
-          trimmed_component_count: 1,
+    JSON.stringify(
+      {
+        schema_version: 1,
+        run_id: "test-run-1",
+        scenario_name: "grid_ctf",
+        generation: 1,
+        stage: "generation_prompt_context",
+        created_at: "2026-01-02T03:04:05.000Z",
+        metadata: {
+          context_budget_telemetry: {
+            input_token_estimate: 120,
+            output_token_estimate: 20,
+            dedupe_hit_count: 1,
+            component_cap_hit_count: 2,
+            trimmed_component_count: 1,
+          },
+          prompt_compaction_cache: {
+            hits: 0,
+            misses: 10,
+            lookups: 10,
+          },
         },
-        prompt_compaction_cache: {
-          hits: 0,
-          misses: 10,
-          lookups: 10,
+        metrics: {
+          candidate_count: 1,
+          selected_count: 1,
+          candidate_token_estimate: 100,
+          selected_token_estimate: 20,
         },
+        candidates: [
+          {
+            artifact_id: "playbook",
+            artifact_type: "prompt_component",
+            source: "prompt_assembly",
+            candidate_token_estimate: 100,
+            selected_token_estimate: 20,
+            selected: true,
+            selection_reason: "retained_after_prompt_assembly",
+            candidate_content_hash: "candidate",
+            selected_content_hash: "selected",
+          },
+        ],
       },
-      metrics: {
-        candidate_count: 1,
-        selected_count: 1,
-        candidate_token_estimate: 100,
-        selected_token_estimate: 20,
-      },
-      candidates: [{
-        artifact_id: "playbook",
-        artifact_type: "prompt_component",
-        source: "prompt_assembly",
-        candidate_token_estimate: 100,
-        selected_token_estimate: 20,
-        selected: true,
-        selection_reason: "retained_after_prompt_assembly",
-        candidate_content_hash: "candidate",
-        selected_content_hash: "selected",
-      }],
-    }, null, 2),
+      null,
+      2,
+    ),
     "utf-8",
   );
 }
@@ -400,71 +438,97 @@ describe("HTTP API — health", () => {
       python: { support: "supported" },
       typescript: { support: "supported" },
     });
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "POST",
-      path: "/api/knowledge/import",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/knowledge/playbook/:scenario",
-      status: "python_gap",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/notebooks",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/monitors",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/openclaw/capabilities",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "POST",
-      path: "/api/openclaw/evaluate",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/cockpit/runs",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/cockpit/runs/:run_id/context-selection",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/cockpit/runtime-sessions",
-      status: "python_gap",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/cockpit/runs/:run_id/runtime-session",
-      status: "python_gap",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/cockpit/runs/:run_id/runtime-session/timeline",
-      status: "python_gap",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/hub/feed",
-      status: "aligned",
-    }));
-    expect(matrix.routes).toContainEqual(expect.objectContaining({
-      method: "GET",
-      path: "/api/missions",
-      status: "python_gap",
-    }));
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/knowledge/import",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/knowledge/playbook/:scenario",
+        status: "python_gap",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/notebooks",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/monitors",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/openclaw/capabilities",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/openclaw/evaluate",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/cockpit/runs",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/cockpit/runs/:run_id/context-selection",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/cockpit/runtime-sessions",
+        status: "python_gap",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/cockpit/runs/:run_id/runtime-session",
+        status: "python_gap",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/cockpit/runs/:run_id/runtime-session/timeline",
+        status: "python_gap",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/hub/feed",
+        status: "aligned",
+      }),
+    );
+    expect(matrix.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/missions",
+        status: "python_gap",
+      }),
+    );
   });
 });
 
@@ -486,7 +550,7 @@ describe("HTTP API — runs", () => {
     expect(status).toBe(200);
     const gens = body as Array<Record<string, unknown>>;
     expect(gens.length).toBe(1);
-    expect(gens[0].best_score).toBeCloseTo(0.70);
+    expect(gens[0].best_score).toBeCloseTo(0.7);
   });
 
   it("GET /api/runs/:id/status returns 404 for missing run", async () => {
@@ -715,10 +779,12 @@ describe("HTTP API — monitors", () => {
     expect(active.body).toEqual([]);
 
     const all = await fetchJson(`${baseUrl}/api/monitors?active_only=false`);
-    expect(all.body).toContainEqual(expect.objectContaining({
-      id: conditionId,
-      active: 0,
-    }));
+    expect(all.body).toContainEqual(
+      expect.objectContaining({
+        id: conditionId,
+        active: 0,
+      }),
+    );
   });
 
   it("DELETE /api/monitors/:condition_id deactivates conditions", async () => {
@@ -756,7 +822,10 @@ describe("HTTP API — monitors", () => {
       best_score: 0.91,
     });
 
-    const { status, body } = await postJson(`${baseUrl}/api/monitors/${conditionId}/wait?timeout=0.1`, {});
+    const { status, body } = await postJson(
+      `${baseUrl}/api/monitors/${conditionId}/wait?timeout=0.1`,
+      {},
+    );
     expect(status).toBe(200);
     expect(body).toMatchObject({
       fired: true,
@@ -811,21 +880,27 @@ describe("HTTP API — cockpit", () => {
     expect(listed.status).toBe(200);
     expect(listed.body).toContainEqual(expect.objectContaining({ session_id: "test-run-1" }));
 
-    const effective = await fetchJson(`${baseUrl}/api/cockpit/notebooks/test-run-1/effective-context`);
+    const effective = await fetchJson(
+      `${baseUrl}/api/cockpit/notebooks/test-run-1/effective-context`,
+    );
     expect(effective.status).toBe(200);
     expect(effective.body).toMatchObject({
       session_id: "test-run-1",
       role_contexts: expect.objectContaining({
         competitor: expect.stringContaining("Keep center control."),
       }),
-      warnings: [expect.objectContaining({
-        field: "best_score",
-        warning_type: "stale_score",
-      })],
+      warnings: [
+        expect.objectContaining({
+          field: "best_score",
+          warning_type: "stale_score",
+        }),
+      ],
       notebook_empty: false,
     });
 
-    const deleted = await fetch(`${baseUrl}/api/cockpit/notebooks/test-run-1`, { method: "DELETE" });
+    const deleted = await fetch(`${baseUrl}/api/cockpit/notebooks/test-run-1`, {
+      method: "DELETE",
+    });
     expect(deleted.status).toBe(200);
   });
 
@@ -833,16 +908,18 @@ describe("HTTP API — cockpit", () => {
     const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs`);
 
     expect(status).toBe(200);
-    expect(body).toContainEqual(expect.objectContaining({
-      run_id: "test-run-1",
-      scenario_name: "grid_ctf",
-      generations_completed: 1,
-      best_score: 0.7,
-      best_elo: 1050,
-      status: "running",
-      runtime_session: null,
-      runtime_session_url: "/api/cockpit/runs/test-run-1/runtime-session",
-    }));
+    expect(body).toContainEqual(
+      expect.objectContaining({
+        run_id: "test-run-1",
+        scenario_name: "grid_ctf",
+        generations_completed: 1,
+        best_score: 0.7,
+        best_elo: 1050,
+        status: "running",
+        runtime_session: null,
+        runtime_session_url: "/api/cockpit/runs/test-run-1/runtime-session",
+      }),
+    );
   });
 
   it("GET /api/cockpit/runs includes runtime-session summaries when present", async () => {
@@ -867,11 +944,13 @@ describe("HTTP API — cockpit", () => {
       scenario_name: "grid_ctf",
       target_generations: 3,
       status: "running",
-      generations: [expect.objectContaining({
-        generation: 1,
-        best_score: 0.7,
-        elo: 1050,
-      })],
+      generations: [
+        expect.objectContaining({
+          generation: 1,
+          best_score: 0.7,
+          elo: 1050,
+        }),
+      ],
     });
     expectTestRunRuntimeSessionDiscovery(body);
   });
@@ -879,7 +958,9 @@ describe("HTTP API — cockpit", () => {
   it("GET /api/cockpit/runs/:run_id/context-selection returns telemetry cards", async () => {
     persistContextSelectionDecision(dir);
 
-    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/context-selection`);
+    const { status, body } = await fetchJson(
+      `${baseUrl}/api/cockpit/runs/test-run-1/context-selection`,
+    );
 
     expect(status).toBe(200);
     expect(body).toMatchObject({
@@ -906,7 +987,9 @@ describe("HTTP API — cockpit", () => {
   });
 
   it("GET /api/cockpit/runs/:run_id/context-selection handles missing artifacts", async () => {
-    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/context-selection`);
+    const { status, body } = await fetchJson(
+      `${baseUrl}/api/cockpit/runs/test-run-1/context-selection`,
+    );
 
     expect(status).toBe(404);
     expect(body).toMatchObject({
@@ -915,11 +998,26 @@ describe("HTTP API — cockpit", () => {
   });
 
   it("GET /api/cockpit/runs/:run_id/context-selection rejects escaped run ids", async () => {
-    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/%2E%2E%2Foutside/context-selection`);
+    const { status, body } = await fetchJson(
+      `${baseUrl}/api/cockpit/runs/%2E%2E%2Foutside/context-selection`,
+    );
 
     expect(status).toBe(422);
     expect(body).toMatchObject({
       detail: expect.stringContaining("escapes runs root"),
+    });
+  });
+
+  it("GET /api/cockpit/runs/:run_id/context-selection returns the pre-branding 422 for a whitespace-only run id", async () => {
+    // AC-855 regression: a %20 path segment decodes to a non-empty, all-whitespace
+    // run id. asRunId must not reject it at the route boundary (that would surface
+    // as an uncaught 500): the branded id has to flow through unchanged to
+    // cockpit-api.ts, which trims internally and returns this same 422.
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/%20/context-selection`);
+
+    expect(status).toBe(422);
+    expect(body).toMatchObject({
+      detail: "run_id is required",
     });
   });
 
@@ -983,20 +1081,24 @@ describe("HTTP API — cockpit", () => {
     mkdirSync(writeupsDir, { recursive: true });
     writeFileSync(
       join(writeupsDir, "trace-writeup-test-run-1.json"),
-      JSON.stringify({
-        writeup_id: "trace-writeup-test-run-1",
-        run_id: "test-run-1",
-        generation_index: 1,
-        findings: [],
-        failure_motifs: [],
-        recovery_paths: [],
-        summary: "Persisted trace-grounded summary.",
-        created_at: "2025-01-01T00:00:00.000Z",
-        metadata: {
-          scenario: "grid_ctf",
-          scenario_family: "game",
+      JSON.stringify(
+        {
+          writeup_id: "trace-writeup-test-run-1",
+          run_id: "test-run-1",
+          generation_index: 1,
+          findings: [],
+          failure_motifs: [],
+          recovery_paths: [],
+          summary: "Persisted trace-grounded summary.",
+          created_at: "2025-01-01T00:00:00.000Z",
+          metadata: {
+            scenario: "grid_ctf",
+            scenario_family: "game",
+          },
         },
-      }, null, 2),
+        null,
+        2,
+      ),
       "utf-8",
     );
 
@@ -1104,7 +1206,9 @@ describe("HTTP API — cockpit", () => {
   it("GET /api/cockpit/runs/:run_id/runtime-session resolves the run-scoped log", async () => {
     await persistRuntimeSession(dir);
 
-    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/runtime-session`);
+    const { status, body } = await fetchJson(
+      `${baseUrl}/api/cockpit/runs/test-run-1/runtime-session`,
+    );
 
     expect(status).toBe(200);
     expect(body).toMatchObject({
@@ -1133,7 +1237,9 @@ describe("HTTP API — cockpit", () => {
   });
 
   it("GET /api/cockpit/runs/:run_id/runtime-session returns 404 when no log exists", async () => {
-    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/runtime-session`);
+    const { status, body } = await fetchJson(
+      `${baseUrl}/api/cockpit/runs/test-run-1/runtime-session`,
+    );
 
     expect(status).toBe(404);
     expect(body).toEqual({
@@ -1163,7 +1269,9 @@ describe("HTTP API — cockpit", () => {
         trigger: "operator_request",
         model_used: "deterministic-dev",
       });
-      expect(readStringProperty(consultation.body, "advisory_markdown")).toContain("Consultation model");
+      expect(readStringProperty(consultation.body, "advisory_markdown")).toContain(
+        "Consultation model",
+      );
 
       const listed = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/consultations`);
       expect(listed.status).toBe(200);
@@ -1274,8 +1382,12 @@ describe("HTTP API — research hub", () => {
     });
     const packageId = (promoted.body as Record<string, unknown>).package_id as string;
     expect(packageId).toMatch(/^pkg-/);
-    expect(existsSync(join(dir, "knowledge", "_hub", "packages", packageId, "shared_package.json"))).toBe(true);
-    expect(existsSync(join(dir, "knowledge", "_hub", "packages", packageId, "strategy_package.json"))).toBe(true);
+    expect(
+      existsSync(join(dir, "knowledge", "_hub", "packages", packageId, "shared_package.json")),
+    ).toBe(true);
+    expect(
+      existsSync(join(dir, "knowledge", "_hub", "packages", packageId, "strategy_package.json")),
+    ).toBe(true);
 
     const listed = await fetchJson(`${baseUrl}/api/hub/packages`);
     expect(listed.status).toBe(200);
@@ -1330,7 +1442,10 @@ describe("HTTP API — research hub", () => {
 
     const fetchedResult = await fetchJson(`${baseUrl}/api/hub/results/${resultId}`);
     expect(fetchedResult.status).toBe(200);
-    expect(fetchedResult.body).toMatchObject({ result_id: resultId, summary: expect.stringContaining("test-run-1") });
+    expect(fetchedResult.body).toMatchObject({
+      result_id: resultId,
+      summary: expect.stringContaining("test-run-1"),
+    });
 
     const promotion = await postJson(`${baseUrl}/api/hub/promotions`, {
       package_id: "pkg-external",
@@ -1448,15 +1563,19 @@ describe("HTTP API — OpenClaw", () => {
       artifact_type: "policy",
     });
 
-    const listed = await fetchJson(`${baseUrl}/api/openclaw/artifacts?scenario=grid_ctf&artifact_type=policy`);
+    const listed = await fetchJson(
+      `${baseUrl}/api/openclaw/artifacts?scenario=grid_ctf&artifact_type=policy`,
+    );
     expect(listed.status).toBe(200);
-    expect(listed.body).toContainEqual(expect.objectContaining({
-      id: "artifact-1",
-      name: "Grid policy",
-      artifact_type: "policy",
-      scenario: "grid_ctf",
-      version: 1,
-    }));
+    expect(listed.body).toContainEqual(
+      expect.objectContaining({
+        id: "artifact-1",
+        name: "Grid policy",
+        artifact_type: "policy",
+        scenario: "grid_ctf",
+        version: 1,
+      }),
+    );
 
     const fetched = await fetchJson(`${baseUrl}/api/openclaw/artifacts/artifact-1`);
     expect(fetched.status).toBe(200);
@@ -1548,11 +1667,13 @@ describe("HTTP API — OpenClaw", () => {
       name: "autocontext",
       rest_base_path: "/api/openclaw",
     });
-    expect((body as Record<string, unknown>).scenarios).toContainEqual(expect.objectContaining({
-      name: "grid_ctf",
-      display_name: "Grid Ctf",
-      scenario_type: "parametric",
-    }));
+    expect((body as Record<string, unknown>).scenarios).toContainEqual(
+      expect.objectContaining({
+        name: "grid_ctf",
+        display_name: "Grid Ctf",
+        scenario_type: "parametric",
+      }),
+    );
   });
 
   it("distillation job endpoints keep Python-compatible lifecycle semantics", async () => {
@@ -1567,7 +1688,9 @@ describe("HTTP API — OpenClaw", () => {
       status: "failed",
       scenario: "grid_ctf",
     });
-    expect((triggered.body as Record<string, unknown>).error).toContain("No distillation sidecar configured");
+    expect((triggered.body as Record<string, unknown>).error).toContain(
+      "No distillation sidecar configured",
+    );
     const jobId = (triggered.body as Record<string, unknown>).job_id as string;
 
     const job = await fetchJson(`${baseUrl}/api/openclaw/distill/${jobId}`);
@@ -1680,12 +1803,12 @@ describe("HTTP API — knowledge", () => {
       metadataWritten: true,
       conflictPolicy: "overwrite",
     });
-    expect(readFileSync(join(dir, "knowledge", "imported_task", "playbook.md"), "utf-8"))
-      .toContain("Use the imported strategy.");
-    expect(readFileSync(
-      join(dir, "knowledge", "imported_task", "package_metadata.json"),
-      "utf-8",
-    )).toContain("http-test");
+    expect(readFileSync(join(dir, "knowledge", "imported_task", "playbook.md"), "utf-8")).toContain(
+      "Use the imported strategy.",
+    );
+    expect(
+      readFileSync(join(dir, "knowledge", "imported_task", "package_metadata.json"), "utf-8"),
+    ).toContain("http-test");
     expect(existsSync(join(dir, "skills", "imported-task-ops", "SKILL.md"))).toBe(true);
   });
 
@@ -1757,9 +1880,11 @@ describe("HTTP API — dashboard event stream", () => {
         });
         ws.once("error", reject);
 
-        const events = (mgr as unknown as {
-          events: { emit: (event: string, payload: Record<string, unknown>) => void };
-        }).events;
+        const events = (
+          mgr as unknown as {
+            events: { emit: (event: string, payload: Record<string, unknown>) => void };
+          }
+        ).events;
         events.emit("run_started", { run_id: "ws-test", scenario: "grid_ctf" });
       });
       ws.once("error", reject);


### PR DESCRIPTION
## Summary

- Adds `ts/src/domain/ids.ts`: `RunId`, `ScenarioName`, `DbPath` branded string types (unique-symbol brand, matching the existing `ts/src/production-traces/contract/branded-ids.ts` pattern) with smart constructors `asRunId` / `asScenarioName` / `asDbPath` (throw only on byte-empty input, identity at runtime) and an `unbrand` passthrough for the rare explicit-drop case.
- `./domain/ids.js` is on the root export allowlist (`root-export-allowlist.json`), so `RunId`, `ScenarioName`, `DbPath`, `asRunId`, `asScenarioName`, `asDbPath`, and `unbrand` are part of the public `autoctx` package surface. This matters because `GenerationRunner` (which now requires `RunId`) is itself root-exported via `loop/index.js`; without this, external consumers could not satisfy its signature without an unexported type or a cast.
- Migrates a first slice to the branded types:
  - `ts/src/loop/generation-runner.ts`: `RunResult.runId` and every public/private method taking `runId` now use `RunId` instead of `string`.
  - `ts/src/execution/sandbox.ts`: the one direct (non-facade) caller of `GenerationRunner.run` that needed updating; wraps the minted run id with `asRunId` at construction.
  - `ts/src/server/routes/{run-list,cockpit,knowledge,openclaw}-routes.ts`: HTTP path params are converted to `RunId` / `ScenarioName` immediately after `decodeURIComponent`, then carried as branded values into the downstream API call.
  - `ts/src/cli/run-command-workflow.ts`, `ts/src/server/run-start-workflow.ts`, `ts/src/knowledge/built-in-game-solve-execution.ts`, `ts/src/mcp/run-management-tools.ts`: the four remaining paths into `GenerationRunner.run`, converted at their own boundary (see below).

## Why these four call sites typechecked with a plain string

All four go through a locally-declared structural facade (or, for `run-start-workflow.ts`, a union with the concrete `GenerationRunner`), e.g. `{ run(runId: string, generations: number): Promise<...> }`. TypeScript checks parameters of methods declared with shorthand syntax (`run(x: T)`) bivariantly rather than contravariantly. Both `GenerationRunner.run` and every one of these facade interfaces declare `run` as a method (a class member or an interface member), not as a property typed with an arrow function (which would get the strict contravariant check under `strictFunctionTypes`). So even though the concrete `GenerationRunner.run` requires `RunId`, the compiler accepted a plain `string` argument at these call sites without complaint.

Fixed by converting each call site's `runId` with `asRunId` immediately before it reaches `.run()`: at the mint site where one exists (`built-in-game-solve-execution.ts`'s `` `solve_${scenarioName}_${jobId}` ``, `run-management-tools.ts`'s `args.runId ?? internals.createRunId()`), or inline at the call (`run-command-workflow.ts`, `run-start-workflow.ts`). The facade interfaces themselves stay typed as `string`, since they're the intended external boundary (CLI args, MCP tool input, HTTP); only the value actually reaching the concrete runner is required to have gone through the constructor.

## Why the remaining scope stops here

`runId`/`scenario` appear as plain strings at ~93 call sites across `control-plane/`, `knowledge/`, and `loop/`. This PR intentionally stops at a clean boundary rather than chasing all of them:

- Downstream consumers called from the migrated route files (`cockpit-api.ts`, `knowledge-api.ts`, `runtime-session-api.ts`, `trace-gate-review-api.ts`, `openclaw-api.ts`, `run-simulation-read-workflow.ts`) all declare their `runId`/`scenarioName` params as plain `string`. A branded value is a structural subtype of `string`, so it can be passed straight in with **no cast and no signature change** to those files. `run-simulation-read-workflow.ts` in particular has zero AC-855 diff (verified with `git diff --stat`), so merge order with the sibling `quality/ac-862-readplaybook` PR (now merged as #1158) didn't matter for that file; this branch has since merged current `main` (including #1157 and #1158) with no conflicts.
- `execution/sandbox.ts` and the four facade call sites above were the only non-route callers of `GenerationRunner.run`; all are now converted.

## Remaining modules (follow-up scope)

- Server API implementations: `cockpit-api.ts`, `knowledge-api.ts`, `runtime-session-api.ts`, `trace-gate-review-api.ts`, `openclaw-api.ts`, `background-session-api.ts`, `run-simulation-read-workflow.ts`: still typed `runId: string` / `scenarioName: string` internally.
- `storage/`: `SQLiteStore`, `generation-run-query-workflow.ts`, `generation-match-output-workflow.ts`.
- `knowledge/`: `ArtifactStore`, `GenerationJournal`, `ScoreTrajectoryBuilder`, etc.
- The four facade interfaces themselves (`StartRunRunnerLike` in `run-start-workflow.ts`, the local `TRunner` bound in `run-command-workflow.ts`, and the equivalents in `built-in-game-solve-execution.ts` and `run-management-tools.ts`) still declare `run(runId: string, ...)`. Tightening those to `RunId` is possible now that every call site converts before calling, but was left as `string` deliberately since they're genuine external-boundary abstractions (see above).
- `DbPath`: brand + constructor exist in `ids.ts` but adoption at the CLI-arg / `SQLiteStore` constructor boundary is not started.

## Cast audit

`git diff` of every migrated file contains no `as RunId` / `as ScenarioName` / `as DbPath` casts outside `ts/src/domain/ids.ts` itself (where the three constructors use `as` internally, which is the intended single point of truth for the brand).

## Validation scope note

`asRunId` / `asScenarioName` / `asDbPath` only reject byte-empty strings (`value.length === 0`), not whitespace-only ones. This is deliberate: several downstream consumers (e.g. `cockpit-api.ts`'s `contextSelection`) trim internally and turn a whitespace-only id into a specific handled 404/422, and a stricter trim-based check here would throw before that code runs, turning a handled 4xx into an uncaught 500. See the doc comment in `ts/src/domain/ids.ts` and the regression test below.

## Test plan

- [x] `npx tsc --noEmit` clean (baseline and after every commit on this branch).
- [x] `npm run lint` clean (baseline and after), including `npm run check:root-index` (now passes with `domain/ids.js` on the allowlist and `src/index.ts` regenerated).
- [x] `npx vitest run tests/generation-loop.test.ts tests/http-api.test.ts tests/generation-loop-orchestrator.test.ts --maxWorkers=1`: baseline (pre-AC-855, on `main`) was 103 passed / 2 failed / 105 total; current branch tip is 104 passed / 2 failed / 106 total. The 2 failures (`POST /api/knowledge/solve`, `GET /api/knowledge/solve/:jobId`) are pre-existing on `main` and unrelated to this change.
- [x] Regression test: `GET /api/cockpit/runs/:run_id/context-selection returns the pre-branding 422 for a whitespace-only run id`, hitting `/api/cockpit/runs/%20/context-selection` and asserting the same `422` / `"run_id is required"` response the endpoint returns on `main`.
- [x] Spot-checked the dedicated test files for the four facade call sites plus their neighbor (`tests/run-command-workflow.test.ts`, `tests/run-start-workflow.test.ts`, `tests/run-management-tools.test.ts`, `tests/built-in-game-solve-execution.test.ts`, `tests/levy-scout.test.ts`) together with the three suites above: 131 passed / 3 failed / 134 total. The 1 additional failure, in `run-command-workflow.test.ts`, is a pre-existing mismatch between a mock's expected call-args object and `GenerationRunnerOpts`'s current field list; confirmed pre-existing by stashing this branch's fix commit and reproducing the identical failure on the merge-with-main commit alone.
- [x] Every test covering a migrated route (cockpit run routes, `context-selection rejects escaped run ids`, knowledge playbook/export incl. path-traversal rejection, openclaw discovery) still passes, confirming zero runtime behavior change.
