### PR TITLE
AC-868: small cleanups from quality-sweep reviews

### DIFF
--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -16,10 +16,10 @@ from autocontext.agents.curator import KnowledgeCurator
 from autocontext.agents.llm_client import DeferredMLXClient, LanguageModelClient, build_client_from_settings
 from autocontext.agents.model_router import ModelRouter, TierConfig
 from autocontext.agents.orchestrator_helpers import (
-    assemble_agent_outputs,
-    run_analyst_coach_architect,
-    run_competitor_phase,
-    run_translator_phase,
+    _assemble_agent_outputs,
+    _run_analyst_coach_architect,
+    _run_competitor_phase,
+    _run_translator_phase,
 )
 from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
 from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext
@@ -543,7 +543,7 @@ class AgentOrchestrator:
             if on_role_event:
                 on_role_event(role, status)
 
-        raw_text, competitor_exec = run_competitor_phase(
+        raw_text, competitor_exec = _run_competitor_phase(
             self,
             prompts,
             generation_index,
@@ -557,7 +557,7 @@ class AgentOrchestrator:
             _notify,
         )
 
-        strategy, translator_exec = run_translator_phase(
+        strategy, translator_exec = _run_translator_phase(
             self,
             raw_text,
             strategy_interface,
@@ -571,7 +571,7 @@ class AgentOrchestrator:
         if generation_index % self.settings.architect_every_n_gens != 0:
             architect_prompt += _ARCHITECT_CADENCE_SKIP
 
-        analyst_exec, coach_exec, architect_exec = run_analyst_coach_architect(
+        analyst_exec, coach_exec, architect_exec = _run_analyst_coach_architect(
             self,
             prompts,
             run_id,
@@ -584,7 +584,7 @@ class AgentOrchestrator:
             _notify,
         )
 
-        return assemble_agent_outputs(
+        return _assemble_agent_outputs(
             self,
             raw_text,
             strategy,

--- a/autocontext/src/autocontext/agents/orchestrator_helpers.py
+++ b/autocontext/src/autocontext/agents/orchestrator_helpers.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 NotifyFn = Callable[[str, str], None]
 
 
-def run_competitor_phase(
+def _run_competitor_phase(
     orchestrator: AgentOrchestrator,
     prompts: PromptBundle,
     generation_index: int,
@@ -87,7 +87,7 @@ def run_competitor_phase(
     return raw_text, competitor_exec
 
 
-def run_translator_phase(
+def _run_translator_phase(
     orchestrator: AgentOrchestrator,
     raw_text: str,
     strategy_interface: str,
@@ -114,7 +114,7 @@ def run_translator_phase(
     return strategy, translator_exec
 
 
-def run_analyst_coach_architect(
+def _run_analyst_coach_architect(
     orchestrator: AgentOrchestrator,
     prompts: PromptBundle,
     run_id: str,
@@ -199,7 +199,7 @@ def run_analyst_coach_architect(
     return analyst_exec, coach_exec, architect_exec
 
 
-def assemble_agent_outputs(
+def _assemble_agent_outputs(
     orchestrator: AgentOrchestrator,
     raw_text: str,
     strategy: dict[str, Any],

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -767,11 +767,6 @@ class SQLiteStore(
 
     # ---- Shared JSON field parsing (used by hub + notebook mixins) ----
 
-    _HUB_SESSION_JSON_FIELDS = frozenset({"metadata_json"})
-    _HUB_PACKAGE_JSON_FIELDS = frozenset({"tags_json", "metadata_json"})
-    _HUB_RESULT_JSON_FIELDS = frozenset({"tags_json", "metadata_json"})
-    _HUB_PROMOTION_JSON_FIELDS = frozenset({"metadata_json"})
-
     @staticmethod
     def _parse_json_field(raw: Any, default: Any) -> Any:
         if not isinstance(raw, str):

--- a/ts/src/server/routes/run-list-routes.ts
+++ b/ts/src/server/routes/run-list-routes.ts
@@ -6,12 +6,15 @@
  * real readPlaybook implementation; the run routes below dispatch route
  * literals that never reach the playbook case, so their shared runSimDeps
  * omits readPlaybook entirely (AC-862; it is optional on the deps type).
+ * playbookDeps uses RunSimulationReadDepsWithPlaybook so the compiler
+ * requires readPlaybook at this one call site (AC-868).
  */
 
 import {
   executeRunSimulationReadRequest,
   type RunSimulationApi,
   type RunSimulationReadDeps,
+  type RunSimulationReadDepsWithPlaybook,
   type RunSimulationReadRunManager,
 } from "../run-simulation-read-workflow.js";
 import { asRunId, asScenarioName } from "../../domain/ids.js";
@@ -23,7 +26,7 @@ export async function tryRunListRoutes(
     runManager: RunSimulationReadRunManager;
     simulationApi: RunSimulationApi;
     runSimDeps: RunSimulationReadDeps;
-    playbookDeps: RunSimulationReadDeps;
+    playbookDeps: RunSimulationReadDepsWithPlaybook;
   },
 ): Promise<boolean> {
   const { runManager, simulationApi, runSimDeps, playbookDeps } = opts;

--- a/ts/src/server/run-simulation-read-workflow.ts
+++ b/ts/src/server/run-simulation-read-workflow.ts
@@ -42,6 +42,13 @@ export interface RunSimulationReadDeps {
   loadReplayArtifactResponse: typeof loadReplayArtifactResponse;
 }
 
+// Deps variant for the playbook call path (AC-868): readPlaybook is required
+// here so the compiler catches a caller wiring the playbook route to deps
+// that omit it, instead of silently falling back to a null response.
+export interface RunSimulationReadDepsWithPlaybook extends RunSimulationReadDeps {
+  readPlaybook: NonNullable<RunSimulationReadDeps["readPlaybook"]>;
+}
+
 export function loadReplayArtifactResponse(opts: {
   runsRoot: string;
   runId: string;

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -44,6 +44,7 @@ import { buildSessionBootstrapMessages, buildStateMessage } from "./websocket-se
 import {
   loadReplayArtifactResponse,
   type RunSimulationReadDeps,
+  type RunSimulationReadDepsWithPlaybook,
 } from "./run-simulation-read-workflow.js";
 import type { HttpRouteContext } from "./routes/http-route-context.js";
 import { tryRootRoutes } from "./routes/root-routes.js";
@@ -301,7 +302,7 @@ export class InteractiveServer {
       openStore,
       loadReplayArtifactResponse,
     };
-    const playbookDeps: RunSimulationReadDeps = {
+    const playbookDeps: RunSimulationReadDepsWithPlaybook = {
       openStore,
       readPlaybook: (playbookScenario, roots) => {
         const artifacts = new ArtifactStore(roots);


### PR DESCRIPTION
## Summary
- Delete the 4 dead `_HUB_*_JSON_FIELDS` frozensets in `autocontext/src/autocontext/storage/sqlite_store.py`; verified zero references tree-wide.
- Add `RunSimulationReadDepsWithPlaybook` (readPlaybook required) and use it for the playbook route's deps parameter in `ts/src/server/routes/run-list-routes.ts` and its construction site in `ts/src/server/ws-server.ts`, so the compiler enforces `readPlaybook`'s presence for the one call path that needs it. The other 7 `executeRunSimulationReadRequest` call sites keep the existing optional-`readPlaybook` contract.
- Rename the four functions in `autocontext/src/autocontext/agents/orchestrator_helpers.py` to leading-underscore names, matching the `loop/stage_helpers/` convention for cross-module-imported helpers. Cosmetic; behavior unchanged.

## Test plan
- [x] `uv run --frozen ruff check src tests` (autocontext/)
- [x] `uv run --frozen mypy src` (autocontext/)
- [x] `uv run --frozen pytest tests/test_sqlite_store.py tests/test_sqlite_store_bootstrap.py tests/test_hub_api.py tests/test_research_hub.py` (item 1 coverage)
- [x] `uv run --frozen pytest` across the 13 test files exercising `AgentOrchestrator.run_generation` (item 3 coverage) — 259 passed
- [x] `npx tsc --noEmit` (ts/)
- [x] `npm run lint` (ts/)
- [x] `npx vitest run tests/run-simulation-read-workflow.test.ts` — 4/4 passed, including the AC-862 regression test
- [x] `npx vitest run tests/http-api.test.ts` — fails identically on this branch and on unmodified origin/main content (isolated-vm native module incompatible with local Node 23.11, abi=131); confirmed pre-existing and unrelated to this change