### PR TITLE
Prepare pi-autocontext 0.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ autocontext is a harness for agent improvement. Give it a goal, it runs the task
 | Python CLI          | `uv tool install autocontext==0.11.0` |
 | Python library/dev  | `uv pip install autocontext==0.11.0`  |
 | TypeScript/Node CLI | `bun add -g autoctx@0.11.0`           |
-| Pi extension        | `pi install npm:pi-autocontext@0.8.0` |
+| Pi extension        | `pi install npm:pi-autocontext@0.9.0` |
 
 The PyPI package is `autocontext`; the CLI is `autoctx`. The npm package is `autoctx` (not the unrelated `autocontext` npm package). Provider variables live in [`.env.example`](.env.example).
 

--- a/autocontext/tests/test_release_surface_manifest.py
+++ b/autocontext/tests/test_release_surface_manifest.py
@@ -62,7 +62,7 @@ def test_release_manifest_checks_package_version_files() -> None:
     sync = _load_sync_module()
     manifest = sync.ReleaseManifest(
         core_version="9.9.9",
-        pi_version="0.9.0",
+        pi_version="0.8.0",
         pi_autoctx_dependency="^0.9.0",
         whats_new=("**One** thing.",),
     )
@@ -70,5 +70,5 @@ def test_release_manifest_checks_package_version_files() -> None:
     issues = sync.check_release_surfaces(manifest)
 
     assert "autocontext/src/autocontext/__init__.py version 0.11.0 != manifest 9.9.9" in issues
-    assert "pi/package.json version 0.8.0 != manifest 0.9.0" in issues
-    assert "pi/package.json autoctx dependency ^0.10.0 != manifest ^0.9.0" in issues
+    assert "pi/package.json version 0.9.0 != manifest 0.8.0" in issues
+    assert "pi/package.json autoctx dependency ^0.11.0 != manifest ^0.9.0" in issues

--- a/docs/release-manifest.json
+++ b/docs/release-manifest.json
@@ -1,7 +1,7 @@
 {
   "core_version": "0.11.0",
-  "pi_version": "0.8.0",
-  "pi_autoctx_dependency": "^0.10.0",
+  "pi_version": "0.9.0",
+  "pi_autoctx_dependency": "^0.11.0",
   "whats_new": [
     "**Guardrail parity** fixes the CLI agent-task path so it applies the same guardrail-adjusted score threshold as the task runner, evaluated against the fully prepared task state.",
     "**Branded id types** add `RunId`, `ScenarioName`, and `DbPath` to the TypeScript package root; `GenerationRunner.run` now takes a `RunId` (construct with `asRunId`), a compile-time-only change.",

--- a/pi/README.md
+++ b/pi/README.md
@@ -5,16 +5,16 @@ autocontext extension for [Pi coding agent](https://github.com/earendil-works/pi
 ## Install
 
 ```bash
-pi install npm:pi-autocontext@0.8.0
+pi install npm:pi-autocontext@0.9.0
 ```
 
-Current package note: `pi-autocontext@0.8.0` is on a separate Pi extension line and depends on `autoctx@^0.10.0`. A follow-up Pi release can move it to a newer `autoctx` line after the core npm package is live.
+Current package note: `pi-autocontext@0.9.0` is on a separate Pi extension line and depends on `autoctx@^0.11.0`. A follow-up Pi release can move it to a newer `autoctx` line after the core npm package is live.
 
 Or add to your project's `.pi/settings.json`:
 
 ```json
 {
-  "packages": ["npm:pi-autocontext@0.8.0"]
+  "packages": ["npm:pi-autocontext@0.9.0"]
 }
 ```
 

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-autocontext",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-autocontext",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "autoctx": "^0.10.0"
+        "autoctx": "^0.11.0"
       },
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.79.0",
@@ -43,7 +43,6 @@
       "version": "0.91.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
       "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -1094,7 +1093,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4059,12 +4058,12 @@
       }
     },
     "node_modules/autoctx": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.10.0.tgz",
-      "integrity": "sha512-qqIUydbZ6+BPq1N0EFyIvlk8CdMSJSDvpmmXD0j4cm7hWJCFA7lFelu8vJWmM1O2Q6o146q0K7K5th/UKkDF8g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.11.0.tgz",
+      "integrity": "sha512-hO3GASO5rs5L80qE5gkfxsmcURa4QS/RJJUKr9CKV0pG0rCAkMlvm+qzvCB0WPSl5QJ04AGCtd8mBsrXnx/oGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.91.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
@@ -4101,26 +4100,6 @@
           "optional": true
         },
         "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/autoctx/node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
           "optional": true
         }
       }

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autocontext",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "autocontext extension for Pi coding agent — iterative strategy generation, LLM judging, and evaluation tools",
   "type": "module",
   "keywords": [
@@ -27,7 +27,7 @@
     "typebox": "*"
   },
   "dependencies": {
-    "autoctx": "^0.10.0"
+    "autoctx": "^0.11.0"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.79.0",

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -356,7 +356,7 @@ describe("Package manifest", () => {
 
   it("depends on the current autoctx toolkit line", () => {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    expect(pkg.dependencies.autoctx).toBe("^0.10.0");
+    expect(pkg.dependencies.autoctx).toBe("^0.11.0");
   });
 });
 


### PR DESCRIPTION
Follow-up release from AC-865: moves pi to the freshly published autoctx 0.11.0 line. pi version 0.8.0 to 0.9.0, autoctx dependency ^0.10.0 to ^0.11.0, lockfile resolved to autoctx 0.11.0, manifest + readme install snippets resynced, manifest self-check expectations updated, pi suite 40/40 and lint green.

Verified explicitly: `npm ci --ignore-scripts` from the committed lockfile passes with NPM_CONFIG_MIN_RELEASE_AGE=7 (the CI gate only applies to fresh resolution, not lockfile installs), so CI is not blocked by autoctx 0.11.0 being minutes old.

After merge: tag `pi-v0.9.0` to trigger publish-pi-autocontext.yml. This clears the final nested @anthropic-ai/sdk Dependabot alert once the new lockfile lands.