### PR TITLE
AC-874: restore CHILD_TASK_STARTED on early child task rejection

### DIFF
--- a/ts/src/session/runtime-child-tasks.ts
+++ b/ts/src/session/runtime-child-tasks.ts
@@ -150,8 +150,26 @@ export class RuntimeChildTaskRunner {
       maxDepth: this.maxDepth,
     });
 
+    this.coordinator.startWorker(worker.workerId, coordinatorLineage);
+    this.parentLog.append(RuntimeSessionEventType.CHILD_TASK_STARTED, {
+      taskId,
+      childSessionId,
+      workerId: worker.workerId,
+      role: opts.role,
+      cwd: childCwd,
+      depth: childDepth,
+      maxDepth: this.maxDepth,
+    });
+    childLog.append(RuntimeSessionEventType.PROMPT_SUBMITTED, {
+      prompt: opts.prompt,
+      role: opts.role,
+      cwd: childCwd,
+      depth: childDepth,
+      maxDepth: this.maxDepth,
+    });
+    this.persist(childLog);
+
     if (this.depth >= this.maxDepth) {
-      this.coordinator.startWorker(worker.workerId, coordinatorLineage);
       return this.failChildTask({
         taskId,
         childSessionId,
@@ -164,7 +182,6 @@ export class RuntimeChildTaskRunner {
       });
     }
     if (activeChildCount >= this.maxConcurrentChildTasks) {
-      this.coordinator.startWorker(worker.workerId, coordinatorLineage);
       return this.failChildTask({
         taskId,
         childSessionId,
@@ -176,18 +193,6 @@ export class RuntimeChildTaskRunner {
         message: `Maximum concurrent child sessions (${this.maxConcurrentChildTasks}) exceeded`,
       });
     }
-
-    this.coordinator.startWorker(worker.workerId, coordinatorLineage);
-    this.parentLog.append(RuntimeSessionEventType.CHILD_TASK_STARTED, {
-      taskId,
-      childSessionId,
-      workerId: worker.workerId,
-      role: opts.role,
-      cwd: childCwd,
-      depth: childDepth,
-      maxDepth: this.maxDepth,
-    });
-    this.persist(childLog);
 
     let childWorkspace: RuntimeWorkspaceEnv;
     try {
@@ -226,13 +231,6 @@ export class RuntimeChildTaskRunner {
         childLog: canceledAfterScope,
       });
     }
-    childLog.append(RuntimeSessionEventType.PROMPT_SUBMITTED, {
-      prompt: opts.prompt,
-      role: opts.role,
-      cwd: childWorkspace.cwd,
-      depth: childDepth,
-      maxDepth: this.maxDepth,
-    });
 
     try {
       const output = await opts.handler({
@@ -268,11 +266,10 @@ export class RuntimeChildTaskRunner {
         depth: childDepth,
         maxDepth: this.maxDepth,
       });
-      this.coordinator.completeWorker(
-        worker.workerId,
-        text,
-        { ...coordinatorLineage, isError: false },
-      );
+      this.coordinator.completeWorker(worker.workerId, text, {
+        ...coordinatorLineage,
+        isError: false,
+      });
       this.parentLog.append(RuntimeSessionEventType.CHILD_TASK_COMPLETED, {
         taskId,
         childSessionId,

--- a/ts/tests/runtime-child-session-controls.test.ts
+++ b/ts/tests/runtime-child-session-controls.test.ts
@@ -69,11 +69,17 @@ describe("runtime child session controls", () => {
       isError: true,
       error: "Maximum concurrent child sessions (1) exceeded",
     });
+    // AC-874: every delegated task attempt, including one rejected by the concurrency
+    // guardrail, logs a paired CHILD_TASK_STARTED/CHILD_TASK_COMPLETED so consumers that
+    // reconcile start/end event pairs (e.g. the runtime-session timeline) never see an
+    // orphaned failure event. This is orthogonal to slot reservation: "second" still loses
+    // the race and never runs its handler (see startedTasks above); it just also gets a
+    // start/end pair recorded for the rejected attempt.
     const parent = eventStore.load("runtime-parent");
     const startedEvents = (parent?.events ?? []).filter(
       (event) => event.eventType === RuntimeSessionEventType.CHILD_TASK_STARTED,
     );
-    expect(startedEvents.map((event) => event.payload.taskId)).toEqual(["first"]);
+    expect(startedEvents.map((event) => event.payload.taskId)).toEqual(["first", "second"]);
 
     eventStore.close();
   });

--- a/ts/tests/runtime-child-tasks.test.ts
+++ b/ts/tests/runtime-child-tasks.test.ts
@@ -154,16 +154,7 @@ describe("RuntimeChildTaskRunner", () => {
     });
   });
 
-  // AC-783 ("model child background sessions") moved the depth/concurrency early-rejection
-  // checks in RuntimeChildTaskRunner.run() to before the CHILD_TASK_STARTED append, so a
-  // depth-exceeded task now logs only CHILD_TASK_COMPLETED (no CHILD_TASK_STARTED) to
-  // parentLog. That is a real, deterministic behavior regression from the pre-AC-783
-  // contract this test encodes (start-then-outcome lifecycle for every delegated task
-  // attempt), not a test-hygiene or environment problem. Fixing RuntimeChildTaskRunner is
-  // out of scope for AC-867 (test-baseline hygiene) and needs its own review since other
-  // consumers may have been written against the current (buggy) event sequence since
-  // June 12. Tracked as a finding in the AC-867 report; not fixed here.
-  it.skip("fails delegated tasks that exceed the configured child task depth", async () => {
+  it("fails delegated tasks that exceed the configured child task depth", async () => {
     const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
     const coordinator = Coordinator.create("parent-session", "ship auth");
     const parentLog = RuntimeSessionEventLog.create({ sessionId: "parent-session" });
@@ -226,6 +217,88 @@ describe("RuntimeChildTaskRunner", () => {
       maxDepth: 1,
     });
     expect(result.childSessionLog.metadata).toMatchObject({ depth: 2, maxDepth: 1 });
+    expect(result.childSessionLog.events.map((event) => event.eventType)).toEqual([
+      RuntimeSessionEventType.PROMPT_SUBMITTED,
+      RuntimeSessionEventType.ASSISTANT_MESSAGE,
+    ]);
+  });
+
+  it("fails delegated tasks that exceed the configured concurrent child task limit", async () => {
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
+    const coordinator = Coordinator.create("parent-session", "ship auth");
+    const parentLog = RuntimeSessionEventLog.create({ sessionId: "parent-session" });
+    const runner = new RuntimeChildTaskRunner({
+      coordinator,
+      parentLog,
+      workspace,
+      maxConcurrentChildTasks: 1,
+    });
+    let called = false;
+
+    // Seed an already-active child session (CHILD_TASK_STARTED with no matching
+    // CHILD_TASK_COMPLETED yet) so the next run() call is rejected for exceeding
+    // maxConcurrentChildTasks.
+    parentLog.append(RuntimeSessionEventType.CHILD_TASK_STARTED, {
+      taskId: "task-in-flight",
+      childSessionId: "task:parent-session:task-in-flight:worker-0",
+      workerId: "worker-0",
+      role: "researcher",
+      cwd: "/workspace",
+      depth: 1,
+      maxDepth: 4,
+    });
+
+    const result = await runner.run({
+      taskId: "task-too-many",
+      prompt: "Research nested auth flow",
+      role: "researcher",
+      handler: () => {
+        called = true;
+        return { text: "should not run" };
+      },
+    });
+
+    expect(called).toBe(false);
+    expect(result).toMatchObject({
+      taskId: "task-too-many",
+      isError: true,
+      text: "",
+      error: "Maximum concurrent child sessions (1) exceeded",
+      depth: 1,
+      maxDepth: 4,
+    });
+    expect(coordinator.workers[0].status).toBe(WorkerStatus.FAILED);
+    expect(
+      coordinator.events.find((event) => event.eventType === CoordinatorEventType.WORKER_FAILED)
+        ?.payload,
+    ).toMatchObject({
+      workerId: result.workerId,
+      taskId: "task-too-many",
+      childSessionId: result.childSessionId,
+      parentSessionId: "parent-session",
+      isError: true,
+      error: "Maximum concurrent child sessions (1) exceeded",
+      depth: 1,
+      maxDepth: 4,
+    });
+    expect(parentLog.events.map((event) => event.eventType)).toEqual([
+      RuntimeSessionEventType.CHILD_TASK_STARTED,
+      RuntimeSessionEventType.CHILD_TASK_STARTED,
+      RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+    ]);
+    expect(parentLog.events[1].payload).toMatchObject({
+      taskId: "task-too-many",
+      depth: 1,
+      maxDepth: 4,
+    });
+    expect(parentLog.events.at(-1)?.payload).toMatchObject({
+      taskId: "task-too-many",
+      isError: true,
+      error: "Maximum concurrent child sessions (1) exceeded",
+      depth: 1,
+      maxDepth: 4,
+    });
+    expect(result.childSessionLog.metadata).toMatchObject({ depth: 1, maxDepth: 4 });
     expect(result.childSessionLog.events.map((event) => event.eventType)).toEqual([
       RuntimeSessionEventType.PROMPT_SUBMITTED,
       RuntimeSessionEventType.ASSISTANT_MESSAGE,


### PR DESCRIPTION
## Summary

`RuntimeChildTaskRunner.run()` dropped `CHILD_TASK_STARTED` from the parent session log whenever a child task was rejected early (depth exceeded, or `maxConcurrentChildTasks` exceeded). Consumers that reconcile start/end event pairs for the parent log never saw a start event for these rejections, only the trailing `CHILD_TASK_COMPLETED` failure.

## Root cause

AC-783 ("model child background sessions", `e7f425b9`) restructured `run()` to check `depth >= maxDepth` and `activeChildCount >= maxConcurrentChildTasks` *before* appending `CHILD_TASK_STARTED`, so both early-rejection paths returned via `failChildTask()` without ever recording a start event. Before AC-783, `CHILD_TASK_STARTED` (and the child log's `PROMPT_SUBMITTED`) were always appended first, then the depth check ran.

## Consumer-contract analysis

Grepped every non-test reference to `CHILD_TASK_STARTED` / `CHILD_TASK_COMPLETED` (there is no separate `CHILD_TASK_FAILED` type; failure is `CHILD_TASK_COMPLETED` with `isError: true`). The decisive consumer is `ts/src/session/runtime-session-timeline.ts`:

- `CHILD_TASK_STARTED` creates a `child_task` timeline item and indexes it by correlation key (`childSessionId`, `taskId:workerId`, `taskId`).
- `CHILD_TASK_COMPLETED` looks up that indexed item via `findChildTaskForCompletion` and marks it `completed`/`failed`. If no matching `CHILD_TASK_STARTED` was ever indexed, the completion event falls through to `genericItemFromEvent` — the failure is silently downgraded from a `child_task` item to an opaque generic log line, breaking timeline/cockpit reconciliation.

This confirms the pre-AC-783 contract (start-then-outcome for every delegated task attempt, including early rejections) is the one downstream code actually depends on. Restored it for **both** early-rejection paths (depth and concurrency), not just depth.

One existing test, `runtime-child-session-controls.test.ts` > "reserves child-session slots before async workspace setup", asserted the *old (buggy)* no-`CHILD_TASK_STARTED`-on-concurrency-rejection behavior as part of testing the race-safety of the concurrency guardrail (two tasks racing for one slot via `Promise.all`). The guardrail's synchronous-check-before-any-`await` reservation logic is untouched by this fix — a rejected task's `CHILD_TASK_STARTED`+`CHILD_TASK_COMPLETED` pair is written atomically within the same synchronous prefix, before any concurrent caller resumes, so it never inflates the active-child count seen by others. Updated that test's assertion (with an inline comment explaining why) to expect both `first` and `second` to log a start event, since `second` is still rejected before its handler runs — only the event-pairing changed, not the reservation semantics.

## RED / GREEN

- RED: un-skipped `runtime-child-tasks.test.ts` > "fails delegated tasks that exceed the configured child task depth" against unmodified `main` — failed on both the parent-log `CHILD_TASK_STARTED`/`CHILD_TASK_COMPLETED` pairing and the child-log `PROMPT_SUBMITTED`/`ASSISTANT_MESSAGE` pairing.
- GREEN: after moving the `CHILD_TASK_STARTED` (parent log) and `PROMPT_SUBMITTED` (child log) appends before both early-rejection checks, the depth test passes. Added a sibling test for the `maxConcurrentChildTasks` rejection path (not previously covered) asserting the same event-pairing contract; it passes.

## Covering suites (serial, Node 22)

`runtime-child-tasks.test.ts`, `runtime-child-session-controls.test.ts`, `runtime-session.test.ts`, `runtime-session-events.test.ts`, `runtime-session-read-model.test.ts`, `runtime-session-run-trace.test.ts`, `runtime-session-command-workflow.test.ts`, `background-session-events.test.ts`, `concept-model-durable-session-events.test.ts`: 59/59 passed.

Full suite (`npx vitest run --pool=forks --poolOptions.forks.singleFork=true`): 805 files, 5634 tests, all passed. `npx tsc --noEmit` clean. `npm run lint` clean.

## Test plan

- [x] Unskipped acceptance test passes (depth rejection)
- [x] New sibling test passes (concurrency rejection)
- [x] Updated stale assertion in `runtime-child-session-controls.test.ts` with documented rationale
- [x] Full `ts/` test suite green (5634 tests)
- [x] `tsc --noEmit` and lint clean