### PR TITLE
AC-870: refresh in-repo documentation after the quality-sweep refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- AC-855 adds branded `RunId`/`ScenarioName`/`DbPath` id types, exported from the TypeScript package root; `GenerationRunner.run` now takes a `RunId` instead of a bare `string` (compile-time only, construct with `asRunId`).
+
+### Changed
+
+- AC-850 through AC-864 decompose several oversized modules with no runtime behavior change: `ws-server` HTTP routing into `ts/src/server/routes/`, the TypeScript CLI dispatcher into `ts/src/cli/commands/` behind a slim `command-handlers.ts` barrel, `stage_tournament` and `run_generation` into named helpers, and `SQLiteStore`/`ArtifactStore` into per-concern mixin modules.
+
 ## [0.10.0] - 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ autocontext/                  # Python package root (pyproject.toml lives here)
   src/autocontext/            # Source code
     agents/                   # LLM agent roles (competitor, analyst, coach, architect, curator)
     knowledge/                # Knowledge processing (trajectory builder, skill export, search, solve-on-demand)
-    loop/                     # Generation runner, event emitter
+    loop/                     # Generation runner, event emitter, stage decomposition helpers (stage_helpers/)
     prompts/                  # Prompt template assembly
     config/                   # Pydantic settings from AUTOCONTEXT_* env vars
-    storage/                  # SQLiteStore, ArtifactStore
+    storage/                  # SQLiteStore, ArtifactStore, split across sqlite_store_*/artifact_* mixin modules
     scenarios/                # Pluggable scenarios (grid_ctf, othello, custom/, agent tasks)
       custom/               # Natural-language → generated scenario pipeline (spec, codegen, validation, loading)
                             # Also: agent task pipeline (agent_task_designer, agent_task_codegen, agent_task_validator, agent_task_creator)
@@ -46,8 +46,11 @@ ts/                           # TypeScript package (autoctx on npm)
     mission/                  # MissionManager, planner, adaptive executor, campaigns (AC-410, AC-435, AC-428)
     traces/                   # Public trace schema, redaction, export, publishers, data plane (AC-462–466)
     training/                 # Model strategy, backends (MLX/CUDA), prompt alignment, promotion (AC-456–460)
+    domain/                   # Branded id types (RunId, ScenarioName, DbPath; AC-855), root-exported
+    server/                   # InteractiveServer: WebSocket protocol + HTTP routing
+      routes/                 # Extracted HTTP route handlers (12 modules; AC-852)
     mcp/                      # MCP server with tool implementations
-    cli/                      # CLI entry point with all commands
+    cli/                      # CLI entry point; command-handlers.ts barrel over commands/ (15 family modules; AC-853)
   tests/                      # Vitest tests (1600+ tests)
   migrations/                 # Shared SQLite migration SQL (cross-compatible with Python)
 pi/                           # Pi coding agent extension (@autocontext/pi)
@@ -150,6 +153,7 @@ Optional (`AUTOCONTEXT_RLM_ENABLED=true`): replaces single-shot analyst/architec
 ### Scenarios (`scenarios/`)
 
 Dual-interface registry (`SCENARIO_REGISTRY` in `scenarios/__init__.py`):
+
 - **Game scenarios** — `ScenarioInterface` ABC (`execute_match`, `describe_rules`, etc.). Built-in: `grid_ctf`, `othello`.
 - **Agent task scenarios** — `AgentTaskInterface` ABC (`evaluate_output`, `get_task_prompt`, `revise_output`, etc.). Evaluated by LLM judge.
 
@@ -206,7 +210,7 @@ All config via `AUTOCONTEXT_*` env vars, loaded in `config/settings.py` as Pydan
 
 ## CI
 
-GitHub Actions (`.github/workflows/ci.yml`) runs: ruff check, mypy, pytest, deterministic smoke runs for both scenarios (`grid_ctf` 3 gens, `othello` 1 gen), and dashboard API health check. A separate `primeintellect-live` job runs when secrets are available. Monty-specific tests (`test_monty_*.py`) are skipped in CI when pydantic-monty is not installed (`pytest.mark.skipif`).
+GitHub Actions (`.github/workflows/ci.yml`) runs: ruff check, mypy, pytest, a `package-boundaries` job (Python/TypeScript topology checks plus the three Python/TS schema sync checks, run under `uv run --frozen`), deterministic smoke runs for both scenarios (`grid_ctf` 3 gens, `othello` 1 gen) with a curl readiness loop, and dashboard API health check. A separate `primeintellect-live` job runs when secrets are available. Monty-specific tests (`test_monty_*.py`) are skipped in CI when pydantic-monty is not installed (`pytest.mark.skipif`).
 
 ## TypeScript Package (`ts/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ autocontext/                  # Python package root (pyproject.toml lives here)
     rlm/                      # REPL-loop mode (optional analyst/architect)
     mcp/                      # MCP server, tool implementations, sandbox manager
     server/                   # FastAPI dashboard + WebSocket events
-  tests/                      # Pytest tests (~2800 tests)
+  tests/                      # Pytest tests (~7700 tests)
   migrations/                 # SQLite migration SQL files (001-007, applied in filename order)
   dashboard/                  # Single-page HTML dashboard
   knowledge/                  # Runtime-generated: per-scenario playbooks, analysis, tools, hints, snapshots
@@ -51,7 +51,7 @@ ts/                           # TypeScript package (autoctx on npm)
       routes/                 # Extracted HTTP route handlers (12 modules; AC-852)
     mcp/                      # MCP server with tool implementations
     cli/                      # CLI entry point; command-handlers.ts barrel over commands/ (15 family modules; AC-853)
-  tests/                      # Vitest tests (1600+ tests)
+  tests/                      # Vitest tests (5000+ tests)
   migrations/                 # Shared SQLite migration SQL (cross-compatible with Python)
 pi/                           # Pi coding agent extension (@autocontext/pi)
   src/                        # Extension with 5 tools (judge, improve, status, scenarios, queue)
@@ -220,7 +220,7 @@ Published as `autoctx` on npm. ESM-only, strict TypeScript, Node.js >=18.
 cd ts
 npm install
 npm run lint          # tsc --noEmit
-npm test              # vitest run (1600+ tests)
+npm test              # vitest run (5000+ tests)
 npm run build         # tsc (outputs to dist/)
 
 # Core commands


### PR DESCRIPTION
## Summary

Refreshes in-repo documentation to match the AC-850 through AC-864 quality-sweep refactors (ws-server routing extraction, CLI command-handlers split, storage mixin split, branded id types, CI package-boundaries job). Most docs were already accurate; only CLAUDE.md and CHANGELOG.md needed changes.

## Audit table

| File | Claim checked | Finding | Fix |
| --- | --- | --- | --- |
| `CLAUDE.md` (Repository Layout, Python side) | `loop/` described as "Generation runner, event emitter" | Stale by omission: `loop/stage_helpers/` gained tournament-decomposition helpers (AC-850/851), dir existed but wasn't mentioned at this granularity | Appended "stage decomposition helpers (stage_helpers/)" |
| `CLAUDE.md` (Repository Layout, Python side) | `storage/` described as "SQLiteStore, ArtifactStore" | Stale: both classes are now split across 6 `sqlite_store_*.py` + 6 `artifact_*.py` mixin modules | Appended "split across sqlite_store_*/artifact_* mixin modules" |
| `CLAUDE.md` (Repository Layout, TS side) | `ts/src/` tree had no `domain/` entry | New dir: `ts/src/domain/ids.ts` (branded `RunId`/`ScenarioName`/`DbPath`, AC-855), root-exported | Added `domain/` line |
| `CLAUDE.md` (Repository Layout, TS side) | `ts/src/` tree had no `server/` entry at all (pre-existing gap, not caused by this sweep, but the sweep's new `routes/` subdir needed a home) | `ws-server`'s HTTP routing was extracted into `ts/src/server/routes/` (12 modules, AC-852); `server/` itself predates this sweep (AC-347) but was missing from the tree | Added `server/` + nested `routes/` lines |
| `CLAUDE.md` (Repository Layout, TS side) | `cli/` described as "CLI entry point with all commands" | Stale: `command-handlers.ts` is now a 96-line barrel over `ts/src/cli/commands/` (15 family modules, AC-853) | Updated description to name the barrel + `commands/` split |
| `CLAUDE.md` (CI section) | CI summary omitted the `package-boundaries` job entirely | Job runs Python/TS topology checks plus 3 schema-sync checks under `uv run --frozen`; smoke job gained a curl readiness loop | Added `package-boundaries` job description + readiness-loop mention |
| `CLAUDE.md` (TypeScript Package section) | "Node.js >=18" | Still accurate per `ts/package.json` `engines`; `.nvmrc` (new, pins Node 22) is a stricter dev/CI pin already documented correctly in `CONTRIBUTING.md` | No change (not invalidated) |
| `README.md`, `pi/README.md` | Generated banner/whats-new blocks, version strings | Test-enforced via `test_banner_sync.py` / `test_release_surface_manifest.py`; nothing in the sweep changed a version or public surface these track | No change |
| `CONTRIBUTING.md` | Node 22 / `.nvmrc` guidance, `pi/` inheriting the native-module requirement | Already correct and already mentions `ts/.nvmrc` pinning Node 22 | No change |
| `AGENTS.md`, `SUPPORT.md` | Repo pointers, working-directory guidance | No layout trees or internals referenced; unaffected by the sweep | No change |
| `docs/*.md` (grepped for `command-handlers`, `ws-server`, `handleHttpRequest`, `SQLiteStore`, `ArtifactStore`, `run_generation`, `stage_tournament`, node version, layout diagrams) | — | Zero hits; `docs/` doesn't reference these internals | No change |
| `autocontext/README.md`, `ts/README.md` | Layout/structure sections | Both stay at package-level granularity (no submodule detail to go stale) | No change |
| `CHANGELOG.md` | `## [Unreleased]` convention present but empty | Sweep includes one public-API-facing change (branded `RunId` on `GenerationRunner.run`) plus several internal decompositions | Added `### Added` entry for AC-855 and a `### Changed` entry summarizing AC-850–864 |

## Test plan

- [x] `uv run --frozen pytest tests/test_banner_sync.py tests/test_release_surface_manifest.py tests/test_module_size_limits.py -q` — 13 passed
- [x] `uv run --frozen pytest tests/test_contributor_guidance.py tests/test_living_docs.py -q` — 9 passed (adjacent doc-guidance tests, unaffected but verified)
- [x] Confirmed no em dashes in any added line (`git diff | grep '^+' | grep -P '—'` — no matches)
- [x] `git status --short` clean except the two intended files (no `.claude/skills` symlink or `build/` dirt)