### PR TITLE
AC-872: run the full TypeScript test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
           nodedir="$(dirname "$(dirname "$(command -v node)")")"
           test -d "$nodedir/include/node"
           echo "npm_config_nodedir=$nodedir" >> "$GITHUB_ENV"
+      - uses: oven-sh/setup-bun@v2
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
         run: npm rebuild better-sqlite3 isolated-vm
       - name: Run full TypeScript test suite
         run: npm test
+        env:
+          # Sync Python subprocess spawns in the hashing-parity property tests
+          # block vitest workers long enough to starve the worker RPC channel
+          # on saturated runners; 25 runs keeps the parity check meaningful
+          # while staying under the RPC timeout. Local runs default to 100.
+          HASHING_PARITY_NUM_RUNS: "25"
 
   smoke:
     needs: [lint, test, package-boundaries]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,40 @@ jobs:
         working-directory: ts
         run: uv run --frozen --project ../autocontext -- npm run check:schemas
 
+  ts-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: ts
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: ts/.nvmrc
+      - name: Reuse setup-node headers for native addons
+        shell: bash
+        run: |
+          nodedir="$(dirname "$(dirname "$(command -v node)")")"
+          test -d "$nodedir/include/node"
+          echo "npm_config_nodedir=$nodedir" >> "$GITHUB_ENV"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+      - name: Install Python parity deps
+        working-directory: autocontext
+        run: uv sync --locked --group dev
+      - name: Install TypeScript deps
+        run: npm ci --ignore-scripts
+      - name: Rebuild native modules (better-sqlite3, isolated-vm)
+        run: npm rebuild better-sqlite3 isolated-vm
+      - name: Run full TypeScript test suite
+        run: npm test
+
   smoke:
     needs: [lint, test, package-boundaries]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,11 @@ jobs:
       - name: Rebuild native modules (better-sqlite3, isolated-vm)
         run: npm rebuild better-sqlite3 isolated-vm
       - name: Run full TypeScript test suite
-        run: npm test
+        # The dot reporter and capped workers keep the vitest host process
+        # responsive: with the default reporter streaming per-test lines for
+        # 5,600+ tests, the host starves worker RPC calls and the run fails
+        # with "Timeout calling onTaskUpdate" despite all tests passing.
+        run: npm test -- --reporter=dot --maxWorkers=2
         env:
           # Sync Python subprocess spawns in the hashing-parity property tests
           # block vitest workers long enough to starve the worker RPC channel

--- a/ts/src/control-plane/emit/pipeline.ts
+++ b/ts/src/control-plane/emit/pipeline.ts
@@ -160,6 +160,7 @@ export async function emitPr(
     layout,
     ...(opts.baseBranch ? { baseBranch: opts.baseBranch } : {}),
     ...(opts.preflightDetector ? { detect: opts.preflightDetector } : {}),
+    ...(opts.env ? { env: opts.env } : {}),
   });
   if (!preflightResult.ok) {
     throw new EmitPreflightError(preflightResult.issues);
@@ -188,8 +189,9 @@ export async function emitPr(
   const branchName = opts.branchName ?? branchNameFor(candidate);
   const decisionBand = decisionBandOf(decision);
   const baseBranch = opts.baseBranch ?? "main";
-  const prTitle = opts.prTitle
-    ?? `autocontext: promote ${candidate.actuatorType} for ${candidate.scenario} (${decisionBand})`;
+  const prTitle =
+    opts.prTitle ??
+    `autocontext: promote ${candidate.actuatorType} for ${candidate.scenario} (${decisionBand})`;
 
   let location: EmitLocation;
   switch (resolvedMode) {
@@ -263,7 +265,11 @@ function resolveBaseline(
   if (arg === null) return null;
   let baseArtifact: Artifact | null = null;
   if (arg === "auto") {
-    baseArtifact = registry.getActive(candidate.scenario, candidate.actuatorType, candidate.environmentTag);
+    baseArtifact = registry.getActive(
+      candidate.scenario,
+      candidate.actuatorType,
+      candidate.environmentTag,
+    );
   } else {
     try {
       baseArtifact = registry.loadArtifact(arg);
@@ -284,10 +290,14 @@ function resolveBaseline(
 function decisionBandOf(d: PromotionDecision): string {
   if (!d.pass) return "HARD FAIL";
   switch (d.recommendedTargetState) {
-    case "active": return "STRONG";
-    case "canary": return "MODERATE";
-    case "shadow": return "MARGINAL";
-    case "disabled": return "HARD FAIL";
+    case "active":
+      return "STRONG";
+    case "canary":
+      return "MODERATE";
+    case "shadow":
+      return "MARGINAL";
+    case "disabled":
+      return "HARD FAIL";
   }
 }
 

--- a/ts/src/control-plane/emit/preflight.ts
+++ b/ts/src/control-plane/emit/preflight.ts
@@ -56,6 +56,8 @@ export interface PreflightInputs {
   readonly baseBranch?: string;
   /** Optional detector; a default implementation shells out to gh/git via execFileSync. */
   readonly detect?: PreflightDetector;
+  /** Env for the default detector's gh/git subprocess calls. Default: process.env. */
+  readonly env?: NodeJS.ProcessEnv;
 }
 
 /**
@@ -66,7 +68,7 @@ export interface PreflightInputs {
  */
 export function preflight(inputs: PreflightInputs): PreflightResult {
   const { candidate, mode, baseBranch } = inputs;
-  const detect = inputs.detect ?? defaultDetector(inputs.cwd);
+  const detect = inputs.detect ?? defaultDetector(inputs.cwd, inputs.env);
   const issues: PreflightIssue[] = [];
 
   // --- 13: target-path / actuator resolvability ---
@@ -167,7 +169,10 @@ function globToRegExp(pattern: string): RegExp {
         re += escapeRe(c);
         i += 1;
       } else {
-        const alts = pattern.slice(i + 1, end).split(",").map(escapeRe);
+        const alts = pattern
+          .slice(i + 1, end)
+          .split(",")
+          .map(escapeRe);
         re += `(?:${alts.join("|")})`;
         i = end + 1;
       }
@@ -186,11 +191,12 @@ function escapeRe(s: string): string {
 
 // ---------- default detector ----------
 
-function defaultDetector(cwd: string): PreflightDetector {
+function defaultDetector(cwd: string, env?: NodeJS.ProcessEnv): PreflightDetector {
+  const subprocessEnv = env ?? process.env;
   return {
     gh(): boolean {
       try {
-        execFileSync("gh", ["auth", "status"], { cwd, stdio: "ignore" });
+        execFileSync("gh", ["auth", "status"], { cwd, env: subprocessEnv, stdio: "ignore" });
         return true;
       } catch {
         return false;
@@ -198,7 +204,7 @@ function defaultDetector(cwd: string): PreflightDetector {
     },
     git(): boolean {
       try {
-        execFileSync("git", ["--version"], { cwd, stdio: "ignore" });
+        execFileSync("git", ["--version"], { cwd, env: subprocessEnv, stdio: "ignore" });
         // Also verify a git repo is initialized at cwd.
         return existsSync(join(cwd, ".git"));
       } catch {
@@ -209,6 +215,7 @@ function defaultDetector(cwd: string): PreflightDetector {
       try {
         const out = execFileSync("git", ["status", "--porcelain"], {
           cwd,
+          env: subprocessEnv,
           stdio: ["ignore", "pipe", "ignore"],
         });
         return out.toString("utf-8").trim().length === 0;
@@ -220,6 +227,7 @@ function defaultDetector(cwd: string): PreflightDetector {
       try {
         execFileSync("git", ["rev-parse", "--verify", branch], {
           cwd,
+          env: subprocessEnv,
           stdio: "ignore",
         });
         return true;
@@ -228,6 +236,7 @@ function defaultDetector(cwd: string): PreflightDetector {
         try {
           execFileSync("git", ["rev-parse", "--verify", `origin/${branch}`], {
             cwd,
+            env: subprocessEnv,
             stdio: "ignore",
           });
           return true;

--- a/ts/tests/campaign-cli.test.ts
+++ b/ts/tests/campaign-cli.test.ts
@@ -234,7 +234,7 @@ describe("autoctx campaign list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.length).toBe(1);
     expect(parsed[0].name).toBe("B");
-  }, 15000);
+  });
 
   it("rejects invalid status filters", () => {
     const { exitCode, stderr } = runCli(["campaign", "list", "--status", "mystery"], { cwd: dir });
@@ -278,7 +278,7 @@ describe("autoctx campaign add-mission and progress", () => {
     });
     const progress = JSON.parse(progressOut);
     expect(progress.totalMissions).toBe(1);
-  }, 15000);
+  });
 
   it("adds a mission with priority and dependencies", () => {
     const { stdout: cOut } = runCli(["campaign", "create", "--name", "C", "--goal", "g"], {
@@ -317,7 +317,7 @@ describe("autoctx campaign add-mission and progress", () => {
     const { stdout: statusOut } = runCli(["campaign", "status", "--id", campaignId], { cwd: dir });
     const status = JSON.parse(statusOut);
     expect(status.missions.length).toBe(2);
-  }, 15000);
+  });
 
   it("rejects invalid priority values", () => {
     const { stdout: cOut } = runCli(["campaign", "create", "--name", "C", "--goal", "g"], {
@@ -345,7 +345,7 @@ describe("autoctx campaign add-mission and progress", () => {
     );
     expect(exitCode).toBe(1);
     expect(stderr).toContain("--priority must be a positive integer");
-  }, 15000);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -387,7 +387,7 @@ describe("autoctx campaign lifecycle", () => {
 
     const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("active");
-  }, 15000);
+  });
 
   it("cancel sets status to canceled", () => {
     const { stdout: created } = runCli(["campaign", "create", "--name", "T", "--goal", "g"], {
@@ -417,7 +417,7 @@ describe("autoctx campaign lifecycle", () => {
 
     const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("canceled");
-  }, 15000);
+  });
 
   it("returns an error for nonexistent campaign IDs", () => {
     const { stderr, exitCode } = runCli(["campaign", "status", "--id", "nonexistent-id"], {

--- a/ts/tests/campaign-cli.test.ts
+++ b/ts/tests/campaign-cli.test.ts
@@ -116,14 +116,7 @@ describe("autoctx campaign create", () => {
 
   it("creates a campaign and returns its ID", () => {
     const { stdout, exitCode } = runCli(
-      [
-        "campaign",
-        "create",
-        "--name",
-        "Q2 Goals",
-        "--goal",
-        "Ship OAuth and billing",
-      ],
+      ["campaign", "create", "--name", "Q2 Goals", "--goal", "Ship OAuth and billing"],
       { cwd: dir },
     );
     expect(exitCode).toBe(0);
@@ -164,16 +157,7 @@ describe("autoctx campaign create", () => {
 
   it("rejects invalid numeric budget flags", () => {
     const { exitCode, stderr } = runCli(
-      [
-        "campaign",
-        "create",
-        "--name",
-        "Bad",
-        "--goal",
-        "g",
-        "--max-missions",
-        "oops",
-      ],
+      ["campaign", "create", "--name", "Bad", "--goal", "g", "--max-missions", "oops"],
       { cwd: dir },
     );
     expect(exitCode).toBe(1);
@@ -237,10 +221,9 @@ describe("autoctx campaign list", () => {
   });
 
   it("filters by status", () => {
-    const { stdout: r1 } = runCli(
-      ["campaign", "create", "--name", "A", "--goal", "g1"],
-      { cwd: dir },
-    );
+    const { stdout: r1 } = runCli(["campaign", "create", "--name", "A", "--goal", "g1"], {
+      cwd: dir,
+    });
     runCli(["campaign", "create", "--name", "B", "--goal", "g2"], { cwd: dir });
     const { id } = JSON.parse(r1);
     runCli(["campaign", "pause", "--id", id], { cwd: dir });
@@ -254,10 +237,7 @@ describe("autoctx campaign list", () => {
   }, 15000);
 
   it("rejects invalid status filters", () => {
-    const { exitCode, stderr } = runCli(
-      ["campaign", "list", "--status", "mystery"],
-      { cwd: dir },
-    );
+    const { exitCode, stderr } = runCli(["campaign", "list", "--status", "mystery"], { cwd: dir });
     expect(exitCode).toBe(1);
     expect(stderr).toContain("--status must be one of");
   });
@@ -277,62 +257,46 @@ describe("autoctx campaign add-mission and progress", () => {
   });
 
   it("adds a mission to a campaign", () => {
-    const { stdout: cOut } = runCli(
-      ["campaign", "create", "--name", "C", "--goal", "g"],
-      { cwd: dir },
-    );
+    const { stdout: cOut } = runCli(["campaign", "create", "--name", "C", "--goal", "g"], {
+      cwd: dir,
+    });
     const campaignId = JSON.parse(cOut).id;
 
-    const { stdout: mOut } = runCli(
-      ["mission", "create", "--name", "M1", "--goal", "mg"],
-      { cwd: dir },
-    );
+    const { stdout: mOut } = runCli(["mission", "create", "--name", "M1", "--goal", "mg"], {
+      cwd: dir,
+    });
     const missionId = JSON.parse(mOut).id;
 
     const { exitCode } = runCli(
-      [
-        "campaign",
-        "add-mission",
-        "--id",
-        campaignId,
-        "--mission-id",
-        missionId,
-      ],
+      ["campaign", "add-mission", "--id", campaignId, "--mission-id", missionId],
       { cwd: dir },
     );
     expect(exitCode).toBe(0);
 
-    const { stdout: progressOut } = runCli(
-      ["campaign", "progress", "--id", campaignId],
-      { cwd: dir },
-    );
+    const { stdout: progressOut } = runCli(["campaign", "progress", "--id", campaignId], {
+      cwd: dir,
+    });
     const progress = JSON.parse(progressOut);
     expect(progress.totalMissions).toBe(1);
   }, 15000);
 
   it("adds a mission with priority and dependencies", () => {
-    const { stdout: cOut } = runCli(
-      ["campaign", "create", "--name", "C", "--goal", "g"],
-      { cwd: dir },
-    );
+    const { stdout: cOut } = runCli(["campaign", "create", "--name", "C", "--goal", "g"], {
+      cwd: dir,
+    });
     const campaignId = JSON.parse(cOut).id;
 
-    const { stdout: m1Out } = runCli(
-      ["mission", "create", "--name", "M1", "--goal", "mg1"],
-      { cwd: dir },
-    );
+    const { stdout: m1Out } = runCli(["mission", "create", "--name", "M1", "--goal", "mg1"], {
+      cwd: dir,
+    });
     const m1Id = JSON.parse(m1Out).id;
 
-    const { stdout: m2Out } = runCli(
-      ["mission", "create", "--name", "M2", "--goal", "mg2"],
-      { cwd: dir },
-    );
+    const { stdout: m2Out } = runCli(["mission", "create", "--name", "M2", "--goal", "mg2"], {
+      cwd: dir,
+    });
     const m2Id = JSON.parse(m2Out).id;
 
-    runCli(
-      ["campaign", "add-mission", "--id", campaignId, "--mission-id", m1Id],
-      { cwd: dir },
-    );
+    runCli(["campaign", "add-mission", "--id", campaignId, "--mission-id", m1Id], { cwd: dir });
     const { exitCode } = runCli(
       [
         "campaign",
@@ -350,25 +314,20 @@ describe("autoctx campaign add-mission and progress", () => {
     );
     expect(exitCode).toBe(0);
 
-    const { stdout: statusOut } = runCli(
-      ["campaign", "status", "--id", campaignId],
-      { cwd: dir },
-    );
+    const { stdout: statusOut } = runCli(["campaign", "status", "--id", campaignId], { cwd: dir });
     const status = JSON.parse(statusOut);
     expect(status.missions.length).toBe(2);
   }, 15000);
 
   it("rejects invalid priority values", () => {
-    const { stdout: cOut } = runCli(
-      ["campaign", "create", "--name", "C", "--goal", "g"],
-      { cwd: dir },
-    );
+    const { stdout: cOut } = runCli(["campaign", "create", "--name", "C", "--goal", "g"], {
+      cwd: dir,
+    });
     const campaignId = JSON.parse(cOut).id;
 
-    const { stdout: mOut } = runCli(
-      ["mission", "create", "--name", "M1", "--goal", "mg"],
-      { cwd: dir },
-    );
+    const { stdout: mOut } = runCli(["mission", "create", "--name", "M1", "--goal", "mg"], {
+      cwd: dir,
+    });
     const missionId = JSON.parse(mOut).id;
 
     const { exitCode, stderr } = runCli(
@@ -386,7 +345,7 @@ describe("autoctx campaign add-mission and progress", () => {
     );
     expect(exitCode).toBe(1);
     expect(stderr).toContain("--priority must be a positive integer");
-  });
+  }, 15000);
 });
 
 // ---------------------------------------------------------------------------
@@ -403,10 +362,9 @@ describe("autoctx campaign lifecycle", () => {
   });
 
   it("pause sets status to paused", () => {
-    const { stdout: created } = runCli(
-      ["campaign", "create", "--name", "T", "--goal", "g"],
-      { cwd: dir },
-    );
+    const { stdout: created } = runCli(["campaign", "create", "--name", "T", "--goal", "g"], {
+      cwd: dir,
+    });
     const { id } = JSON.parse(created);
 
     const { exitCode } = runCli(["campaign", "pause", "--id", id], {
@@ -419,10 +377,9 @@ describe("autoctx campaign lifecycle", () => {
   });
 
   it("resume sets status back to active", () => {
-    const { stdout: created } = runCli(
-      ["campaign", "create", "--name", "T", "--goal", "g"],
-      { cwd: dir },
-    );
+    const { stdout: created } = runCli(["campaign", "create", "--name", "T", "--goal", "g"], {
+      cwd: dir,
+    });
     const { id } = JSON.parse(created);
 
     runCli(["campaign", "pause", "--id", id], { cwd: dir });
@@ -433,10 +390,9 @@ describe("autoctx campaign lifecycle", () => {
   }, 15000);
 
   it("cancel sets status to canceled", () => {
-    const { stdout: created } = runCli(
-      ["campaign", "create", "--name", "T", "--goal", "g"],
-      { cwd: dir },
-    );
+    const { stdout: created } = runCli(["campaign", "create", "--name", "T", "--goal", "g"], {
+      cwd: dir,
+    });
     const { id } = JSON.parse(created);
 
     runCli(["campaign", "cancel", "--id", id], { cwd: dir });
@@ -446,10 +402,9 @@ describe("autoctx campaign lifecycle", () => {
   });
 
   it("does not allow canceled campaigns to resume", () => {
-    const { stdout: created } = runCli(
-      ["campaign", "create", "--name", "T", "--goal", "g"],
-      { cwd: dir },
-    );
+    const { stdout: created } = runCli(["campaign", "create", "--name", "T", "--goal", "g"], {
+      cwd: dir,
+    });
     const { id } = JSON.parse(created);
 
     runCli(["campaign", "cancel", "--id", id], { cwd: dir });
@@ -462,13 +417,12 @@ describe("autoctx campaign lifecycle", () => {
 
     const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("canceled");
-  });
+  }, 15000);
 
   it("returns an error for nonexistent campaign IDs", () => {
-    const { stderr, exitCode } = runCli(
-      ["campaign", "status", "--id", "nonexistent-id"],
-      { cwd: dir },
-    );
+    const { stderr, exitCode } = runCli(["campaign", "status", "--id", "nonexistent-id"], {
+      cwd: dir,
+    });
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Campaign not found");
   });

--- a/ts/tests/package-parity.test.ts
+++ b/ts/tests/package-parity.test.ts
@@ -172,7 +172,7 @@ describe("CLI help matches README", () => {
     for (const cmd of expected) {
       expect(help).toContain(cmd);
     }
-  }, 15000);
+  }, 120000);
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/production-traces/sdk/hashing-parity.property.test.ts
+++ b/ts/tests/production-traces/sdk/hashing-parity.property.test.ts
@@ -38,7 +38,11 @@ const idArb = fc
 // worker long enough under CI load to starve the worker RPC channel
 // ("Timeout calling onTaskUpdate"). CI sets HASHING_PARITY_NUM_RUNS to a
 // smaller count; local runs keep the full 100.
-const numRuns = Number(process.env.HASHING_PARITY_NUM_RUNS ?? "100");
+// Guard against empty-string/typo env values: Number("") is 0 and fast-check
+// with numRuns 0 passes vacuously, so fall back to 100 unless the value is a
+// positive integer.
+const parsedNumRuns = Number(process.env.HASHING_PARITY_NUM_RUNS ?? "100");
+const numRuns = Number.isInteger(parsedNumRuns) && parsedNumRuns > 0 ? parsedNumRuns : 100;
 
 maybeSuite(`P-hashing-parity (property, ${numRuns} runs)`, () => {
   test("hashUserId matches Python hash_user_id byte-for-byte", async () => {

--- a/ts/tests/production-traces/sdk/hashing-parity.property.test.ts
+++ b/ts/tests/production-traces/sdk/hashing-parity.property.test.ts
@@ -1,9 +1,6 @@
 import { describe, test } from "vitest";
 import fc from "fast-check";
-import {
-  hashUserId,
-  hashSessionId,
-} from "../../../src/production-traces/sdk/hashing.js";
+import { hashUserId, hashSessionId } from "../../../src/production-traces/sdk/hashing.js";
 import {
   callPythonHashUserIdAsync,
   callPythonHashSessionIdAsync,
@@ -30,10 +27,20 @@ const maybeSuite = parity ? describe : describe.skip;
 // encoding. The actual production install-salt is 64 hex chars, but the
 // primitive admits any non-empty salt, so we property-test the algorithm
 // shape broadly.
-const saltArb = fc.string({ minLength: 1, maxLength: 64 }).filter((s) => s.length > 0 && !s.includes("\u0000"));
-const idArb = fc.string({ minLength: 1, maxLength: 64 }).filter((s) => s.length > 0 && !s.includes("\u0000"));
+const saltArb = fc
+  .string({ minLength: 1, maxLength: 64 })
+  .filter((s) => s.length > 0 && !s.includes("\u0000"));
+const idArb = fc
+  .string({ minLength: 1, maxLength: 64 })
+  .filter((s) => s.length > 0 && !s.includes("\u0000"));
 
-maybeSuite("P-hashing-parity (property, 100 runs)", () => {
+// Each property run spawns a Python subprocess, which blocks the vitest
+// worker long enough under CI load to starve the worker RPC channel
+// ("Timeout calling onTaskUpdate"). CI sets HASHING_PARITY_NUM_RUNS to a
+// smaller count; local runs keep the full 100.
+const numRuns = Number(process.env.HASHING_PARITY_NUM_RUNS ?? "100");
+
+maybeSuite(`P-hashing-parity (property, ${numRuns} runs)`, () => {
   test("hashUserId matches Python hash_user_id byte-for-byte", async () => {
     await fc.assert(
       fc.asyncProperty(idArb, saltArb, async (userId, salt) => {
@@ -41,7 +48,7 @@ maybeSuite("P-hashing-parity (property, 100 runs)", () => {
         const py = await callPythonHashUserIdAsync(userId, salt);
         return ts === py;
       }),
-      { numRuns: 100 },
+      { numRuns },
     );
   }, 120_000);
 
@@ -52,7 +59,7 @@ maybeSuite("P-hashing-parity (property, 100 runs)", () => {
         const py = await callPythonHashSessionIdAsync(sessionId, salt);
         return ts === py;
       }),
-      { numRuns: 100 },
+      { numRuns },
     );
   }, 120_000);
 });

--- a/ts/vitest.config.ts
+++ b/ts/vitest.config.ts
@@ -4,5 +4,13 @@ export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
     maxWorkers: 4,
+    // Many tests spawn the CLI cold (npx tsx src/cli/index.ts) rather than
+    // against a pre-built dist/. That's ~1-2s per spawn on a fast dev
+    // machine but can run ~5s+ per spawn on CI runner hardware, and several
+    // tests chain 3-5 spawns. The vitest default (5000ms) is tuned for the
+    // former and flakes on the latter; 30000ms gives CI headroom without
+    // masking genuine hangs. Individual tests with a slower one-off step
+    // (e.g. a real `npm run build`) still set their own larger override.
+    testTimeout: 30000,
   },
 });


### PR DESCRIPTION
Adds a `ts-test` job to ci.yml running the entire TypeScript suite (805 files, 5,624 tests: 5,622 pass, 2 deliberate known-bug skips tracked by AC-873/AC-874). Before this, CI executed only the package-topology/boundary tests and the SDK-matrix subsets; the bulk of ts/tests/ ran nowhere (AC-872), which is how real regressions went undetected.

Job design: Node 22 via .nvmrc, npm ci --ignore-scripts + targeted rebuild of better-sqlite3/isolated-vm, Python parity deps for the cross-language tests, full vitest run. Green run duration: ~6 minutes.

It took five iterations to stabilize on real runners; the fixes are all in this PR:
1. CI-environment test fixes: spawned-CLI timeout headroom, a hermetic gh shim for the emit-pr integration test (runners carry a real authenticated gh), stdin-driven CLI test fixes.
2. File-wide vitest testTimeout for spawn-heavy CLI test files (per-test whack-a-mole failed: different tests died each run).
3. HASHING_PARITY_NUM_RUNS env knob: the parity property tests spawn a Python subprocess per run; CI uses 25 runs, local keeps 100.
4. Dot reporter + maxWorkers=2 for the CI run: with the default reporter streaming per-test lines for 5,600+ tests, the vitest host process starved worker RPC calls and the run failed with "Timeout calling onTaskUpdate" despite all tests passing.

Verification: ts-test green on this PR (run a535e921), all other checks green.