### PR TITLE
AC-866: branded-id migration slice 2 and constructor-idiom reconciliation

### DIFF
--- a/ts/src/analysis/engine.ts
+++ b/ts/src/analysis/engine.ts
@@ -16,6 +16,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
+import { asDbPath } from "../domain/ids.js";
 import { SQLiteStore } from "../storage/index.js";
 import { MissionManager } from "../mission/manager.js";
 import { normalizeConfidence } from "../analytics/number-utils.js";
@@ -176,7 +177,9 @@ export class AnalysisEngine {
     if (!left) limitations.push(`Left artifact '${request.left.id}' not found`);
     if (!right) limitations.push(`Right artifact '${request.right.id}' not found`);
     if (request.left.type !== request.right.type) {
-      limitations.push(`Comparing different types (${request.left.type} vs ${request.right.type}) — results may be limited`);
+      limitations.push(
+        `Comparing different types (${request.left.type} vs ${request.right.type}) — results may be limited`,
+      );
     }
 
     if (!left || !right) {
@@ -199,7 +202,10 @@ export class AnalysisEngine {
         target: request.left,
         compareTarget: request.right,
         mode: "compare",
-        summary: { headline: "Comparison unavailable across different artifact types", confidence: 0 },
+        summary: {
+          headline: "Comparison unavailable across different artifact types",
+          confidence: 0,
+        },
         findings: [],
         regressions: [],
         limitations,
@@ -316,7 +322,7 @@ export class AnalysisEngine {
       return null;
     }
 
-    const store = new SQLiteStore(this.dbPath);
+    const store = new SQLiteStore(asDbPath(this.dbPath));
     try {
       const run = store.getRun(id);
       if (!run) {
@@ -442,7 +448,12 @@ export class AnalysisEngine {
       });
       if (summary && typeof summary.score === "number") {
         findings.push({
-          kind: summary.score >= 0.8 ? "improvement" : summary.score >= 0.5 ? "observation" : "regression",
+          kind:
+            summary.score >= 0.8
+              ? "improvement"
+              : summary.score >= 0.5
+                ? "observation"
+                : "regression",
           statement: `Best generation score reached ${summary.score.toFixed(2)}`,
           evidence: ["run trajectory"],
         });
@@ -454,7 +465,12 @@ export class AnalysisEngine {
       const name = String(mission.name ?? mission.id ?? "mission");
       const status = String(mission.status ?? artifact.status ?? "unknown");
       findings.push({
-        kind: status === "completed" ? "conclusion" : status === "failed" || status === "verifier_failed" ? "warning" : "observation",
+        kind:
+          status === "completed"
+            ? "conclusion"
+            : status === "failed" || status === "verifier_failed"
+              ? "warning"
+              : "observation",
         statement: `Mission '${name}' is ${status}`,
         evidence: ["mission status"],
       });
@@ -479,7 +495,10 @@ export class AnalysisEngine {
     return findings;
   }
 
-  private extractRegressions(artifact: Record<string, unknown>, type: AnalysisTargetType): string[] {
+  private extractRegressions(
+    artifact: Record<string, unknown>,
+    type: AnalysisTargetType,
+  ): string[] {
     const regressions: string[] = [];
     if (type === "simulation") {
       const summary = artifact.summary as Record<string, unknown> | undefined;
@@ -502,7 +521,9 @@ export class AnalysisEngine {
     if (type === "mission") {
       const mission = (artifact.mission as Record<string, unknown> | undefined) ?? artifact;
       const status = String(mission.status ?? artifact.status ?? "unknown");
-      if (["failed", "verifier_failed", "blocked", "budget_exhausted", "canceled"].includes(status)) {
+      if (
+        ["failed", "verifier_failed", "blocked", "budget_exhausted", "canceled"].includes(status)
+      ) {
         regressions.push(`Mission status is ${status}`);
       }
       const latestVerification = artifact.latestVerification as Record<string, unknown> | undefined;
@@ -513,7 +534,11 @@ export class AnalysisEngine {
     return regressions;
   }
 
-  private buildSummary(artifact: Record<string, unknown>, type: AnalysisTargetType, findings: Finding[]): AnalysisSummary {
+  private buildSummary(
+    artifact: Record<string, unknown>,
+    type: AnalysisTargetType,
+    findings: Finding[],
+  ): AnalysisSummary {
     if (type === "simulation") {
       const summary = artifact.summary as Record<string, unknown> | undefined;
       const score = Number(summary?.score ?? 0);
@@ -542,7 +567,8 @@ export class AnalysisEngine {
       const status = String(mission.status ?? artifact.status ?? "unknown");
       return {
         headline: `Mission '${mission.name ?? mission.id ?? "unknown"}' is ${status}`,
-        confidence: status === "completed" ? 0.9 : status === "active" || status === "paused" ? 0.6 : 0.7,
+        confidence:
+          status === "completed" ? 0.9 : status === "active" || status === "paused" ? 0.6 : 0.7,
       };
     }
     return {
@@ -560,7 +586,8 @@ export class AnalysisEngine {
     }
     if (type === "investigation") {
       limitations.push("Analysis based on generated investigation scenario");
-      const lims = (artifact.conclusion as Record<string, unknown> | undefined)?.limitations as string[] | undefined;
+      const lims = (artifact.conclusion as Record<string, unknown> | undefined)?.limitations as
+        string[] | undefined;
       if (lims) limitations.push(...lims);
     }
     if (type === "run") {
@@ -584,7 +611,9 @@ export class AnalysisEngine {
   // -------------------------------------------------------------------------
 
   private compareFindings(
-    left: Record<string, unknown>, right: Record<string, unknown>, type: AnalysisTargetType,
+    left: Record<string, unknown>,
+    right: Record<string, unknown>,
+    type: AnalysisTargetType,
   ): Finding[] {
     const findings: Finding[] = [];
     const leftScore = this.extractScore(left);
@@ -618,30 +647,44 @@ export class AnalysisEngine {
     }
 
     if (findings.length === 0) {
-      findings.push({ kind: "observation", statement: "No significant differences found", evidence: ["comparison"] });
+      findings.push({
+        kind: "observation",
+        statement: "No significant differences found",
+        evidence: ["comparison"],
+      });
     }
 
     return findings;
   }
 
-  private compareRegressions(left: Record<string, unknown>, right: Record<string, unknown>): string[] {
+  private compareRegressions(
+    left: Record<string, unknown>,
+    right: Record<string, unknown>,
+  ): string[] {
     const regressions: string[] = [];
     const leftScore = this.extractScore(left) ?? 0;
     const rightScore = this.extractScore(right) ?? 0;
     if (rightScore < leftScore - 0.05) {
-      regressions.push(`Overall score regressed from ${leftScore.toFixed(2)} to ${rightScore.toFixed(2)}`);
+      regressions.push(
+        `Overall score regressed from ${leftScore.toFixed(2)} to ${rightScore.toFixed(2)}`,
+      );
     }
     const leftDims = this.extractDimensionScores(left);
     const rightDims = this.extractDimensionScores(right);
     for (const dim of Object.keys(leftDims)) {
       if ((rightDims[dim] ?? 0) < leftDims[dim] - 0.1) {
-        regressions.push(`${dim} regressed from ${leftDims[dim].toFixed(2)} to ${(rightDims[dim] ?? 0).toFixed(2)}`);
+        regressions.push(
+          `${dim} regressed from ${leftDims[dim].toFixed(2)} to ${(rightDims[dim] ?? 0).toFixed(2)}`,
+        );
       }
     }
     return regressions;
   }
 
-  private computeAttribution(left: Record<string, unknown>, right: Record<string, unknown>): Attribution {
+  private computeAttribution(
+    left: Record<string, unknown>,
+    right: Record<string, unknown>,
+  ): Attribution {
     const leftDims = this.extractDimensionScores(left);
     const rightDims = this.extractDimensionScores(right);
     const factors: Array<{ name: string; weight: number }> = [];
@@ -658,8 +701,10 @@ export class AnalysisEngine {
   }
 
   private buildCompareSummary(
-    left: Record<string, unknown>, right: Record<string, unknown>,
-    findings: Finding[], regressions: string[],
+    left: Record<string, unknown>,
+    right: Record<string, unknown>,
+    findings: Finding[],
+    regressions: string[],
   ): AnalysisSummary {
     const leftScore = this.extractScore(left);
     const rightScore = this.extractScore(right);
@@ -669,11 +714,12 @@ export class AnalysisEngine {
     let headline: string;
     if (leftScore != null && rightScore != null) {
       const delta = rightScore - leftScore;
-      headline = delta > 0
-        ? `Score improved by ${delta.toFixed(2)} (${leftScore.toFixed(2)} → ${rightScore.toFixed(2)}) with ${improvements} improvement(s)`
-        : delta < 0
-        ? `Score regressed by ${Math.abs(delta).toFixed(2)} (${leftScore.toFixed(2)} → ${rightScore.toFixed(2)}) with ${regCount} regression(s)`
-        : `Score unchanged at ${leftScore.toFixed(2)}`;
+      headline =
+        delta > 0
+          ? `Score improved by ${delta.toFixed(2)} (${leftScore.toFixed(2)} → ${rightScore.toFixed(2)}) with ${improvements} improvement(s)`
+          : delta < 0
+            ? `Score regressed by ${Math.abs(delta).toFixed(2)} (${leftScore.toFixed(2)} → ${rightScore.toFixed(2)}) with ${regCount} regression(s)`
+            : `Score unchanged at ${leftScore.toFixed(2)}`;
     } else {
       headline = `Comparison: ${findings.length} finding(s), ${regCount} regression(s)`;
     }

--- a/ts/src/cli/commands/evaluate.ts
+++ b/ts/src/cli/commands/evaluate.ts
@@ -4,6 +4,7 @@
  */
 import { parseArgs } from "node:util";
 import { resolve } from "node:path";
+import { asDbPath } from "../../domain/ids.js";
 import type { LLMProvider } from "../../types/index.js";
 import {
   errorMessage,
@@ -56,7 +57,7 @@ export async function cmdSolve(dbPath: string): Promise<void> {
   const { SolveManager } = await import("../../knowledge/solver.js");
 
   const settings = loadSettings();
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
 
   let provider: LLMProvider | undefined;

--- a/ts/src/cli/commands/export.ts
+++ b/ts/src/cli/commands/export.ts
@@ -4,6 +4,7 @@
  */
 import { parseArgs } from "node:util";
 import { resolve, dirname } from "node:path";
+import { asDbPath } from "../../domain/ids.js";
 import { errorMessage, getMigrationsDir, resolveScenarioOption } from "./shared.js";
 
 export async function cmdExport(dbPath: string): Promise<void> {
@@ -33,7 +34,7 @@ export async function cmdExport(dbPath: string): Promise<void> {
   const { SQLiteStore } = await import("../../storage/index.js");
 
   const settings = loadSettings();
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
 
   let plan;
@@ -114,7 +115,7 @@ export async function cmdExportTrainingData(dbPath: string): Promise<void> {
   const { exportTrainingData } = await import("../../training/export.js");
 
   const settings = loadSettings();
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
   const artifacts = new ArtifactStore({
     runsRoot: resolve(settings.runsRoot),

--- a/ts/src/cli/commands/queue.ts
+++ b/ts/src/cli/commands/queue.ts
@@ -2,6 +2,7 @@
  * `queue` and `worker` commands (AC-853 split of command-handlers.ts).
  */
 import { parseArgs } from "node:util";
+import { asDbPath } from "../../domain/ids.js";
 import { getMigrationsDir, getProvider, loadSavedAgentTaskScenario } from "./shared.js";
 
 export async function cmdQueue(dbPath: string): Promise<void> {
@@ -33,7 +34,7 @@ export async function cmdQueue(dbPath: string): Promise<void> {
     const { executeStatusCommandWorkflow, renderStatusResult } =
       await import("../queue-status-command-workflow.js");
     const { SQLiteStore } = await import("../../storage/index.js");
-    const store = new SQLiteStore(dbPath);
+    const store = new SQLiteStore(asDbPath(dbPath));
     const result = executeStatusCommandWorkflow({
       store,
       migrationsDir: getMigrationsDir(),
@@ -79,7 +80,7 @@ export async function cmdQueue(dbPath: string): Promise<void> {
   const { enqueueTask } = await import("../../execution/task-runner.js");
   const savedScenario = await loadSavedAgentTaskScenario(values.spec);
 
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   const migrationsDir = getMigrationsDir();
   store.migrate(migrationsDir);
 
@@ -119,7 +120,7 @@ export async function cmdWorker(dbPath: string): Promise<void> {
   const { initializeHookBus } = await import("../../extensions/index.js");
 
   const settings = loadSettings();
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
   const { provider, model } = await getProvider(plan.model ? { model: plan.model } : {});
   const concurrency = resolveWorkerConcurrency(provider, plan.concurrency);

--- a/ts/src/cli/commands/run.ts
+++ b/ts/src/cli/commands/run.ts
@@ -4,6 +4,7 @@
  */
 import { parseArgs } from "node:util";
 import { resolve, join } from "node:path";
+import { asDbPath } from "../../domain/ids.js";
 import {
   errorMessage,
   getMigrationsDir,
@@ -107,7 +108,7 @@ export async function cmdRun(dbPath: string): Promise<void> {
         hookBus,
         dbPath,
         migrationsDir: getMigrationsDir(),
-        createStore: (runDbPath) => new SQLiteStore(runDbPath),
+        createStore: (runDbPath) => new SQLiteStore(asDbPath(runDbPath)),
       });
       const rendered = renderRunResult(result, plan.json);
       if (rendered.stderr) {
@@ -140,7 +141,7 @@ export async function cmdRun(dbPath: string): Promise<void> {
     providerBundle,
     ScenarioClass,
     assertFamilyContract,
-    createStore: (runDbPath) => new SQLiteStore(runDbPath),
+    createStore: (runDbPath) => new SQLiteStore(asDbPath(runDbPath)),
     createRunner: (runnerOpts) =>
       new GenerationRunner({
         ...(runnerOpts as import("../../loop/generation-runner.js").GenerationRunnerOpts),
@@ -176,7 +177,7 @@ export async function cmdList(dbPath: string): Promise<void> {
   }
 
   const { SQLiteStore } = await import("../../storage/index.js");
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
 
   try {
@@ -303,7 +304,7 @@ export async function cmdShow(dbPath: string): Promise<void> {
   }
 
   const { SQLiteStore } = await import("../../storage/index.js");
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
   try {
     const run = store.getRun(runId);
@@ -356,7 +357,7 @@ export async function cmdWatch(dbPath: string): Promise<void> {
   }
 
   const { SQLiteStore } = await import("../../storage/index.js");
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
   try {
     while (true) {
@@ -451,7 +452,7 @@ export async function cmdStatus(dbPath: string): Promise<void> {
   }
 
   const { SQLiteStore } = await import("../../storage/index.js");
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   const { renderRunStatus } = await import("../run-inspection-command-workflow.js");
   store.migrate(getMigrationsDir());
   const run = store.getRun(runId);
@@ -539,7 +540,7 @@ export async function cmdBenchmark(dbPath: string): Promise<void> {
     providerBundle,
     ScenarioClass,
     assertFamilyContract,
-    createStore: (benchmarkDbPath) => new SQLiteStore(benchmarkDbPath),
+    createStore: (benchmarkDbPath) => new SQLiteStore(asDbPath(benchmarkDbPath)),
     createRunner: (runnerOpts) =>
       new GenerationRunner({
         ...runnerOpts,

--- a/ts/src/cli/commands/serve.ts
+++ b/ts/src/cli/commands/serve.ts
@@ -3,6 +3,7 @@
  */
 import { parseArgs } from "node:util";
 import { resolve } from "node:path";
+import { asDbPath } from "../../domain/ids.js";
 import { getMigrationsDir, getProvider } from "./shared.js";
 
 export async function cmdServeHttp(dbPath: string): Promise<void> {
@@ -116,7 +117,7 @@ export async function cmdMcpServe(dbPath: string): Promise<void> {
   const { startServer } = await import("../../mcp/server.js");
   const { loadSettings } = await import("../../config/index.js");
 
-  const store = new SQLiteStore(dbPath);
+  const store = new SQLiteStore(asDbPath(dbPath));
   store.migrate(getMigrationsDir());
 
   const { provider, model } = await getProvider();

--- a/ts/src/cli/commands/shared.ts
+++ b/ts/src/cli/commands/shared.ts
@@ -3,6 +3,7 @@
  */
 import { resolve, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { asDbPath } from "../../domain/ids.js";
 
 export function getMigrationsDir(): string {
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -135,7 +136,7 @@ export async function buildProjectConfigSummary(): Promise<Record<string, unknow
   let activeRuns = 0;
   if (existsSync(dbPath)) {
     const { SQLiteStore } = await import("../../storage/index.js");
-    const store = new SQLiteStore(dbPath);
+    const store = new SQLiteStore(asDbPath(dbPath));
     try {
       store.migrate(getMigrationsDir());
       const runs = store.listRuns(1000);

--- a/ts/src/domain/ids.ts
+++ b/ts/src/domain/ids.ts
@@ -30,6 +30,27 @@
  * trim-based check here would throw before that code ever runs, replacing
  * a handled 4xx with an unhandled 500. These constructors exist to add a
  * type boundary, not to change what counts as a valid id.
+ *
+ * Constructor idiom (AC-866): throwing `asX()` here vs. nullable `parseX()`
+ * in `production-traces/contract/branded-ids.ts` is a deliberate,
+ * boundary-driven split, not an inconsistency to unify away:
+ *   - `RunId` / `ScenarioName` / `DbPath` cross boundaries where the raw
+ *     string is already format-guaranteed by something upstream: a route
+ *     regex that requires at least one non-slash character, a required CLI
+ *     argument, a primary key read back out of SQLite. A byte-empty value
+ *     at one of these boundaries means a caller broke an invariant, not
+ *     that a user typed something invalid — throwing is the right response.
+ *   - `production-traces`' brands (`ProductionTraceId`, `AppId`,
+ *     `UserIdHash`, `FeedbackRefId`, etc.) cross boundaries where malformed
+ *     input is routine: an HTTP path segment checked against a strict
+ *     ULID/slug/hex-hash regex, or an opaque customer-supplied reference.
+ *     Failure there is an expected, per-request outcome that the caller
+ *     branches on (typically into a 404), so a nullable return is the right
+ *     shape — throwing would turn routine bad input into an uncaught 500.
+ * Same brand mechanism, two constructor shapes, chosen by what a real
+ * caller at each boundary needs to do when validation fails. Do not add a
+ * nullable `parseRunId` / `parseScenarioName` / `parseDbPath` here without a
+ * concrete boundary that needs one.
  */
 
 declare const brand: unique symbol;

--- a/ts/src/execution/sandbox.ts
+++ b/ts/src/execution/sandbox.ts
@@ -4,7 +4,7 @@
  */
 
 import { ArtifactStore } from "../knowledge/artifact-store.js";
-import { asRunId } from "../domain/ids.js";
+import { asRunId, asScenarioName } from "../domain/ids.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
 import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
 import type { LLMProvider } from "../types/index.js";
@@ -114,7 +114,7 @@ export class SandboxManager {
       runsRoot: this.#runsRoot,
       knowledgeRoot: this.#knowledgeRoot,
     });
-    return artifacts.readPlaybook(sandbox.scenarioName);
+    return artifacts.readPlaybook(asScenarioName(sandbox.scenarioName));
   }
 
   destroy(sandboxId: string): boolean {

--- a/ts/src/knowledge/artifact-store.ts
+++ b/ts/src/knowledge/artifact-store.ts
@@ -14,6 +14,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import type { RunId, ScenarioName } from "../domain/ids.js";
 import { HookEvents, type HookBus } from "../extensions/index.js";
 import { PlaybookManager, EMPTY_PLAYBOOK_SENTINEL } from "./playbook.js";
 import {
@@ -64,27 +65,24 @@ export class ArtifactStore {
     this.runsRoot = opts.runsRoot;
     this.knowledgeRoot = opts.knowledgeRoot;
     this.hookBus = opts.hookBus ?? null;
-    this.playbookManager = new PlaybookManager(
-      opts.knowledgeRoot,
-      opts.maxPlaybookVersions ?? 5,
-    );
+    this.playbookManager = new PlaybookManager(opts.knowledgeRoot, opts.maxPlaybookVersions ?? 5);
     this.compactionLedger = new CompactionLedgerStore(this.runsRoot);
   }
 
-  generationDir(runId: string, generationIndex: number): string {
+  generationDir(runId: RunId, generationIndex: number): string {
     return join(this.runsRoot, runId, "generations", `gen_${generationIndex}`);
   }
 
-  compactionLedgerPath(runId: string): string {
+  compactionLedgerPath(runId: RunId): string {
     return this.compactionLedger.ledgerPath(runId);
   }
 
-  compactionLatestEntryPath(runId: string): string {
+  compactionLatestEntryPath(runId: RunId): string {
     return this.compactionLedger.latestEntryPath(runId);
   }
 
   appendCompactionEntries(
-    runId: string,
+    runId: RunId,
     entries: CompactionEntry[],
   ): AppendedCompactionEntries | null {
     if (entries.length === 0) return null;
@@ -97,13 +95,15 @@ export class ArtifactStore {
       payload: { entries: normalizedEntries },
       content: originalLedgerContent,
     });
-    const contentChanged = ledgerRequest.content !== undefined
-      && ledgerRequest.content !== originalLedgerContent;
+    const contentChanged =
+      ledgerRequest.content !== undefined && ledgerRequest.content !== originalLedgerContent;
     const contentEntries = contentChanged
       ? readCompactionEntriesJsonl(ledgerRequest.content)
       : null;
     if (contentChanged && contentEntries === null) {
-      throw new Error("artifact_write content for compaction ledger must be JSONL compaction entries");
+      throw new Error(
+        "artifact_write content for compaction ledger must be JSONL compaction entries",
+      );
     }
     const payloadEntries = readCompactionEntries(ledgerRequest.payload?.entries);
     const finalEntries = contentEntries ?? payloadEntries ?? normalizedEntries;
@@ -132,11 +132,11 @@ export class ArtifactStore {
     };
   }
 
-  readCompactionEntries(runId: string, opts: { limit?: number } = {}): CompactionEntry[] {
+  readCompactionEntries(runId: RunId, opts: { limit?: number } = {}): CompactionEntry[] {
     return this.compactionLedger.readEntries(runId, opts);
   }
 
-  latestCompactionEntryId(runId: string): string {
+  latestCompactionEntryId(runId: RunId): string {
     return this.compactionLedger.latestEntryId(runId);
   }
 
@@ -180,11 +180,11 @@ export class ArtifactStore {
     }
   }
 
-  readPlaybook(scenarioName: string): string {
+  readPlaybook(scenarioName: ScenarioName): string {
     return this.playbookManager.read(scenarioName);
   }
 
-  writePlaybook(scenarioName: string, content: string): void {
+  writePlaybook(scenarioName: ScenarioName, content: string): void {
     const path = join(this.knowledgeRoot, scenarioName, "playbook.md");
     const request = this.applyArtifactWriteHook({
       path,
@@ -202,11 +202,11 @@ export class ArtifactStore {
   }
 
   writeOrStagePlaybook(
-    scenarioName: string,
+    scenarioName: ScenarioName,
     content: string,
     opts: {
       requireApproval: boolean;
-      sourceRunId: string;
+      sourceRunId: RunId;
       generation: number;
       curatorDecision: string;
     },
@@ -226,24 +226,30 @@ export class ArtifactStore {
     });
   }
 
-  readPendingPlaybook(scenarioName: string): PendingPlaybookView {
+  readPendingPlaybook(scenarioName: ScenarioName): PendingPlaybookView {
     return readPendingPlaybook(this.knowledgeRoot, scenarioName);
   }
 
-  approvePendingPlaybook(scenarioName: string): { ok: boolean; status: "approved" | "missing" } {
+  approvePendingPlaybook(scenarioName: ScenarioName): {
+    ok: boolean;
+    status: "approved" | "missing";
+  } {
     return approvePendingPlaybook(this.knowledgeRoot, scenarioName, this.writePlaybook.bind(this));
   }
 
-  rejectPendingPlaybook(scenarioName: string): { ok: boolean; status: "rejected" | "missing" } {
+  rejectPendingPlaybook(scenarioName: ScenarioName): {
+    ok: boolean;
+    status: "rejected" | "missing";
+  } {
     return rejectPendingPlaybook(this.knowledgeRoot, scenarioName);
   }
 
-  readDeadEnds(scenarioName: string): string {
+  readDeadEnds(scenarioName: ScenarioName): string {
     const path = join(this.knowledgeRoot, scenarioName, "dead_ends.md");
     return existsSync(path) ? readFileSync(path, "utf-8") : "";
   }
 
-  appendDeadEnd(scenarioName: string, entry: string): void {
+  appendDeadEnd(scenarioName: ScenarioName, entry: string): void {
     const path = join(this.knowledgeRoot, scenarioName, "dead_ends.md");
     const request = this.applyArtifactWriteHook({
       path,
@@ -261,12 +267,12 @@ export class ArtifactStore {
     }
   }
 
-  replaceDeadEnds(scenarioName: string, content: string): void {
+  replaceDeadEnds(scenarioName: ScenarioName, content: string): void {
     const path = join(this.knowledgeRoot, scenarioName, "dead_ends.md");
     this.writeMarkdown(path, content);
   }
 
-  writeSessionReport(scenarioName: string, runId: string, content: string): string {
+  writeSessionReport(scenarioName: ScenarioName, runId: RunId, content: string): string {
     const path = join(this.knowledgeRoot, scenarioName, "session_reports", `${runId}.md`);
     this.writeMarkdown(path, content);
     return path;
@@ -279,7 +285,7 @@ export class ArtifactStore {
     }
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
+      ? (parsed as Record<string, unknown>)
       : null;
   }
 
@@ -365,7 +371,7 @@ export class ArtifactStore {
     return null;
   }
 
-  readSessionReports(scenarioName: string, limit = 3): string {
+  readSessionReports(scenarioName: ScenarioName, limit = 3): string {
     const dir = join(this.knowledgeRoot, scenarioName, "session_reports");
     if (!existsSync(dir)) return "";
     const reports = readdirSync(dir)
@@ -380,7 +386,10 @@ export class ArtifactStore {
       })
       .sort((a, b) => b.mtimeMs - a.mtimeMs)
       .slice(0, limit)
-      .map((entry) => `### ${entry.name.replace(/\.md$/, "")}\n\n${readFileSync(entry.path, "utf-8").trim()}`);
+      .map(
+        (entry) =>
+          `### ${entry.name.replace(/\.md$/, "")}\n\n${readFileSync(entry.path, "utf-8").trim()}`,
+      );
 
     return reports.join("\n\n").trim();
   }
@@ -408,9 +417,10 @@ function readCompactionEntries(value: unknown): CompactionEntry[] | null {
       timestamp: typeof raw.timestamp === "string" ? raw.timestamp : "",
       summary: typeof raw.summary === "string" ? raw.summary : "",
       firstKeptEntryId: typeof raw.firstKeptEntryId === "string" ? raw.firstKeptEntryId : "",
-      tokensBefore: typeof raw.tokensBefore === "number" && Number.isFinite(raw.tokensBefore)
-        ? raw.tokensBefore
-        : 0,
+      tokensBefore:
+        typeof raw.tokensBefore === "number" && Number.isFinite(raw.tokensBefore)
+          ? raw.tokensBefore
+          : 0,
       details: isRecord(raw.details) ? raw.details : {},
     });
   }
@@ -422,7 +432,10 @@ function readCompactionEntriesJsonl(content: string | undefined): CompactionEntr
     return null;
   }
   const parsedEntries: unknown[] = [];
-  for (const line of content.split(/\r?\n/).map((part) => part.trim()).filter(Boolean)) {
+  for (const line of content
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .filter(Boolean)) {
     try {
       parsedEntries.push(JSON.parse(line) as unknown);
     } catch {

--- a/ts/src/knowledge/compaction-ledger.ts
+++ b/ts/src/knowledge/compaction-ledger.ts
@@ -10,6 +10,7 @@ import {
   appendFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
+import type { RunId } from "../domain/ids.js";
 
 const COMPACTION_LEDGER_TAIL_BYTES = 64 * 1024;
 
@@ -31,15 +32,15 @@ export class CompactionLedgerStore {
     this.runsRoot = runsRoot;
   }
 
-  ledgerPath(runId: string): string {
+  ledgerPath(runId: RunId): string {
     return this.resolveRunPath(runId, "compactions.jsonl");
   }
 
-  latestEntryPath(runId: string): string {
+  latestEntryPath(runId: RunId): string {
     return this.resolveRunPath(runId, "compactions.latest");
   }
 
-  appendEntries(runId: string, entries: CompactionEntry[]): void {
+  appendEntries(runId: RunId, entries: CompactionEntry[]): void {
     if (entries.length === 0) return;
     const path = this.ledgerPath(runId);
     mkdirSync(dirname(path), { recursive: true });
@@ -47,7 +48,7 @@ export class CompactionLedgerStore {
     writeFileSync(this.latestEntryPath(runId), `${entries.at(-1)!.id}\n`, "utf-8");
   }
 
-  readEntries(runId: string, opts: { limit?: number } = {}): CompactionEntry[] {
+  readEntries(runId: RunId, opts: { limit?: number } = {}): CompactionEntry[] {
     const limit = opts.limit ?? 20;
     const path = this.ledgerPath(runId);
     if (!existsSync(path)) return [];
@@ -59,7 +60,10 @@ export class CompactionLedgerStore {
     } else {
       [text, truncated] = readTailText(path, COMPACTION_LEDGER_TAIL_BYTES);
     }
-    const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const lines = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
     const parseableLines = truncated ? lines.slice(1) : lines;
     const entries = parseableLines
       .map(parseEntry)
@@ -67,7 +71,7 @@ export class CompactionLedgerStore {
     return limit > 0 ? entries.slice(-limit) : entries;
   }
 
-  latestEntryId(runId: string): string {
+  latestEntryId(runId: RunId): string {
     const latestPath = this.latestEntryPath(runId);
     if (existsSync(latestPath)) {
       return readFileSync(latestPath, "utf-8").trim();
@@ -75,7 +79,10 @@ export class CompactionLedgerStore {
     const path = this.ledgerPath(runId);
     if (!existsSync(path)) return "";
     const [text, truncated] = readTailText(path, COMPACTION_LEDGER_TAIL_BYTES);
-    const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const lines = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
     const parseableLines = truncated ? lines.slice(1) : lines;
     for (const line of parseableLines.reverse()) {
       const entry = parseEntry(line);
@@ -84,7 +91,7 @@ export class CompactionLedgerStore {
     return "";
   }
 
-  private resolveRunPath(runId: string, fileName: string): string {
+  private resolveRunPath(runId: RunId, fileName: string): string {
     const root = resolve(this.runsRoot);
     const runDir = resolve(root, runId);
     const relativeRunPath = relative(root, runDir);

--- a/ts/src/knowledge/lesson-lifecycle.ts
+++ b/ts/src/knowledge/lesson-lifecycle.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { ScenarioName } from "../domain/ids.js";
 import { ArtifactStore } from "./artifact-store.js";
 import { PLAYBOOK_MARKERS } from "./playbook.js";
 import { normalizeScenarioSegment } from "./scenario-paths.js";
@@ -65,7 +66,7 @@ function playbookBlock(content: string): { start: number; end: number; body: str
   return { start, end, body: content.slice(start, end) };
 }
 
-function playbookLessons(artifacts: ArtifactStore, scenario: string): DerivedLesson[] {
+function playbookLessons(artifacts: ArtifactStore, scenario: ScenarioName): DerivedLesson[] {
   const block = playbookBlock(artifacts.readPlaybook(scenario));
   if (!block) return [];
   return block.body
@@ -80,7 +81,7 @@ function playbookLessons(artifacts: ArtifactStore, scenario: string): DerivedLes
     }));
 }
 
-function skillLessons(skillsRoot: string | undefined, scenario: string): DerivedLesson[] {
+function skillLessons(skillsRoot: string | undefined, scenario: ScenarioName): DerivedLesson[] {
   if (!skillsRoot) return [];
   const skillPath = join(skillsRoot, `${scenario.replace(/_/g, "-")}-ops`, "SKILL.md");
   if (!existsSync(skillPath)) return [];
@@ -105,7 +106,7 @@ function skillLessons(skillsRoot: string | undefined, scenario: string): Derived
 
 function derivedLessons(
   artifacts: ArtifactStore,
-  scenario: string,
+  scenario: ScenarioName,
   skillsRoot: string | undefined,
 ): DerivedLesson[] {
   const seen = new Set<string>();

--- a/ts/src/knowledge/package.ts
+++ b/ts/src/knowledge/package.ts
@@ -4,10 +4,7 @@ import type { SQLiteStore } from "../storage/index.js";
 import type { GenerationRow, MatchRow } from "../storage/storage-contracts.js";
 import { ArtifactStore, EMPTY_PLAYBOOK_SENTINEL } from "./artifact-store.js";
 import { HarnessStore } from "./harness-store.js";
-import {
-  SkillPackage,
-  type SkillPackageDict,
-} from "./skill-package.js";
+import { SkillPackage, type SkillPackageDict } from "./skill-package.js";
 import {
   bestStrategyForScenario,
   descriptionForScenario,
@@ -15,13 +12,10 @@ import {
   readPackageMetadata,
   writePackageMetadata,
 } from "./package-metadata.js";
-import {
-  harnessForScenario,
-  hintsFromPlaybook,
-  lessonsFromPlaybook,
-} from "./package-content.js";
+import { harnessForScenario, hintsFromPlaybook, lessonsFromPlaybook } from "./package-content.js";
 import { coercePackage } from "./package-coercion.js";
 import { assertSafeScenarioId } from "./scenario-id.js";
+import { asScenarioName } from "../domain/ids.js";
 import type {
   ConflictPolicy,
   ImportStrategyPackageResult,
@@ -31,7 +25,11 @@ import type {
 
 const PACKAGE_FORMAT_VERSION = 1;
 
-export type { ConflictPolicy, ImportStrategyPackageResult, StrategyPackageData } from "./package-types.js";
+export type {
+  ConflictPolicy,
+  ImportStrategyPackageResult,
+  StrategyPackageData,
+} from "./package-types.js";
 
 export function exportStrategyPackage(opts: {
   scenarioName: string;
@@ -44,11 +42,13 @@ export function exportStrategyPackage(opts: {
     throw new Error(`Unknown run: ${opts.sourceRunId}`);
   }
   if (sourceRun && sourceRun.scenario !== opts.scenarioName) {
-    throw new Error(`Run '${opts.sourceRunId}' belongs to scenario '${sourceRun.scenario}', not '${opts.scenarioName}'`);
+    throw new Error(
+      `Run '${opts.sourceRunId}' belongs to scenario '${sourceRun.scenario}', not '${opts.scenarioName}'`,
+    );
   }
 
   const persisted = readPackageMetadata(opts.artifacts.knowledgeRoot, opts.scenarioName);
-  const playbook = opts.artifacts.readPlaybook(opts.scenarioName);
+  const playbook = opts.artifacts.readPlaybook(asScenarioName(opts.scenarioName));
   const bestGeneration = opts.sourceRunId
     ? bestGenerationForRun(opts.store.getGenerations(opts.sourceRunId), opts.sourceRunId)
     : opts.store.getBestGenerationForScenario(opts.scenarioName);
@@ -57,7 +57,9 @@ export function exportStrategyPackage(opts: {
   }
   const completedRuns = opts.store.countCompletedRuns(opts.scenarioName);
   const persistedMeta =
-    persisted.metadata && typeof persisted.metadata === "object" && !Array.isArray(persisted.metadata)
+    persisted.metadata &&
+    typeof persisted.metadata === "object" &&
+    !Array.isArray(persisted.metadata)
       ? persisted.metadata
       : {};
 
@@ -67,9 +69,10 @@ export function exportStrategyPackage(opts: {
     description: descriptionForScenario(opts.scenarioName),
     playbook,
     lessons: lessonsFromPlaybook(playbook),
-    bestStrategy: opts.sourceRunId && bestGeneration
-      ? bestStrategyForRun(opts.store, opts.sourceRunId, bestGeneration.generation_index)
-      : bestStrategyForScenario(opts.store, opts.scenarioName, persisted),
+    bestStrategy:
+      opts.sourceRunId && bestGeneration
+        ? bestStrategyForRun(opts.store, opts.sourceRunId, bestGeneration.generation_index)
+        : bestStrategyForScenario(opts.store, opts.scenarioName, persisted),
     bestScore: bestGeneration?.best_score ?? persisted.best_score ?? 0,
     bestElo: bestGeneration?.elo ?? persisted.best_elo ?? 1500,
     hints: hintsFromPlaybook(playbook),
@@ -81,18 +84,18 @@ export function exportStrategyPackage(opts: {
         typeof persistedMeta.completed_runs === "number" ? persistedMeta.completed_runs : 0,
       ),
       has_snapshot:
-        bestGeneration != null
-        || Boolean(
-          typeof persistedMeta.has_snapshot === "boolean"
-            ? persistedMeta.has_snapshot
-            : false,
+        bestGeneration != null ||
+        Boolean(
+          typeof persistedMeta.has_snapshot === "boolean" ? persistedMeta.has_snapshot : false,
         ),
       source_run_id:
-        bestGeneration?.run_id
-        ?? (typeof persistedMeta.source_run_id === "string" ? persistedMeta.source_run_id : null),
+        bestGeneration?.run_id ??
+        (typeof persistedMeta.source_run_id === "string" ? persistedMeta.source_run_id : null),
       source_generation:
-        bestGeneration?.generation_index
-        ?? (typeof persistedMeta.source_generation === "number" ? persistedMeta.source_generation : null),
+        bestGeneration?.generation_index ??
+        (typeof persistedMeta.source_generation === "number"
+          ? persistedMeta.source_generation
+          : null),
     },
   });
 
@@ -107,8 +110,8 @@ function bestGenerationForRun(
     if (!currentBest) return generation;
     if (generation.best_score > currentBest.best_score) return generation;
     if (
-      generation.best_score === currentBest.best_score
-      && generation.generation_index > currentBest.generation_index
+      generation.best_score === currentBest.best_score &&
+      generation.generation_index > currentBest.generation_index
     ) {
       return generation;
     }
@@ -136,10 +139,7 @@ function bestStrategyForRun(
   return parsedCompetitor ?? null;
 }
 
-function bestMatchForRunGeneration(
-  matches: MatchRow[],
-  generationIndex: number,
-): MatchRow | null {
+function bestMatchForRunGeneration(matches: MatchRow[], generationIndex: number): MatchRow | null {
   return matches
     .filter((match) => match.generation_index === generationIndex)
     .reduce<MatchRow | null>((best, match) => {
@@ -157,7 +157,7 @@ function parseStrategyJson(raw: string | undefined): Record<string, unknown> | n
   try {
     const parsed = JSON.parse(raw) as unknown;
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
+      ? (parsed as Record<string, unknown>)
       : null;
   } catch {
     return null;
@@ -200,18 +200,16 @@ export function importStrategyPackage(opts: {
     conflictPolicy,
   };
 
-  const existingPlaybook = opts.artifacts.readPlaybook(pkg.scenarioName);
+  const existingPlaybook = opts.artifacts.readPlaybook(asScenarioName(pkg.scenarioName));
   const isExistingPlaybookEmpty = !existingPlaybook || existingPlaybook === EMPTY_PLAYBOOK_SENTINEL;
   const shouldWritePlaybook =
-    pkg.playbook
-    && (
-      conflictPolicy === "overwrite"
-      || (conflictPolicy === "merge" && isExistingPlaybookEmpty)
-      || (conflictPolicy === "skip" && isExistingPlaybookEmpty)
-    );
+    pkg.playbook &&
+    (conflictPolicy === "overwrite" ||
+      (conflictPolicy === "merge" && isExistingPlaybookEmpty) ||
+      (conflictPolicy === "skip" && isExistingPlaybookEmpty));
 
   if (shouldWritePlaybook) {
-    opts.artifacts.writePlaybook(pkg.scenarioName, pkg.playbook);
+    opts.artifacts.writePlaybook(asScenarioName(pkg.scenarioName), pkg.playbook);
     result.playbookWritten = true;
   }
 
@@ -241,14 +239,15 @@ export function importStrategyPackage(opts: {
 
   const skillDir = join(opts.skillsRoot, `${pkg.scenarioName.replace(/_/g, "-")}-ops`);
   const skillPath = join(skillDir, "SKILL.md");
-  const skillMarkdown = typeof opts.rawPackage.skill_markdown === "string"
-    ? opts.rawPackage.skill_markdown
-    : new SkillPackage(pkg).toSkillMarkdown();
+  const skillMarkdown =
+    typeof opts.rawPackage.skill_markdown === "string"
+      ? opts.rawPackage.skill_markdown
+      : new SkillPackage(pkg).toSkillMarkdown();
   const shouldWriteSkill =
-    conflictPolicy === "overwrite"
-    || !existsSync(skillPath)
-    || (conflictPolicy === "merge" && !existsSync(skillPath))
-    || (conflictPolicy === "skip" && !existsSync(skillPath));
+    conflictPolicy === "overwrite" ||
+    !existsSync(skillPath) ||
+    (conflictPolicy === "merge" && !existsSync(skillPath)) ||
+    (conflictPolicy === "skip" && !existsSync(skillPath));
   if (shouldWriteSkill) {
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(skillPath, skillMarkdown.trimEnd() + "\n", "utf-8");

--- a/ts/src/knowledge/playbook-approval.ts
+++ b/ts/src/knowledge/playbook-approval.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { RunId, ScenarioName } from "../domain/ids.js";
 import { resolveScenarioRoot } from "./scenario-paths.js";
 
 export interface PendingPlaybookProvenance {
@@ -20,7 +21,7 @@ export interface PendingPlaybookView {
 }
 
 export interface StagePendingPlaybookOptions {
-  sourceRunId: string;
+  sourceRunId: RunId;
   generation: number;
   curatorDecision: string;
   createdAt?: string;
@@ -28,7 +29,7 @@ export interface StagePendingPlaybookOptions {
 
 export function stagePendingPlaybook(
   knowledgeRoot: string,
-  scenarioName: string,
+  scenarioName: ScenarioName,
   content: string,
   opts: StagePendingPlaybookOptions,
 ): "pending" {
@@ -60,7 +61,7 @@ export function stagePendingPlaybook(
 
 export function readPendingPlaybook(
   knowledgeRoot: string,
-  scenarioName: string,
+  scenarioName: ScenarioName,
 ): PendingPlaybookView {
   const scenarioDir = resolveScenarioRoot(knowledgeRoot, scenarioName);
   const pendingPath = pendingMd(scenarioDir);
@@ -81,8 +82,8 @@ export function readPendingPlaybook(
 
 export function approvePendingPlaybook(
   knowledgeRoot: string,
-  scenarioName: string,
-  writeLivePlaybook: (scenarioName: string, content: string) => void,
+  scenarioName: ScenarioName,
+  writeLivePlaybook: (scenarioName: ScenarioName, content: string) => void,
 ): { ok: boolean; status: "approved" | "missing" } {
   const pending = readPendingPlaybook(knowledgeRoot, scenarioName);
   if (!pending.hasPending || pending.provenance === null) return { ok: false, status: "missing" };
@@ -93,7 +94,7 @@ export function approvePendingPlaybook(
 
 export function rejectPendingPlaybook(
   knowledgeRoot: string,
-  scenarioName: string,
+  scenarioName: ScenarioName,
 ): { ok: boolean; status: "rejected" | "missing" } {
   const pending = readPendingPlaybook(knowledgeRoot, scenarioName);
   if (!pending.hasPending || pending.provenance === null) return { ok: false, status: "missing" };

--- a/ts/src/knowledge/playbook.ts
+++ b/ts/src/knowledge/playbook.ts
@@ -6,6 +6,7 @@
 
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
+import type { ScenarioName } from "../domain/ids.js";
 import { VersionedFileStore } from "./versioned-store.js";
 
 export const EMPTY_PLAYBOOK_SENTINEL =
@@ -30,7 +31,7 @@ export class PlaybookManager {
     this.maxVersions = maxVersions;
   }
 
-  private store(scenarioName: string): VersionedFileStore {
+  private store(scenarioName: ScenarioName): VersionedFileStore {
     let s = this.stores.get(scenarioName);
     if (!s) {
       s = new VersionedFileStore(join(this.knowledgeRoot, scenarioName), {
@@ -44,21 +45,21 @@ export class PlaybookManager {
     return s;
   }
 
-  read(scenarioName: string): string {
+  read(scenarioName: ScenarioName): string {
     const content = this.store(scenarioName).read("playbook.md");
     return content || EMPTY_PLAYBOOK_SENTINEL;
   }
 
-  write(scenarioName: string, content: string): void {
+  write(scenarioName: ScenarioName, content: string): void {
     mkdirSync(join(this.knowledgeRoot, scenarioName), { recursive: true });
     this.store(scenarioName).write("playbook.md", content.trim() + "\n");
   }
 
-  rollback(scenarioName: string): boolean {
+  rollback(scenarioName: ScenarioName): boolean {
     return this.store(scenarioName).rollback("playbook.md");
   }
 
-  versionCount(scenarioName: string): number {
+  versionCount(scenarioName: ScenarioName): number {
     return this.store(scenarioName).versionCount("playbook.md");
   }
 }
@@ -101,10 +102,16 @@ export class PlaybookGuard {
 
     for (const [start, end] of PlaybookGuard.REQUIRED_MARKERS) {
       if (current.includes(start) && !proposed.includes(start)) {
-        return { approved: false, reason: `Required marker '${start}' missing from proposed playbook` };
+        return {
+          approved: false,
+          reason: `Required marker '${start}' missing from proposed playbook`,
+        };
       }
       if (current.includes(end) && !proposed.includes(end)) {
-        return { approved: false, reason: `Required marker '${end}' missing from proposed playbook` };
+        return {
+          approved: false,
+          reason: `Required marker '${end}' missing from proposed playbook`,
+        };
       }
     }
 

--- a/ts/src/knowledge/scenario-paths.ts
+++ b/ts/src/knowledge/scenario-paths.ts
@@ -1,13 +1,14 @@
 /** Per-scenario path containment (mirrors Python autocontext/storage/scenario_paths.py). */
 import { resolve, sep } from "node:path";
+import { asScenarioName, type ScenarioName } from "../domain/ids.js";
 
-export function normalizeScenarioSegment(scenario: string): string {
+export function normalizeScenarioSegment(scenario: string): ScenarioName {
   const s = scenario.trim();
   if (!s) throw new Error("scenario name is required");
   if (s.includes("/") || s.includes("\\") || s === "." || s === "..") {
     throw new Error(`scenario name must be a single path segment: ${scenario}`);
   }
-  return s;
+  return asScenarioName(s);
 }
 
 /** Resolve a scenario directory and ensure it stays under knowledgeRoot. Throws on unsafe input. */

--- a/ts/src/knowledge/session-report.ts
+++ b/ts/src/knowledge/session-report.ts
@@ -3,6 +3,8 @@
  * Mirrors Python's autocontext/knowledge/report.py.
  */
 
+import type { RunId, ScenarioName } from "../domain/ids.js";
+
 function toFloat(val: unknown, fallback = 0.0): number {
   if (typeof val === "number" && Number.isFinite(val)) return val;
   const n = Number(val);
@@ -10,8 +12,8 @@ function toFloat(val: unknown, fallback = 0.0): number {
 }
 
 export interface SessionReport {
-  runId: string;
-  scenario: string;
+  runId: RunId;
+  scenario: ScenarioName;
   startScore: number;
   endScore: number;
   startElo: number;
@@ -34,8 +36,8 @@ export interface GenerateReportOpts {
 }
 
 export function generateSessionReport(
-  runId: string,
-  scenario: string,
+  runId: RunId,
+  scenario: ScenarioName,
   trajectoryRows: Array<Record<string, unknown>>,
   opts: GenerateReportOpts = {},
 ): SessionReport {
@@ -105,8 +107,8 @@ export function generateSessionReport(
 }
 
 interface ReportData {
-  runId: string;
-  scenario: string;
+  runId: RunId;
+  scenario: ScenarioName;
   startScore: number;
   endScore: number;
   startElo: number;
@@ -152,7 +154,9 @@ function makeReport(data: ReportData): SessionReport {
         lines.push("|-----|-------|-------------|");
         for (const imp of data.topImprovements) {
           const d = toFloat(imp.delta);
-          lines.push(`| ${imp.gen ?? "?"} | ${d >= 0 ? "+" : ""}${d.toFixed(4)} | ${imp.description ?? ""} |`);
+          lines.push(
+            `| ${imp.gen ?? "?"} | ${d >= 0 ? "+" : ""}${d.toFixed(4)} | ${imp.description ?? ""} |`,
+          );
         }
       } else {
         lines.push("No significant improvements recorded.");

--- a/ts/src/loop/generation-journal.ts
+++ b/ts/src/loop/generation-journal.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { asScenarioName, type RunId } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { generateSessionReport } from "../knowledge/session-report.js";
 import { ScoreTrajectoryBuilder } from "../knowledge/trajectory.js";
@@ -35,7 +36,11 @@ export class GenerationJournal {
     this.#scenario = opts.scenario;
   }
 
-  persistGeneration(runId: string, generationIndex: number, attempt: GenerationJournalAttempt): void {
+  persistGeneration(
+    runId: RunId,
+    generationIndex: number,
+    attempt: GenerationJournalAttempt,
+  ): void {
     this.#store.upsertGeneration(runId, generationIndex, {
       meanScore: attempt.tournamentResult.meanScore,
       bestScore: attempt.tournamentResult.bestScore,
@@ -58,38 +63,53 @@ export class GenerationJournal {
       });
     }
 
-    this.#store.appendAgentOutput(runId, generationIndex, "competitor", attempt.competitorResultText);
+    this.#store.appendAgentOutput(
+      runId,
+      generationIndex,
+      "competitor",
+      attempt.competitorResultText,
+    );
 
     const generationDir = this.#artifacts.generationDir(runId, generationIndex);
-    this.#artifacts.writeMarkdown(join(generationDir, "competitor_prompt.md"), attempt.competitorPrompt);
-    this.#artifacts.writeMarkdown(join(generationDir, "competitor_output.md"), attempt.competitorResultText);
+    this.#artifacts.writeMarkdown(
+      join(generationDir, "competitor_prompt.md"),
+      attempt.competitorPrompt,
+    );
+    this.#artifacts.writeMarkdown(
+      join(generationDir, "competitor_output.md"),
+      attempt.competitorResultText,
+    );
     this.#artifacts.writeMarkdown(
       join(generationDir, "trajectory.md"),
-      new ScoreTrajectoryBuilder(this.#store.getScoreTrajectory(runId)).build() || "No prior trajectory yet.",
+      new ScoreTrajectoryBuilder(this.#store.getScoreTrajectory(runId)).build() ||
+        "No prior trajectory yet.",
     );
 
     const bestReplayMatch = attempt.tournamentResult.matches.reduce((best, current) =>
       current.score > best.score ? current : best,
     );
 
-    this.#artifacts.writeJson(join(generationDir, "replays", `${this.#scenario.name}_${generationIndex}.json`), {
-      run_id: runId,
-      generation: generationIndex,
-      scenario: this.#scenario.name,
-      seed: bestReplayMatch.seed,
-      score: bestReplayMatch.score,
-      winner: bestReplayMatch.winner,
-      narrative: this.#scenario.replayToNarrative(bestReplayMatch.replay),
-      timeline: bestReplayMatch.replay,
-      matches: attempt.tournamentResult.matches.map((match) => ({
-        seed: match.seed,
-        score: match.score,
-        winner: match.winner,
-        passed_validation: match.passedValidation,
-        validation_errors: match.validationErrors,
-        timeline: match.replay,
-      })),
-    });
+    this.#artifacts.writeJson(
+      join(generationDir, "replays", `${this.#scenario.name}_${generationIndex}.json`),
+      {
+        run_id: runId,
+        generation: generationIndex,
+        scenario: this.#scenario.name,
+        seed: bestReplayMatch.seed,
+        score: bestReplayMatch.score,
+        winner: bestReplayMatch.winner,
+        narrative: this.#scenario.replayToNarrative(bestReplayMatch.replay),
+        timeline: bestReplayMatch.replay,
+        matches: attempt.tournamentResult.matches.map((match) => ({
+          seed: match.seed,
+          score: match.score,
+          winner: match.winner,
+          passed_validation: match.passedValidation,
+          validation_errors: match.validationErrors,
+          timeline: match.replay,
+        })),
+      },
+    );
 
     this.#artifacts.writeJson(join(generationDir, "tournament_summary.json"), {
       gate_decision: attempt.gateDecision,
@@ -102,15 +122,15 @@ export class GenerationJournal {
   }
 
   countDeadEnds(): number {
-    const content = this.#artifacts.readDeadEnds(this.#scenario.name);
+    const content = this.#artifacts.readDeadEnds(asScenarioName(this.#scenario.name));
     if (!content) return 0;
     return content.split("\n").filter((line) => line.startsWith("### Dead End")).length;
   }
 
-  persistSessionReport(runId: string, context: SessionReportContext): string {
+  persistSessionReport(runId: RunId, context: SessionReportContext): string {
     const report = generateSessionReport(
       runId,
-      this.#scenario.name,
+      asScenarioName(this.#scenario.name),
       this.#store.getScoreTrajectory(runId) as unknown as Array<Record<string, unknown>>,
       {
         durationSeconds: (Date.now() - context.runStartedAtMs) / 1000,
@@ -121,7 +141,7 @@ export class GenerationJournal {
     const markdown = report.toMarkdown();
     const runPath = join(this.#artifacts.runsRoot, runId, "session_report.md");
     this.#artifacts.writeMarkdown(runPath, markdown);
-    this.#artifacts.writeSessionReport(this.#scenario.name, runId, markdown);
+    this.#artifacts.writeSessionReport(asScenarioName(this.#scenario.name), runId, markdown);
     return runPath;
   }
 }

--- a/ts/src/loop/generation-recovery.ts
+++ b/ts/src/loop/generation-recovery.ts
@@ -1,3 +1,4 @@
+import type { RunId, ScenarioName } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { DeadEndEntry, consolidateDeadEnds } from "../knowledge/dead-end.js";
 import { PLAYBOOK_MARKERS } from "../knowledge/playbook.js";
@@ -6,7 +7,7 @@ import type { StagnationDetector, StagnationReport } from "./stagnation.js";
 
 export interface GenerationRecoveryOpts {
   artifacts: ArtifactStore;
-  scenarioName: string;
+  scenarioName: ScenarioName;
   deadEndTrackingEnabled: boolean;
   deadEndMaxEntries: number;
   stagnationResetEnabled: boolean;
@@ -44,7 +45,7 @@ function extractMarkedSection(content: string, startMarker: string, endMarker: s
 
 export class GenerationRecovery {
   readonly #artifacts: ArtifactStore;
-  readonly #scenarioName: string;
+  readonly #scenarioName: ScenarioName;
   readonly #deadEndTrackingEnabled: boolean;
   readonly #deadEndMaxEntries: number;
   readonly #stagnationResetEnabled: boolean;
@@ -63,7 +64,7 @@ export class GenerationRecovery {
     this.#stagnationDetector = opts.stagnationDetector;
   }
 
-  handleAttempt(runId: string, attempt: GenerationRecoveryAttempt): GenerationRecoveryOutcome {
+  handleAttempt(runId: RunId, attempt: GenerationRecoveryAttempt): GenerationRecoveryOutcome {
     const events: GenerationRecoveryEvent[] = [];
     let deadEndRecorded = false;
 
@@ -134,7 +135,8 @@ export class GenerationRecovery {
       .filter((line) => line.startsWith("-"))
       .slice(0, this.#stagnationDistillTopLessons);
 
-    const deadEnds = this.#artifacts.readDeadEnds(this.#scenarioName)
+    const deadEnds = this.#artifacts
+      .readDeadEnds(this.#scenarioName)
       .split("\n")
       .map((line) => line.trim())
       .filter((line) => line.startsWith("- **Gen"))

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -11,7 +11,7 @@
  */
 
 import type { CompletionResult, LLMProvider } from "../types/index.js";
-import type { RunId } from "../domain/ids.js";
+import { asScenarioName, type RunId, type ScenarioName } from "../domain/ids.js";
 import type { ScenarioInterface } from "../scenarios/game-interface.js";
 import type { SQLiteStore } from "../storage/index.js";
 import { TournamentRunner } from "../execution/tournament.js";
@@ -145,6 +145,7 @@ export class GenerationRunner {
   #roleProviders: Partial<Record<GenerationRole, LLMProvider>>;
   #roleModels: Partial<Record<GenerationRole, string>>;
   #scenario: ScenarioInterface;
+  #scenarioName: ScenarioName;
   #store: SQLiteStore;
   #artifactStore: ArtifactStore;
   #journal: GenerationJournal;
@@ -190,6 +191,7 @@ export class GenerationRunner {
     this.#roleProviders = opts.roleProviders ?? {};
     this.#roleModels = opts.roleModels ?? {};
     this.#scenario = opts.scenario;
+    this.#scenarioName = asScenarioName(this.#scenario.name);
     this.#store = opts.store;
     this.#artifactStore = new ArtifactStore({
       runsRoot: opts.runsRoot,
@@ -227,7 +229,7 @@ export class GenerationRunner {
     });
     this.#recovery = new GenerationRecovery({
       artifacts: this.#artifactStore,
-      scenarioName: this.#scenario.name,
+      scenarioName: this.#scenarioName,
       deadEndTrackingEnabled: this.#deadEndTrackingEnabled,
       deadEndMaxEntries: this.#deadEndMaxEntries,
       stagnationResetEnabled: this.#stagnationResetEnabled,
@@ -490,15 +492,15 @@ export class GenerationRunner {
       scale: this.#levyScoutScale,
     });
     const contextComponents = this.applyContextComponentsHook(runId, generation, "competitor", {
-      playbook: this.#artifactStore.readPlaybook(this.#scenario.name),
+      playbook: this.#artifactStore.readPlaybook(this.#scenarioName),
       trajectory: new ScoreTrajectoryBuilder(this.#store.getScoreTrajectory(runId)).build(),
-      session_reports: this.#artifactStore.readSessionReports(this.#scenario.name),
+      session_reports: this.#artifactStore.readSessionReports(this.#scenarioName),
       scout_mutation_guidance: scoutHint,
     });
     const compacted = this.compactPromptComponentsForRun(runId, generation, contextComponents);
     const trimmed = this.#contextBudget.apply({
       ...compacted,
-      dead_ends: this.#artifactStore.readDeadEnds(this.#scenario.name),
+      dead_ends: this.#artifactStore.readDeadEnds(this.#scenarioName),
     });
     const injectedHint = this.#controller?.takeHint();
     const operatorHint =
@@ -587,14 +589,14 @@ export class GenerationRunner {
     attempt: GenerationAttempt,
   ): string {
     const trimmed = this.#contextBudget.apply({
-      playbook: this.#artifactStore.readPlaybook(this.#scenario.name),
+      playbook: this.#artifactStore.readPlaybook(this.#scenarioName),
       trajectory: new ScoreTrajectoryBuilder(this.#store.getScoreTrajectory(runId)).build(),
       analysis:
         `Gate decision: ${attempt.gateDecision}\n` +
         `Best score: ${attempt.tournamentResult.bestScore.toFixed(4)}\n` +
         `Mean score: ${attempt.tournamentResult.meanScore.toFixed(4)}\n` +
         `Wins/Losses: ${attempt.tournamentResult.wins}/${attempt.tournamentResult.losses}`,
-      dead_ends: this.#artifactStore.readDeadEnds(this.#scenario.name),
+      dead_ends: this.#artifactStore.readDeadEnds(this.#scenarioName),
     });
 
     const prompt = buildSupportPrompt({
@@ -690,7 +692,7 @@ export class GenerationRunner {
       `Generation ${gen} Coach`,
     );
 
-    const currentPlaybook = this.#artifactStore.readPlaybook(this.#scenario.name);
+    const currentPlaybook = this.#artifactStore.readPlaybook(this.#scenarioName);
     const normalizedPlaybook = currentPlaybook === EMPTY_PLAYBOOK_SENTINEL ? "" : currentPlaybook;
     const hasStructuredPlaybook =
       coachResult.text.includes(PLAYBOOK_MARKERS.PLAYBOOK_START) &&
@@ -737,7 +739,7 @@ export class GenerationRunner {
 
     if (nextPlaybook) {
       const playbookResult = this.#artifactStore.writeOrStagePlaybook(
-        this.#scenario.name,
+        this.#scenarioName,
         nextPlaybook,
         {
           requireApproval: this.#requirePlaybookApproval,
@@ -766,7 +768,7 @@ export class GenerationRunner {
 
   private async runCuratorConsolidation(runId: RunId, gen: number): Promise<void> {
     if (this.#requirePlaybookApproval) return;
-    const playbook = this.#artifactStore.readPlaybook(this.#scenario.name);
+    const playbook = this.#artifactStore.readPlaybook(this.#scenarioName);
     if (!playbook || playbook === EMPTY_PLAYBOOK_SENTINEL) return;
 
     const lessons = extractMarkedSection(
@@ -800,7 +802,7 @@ export class GenerationRunner {
       PLAYBOOK_MARKERS.LESSONS_END,
       parsed.consolidatedLessons,
     );
-    this.#artifactStore.writePlaybook(this.#scenario.name, updatedPlaybook);
+    this.#artifactStore.writePlaybook(this.#scenarioName, updatedPlaybook);
   }
 
   private async applyAdvancedFeatures(
@@ -845,7 +847,7 @@ export class GenerationRunner {
 
   private persistExplorationCollapseGuard(runId: RunId, gen: number): void {
     if (!this.#explorationCollapseGuard) return;
-    const playbook = this.#artifactStore.readPlaybook(this.#scenario.name).trim();
+    const playbook = this.#artifactStore.readPlaybook(this.#scenarioName).trim();
     if (!playbook || playbook === EMPTY_PLAYBOOK_SENTINEL) return;
     const snapshots = explorationSnapshots(this.#store.getScoreTrajectory(runId));
     if (snapshots.length < 2) return;

--- a/ts/src/mcp/knowledge-readback-tools.ts
+++ b/ts/src/mcp/knowledge-readback-tools.ts
@@ -55,7 +55,7 @@ function jsonText(payload: unknown, indent?: number): JsonToolResponse {
 const ReadTrajectoryArgsSchema = z.object({ runId: z.string() });
 type ReadTrajectoryArgs = z.infer<typeof ReadTrajectoryArgsSchema>;
 
-const ScenarioArgsSchema = z.object({ scenario: z.string() });
+const ScenarioArgsSchema = z.object({ scenario: z.string().min(1) });
 type ScenarioArgs = z.infer<typeof ScenarioArgsSchema>;
 
 const ReadAnalysisArgsSchema = z.object({

--- a/ts/src/mcp/knowledge-readback-tools.ts
+++ b/ts/src/mcp/knowledge-readback-tools.ts
@@ -2,16 +2,12 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 
+import { asScenarioName } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { exportStrategyPackage } from "../knowledge/package.js";
 import { ScoreTrajectoryBuilder, type TrajectoryRow } from "../knowledge/trajectory.js";
 import { extractDelimitedSection } from "../agents/roles.js";
-import type {
-  AgentOutputRow,
-  GenerationRow,
-  RunRow,
-  SQLiteStore,
-} from "../storage/index.js";
+import type { AgentOutputRow, GenerationRow, RunRow, SQLiteStore } from "../storage/index.js";
 
 interface JsonToolResponse {
   content: Array<{
@@ -25,7 +21,10 @@ type McpToolRegistrar = {
 };
 
 interface KnowledgeReadbackInternals {
-  createArtifactStore(opts: { runsRoot: string; knowledgeRoot: string }): Pick<ArtifactStore, "readPlaybook">;
+  createArtifactStore(opts: {
+    runsRoot: string;
+    knowledgeRoot: string;
+  }): Pick<ArtifactStore, "readPlaybook">;
   extractDelimitedSection(content: string, startMarker: string, endMarker: string): string | null;
   exportStrategyPackage(opts: {
     scenarioName: string;
@@ -111,12 +110,13 @@ export function registerKnowledgeReadbackTools(
         runsRoot: opts.runsRoot,
         knowledgeRoot: opts.knowledgeRoot,
       });
-      const playbook = artifacts.readPlaybook(args.scenario);
-      const hints = internals.extractDelimitedSection(
-        playbook,
-        "<!-- COMPETITOR_HINTS_START -->",
-        "<!-- COMPETITOR_HINTS_END -->",
-      ) ?? "";
+      const playbook = artifacts.readPlaybook(asScenarioName(args.scenario));
+      const hints =
+        internals.extractDelimitedSection(
+          playbook,
+          "<!-- COMPETITOR_HINTS_START -->",
+          "<!-- COMPETITOR_HINTS_END -->",
+        ) ?? "";
       return {
         content: [{ type: "text", text: hints || "No hints available." }],
       };
@@ -128,10 +128,7 @@ export function registerKnowledgeReadbackTools(
     "Read the analyst output for a specific generation",
     ReadAnalysisArgsSchema.shape,
     async (args: ReadAnalysisArgs) => {
-      const outputs = opts.store.getAgentOutputs(
-        args.runId,
-        args.generation,
-      );
+      const outputs = opts.store.getAgentOutputs(args.runId, args.generation);
       const analyst = outputs.find((output) => output.role === "analyst");
       return {
         content: [{ type: "text", text: analyst?.content ?? "No analysis found." }],
@@ -165,12 +162,14 @@ export function registerKnowledgeReadbackTools(
     async (args: ScenarioArgs) => {
       const skillPath = join(opts.knowledgeRoot, args.scenario, "SKILL.md");
       return {
-        content: [{
-          type: "text",
-          text: existsSync(skillPath)
-            ? readFileSync(skillPath, "utf-8")
-            : "No skill notes found.",
-        }],
+        content: [
+          {
+            type: "text",
+            text: existsSync(skillPath)
+              ? readFileSync(skillPath, "utf-8")
+              : "No skill notes found.",
+          },
+        ],
       };
     },
   );
@@ -240,10 +239,7 @@ export function registerKnowledgeReadbackTools(
       for (const run of runs) {
         const generations: GenerationRow[] = opts.store.getGenerations(run.run_id);
         for (const generation of generations) {
-          const outputs = opts.store.getAgentOutputs(
-            run.run_id,
-            generation.generation_index,
-          );
+          const outputs = opts.store.getAgentOutputs(run.run_id, generation.generation_index);
           const competitor = outputs.find((output) => output.role === "competitor");
           if (competitor && competitor.content.toLowerCase().includes(queryLower)) {
             results.push({

--- a/ts/src/mcp/run-management-tools.ts
+++ b/ts/src/mcp/run-management-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import type { LLMProvider } from "../types/index.js";
-import { asRunId } from "../domain/ids.js";
+import { asRunId, asScenarioName } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { GenerationRunner } from "../loop/generation-runner.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
@@ -215,7 +215,7 @@ export function registerRunManagementTools(
       return jsonText(
         {
           scenario: args.scenario,
-          content: artifacts.readPlaybook(args.scenario),
+          content: artifacts.readPlaybook(asScenarioName(args.scenario)),
         },
         2,
       );

--- a/ts/src/mcp/run-management-tools.ts
+++ b/ts/src/mcp/run-management-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import type { LLMProvider } from "../types/index.js";
-import { asRunId, asScenarioName } from "../domain/ids.js";
+import { asRunId, asScenarioName, type ScenarioName } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { GenerationRunner } from "../loop/generation-runner.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
@@ -47,7 +47,7 @@ interface RunControlSettings {
 
 interface RunManagementInternals {
   createArtifactStore(opts: { runsRoot: string; knowledgeRoot: string }): {
-    readPlaybook(scenarioName: string): string;
+    readPlaybook(scenarioName: ScenarioName): string;
   };
   loadScenarioRegistry(): ScenarioRegistry;
   assertFamilyContract(scenario: ScenarioLike, family: "game", label: string): void;
@@ -123,7 +123,7 @@ const RunIdArgsSchema = z.object({
 type RunIdArgs = z.infer<typeof RunIdArgsSchema>;
 
 const GetPlaybookArgsSchema = z.object({
-  scenario: z.string().describe("Scenario name"),
+  scenario: z.string().min(1).describe("Scenario name"),
 });
 type GetPlaybookArgs = z.infer<typeof GetPlaybookArgsSchema>;
 

--- a/ts/src/production-traces/contract/branded-ids.ts
+++ b/ts/src/production-traces/contract/branded-ids.ts
@@ -3,7 +3,11 @@ import { ulid } from "ulid";
 declare const brand: unique symbol;
 type Brand<T, B> = T & { readonly [brand]: B };
 
-// Branded IDs introduced by the production-traces contract.
+// Branded IDs introduced by the production-traces contract. These use
+// nullable `parseX()` constructors (routine, per-request format failures
+// that callers branch on), as opposed to `domain/ids.ts`'s throwing
+// `asX()` constructors (invariant-guaranteed boundaries). See the AC-866
+// note in `domain/ids.ts` for the full boundary-driven rationale.
 export type ProductionTraceId = Brand<string, "ProductionTraceId">;
 export type AppId = Brand<string, "AppId">;
 export type UserIdHash = Brand<string, "UserIdHash">;
@@ -25,49 +29,45 @@ const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 const CONTENT_HASH_RE = /^sha256:[0-9a-f]{64}$/;
 
 export function newProductionTraceId(): ProductionTraceId {
-	return ulid() as ProductionTraceId;
+  return ulid() as ProductionTraceId;
 }
 
-export function parseProductionTraceId(
-	input: string,
-): ProductionTraceId | null {
-	return ULID_RE.test(input) ? (input as ProductionTraceId) : null;
+export function parseProductionTraceId(input: string): ProductionTraceId | null {
+  return ULID_RE.test(input) ? (input as ProductionTraceId) : null;
 }
 
 export function parseAppId(input: string): AppId | null {
-	if (input === ".." || input.includes("/") || input.includes("\\"))
-		return null;
-	return SLUG_RE.test(input) ? (input as AppId) : null;
+  if (input === ".." || input.includes("/") || input.includes("\\")) return null;
+  return SLUG_RE.test(input) ? (input as AppId) : null;
 }
 
 export function parseUserIdHash(input: string): UserIdHash | null {
-	return SHA256_HEX_RE.test(input) ? (input as UserIdHash) : null;
+  return SHA256_HEX_RE.test(input) ? (input as UserIdHash) : null;
 }
 
 export function parseSessionIdHash(input: string): SessionIdHash | null {
-	return SHA256_HEX_RE.test(input) ? (input as SessionIdHash) : null;
+  return SHA256_HEX_RE.test(input) ? (input as SessionIdHash) : null;
 }
 
 export function parseFeedbackRefId(input: string): FeedbackRefId | null {
-	// Opaque customer-supplied identifier: reject only if fully whitespace or empty.
-	if (input.trim().length === 0) return null;
-	return input as FeedbackRefId;
+  // Opaque customer-supplied identifier: reject only if fully whitespace or empty.
+  if (input.trim().length === 0) return null;
+  return input as FeedbackRefId;
 }
 
 export function parseEnvironmentTag(input: string): EnvironmentTag | null {
-	if (input === ".." || input.includes("/") || input.includes("\\"))
-		return null;
-	return ENV_TAG_RE.test(input) ? (input as EnvironmentTag) : null;
+  if (input === ".." || input.includes("/") || input.includes("\\")) return null;
+  return ENV_TAG_RE.test(input) ? (input as EnvironmentTag) : null;
 }
 
 export function defaultEnvironmentTag(): EnvironmentTag {
-	return "production" as EnvironmentTag;
+  return "production" as EnvironmentTag;
 }
 
 export function parseContentHash(input: string): ContentHash | null {
-	return CONTENT_HASH_RE.test(input) ? (input as ContentHash) : null;
+  return CONTENT_HASH_RE.test(input) ? (input as ContentHash) : null;
 }
 
 export function parseScenario(input: string): Scenario | null {
-	return SLUG_RE.test(input) ? (input as Scenario) : null;
+  return SLUG_RE.test(input) ? (input as Scenario) : null;
 }

--- a/ts/src/server/knowledge-api.ts
+++ b/ts/src/server/knowledge-api.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
+import type { ScenarioName } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import {
   approveLesson as approveLessonLifecycle,
@@ -30,19 +31,19 @@ export interface KnowledgeSolveManager {
 
 export interface KnowledgeApiRoutes {
   listSolved(): KnowledgeApiResponse;
-  exportScenario(scenarioName: string): KnowledgeApiResponse;
+  exportScenario(scenarioName: ScenarioName): KnowledgeApiResponse;
   importPackage(body: Record<string, unknown>): KnowledgeApiResponse;
   search(body: Record<string, unknown>): KnowledgeApiResponse;
   submitSolve(body: Record<string, unknown>): KnowledgeApiResponse;
   solveStatus(jobId: string): KnowledgeApiResponse;
-  pendingPlaybook(scenarioName: string): KnowledgeApiResponse;
-  approvePendingPlaybook(scenarioName: string): KnowledgeApiResponse;
-  rejectPendingPlaybook(scenarioName: string): KnowledgeApiResponse;
-  lessonLifecycle(scenarioName: string): KnowledgeApiResponse;
-  approveLesson(scenarioName: string, lessonId: string): KnowledgeApiResponse;
-  rejectLesson(scenarioName: string, lessonId: string): KnowledgeApiResponse;
+  pendingPlaybook(scenarioName: ScenarioName): KnowledgeApiResponse;
+  approvePendingPlaybook(scenarioName: ScenarioName): KnowledgeApiResponse;
+  rejectPendingPlaybook(scenarioName: ScenarioName): KnowledgeApiResponse;
+  lessonLifecycle(scenarioName: ScenarioName): KnowledgeApiResponse;
+  approveLesson(scenarioName: ScenarioName, lessonId: string): KnowledgeApiResponse;
+  rejectLesson(scenarioName: ScenarioName, lessonId: string): KnowledgeApiResponse;
   curateLesson(
-    scenarioName: string,
+    scenarioName: ScenarioName,
     lessonId: string,
     body: Record<string, unknown>,
   ): KnowledgeApiResponse;
@@ -230,13 +231,13 @@ export function buildKnowledgeApiRoutes(opts: {
   };
 }
 
-function invalidScenario(scenarioName: string): KnowledgeApiResponse {
+function invalidScenario(scenarioName: ScenarioName): KnowledgeApiResponse {
   return { status: 422, body: { error: `Invalid scenario '${scenarioName}'` } };
 }
 
 function withPlaybookApproval(
   opts: { runsRoot: string; knowledgeRoot: string },
-  scenarioName: string,
+  scenarioName: ScenarioName,
   fn: (artifacts: ArtifactStore) => KnowledgeApiResponse,
 ): KnowledgeApiResponse {
   const scenarioDir = resolveKnowledgeScenarioDir(opts.knowledgeRoot, scenarioName);
@@ -391,8 +392,7 @@ function clampInteger(value: unknown, fallback: number, min: number, max: number
 }
 
 type SolveSubmitOptionsResult =
-  | { ok: true; options?: SolveSubmitOptions }
-  | { ok: false; error: string };
+  { ok: true; options?: SolveSubmitOptions } | { ok: false; error: string };
 
 function parseSolveSubmitOptions(body: Record<string, unknown>): SolveSubmitOptionsResult {
   const family = readOptionalString(body, ["family", "familyOverride", "family_override"]);

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import type { AppSettings } from "../config/index.js";
-import { asRunId } from "../domain/ids.js";
+import { asDbPath, asRunId } from "../domain/ids.js";
 import type { LoopController } from "../loop/controller.js";
 import type { EventStreamEmitter } from "../loop/events.js";
 import { GenerationRunner } from "../loop/generation-runner.js";
@@ -127,7 +127,8 @@ export async function executeBuiltInGameStartRun(opts: {
       resolveScenarioClass: opts.deps?.resolveScenarioClass,
     });
 
-  const store = opts.deps?.createStore?.(opts.opts.dbPath) ?? new SQLiteStore(opts.opts.dbPath);
+  const store =
+    opts.deps?.createStore?.(opts.opts.dbPath) ?? new SQLiteStore(asDbPath(opts.opts.dbPath));
   store.migrate(opts.opts.migrationsDir);
   const { hookBus, loadedExtensions } = await initializeHookBus({
     extensions: opts.settings.extensions,

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -66,6 +66,7 @@ import type { EventCallback } from "../loop/events.js";
 import { loadSettings, type AppSettings } from "../config/index.js";
 import { RuntimeSessionEventStore } from "../session/runtime-events.js";
 import { SQLiteStore } from "../storage/index.js";
+import { asDbPath, asScenarioName } from "../domain/ids.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { SolveManager } from "../knowledge/solver.js";
 import type { LLMProvider } from "../types/index.js";
@@ -306,7 +307,7 @@ export class InteractiveServer {
       openStore,
       readPlaybook: (playbookScenario, roots) => {
         const artifacts = new ArtifactStore(roots);
-        return artifacts.readPlaybook(playbookScenario);
+        return artifacts.readPlaybook(asScenarioName(playbookScenario));
       },
       loadReplayArtifactResponse,
     };
@@ -359,7 +360,7 @@ export class InteractiveServer {
   }
 
   #openStore(): SQLiteStore {
-    const store = new SQLiteStore(this.#runManager.getDbPath());
+    const store = new SQLiteStore(asDbPath(this.#runManager.getDbPath()));
     store.migrate(this.#runManager.getMigrationsDir());
     return store;
   }

--- a/ts/src/storage/sqlite-store.ts
+++ b/ts/src/storage/sqlite-store.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 
+import type { DbPath } from "../domain/ids.js";
 import type {
   AgentOutputRow,
   ConsultationRow,
@@ -105,7 +106,7 @@ export function configureSqliteDatabase(db: Pick<Database.Database, "pragma">): 
 export class SQLiteStore {
   #db: Database.Database;
 
-  constructor(dbPath: string) {
+  constructor(dbPath: DbPath) {
     this.#db = new Database(dbPath);
     configureSqliteDatabase(this.#db);
   }

--- a/ts/src/training/export-records-workflow.ts
+++ b/ts/src/training/export-records-workflow.ts
@@ -1,3 +1,4 @@
+import { asScenarioName } from "../domain/ids.js";
 import type { ArtifactStore } from "../knowledge/artifact-store.js";
 import type { SQLiteStore } from "../storage/index.js";
 import {
@@ -14,10 +15,7 @@ import type {
   TrainingRecord,
 } from "./export-types.js";
 
-export function resolveTrainingExportRuns(
-  store: SQLiteStore,
-  opts: ExportOpts,
-): ExportRunRef[] {
+export function resolveTrainingExportRuns(store: SQLiteStore, opts: ExportOpts): ExportRunRef[] {
   if (opts.runId) {
     const run = store.getRun(opts.runId);
     if (!run) {
@@ -49,10 +47,13 @@ export function buildTrainingExportRecordsForRun(opts: {
   run: ExportRunRef;
   keptOnly?: boolean;
   includeMatches?: boolean;
-  onGenerationRecords?: (generationIndex: number, generationRecords: TrainingExportRecord[]) => void;
+  onGenerationRecords?: (
+    generationIndex: number,
+    generationRecords: TrainingExportRecord[],
+  ) => void;
 }): TrainingExportRecord[] {
   const records: TrainingExportRecord[] = [];
-  const playbook = opts.artifacts.readPlaybook(opts.run.scenario);
+  const playbook = opts.artifacts.readPlaybook(asScenarioName(opts.run.scenario));
   const hints = extractTrainingHints(playbook);
   const promptContext = resolveTrainingPromptContext(opts.artifacts, opts.run.scenario);
   const generations = opts.store.getGenerations(opts.run.run_id);
@@ -81,15 +82,20 @@ export function buildTrainingExportRecordsForRun(opts: {
     const generationRecords: TrainingExportRecord[] = [record];
 
     if (opts.includeMatches) {
-      const matches = opts.store.getMatchesForGeneration(opts.run.run_id, generation.generation_index);
-      generationRecords.push(...matches.map((match): MatchRecord => ({
-        run_id: opts.run.run_id,
-        generation_index: generation.generation_index,
-        seed: match.seed,
-        score: match.score,
-        passed_validation: !!match.passed_validation,
-        validation_errors: match.validation_errors,
-      })));
+      const matches = opts.store.getMatchesForGeneration(
+        opts.run.run_id,
+        generation.generation_index,
+      );
+      generationRecords.push(
+        ...matches.map((match): MatchRecord => ({
+          run_id: opts.run.run_id,
+          generation_index: generation.generation_index,
+          seed: match.seed,
+          score: match.score,
+          passed_validation: !!match.passed_validation,
+          validation_errors: match.validation_errors,
+        })),
+      );
     }
 
     records.push(...generationRecords);

--- a/ts/src/tui/commands.ts
+++ b/ts/src/tui/commands.ts
@@ -1,4 +1,5 @@
 import type { TraceGateOperatorView } from "../analytics/trace-gate-operator-view.js";
+import { asDbPath } from "../domain/ids.js";
 import type { RunManager } from "../server/run-manager.js";
 import type { TuiActivitySettings } from "./activity-summary.js";
 import { resetTuiActivitySettings, saveTuiActivitySettings } from "./activity-settings-store.js";
@@ -47,7 +48,7 @@ async function loadTuiRunInspection(
   generations: import("../cli/run-inspection-command-workflow.js").RunInspectionGeneration[];
 }> {
   const { SQLiteStore } = await import("../storage/index.js");
-  const store = new SQLiteStore(manager.getDbPath());
+  const store = new SQLiteStore(asDbPath(manager.getDbPath()));
   store.migrate(manager.getMigrationsDir());
   try {
     const run = store.getRun(runId);


### PR DESCRIPTION
## Summary

Slice 2 of the branded-id migration (follow-up to AC-855 / #1159). Migrates `RunId` / `ScenarioName` / `DbPath` through the knowledge, loop, server/MCP, storage, and CLI layers, and documents the constructor-idiom split between `domain/ids.ts` and `production-traces/contract/branded-ids.ts`.

## Scoping correction vs. #1159's follow-up note

#1159 described the remaining ~93 raw-string sites as living mostly in `ts/src/control-plane/` and `ts/src/knowledge/`. Investigating the actual call graph found that `control-plane/`'s `runId` sites (`contract/types.ts`'s `EvalRun.runId`, `registry/eval-run-store.ts`) are a **different bounded context**: an eval-harness run id, validated by its own path-safe regex (`isPathSafeRunId`), unrelated to the generation-loop `RunId` this migration brands. Forcing it through `asRunId`/`RunId` would conflate two distinct domain concepts and silently change validation semantics (byte-empty-only vs. path-safe-slug). That folder is untouched here; the real remaining surface was `server/*-api.ts` + `server/*-workflow.ts` + `storage/` + `knowledge/`, which is what this PR covers.

## Migration inventory

**RunId / ScenarioName** — carried from `generation-runner.ts` (already `RunId`-typed post-#1159) down through:
- `knowledge/`: `ArtifactStore`, `CompactionLedgerStore`, `PlaybookManager`, `playbook-approval.ts`, `session-report.ts`, `scenario-paths.ts` (new boundary: `normalizeScenarioSegment` already enforces path-safety, strictly stronger than `asScenarioName`'s byte-empty check, so it now returns `ScenarioName`), `lesson-lifecycle.ts`, `package.ts` (boundary-wrapped, not rebranded — see below)
- `loop/`: `generation-runner.ts` (adds a cached `#scenarioName: ScenarioName` field), `generation-journal.ts`, `generation-recovery.ts`
- `execution/sandbox.ts`
- `server/knowledge-api.ts`: brands all 8 `KnowledgeApiRoutes` scenario-taking methods (`exportScenario`, `pendingPlaybook`, `approve/rejectPendingPlaybook`, `lessonLifecycle`, `approve/rejectLesson`, `curateLesson`) — matches how `knowledge-routes.ts` already calls them
- `mcp/knowledge-readback-tools.ts`, `mcp/run-management-tools.ts`, `server/ws-server.ts`, `training/export-records-workflow.ts` — boundary conversions at the last raw-string hop into an already-migrated signature

**DbPath** — previously unstarted (per #1159). Branded `SQLiteStore`'s constructor and converted all ~19 call sites: `storage/sqlite-store.ts`, `cli/commands/{run,evaluate,export,queue,serve,shared}.ts`, `tui/commands.ts`, `analysis/engine.ts`, `server/run-start-workflow.ts`, `server/ws-server.ts`. `RunManager.getDbPath()` and its other consumers (`MissionManager`, `CampaignStore`, `RuntimeSessionEventStore`) are left as `string` — only the `SQLiteStore` boundary is in scope.

**Sites converted**: 21 new `: RunId` annotations, 41 new `: ScenarioName` annotations, 19 `asDbPath()` call-site conversions, across 29 `src/` files.

## Boundary discipline / bivariance audit

- No `as RunId` / `as ScenarioName` / `as DbPath` casts outside `domain/ids.ts` (verified via `git diff`).
- Every class whose methods were branded was checked for facade/instantiation risk: `ArtifactStore`, `CompactionLedgerStore`, `PlaybookManager`, `GenerationRecovery`, `GenerationJournal` each have exactly one instantiation site with no separately-typed facade — safe. `KnowledgeApiRoutes` (method-shorthand interface) has one factory + 3 test consumers — safe. Found and fixed one live bivariance gap: `mcp/run-management-tools.ts`'s `createArtifactStore` facade declares `readPlaybook(scenarioName: string)` with method-shorthand syntax, so TypeScript silently accepted `new ArtifactStore(...)` there even after `ArtifactStore.readPlaybook` required `ScenarioName`. Fixed by converting `args.scenario` explicitly at the call site.
- Validation semantics unchanged: `asScenarioName`/`asRunId`/`asDbPath` remain byte-empty-only; `normalizeScenarioSegment`'s existing (stronger) path-safety check now also returns `ScenarioName` via `asScenarioName` internally, with no change to what it rejects.

## Constructor-idiom reconciliation

Chose **(b)**, a documented non-unification (see `domain/ids.ts`'s new doc comment): `domain/ids.ts`'s three brands cross boundaries that are already invariant-guaranteed upstream (a route regex requiring ≥1 non-slash char, a required CLI arg, a SQLite primary key read-back) — byte-empty there means a broken caller invariant, so throwing is correct. `production-traces`' brands cross boundaries where malformed input is a routine per-request outcome the caller branches into a 404/null on (HTTP path segments checked against strict ULID/slug/hash regexes, opaque customer-supplied refs) — nullable `parseX()` is correct there. Added a short cross-reference comment in `production-traces/contract/branded-ids.ts` pointing back. Neither module's brands, constructors, or exports changed behavior.

## Remaining scope (intentionally out of this PR)

The largest remaining item is `SQLiteStore`'s run/generation/match CRUD method surface (`storage-contracts.ts`'s ~15 interfaces, the `storage-*-facade.ts` modules, and the server API layer that's still `string`-typed: `cockpit-api.ts`, `runtime-session-api.ts`, `trace-gate-review-api.ts`, `openclaw-api.ts`, `background-session-api.ts`, `run-simulation-read-workflow.ts`, `hub-api.ts`) plus `loop/generation-*-workflow.ts` orchestration internals, `analytics/`, `session/`, `blobstore/`, `evidence/`, `traces/`, `openclaw/`. This is comparable in size to a full slice on its own and is left for a slice 3. `ts/src/control-plane/` is out of scope per the bounded-context note above.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run check:root-index` clean (no new root-exports needed; `RunId`/`ScenarioName`/`DbPath` already on the allowlist from #1159).
- [x] Baseline-first serial `vitest` runs (Node 22, `--maxWorkers=1`) of every covering suite for files touched, compared pre/post: knowledge+loop layer 18 files / 112 tests, storage+CLI layer 16 files / 112 tests — identical pass counts before and after.
- [x] Full suite: `npx vitest run` — 805 test files / 5634 tests, all passing.
- [x] Cast audit: `git diff` shows zero `as RunId`/`as ScenarioName`/`as DbPath` outside `domain/ids.ts`.