### PR TITLE
ambient trainer plan 1: charter, policy, queue, daemon skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `autoctx ambient` foundation: a charter-driven resident daemon skeleton (interview wizard, autonomy dial with guardrail floors, durable stage queue, five stages with auto-pause breakers, status/run/once cli). Stages are no-ops pending the ingest, curation, and training plans (docs/ambient-trainer-design.md).
+
 ## [0.11.0] - 2026-07-02
 
 ### Added

--- a/autocontext/src/autocontext/ambient/__init__.py
+++ b/autocontext/src/autocontext/ambient/__init__.py
@@ -1,0 +1,1 @@
+"""ambient trainer: resident daemon that learns from traces (docs/ambient-trainer-design.md)."""

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 AutonomyLevel = Literal["propose", "train", "full"]
 DeploymentTier = Literal["oss", "hosted-box"]
@@ -19,6 +19,12 @@ _FLOOR_MESSAGE = "guardrail floor: this protection cannot be disabled through th
 
 
 class GuardrailConfig(BaseModel):
+    # validate_assignment closes the silent post-construction bypass
+    # (attribute assignment re-runs the floor validators). model_construct
+    # and model_copy(update=...) still skip validation by pydantic design;
+    # never use them on charter models with untrusted input.
+    model_config = ConfigDict(validate_assignment=True)
+
     frozen_anchor: bool = True
     provenance_quarantine: bool = True
     asymmetric_trainability: bool = True

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -79,3 +79,12 @@ class Charter(BaseModel):
             if source.kind == "full-box" and self.tier != "hosted-box":
                 raise ValueError("full-box sources require the hosted-box tier")
         return self
+
+    @model_validator(mode="after")
+    def _target_names_unique(self) -> Charter:
+        # policy lookups and proposal keying treat target name as a unique key
+        names = [target.name for target in self.targets]
+        duplicates = {name for name in names if names.count(name) > 1}
+        if duplicates:
+            raise ValueError(f"duplicate target names: {sorted(duplicates)}")
+        return self

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -23,7 +23,7 @@ class GuardrailConfig(BaseModel):
     # (attribute assignment re-runs the floor validators). model_construct
     # and model_copy(update=...) still skip validation by pydantic design;
     # never use them on charter models with untrusted input.
-    model_config = ConfigDict(validate_assignment=True)
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
     frozen_anchor: bool = True
     provenance_quarantine: bool = True
@@ -40,6 +40,8 @@ class GuardrailConfig(BaseModel):
 
 
 class CharterSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(min_length=1)
     kind: SourceKind
     enabled: bool = True
@@ -47,6 +49,8 @@ class CharterSource(BaseModel):
 
 
 class CharterTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(min_length=1)
     kind: Literal["role", "task_family"]
     selector: str = Field(min_length=1)
@@ -58,6 +62,8 @@ class CharterTarget(BaseModel):
 
 
 class CharterBudgets(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     gpu_hours_per_window: float = Field(gt=0)
     window_hours: int = Field(ge=1)
     disk_quota_gb: float = Field(gt=0)
@@ -65,6 +71,8 @@ class CharterBudgets(BaseModel):
 
 
 class Charter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     tier: DeploymentTier
     control_surface: Literal["local", "autowork"] = "local"
     autonomy: AutonomyLevel = "propose"

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -1,0 +1,75 @@
+"""charter models: the ambient daemon's only policy input.
+
+Guardrail floors are enforced here so no charter file can disable them
+(spec: docs/ambient-trainer-design.md, "The charter").
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+AutonomyLevel = Literal["propose", "train", "full"]
+DeploymentTier = Literal["oss", "hosted-box"]
+SourceKind = Literal["autocontext", "otel", "proxy", "full-box"]
+TrainingMethod = Literal["sft-distill", "rlvr-experimental"]
+
+_FLOOR_MESSAGE = "guardrail floor: this protection cannot be disabled through the charter"
+
+
+class GuardrailConfig(BaseModel):
+    frozen_anchor: bool = True
+    provenance_quarantine: bool = True
+    asymmetric_trainability: bool = True
+    drift_canaries: bool = True
+    min_frontier_fraction: float = Field(default=0.2, ge=0.05, le=1.0)
+
+    @field_validator("frozen_anchor", "provenance_quarantine", "asymmetric_trainability", "drift_canaries")
+    @classmethod
+    def _floor(cls, value: bool) -> bool:
+        if value is not True:
+            raise ValueError(_FLOOR_MESSAGE)
+        return value
+
+
+class CharterSource(BaseModel):
+    name: str = Field(min_length=1)
+    kind: SourceKind
+    enabled: bool = True
+    redaction_profile: str = "default"
+
+
+class CharterTarget(BaseModel):
+    name: str = Field(min_length=1)
+    kind: Literal["role", "task_family"]
+    selector: str = Field(min_length=1)
+    base_model: str = Field(min_length=1)
+    method: TrainingMethod = "sft-distill"
+    min_dataset_records: int = Field(ge=1)
+    eval_suite: str = Field(min_length=1)
+    autonomy: AutonomyLevel | None = None
+
+
+class CharterBudgets(BaseModel):
+    gpu_hours_per_window: float = Field(gt=0)
+    window_hours: int = Field(ge=1)
+    disk_quota_gb: float = Field(gt=0)
+    priority: Literal["serving", "training"] = "serving"
+
+
+class Charter(BaseModel):
+    tier: DeploymentTier
+    control_surface: Literal["local", "autowork"] = "local"
+    autonomy: AutonomyLevel = "propose"
+    sources: list[CharterSource]
+    targets: list[CharterTarget]
+    budgets: CharterBudgets
+    guardrails: GuardrailConfig = Field(default_factory=GuardrailConfig)
+
+    @model_validator(mode="after")
+    def _full_box_requires_hosted(self) -> Charter:
+        for source in self.sources:
+            if source.kind == "full-box" and self.tier != "hosted-box":
+                raise ValueError("full-box sources require the hosted-box tier")
+        return self

--- a/autocontext/src/autocontext/ambient/charter_io.py
+++ b/autocontext/src/autocontext/ambient/charter_io.py
@@ -1,0 +1,37 @@
+"""load and save the ambient charter yaml with actionable errors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+from pydantic import ValidationError
+
+from autocontext.ambient.charter import Charter
+
+
+class CharterLoadError(Exception):
+    def __init__(self, path: Path, message: str) -> None:
+        self.path = path
+        super().__init__(f"charter at {path}: {message}")
+
+
+def load_charter(path: Path) -> Charter:
+    if not path.exists():
+        raise CharterLoadError(path, "file not found (run `autoctx ambient init` to create one)")
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise CharterLoadError(path, f"yaml parse error: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise CharterLoadError(path, "yaml parse error: top level must be a mapping")
+    try:
+        return Charter(**raw)
+    except ValidationError as exc:
+        raise CharterLoadError(path, f"schema violation: {exc}") from exc
+
+
+def save_charter(charter: Charter, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = charter.model_dump(mode="json")
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")

--- a/autocontext/src/autocontext/ambient/daemon.py
+++ b/autocontext/src/autocontext/ambient/daemon.py
@@ -45,12 +45,13 @@ class AmbientDaemon:
     def run_stage_once(self, stage_name: str) -> StageResult:
         stage = self._stages[stage_name]
         breaker = self._breakers[stage_name]
+        was_paused = breaker.paused
         try:
             result = stage.run_once(self._context())
         except Exception as exc:
             breaker.record_exception()
             self.emitter.emit("stage_failed", {"stage": stage_name, "error": str(exc)}, channel="ambient")
-            if breaker.paused:
+            if breaker.paused and not was_paused:
                 self.emitter.emit("stage_paused", {"stage": stage_name}, channel="ambient")
             return StageResult(errors=1)
         breaker.record(result)
@@ -59,6 +60,11 @@ class AmbientDaemon:
             {"stage": stage_name, "processed": result.processed, "errors": result.errors},
             channel="ambient",
         )
+        # a stage that reports errors without raising can also trip the
+        # breaker; emit the pause transition here too so alerting never
+        # misses an auto-pause
+        if breaker.paused and not was_paused:
+            self.emitter.emit("stage_paused", {"stage": stage_name}, channel="ambient")
         return result
 
     def run_cycle(self) -> dict[str, StageResult]:

--- a/autocontext/src/autocontext/ambient/daemon.py
+++ b/autocontext/src/autocontext/ambient/daemon.py
@@ -33,11 +33,6 @@ class AmbientDaemon:
         self._breakers: dict[str, AutoPauseBreaker] = {
             name: AutoPauseBreaker(threshold=breaker_threshold) for name in self._stages
         }
-        # crash recovery: jobs stuck in running from a previous process
-        # return to pending before the first cycle
-        requeued = self.queue.requeue_stale_running()
-        if requeued:
-            self.emitter.emit("stale_jobs_requeued", {"count": requeued}, channel="ambient")
 
     def _context(self) -> StageContext:
         return StageContext(charter=self.charter, queue=self.queue, emitter=self.emitter)
@@ -76,6 +71,12 @@ class AmbientDaemon:
         return results
 
     def run_forever(self, poll_seconds: float, max_cycles: int | None = None) -> None:
+        # crash recovery lives here, not in the constructor: read-only
+        # commands (status) and manual one-shots construct a daemon too, and
+        # must never yank another process's in-flight jobs back to pending
+        requeued = self.queue.requeue_stale_running()
+        if requeued:
+            self.emitter.emit("stale_jobs_requeued", {"count": requeued}, channel="ambient")
         cycles = 0
         while max_cycles is None or cycles < max_cycles:
             self.run_cycle()

--- a/autocontext/src/autocontext/ambient/daemon.py
+++ b/autocontext/src/autocontext/ambient/daemon.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import fcntl
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from autocontext.ambient.charter import Charter
 from autocontext.ambient.queue import AmbientQueue
@@ -70,19 +73,42 @@ class AmbientDaemon:
             results[name] = self.run_stage_once(name)
         return results
 
+    @contextmanager
+    def _exclusive_daemon_lock(self) -> Iterator[None]:
+        # exactly one resident daemon per queue database: without this, a
+        # second daemon's startup requeue would hand the first daemon's
+        # in-flight jobs out again (double-claim)
+        lock_path = self.queue.db_path.with_suffix(".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("w")
+        try:
+            try:
+                fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"another ambient daemon already holds {lock_path}; refusing to start a second resident loop"
+                ) from exc
+            yield
+        finally:
+            handle.close()
+
     def run_forever(self, poll_seconds: float, max_cycles: int | None = None) -> None:
-        # crash recovery lives here, not in the constructor: read-only
-        # commands (status) and manual one-shots construct a daemon too, and
-        # must never yank another process's in-flight jobs back to pending
-        requeued = self.queue.requeue_stale_running()
-        if requeued:
-            self.emitter.emit("stale_jobs_requeued", {"count": requeued}, channel="ambient")
-        cycles = 0
-        while max_cycles is None or cycles < max_cycles:
-            self.run_cycle()
-            cycles += 1
-            if poll_seconds > 0:
-                time.sleep(poll_seconds)
+        if poll_seconds < 0:
+            raise ValueError("poll_seconds must be zero or positive")
+        with self._exclusive_daemon_lock():
+            # crash recovery lives here, not in the constructor: read-only
+            # commands (status) and manual one-shots construct a daemon too,
+            # and must never yank another process's in-flight jobs back to
+            # pending; the exclusive lock above makes the requeue safe
+            requeued = self.queue.requeue_stale_running()
+            if requeued:
+                self.emitter.emit("stale_jobs_requeued", {"count": requeued}, channel="ambient")
+            cycles = 0
+            while max_cycles is None or cycles < max_cycles:
+                self.run_cycle()
+                cycles += 1
+                if poll_seconds > 0:
+                    time.sleep(poll_seconds)
 
     def status(self) -> dict[str, dict[str, object]]:
         """per-stage view: paused reflects only this process's breakers, and

--- a/autocontext/src/autocontext/ambient/daemon.py
+++ b/autocontext/src/autocontext/ambient/daemon.py
@@ -1,0 +1,81 @@
+"""the ambient daemon: orchestrates the five stages with per-stage breakers."""
+
+from __future__ import annotations
+
+import time
+
+from autocontext.ambient.charter import Charter
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage import (
+    STAGE_NAMES,
+    AutoPauseBreaker,
+    NoOpStage,
+    Stage,
+    StageContext,
+    StageResult,
+)
+from autocontext.harness.core.events import EventStreamEmitter
+
+
+class AmbientDaemon:
+    def __init__(
+        self,
+        charter: Charter,
+        queue: AmbientQueue,
+        emitter: EventStreamEmitter,
+        stages: dict[str, Stage] | None = None,
+        breaker_threshold: int = 3,
+    ) -> None:
+        self.charter = charter
+        self.queue = queue
+        self.emitter = emitter
+        self._stages: dict[str, Stage] = stages if stages is not None else {name: NoOpStage(name=name) for name in STAGE_NAMES}
+        self._breakers: dict[str, AutoPauseBreaker] = {
+            name: AutoPauseBreaker(threshold=breaker_threshold) for name in self._stages
+        }
+        # crash recovery: jobs stuck in running from a previous process
+        # return to pending before the first cycle
+        requeued = self.queue.requeue_stale_running()
+        if requeued:
+            self.emitter.emit("stale_jobs_requeued", {"count": requeued}, channel="ambient")
+
+    def _context(self) -> StageContext:
+        return StageContext(charter=self.charter, queue=self.queue, emitter=self.emitter)
+
+    def run_stage_once(self, stage_name: str) -> StageResult:
+        stage = self._stages[stage_name]
+        breaker = self._breakers[stage_name]
+        try:
+            result = stage.run_once(self._context())
+        except Exception as exc:
+            breaker.record_exception()
+            self.emitter.emit("stage_failed", {"stage": stage_name, "error": str(exc)}, channel="ambient")
+            if breaker.paused:
+                self.emitter.emit("stage_paused", {"stage": stage_name}, channel="ambient")
+            return StageResult(errors=1)
+        breaker.record(result)
+        self.emitter.emit(
+            "stage_completed",
+            {"stage": stage_name, "processed": result.processed, "errors": result.errors},
+            channel="ambient",
+        )
+        return result
+
+    def run_cycle(self) -> dict[str, StageResult]:
+        results: dict[str, StageResult] = {}
+        for name in self._stages:
+            if self._breakers[name].paused:
+                continue
+            results[name] = self.run_stage_once(name)
+        return results
+
+    def run_forever(self, poll_seconds: float, max_cycles: int | None = None) -> None:
+        cycles = 0
+        while max_cycles is None or cycles < max_cycles:
+            self.run_cycle()
+            cycles += 1
+            if poll_seconds > 0:
+                time.sleep(poll_seconds)
+
+    def status(self) -> dict[str, dict[str, object]]:
+        return {name: {"paused": self._breakers[name].paused, "queue_depth": self.queue.depth(name)} for name in self._stages}

--- a/autocontext/src/autocontext/ambient/daemon.py
+++ b/autocontext/src/autocontext/ambient/daemon.py
@@ -85,4 +85,7 @@ class AmbientDaemon:
                 time.sleep(poll_seconds)
 
     def status(self) -> dict[str, dict[str, object]]:
+        """per-stage view: paused reflects only this process's breakers, and
+        queue_depth counts pending backlog only (in-flight jobs are invisible).
+        """
         return {name: {"paused": self._breakers[name].paused, "queue_depth": self.queue.depth(name)} for name in self._stages}

--- a/autocontext/src/autocontext/ambient/interview.py
+++ b/autocontext/src/autocontext/ambient/interview.py
@@ -1,0 +1,71 @@
+"""interview wizard: turns a short q and a session into a valid charter."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pydantic import BaseModel
+
+from autocontext.ambient.charter import (
+    AutonomyLevel,
+    Charter,
+    CharterBudgets,
+    CharterSource,
+    CharterTarget,
+    DeploymentTier,
+)
+
+PromptFn = Callable[[str, str], str]
+
+
+class InterviewAnswers(BaseModel):
+    tier: DeploymentTier
+    autonomy: AutonomyLevel
+    enable_otel: bool
+    enable_proxy: bool
+    first_target_role: str
+    base_model: str
+    gpu_hours_per_window: float
+    window_hours: int
+    disk_quota_gb: float
+
+
+def build_charter(answers: InterviewAnswers) -> Charter:
+    sources = [CharterSource(name="native", kind="autocontext")]
+    if answers.enable_otel:
+        sources.append(CharterSource(name="otel", kind="otel"))
+    if answers.enable_proxy:
+        sources.append(CharterSource(name="proxy", kind="proxy"))
+    role = answers.first_target_role.split("@", 1)[0]
+    target = CharterTarget(
+        name=answers.first_target_role.replace("@", "-"),
+        kind="role",
+        selector=answers.first_target_role,
+        base_model=answers.base_model,
+        min_dataset_records=500,
+        eval_suite=f"{role}_holdout",
+    )
+    budgets = CharterBudgets(
+        gpu_hours_per_window=answers.gpu_hours_per_window,
+        window_hours=answers.window_hours,
+        disk_quota_gb=answers.disk_quota_gb,
+    )
+    return Charter(tier=answers.tier, autonomy=answers.autonomy, sources=sources, targets=[target], budgets=budgets)
+
+
+def _yes(value: str) -> bool:
+    return value.strip().lower() in ("y", "yes", "true", "1")
+
+
+def run_interview(prompt: PromptFn) -> InterviewAnswers:
+    return InterviewAnswers(
+        tier=prompt("deployment tier (oss | hosted-box)", "oss"),  # type: ignore[arg-type]
+        autonomy=prompt("autonomy (propose | train | full)", "propose"),  # type: ignore[arg-type]
+        enable_otel=_yes(prompt("enable otel source? (y/n)", "n")),
+        enable_proxy=_yes(prompt("enable llm proxy source? (y/n)", "n")),
+        first_target_role=prompt("first target role (role@scenario)", "competitor@grid_ctf"),
+        base_model=prompt("base model", "Qwen/Qwen2.5-3B-Instruct"),
+        gpu_hours_per_window=float(prompt("gpu hours per window", "8")),
+        window_hours=int(prompt("window hours", "24")),
+        disk_quota_gb=float(prompt("disk quota gb", "200")),
+    )

--- a/autocontext/src/autocontext/ambient/policy.py
+++ b/autocontext/src/autocontext/ambient/policy.py
@@ -1,0 +1,39 @@
+"""pure policy functions over the charter: the autonomy dial and budget windows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from autocontext.ambient.charter import AutonomyLevel, Charter, CharterBudgets
+
+Action = Literal["train", "promote"]
+
+
+@dataclass(slots=True)
+class PolicyDecision:
+    allowed: bool
+    requires_approval: bool
+    reason: str
+
+
+def effective_autonomy(charter: Charter, target_name: str) -> AutonomyLevel:
+    for target in charter.targets:
+        if target.name == target_name:
+            return target.autonomy or charter.autonomy
+    raise KeyError(f"unknown charter target: {target_name}")
+
+
+def decide(charter: Charter, action: Action, target_name: str) -> PolicyDecision:
+    autonomy = effective_autonomy(charter, target_name)
+    if autonomy == "propose":
+        return PolicyDecision(True, True, f"autonomy=propose: {action} requires approval")
+    if autonomy == "train":
+        if action == "train":
+            return PolicyDecision(True, False, "autonomy=train: training is autonomous")
+        return PolicyDecision(True, True, "autonomy=train: promotion requires approval")
+    return PolicyDecision(True, False, f"autonomy=full: {action} is autonomous within budgets")
+
+
+def budget_allows(budgets: CharterBudgets, used_gpu_hours_in_window: float, requested_gpu_hours: float) -> bool:
+    return used_gpu_hours_in_window + requested_gpu_hours <= budgets.gpu_hours_per_window

--- a/autocontext/src/autocontext/ambient/proposals.py
+++ b/autocontext/src/autocontext/ambient/proposals.py
@@ -1,0 +1,69 @@
+"""charter proposals: structured diffs the advisor emits and the control surface approves."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterTarget
+
+
+class ProposalError(Exception):
+    pass
+
+
+class CharterProposal(BaseModel):
+    proposal_id: str = Field(min_length=1)
+    kind: Literal["add_target", "update_budgets"]
+    payload: dict[str, Any]
+    rationale: str = Field(min_length=1)
+    status: Literal["pending", "applied", "rejected"] = "pending"
+
+
+def apply_proposal(charter: Charter, proposal: CharterProposal) -> Charter:
+    # rebuild through full validation rather than model_copy(update=...),
+    # which skips validators by pydantic design and would let a malformed
+    # proposal sidestep the charter's guardrail and schema checks.
+    data = charter.model_dump(mode="json")
+    if proposal.kind == "add_target":
+        target = CharterTarget(**proposal.payload)
+        if any(existing.name == target.name for existing in charter.targets):
+            raise ProposalError(f"target {target.name} already exists")
+        data["targets"] = [*data["targets"], target.model_dump(mode="json")]
+        return Charter(**data)
+    data["budgets"] = CharterBudgets(**proposal.payload).model_dump(mode="json")
+    return Charter(**data)
+
+
+class ProposalStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def _read_all(self) -> dict[str, CharterProposal]:
+        records: dict[str, CharterProposal] = {}
+        if not self.path.exists():
+            return records
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            proposal = CharterProposal(**json.loads(line))
+            records[proposal.proposal_id] = proposal
+        return records
+
+    def append(self, proposal: CharterProposal) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(proposal.model_dump(mode="json")) + "\n")
+
+    def pending(self) -> list[CharterProposal]:
+        return [p for p in self._read_all().values() if p.status == "pending"]
+
+    def mark(self, proposal_id: str, status: Literal["applied", "rejected"]) -> None:
+        records = self._read_all()
+        if proposal_id not in records:
+            raise ProposalError(f"unknown proposal: {proposal_id}")
+        updated = records[proposal_id].model_copy(update={"status": status})
+        self.append(updated)

--- a/autocontext/src/autocontext/ambient/proposals.py
+++ b/autocontext/src/autocontext/ambient/proposals.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from autocontext.ambient.charter import Charter, CharterBudgets, CharterTarget
 
@@ -49,14 +49,26 @@ class ProposalStore:
         for line in self.path.read_text(encoding="utf-8").splitlines():
             if not line.strip():
                 continue
-            proposal = CharterProposal(**json.loads(line))
+            try:
+                proposal = CharterProposal(**json.loads(line))
+            except (json.JSONDecodeError, ValidationError):
+                # a crash mid-append can leave a torn trailing line; skip it
+                # rather than bricking every read of the store
+                continue
             records[proposal.proposal_id] = proposal
         return records
 
     def append(self, proposal: CharterProposal) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        prefix = ""
+        if self.path.exists():
+            tail = self.path.read_bytes()[-1:]
+            if tail and tail != b"\n":
+                # a torn trailing line from a crash mid-append must not
+                # swallow the next record; start it on a fresh line
+                prefix = "\n"
         with self.path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(proposal.model_dump(mode="json")) + "\n")
+            handle.write(prefix + json.dumps(proposal.model_dump(mode="json")) + "\n")
 
     def pending(self) -> list[CharterProposal]:
         return [p for p in self._read_all().values() if p.status == "pending"]

--- a/autocontext/src/autocontext/ambient/queue.py
+++ b/autocontext/src/autocontext/ambient/queue.py
@@ -1,0 +1,80 @@
+"""durable sqlite work queue connecting the ambient stages (task-queue idiom)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ambient_queue (
+    job_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stage TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+)
+"""
+
+
+@dataclass(slots=True)
+class AmbientJob:
+    job_id: int
+    stage: str
+    kind: str
+    payload: dict[str, Any]
+    attempts: int
+
+
+class AmbientQueue:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(_SCHEMA)
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def enqueue(self, stage: str, kind: str, payload: dict[str, Any]) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT INTO ambient_queue (stage, kind, payload) VALUES (?, ?, ?)",
+                (stage, kind, json.dumps(payload)),
+            )
+            return int(cursor.lastrowid or 0)
+
+    def claim(self, stage: str) -> AmbientJob | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT job_id, stage, kind, payload, attempts FROM ambient_queue "
+                "WHERE stage = ? AND status = 'pending' ORDER BY job_id LIMIT 1",
+                (stage,),
+            ).fetchone()
+            if row is None:
+                return None
+            conn.execute("UPDATE ambient_queue SET status = 'running' WHERE job_id = ?", (row[0],))
+            return AmbientJob(row[0], row[1], row[2], json.loads(row[3]), row[4])
+
+    def complete(self, job_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute("UPDATE ambient_queue SET status = 'done' WHERE job_id = ?", (job_id,))
+
+    def fail(self, job_id: int, error: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE ambient_queue SET status = 'pending', attempts = attempts + 1, last_error = ? WHERE job_id = ?",
+                (error, job_id),
+            )
+
+    def depth(self, stage: str) -> int:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM ambient_queue WHERE stage = ? AND status = 'pending'",
+                (stage,),
+            ).fetchone()
+            return int(row[0])

--- a/autocontext/src/autocontext/ambient/queue.py
+++ b/autocontext/src/autocontext/ambient/queue.py
@@ -49,16 +49,25 @@ class AmbientQueue:
             return int(cursor.lastrowid or 0)
 
     def claim(self, stage: str) -> AmbientJob | None:
+        # single atomic statement: a select-then-update pair would let two
+        # connections claim the same pending row (toctou double-claim)
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT job_id, stage, kind, payload, attempts FROM ambient_queue "
-                "WHERE stage = ? AND status = 'pending' ORDER BY job_id LIMIT 1",
+                "UPDATE ambient_queue SET status = 'running' WHERE job_id = ("
+                "SELECT job_id FROM ambient_queue WHERE stage = ? AND status = 'pending' "
+                "ORDER BY job_id LIMIT 1) AND status = 'pending' "
+                "RETURNING job_id, stage, kind, payload, attempts",
                 (stage,),
             ).fetchone()
             if row is None:
                 return None
-            conn.execute("UPDATE ambient_queue SET status = 'running' WHERE job_id = ?", (row[0],))
             return AmbientJob(row[0], row[1], row[2], json.loads(row[3]), row[4])
+
+    def requeue_stale_running(self) -> int:
+        """return jobs stuck in running (for example after a crash) to pending."""
+        with self._connect() as conn:
+            cursor = conn.execute("UPDATE ambient_queue SET status = 'pending' WHERE status = 'running'")
+            return int(cursor.rowcount)
 
     def complete(self, job_id: int) -> None:
         with self._connect() as conn:

--- a/autocontext/src/autocontext/ambient/queue.py
+++ b/autocontext/src/autocontext/ambient/queue.py
@@ -64,7 +64,11 @@ class AmbientQueue:
             return AmbientJob(row[0], row[1], row[2], json.loads(row[3]), row[4])
 
     def requeue_stale_running(self) -> int:
-        """return jobs stuck in running (for example after a crash) to pending."""
+        """return jobs stuck in running (for example after a crash) to pending.
+
+        Assumes a single resident daemon per database: a second concurrent
+        daemon calling this would clobber the first one's in-flight jobs.
+        """
         with self._connect() as conn:
             cursor = conn.execute("UPDATE ambient_queue SET status = 'pending' WHERE status = 'running'")
             return int(cursor.rowcount)

--- a/autocontext/src/autocontext/ambient/stage.py
+++ b/autocontext/src/autocontext/ambient/stage.py
@@ -1,0 +1,58 @@
+"""stage framework: the contract every ambient stage implements, plus the auto-pause breaker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from autocontext.ambient.charter import Charter
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.harness.core.events import EventStreamEmitter
+
+STAGE_NAMES: tuple[str, ...] = ("ingest", "curate", "advise", "train", "evaluate")
+
+
+@dataclass(slots=True)
+class StageResult:
+    processed: int = 0
+    errors: int = 0
+
+
+@dataclass(slots=True)
+class StageContext:
+    charter: Charter
+    queue: AmbientQueue
+    emitter: EventStreamEmitter
+
+
+class Stage(Protocol):
+    name: str
+
+    def run_once(self, ctx: StageContext) -> StageResult: ...
+
+
+@dataclass(slots=True)
+class AutoPauseBreaker:
+    threshold: int
+    consecutive_failures: int = field(default=0)
+
+    def record(self, result: StageResult) -> None:
+        if result.errors > 0:
+            self.consecutive_failures += 1
+        else:
+            self.consecutive_failures = 0
+
+    def record_exception(self) -> None:
+        self.consecutive_failures += 1
+
+    @property
+    def paused(self) -> bool:
+        return self.consecutive_failures >= self.threshold
+
+
+@dataclass(slots=True)
+class NoOpStage:
+    name: str
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        return StageResult()

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -20,6 +20,7 @@ from rich.console import Console
 from rich.table import Table
 
 from autocontext.agents.orchestrator import AgentOrchestrator
+from autocontext.cli_ambient import ambient_app
 from autocontext.cli_analytics import register_analytics_command
 from autocontext.cli_capabilities import register_capabilities_command
 from autocontext.cli_hermes import register_hermes_command
@@ -692,6 +693,7 @@ def _serve_mcp() -> None:
 
 
 app.add_typer(_serve_app, name="serve")
+app.add_typer(ambient_app, name="ambient")
 
 
 @app.command()

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -64,7 +64,7 @@ def status(
         raise typer.Exit(code=1) from exc
     charter = daemon.charter
     console.print(f"tier={charter.tier} autonomy={charter.autonomy} targets={len(charter.targets)}")
-    table = Table("stage", "paused", "queue depth")
+    table = Table("stage", "paused (this process)", "backlog")
     for name, info in daemon.status().items():
         table.add_row(name, str(info["paused"]), str(info["queue_depth"]))
     console.print(table)

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -1,0 +1,108 @@
+"""cli for the ambient trainer daemon: init, status, run, once."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+from rich.table import Table
+
+from autocontext.ambient.charter_io import CharterLoadError, load_charter, save_charter
+from autocontext.ambient.daemon import AmbientDaemon
+from autocontext.ambient.interview import build_charter, run_interview
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.harness.core.events import EventStreamEmitter
+
+ambient_app = typer.Typer(help="ambient trainer: resident daemon that learns from traces")
+console = Console()
+
+_DEFAULT_CHARTER = Path("ambient-charter.yaml")
+_DEFAULT_DB = Path("runs/ambient.sqlite3")
+_DEFAULT_EVENTS = Path("runs/ambient-events.ndjson")
+
+
+def _daemon(charter_path: Path, db_path: Path, events_path: Path) -> AmbientDaemon:
+    charter = load_charter(charter_path)
+    return AmbientDaemon(
+        charter=charter,
+        queue=AmbientQueue(db_path),
+        emitter=EventStreamEmitter(events_path),
+    )
+
+
+@ambient_app.command()
+def init(
+    charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
+    force: Annotated[bool, typer.Option("--force")] = False,
+) -> None:
+    if charter_path.exists() and not force:
+        console.print(f"[red]charter already exists at {charter_path}; use --force to overwrite[/red]")
+        raise typer.Exit(code=1)
+    try:
+        answers = run_interview(lambda question, default: typer.prompt(question, default=default))
+        charter = build_charter(answers)
+    except (ValueError, ValidationError) as exc:
+        console.print(f"[red]invalid interview input: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    save_charter(charter, charter_path)
+    console.print(f"charter written to {charter_path}")
+
+
+@ambient_app.command()
+def status(
+    charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
+    db_path: Annotated[Path, typer.Option("--db-path")] = _DEFAULT_DB,
+    events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
+) -> None:
+    try:
+        daemon = _daemon(charter_path, db_path, events_path)
+    except CharterLoadError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    charter = daemon.charter
+    console.print(f"tier={charter.tier} autonomy={charter.autonomy} targets={len(charter.targets)}")
+    table = Table("stage", "paused", "queue depth")
+    for name, info in daemon.status().items():
+        table.add_row(name, str(info["paused"]), str(info["queue_depth"]))
+    console.print(table)
+
+
+@ambient_app.command()
+def run(
+    charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
+    db_path: Annotated[Path, typer.Option("--db-path")] = _DEFAULT_DB,
+    events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
+    poll_seconds: Annotated[float, typer.Option("--poll-seconds")] = 30.0,
+    max_cycles: Annotated[int | None, typer.Option("--max-cycles", hidden=True)] = None,
+) -> None:
+    try:
+        daemon = _daemon(charter_path, db_path, events_path)
+    except CharterLoadError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    daemon.run_forever(poll_seconds=poll_seconds, max_cycles=max_cycles)
+
+
+@ambient_app.command()
+def once(
+    stage: Annotated[str, typer.Argument()],
+    charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
+    db_path: Annotated[Path, typer.Option("--db-path")] = _DEFAULT_DB,
+    events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
+) -> None:
+    try:
+        daemon = _daemon(charter_path, db_path, events_path)
+    except CharterLoadError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    try:
+        result = daemon.run_stage_once(stage)
+    except KeyError as exc:
+        console.print(f"[red]unknown stage: {stage}[/red]")
+        raise typer.Exit(code=1) from exc
+    console.print(f"processed={result.processed} errors={result.errors}")
+    if result.errors > 0:
+        raise typer.Exit(code=1)

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -75,7 +75,7 @@ def run(
     charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
     db_path: Annotated[Path, typer.Option("--db-path")] = _DEFAULT_DB,
     events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
-    poll_seconds: Annotated[float, typer.Option("--poll-seconds")] = 30.0,
+    poll_seconds: Annotated[float, typer.Option("--poll-seconds", min=0.0)] = 30.0,
     max_cycles: Annotated[int | None, typer.Option("--max-cycles", hidden=True)] = None,
 ) -> None:
     try:
@@ -83,7 +83,11 @@ def run(
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
-    daemon.run_forever(poll_seconds=poll_seconds, max_cycles=max_cycles)
+    try:
+        daemon.run_forever(poll_seconds=poll_seconds, max_cycles=max_cycles)
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
 
 @ambient_app.command()

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -73,3 +73,11 @@ def test_full_box_source_allowed_on_hosted_tier() -> None:
 def test_target_autonomy_override_optional() -> None:
     charter = _minimal_charter()
     assert charter.targets[0].autonomy is None
+
+
+def test_guardrail_floor_holds_on_assignment() -> None:
+    config = GuardrailConfig()
+    with pytest.raises(ValidationError, match="guardrail floor"):
+        config.frozen_anchor = False
+    with pytest.raises(ValidationError):
+        config.min_frontier_fraction = 0.0

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -81,3 +81,16 @@ def test_guardrail_floor_holds_on_assignment() -> None:
         config.frozen_anchor = False
     with pytest.raises(ValidationError):
         config.min_frontier_fraction = 0.0
+
+
+def test_duplicate_target_names_rejected() -> None:
+    target = CharterTarget(
+        name="dup",
+        kind="role",
+        selector="competitor@grid_ctf",
+        base_model="Qwen/Qwen2.5-3B-Instruct",
+        min_dataset_records=1,
+        eval_suite="s",
+    )
+    with pytest.raises(ValidationError, match="duplicate target names"):
+        _minimal_charter(targets=[target, target.model_copy()])

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.ambient.charter import (
+    Charter,
+    CharterBudgets,
+    CharterSource,
+    CharterTarget,
+    GuardrailConfig,
+)
+
+
+def _minimal_charter(**overrides: object) -> Charter:
+    base: dict[str, object] = dict(
+        tier="oss",
+        control_surface="local",
+        autonomy="propose",
+        sources=[CharterSource(name="native", kind="autocontext", enabled=True)],
+        targets=[
+            CharterTarget(
+                name="competitor-grid",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="Qwen/Qwen2.5-3B-Instruct",
+                method="sft-distill",
+                min_dataset_records=500,
+                eval_suite="grid_ctf_holdout",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=8.0, window_hours=24, disk_quota_gb=200.0),
+    )
+    base.update(overrides)
+    return Charter(**base)  # type: ignore[arg-type]
+
+
+def test_minimal_charter_validates() -> None:
+    charter = _minimal_charter()
+    assert charter.autonomy == "propose"
+    assert charter.guardrails.frozen_anchor is True
+    assert charter.guardrails.min_frontier_fraction == pytest.approx(0.2)
+
+
+def test_guardrail_booleans_cannot_be_disabled() -> None:
+    with pytest.raises(ValidationError, match="guardrail floor"):
+        GuardrailConfig(frozen_anchor=False)
+    with pytest.raises(ValidationError, match="guardrail floor"):
+        GuardrailConfig(provenance_quarantine=False)
+
+
+def test_min_frontier_fraction_floor() -> None:
+    with pytest.raises(ValidationError):
+        GuardrailConfig(min_frontier_fraction=0.01)
+    assert GuardrailConfig(min_frontier_fraction=0.05).min_frontier_fraction == pytest.approx(0.05)
+
+
+def test_full_box_source_requires_hosted_tier() -> None:
+    with pytest.raises(ValidationError, match="full-box"):
+        _minimal_charter(
+            sources=[CharterSource(name="box", kind="full-box", enabled=True)],
+        )
+
+
+def test_full_box_source_allowed_on_hosted_tier() -> None:
+    charter = _minimal_charter(
+        tier="hosted-box",
+        sources=[CharterSource(name="box", kind="full-box", enabled=True)],
+    )
+    assert charter.sources[0].kind == "full-box"
+
+
+def test_target_autonomy_override_optional() -> None:
+    charter = _minimal_charter()
+    assert charter.targets[0].autonomy is None

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -94,3 +94,18 @@ def test_duplicate_target_names_rejected() -> None:
     )
     with pytest.raises(ValidationError, match="duplicate target names"):
         _minimal_charter(targets=[target, target.model_copy()])
+
+
+def test_unknown_charter_keys_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _minimal_charter(autonmy="full")  # typo'd key must fail loudly
+    with pytest.raises(ValidationError):
+        CharterTarget(
+            name="t",
+            kind="role",
+            selector="s",
+            base_model="m",
+            min_dataset_records=1,
+            eval_suite="e",
+            autonmy="full",
+        )

--- a/autocontext/tests/test_ambient_charter_io.py
+++ b/autocontext/tests/test_ambient_charter_io.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.charter_io import CharterLoadError, load_charter, save_charter
+
+
+def _charter() -> Charter:
+    return Charter(
+        tier="oss",
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="Qwen/Qwen2.5-3B-Instruct",
+                min_dataset_records=10,
+                eval_suite="grid_ctf_holdout",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=1.0, window_hours=24, disk_quota_gb=10.0),
+    )
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "ambient-charter.yaml"
+    save_charter(_charter(), path)
+    loaded = load_charter(path)
+    assert loaded == _charter()
+
+
+def test_missing_file_raises_load_error(tmp_path: Path) -> None:
+    with pytest.raises(CharterLoadError, match="not found"):
+        load_charter(tmp_path / "absent.yaml")
+
+
+def test_invalid_yaml_raises_load_error(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("tier: [unclosed", encoding="utf-8")
+    with pytest.raises(CharterLoadError, match="parse"):
+        load_charter(path)
+
+
+def test_schema_violation_raises_load_error_with_detail(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("tier: oss\nsources: []\ntargets: []\n", encoding="utf-8")
+    with pytest.raises(CharterLoadError, match="budgets"):
+        load_charter(path)

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+
+runner = CliRunner()
+
+
+def _init(tmp_path: Path) -> Path:
+    charter_path = tmp_path / "ambient-charter.yaml"
+    result = runner.invoke(
+        app,
+        ["ambient", "init", "--charter-path", str(charter_path)],
+        input="oss\npropose\nn\nn\ncompetitor@grid_ctf\nQwen/Qwen2.5-3B-Instruct\n8\n24\n200\n",
+    )
+    assert result.exit_code == 0, result.output
+    return charter_path
+
+
+def test_init_writes_charter(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    assert charter_path.exists()
+    assert "competitor@grid_ctf" in charter_path.read_text(encoding="utf-8")
+
+
+def test_init_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(app, ["ambient", "init", "--charter-path", str(charter_path)])
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+
+
+def test_init_rejects_invalid_numeric_input(tmp_path: Path) -> None:
+    charter_path = tmp_path / "ambient-charter.yaml"
+    result = runner.invoke(
+        app,
+        ["ambient", "init", "--charter-path", str(charter_path)],
+        input="oss\npropose\nn\nn\ncompetitor@grid_ctf\nQwen/Qwen2.5-3B-Instruct\nabc\n24\n200\n",
+    )
+    assert result.exit_code == 1
+    assert "invalid interview input" in result.output
+    assert not charter_path.exists()
+
+
+def test_status_reports_stages(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        ["ambient", "status", "--charter-path", str(charter_path), "--db-path", str(tmp_path / "a.sqlite3")],
+    )
+    assert result.exit_code == 0, result.output
+    for stage in ("ingest", "curate", "advise", "train", "evaluate"):
+        assert stage in result.output
+
+
+def test_status_missing_charter_exits_nonzero(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["ambient", "status", "--charter-path", str(tmp_path / "none.yaml")])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_run_with_max_cycles_terminates(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "run",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(tmp_path / "a.sqlite3"),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+            "--poll-seconds",
+            "0",
+            "--max-cycles",
+            "2",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "events.ndjson").exists()
+
+
+def test_once_runs_single_stage(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "once",
+            "ingest",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(tmp_path / "a.sqlite3"),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "processed" in result.output

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -119,3 +119,18 @@ def test_status_does_not_requeue_running_jobs(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert queue.depth("ingest") == 0  # still running, not yanked back
+
+
+def test_run_rejects_negative_poll_seconds(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient", "run",
+            "--charter-path", str(charter_path),
+            "--db-path", str(tmp_path / "a.sqlite3"),
+            "--events-path", str(tmp_path / "events.ndjson"),
+            "--poll-seconds", "-1",
+        ],
+    )
+    assert result.exit_code != 0

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -103,3 +103,19 @@ def test_once_runs_single_stage(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert "processed" in result.output
+
+
+def test_status_does_not_requeue_running_jobs(tmp_path: Path) -> None:
+    from autocontext.ambient.queue import AmbientQueue
+
+    charter_path = _init(tmp_path)
+    db_path = tmp_path / "a.sqlite3"
+    queue = AmbientQueue(db_path)
+    queue.enqueue("ingest", "poll_source", {})
+    assert queue.claim("ingest") is not None  # in-flight in another process
+    result = runner.invoke(
+        app,
+        ["ambient", "status", "--charter-path", str(charter_path), "--db-path", str(db_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert queue.depth("ingest") == 0  # still running, not yanked back

--- a/autocontext/tests/test_ambient_daemon.py
+++ b/autocontext/tests/test_ambient_daemon.py
@@ -98,7 +98,7 @@ def test_run_stage_once_unknown_stage_raises(tmp_path: Path) -> None:
         _daemon(tmp_path).run_stage_once("nonsense")
 
 
-def test_daemon_requeues_stale_running_jobs_on_startup(tmp_path: Path) -> None:
+def test_run_forever_requeues_stale_running_jobs_before_first_cycle(tmp_path: Path) -> None:
     queue = AmbientQueue(tmp_path / "ambient.sqlite3")
     queue.enqueue("ingest", "poll_source", {})
     assert queue.claim("ingest") is not None  # simulate a crash mid-job
@@ -107,6 +107,9 @@ def test_daemon_requeues_stale_running_jobs_on_startup(tmp_path: Path) -> None:
         queue=queue,
         emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
     )
+    # construction is side-effect free: the in-flight job stays running
+    assert daemon.status()["ingest"]["queue_depth"] == 0
+    daemon.run_forever(poll_seconds=0.0, max_cycles=0)
     assert daemon.status()["ingest"]["queue_depth"] == 1
 
 

--- a/autocontext/tests/test_ambient_daemon.py
+++ b/autocontext/tests/test_ambient_daemon.py
@@ -142,3 +142,35 @@ def test_returned_errors_trip_breaker_and_emit_stage_paused(tmp_path: Path) -> N
     assert daemon.status()["ingest"]["paused"] is True
     contents = events_path.read_text(encoding="utf-8")
     assert contents.count("stage_paused") == 1
+
+
+def test_run_forever_rejects_negative_poll_seconds(tmp_path: Path) -> None:
+    daemon = _daemon(tmp_path)
+    with pytest.raises(ValueError, match="zero or positive"):
+        daemon.run_forever(poll_seconds=-1.0)
+
+
+def test_second_resident_daemon_refuses_to_start(tmp_path: Path) -> None:
+    import fcntl
+
+    queue = AmbientQueue(tmp_path / "ambient.sqlite3")
+    daemon = AmbientDaemon(
+        charter=_charter(),
+        queue=queue,
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+    lock_path = queue.db_path.with_suffix(".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    holder = lock_path.open("w")
+    fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)  # first daemon holds the lock
+    try:
+        with pytest.raises(RuntimeError, match="another ambient daemon"):
+            daemon.run_forever(poll_seconds=0.0, max_cycles=0)
+    finally:
+        holder.close()
+
+
+def test_lock_releases_after_run_forever(tmp_path: Path) -> None:
+    daemon = _daemon(tmp_path)
+    daemon.run_forever(poll_seconds=0.0, max_cycles=1)
+    daemon.run_forever(poll_seconds=0.0, max_cycles=1)  # second sequential run acquires cleanly

--- a/autocontext/tests/test_ambient_daemon.py
+++ b/autocontext/tests/test_ambient_daemon.py
@@ -115,3 +115,27 @@ def test_run_forever_respects_max_cycles(tmp_path: Path) -> None:
     daemon = _daemon(tmp_path, stages={"curate": counting})
     daemon.run_forever(poll_seconds=0.0, max_cycles=3)
     assert counting.runs == 3
+
+
+@dataclass
+class ErrorReportingStage:
+    name: str
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        return StageResult(processed=0, errors=1)
+
+
+def test_returned_errors_trip_breaker_and_emit_stage_paused(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.ndjson"
+    daemon = AmbientDaemon(
+        charter=_charter(),
+        queue=AmbientQueue(tmp_path / "ambient.sqlite3"),
+        emitter=EventStreamEmitter(events_path),
+        stages={"ingest": ErrorReportingStage(name="ingest")},
+        breaker_threshold=2,
+    )
+    daemon.run_cycle()
+    daemon.run_cycle()
+    assert daemon.status()["ingest"]["paused"] is True
+    contents = events_path.read_text(encoding="utf-8")
+    assert contents.count("stage_paused") == 1

--- a/autocontext/tests/test_ambient_daemon.py
+++ b/autocontext/tests/test_ambient_daemon.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.daemon import AmbientDaemon
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage import STAGE_NAMES, StageContext, StageResult
+from autocontext.harness.core.events import EventStreamEmitter
+
+
+def _charter() -> Charter:
+    return Charter(
+        tier="oss",
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="Qwen/Qwen2.5-3B-Instruct",
+                min_dataset_records=10,
+                eval_suite="grid_ctf_holdout",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=1.0, window_hours=24, disk_quota_gb=10.0),
+    )
+
+
+def _daemon(tmp_path: Path, stages: dict[str, object] | None = None, threshold: int = 3) -> AmbientDaemon:
+    return AmbientDaemon(
+        charter=_charter(),
+        queue=AmbientQueue(tmp_path / "ambient.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        stages=stages,  # type: ignore[arg-type]
+        breaker_threshold=threshold,
+    )
+
+
+@dataclass
+class ExplodingStage:
+    name: str
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        raise RuntimeError("stage exploded")
+
+
+@dataclass
+class CountingStage:
+    name: str
+    runs: int = 0
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        self.runs += 1
+        return StageResult(processed=1)
+
+
+def test_default_daemon_has_five_noop_stages(tmp_path: Path) -> None:
+    daemon = _daemon(tmp_path)
+    assert set(daemon.status().keys()) == set(STAGE_NAMES)
+
+
+def test_run_cycle_isolates_stage_exceptions(tmp_path: Path) -> None:
+    counting = CountingStage(name="curate")
+    stages = {"ingest": ExplodingStage(name="ingest"), "curate": counting}
+    daemon = _daemon(tmp_path, stages=stages)
+    results = daemon.run_cycle()
+    assert counting.runs == 1
+    assert results["curate"] == StageResult(processed=1)
+    assert "ingest" not in results or results["ingest"].errors >= 1
+
+
+def test_breaker_pauses_stage_and_others_continue(tmp_path: Path) -> None:
+    counting = CountingStage(name="curate")
+    daemon = _daemon(tmp_path, stages={"ingest": ExplodingStage(name="ingest"), "curate": counting}, threshold=2)
+    for _ in range(3):
+        daemon.run_cycle()
+    assert daemon.status()["ingest"]["paused"] is True
+    assert counting.runs == 3
+
+
+def test_run_stage_once_manual_lever_resets_breaker(tmp_path: Path) -> None:
+    counting = CountingStage(name="ingest")
+    daemon = _daemon(tmp_path, stages={"ingest": ExplodingStage(name="ingest")}, threshold=1)
+    daemon.run_cycle()
+    assert daemon.status()["ingest"]["paused"] is True
+    daemon._stages["ingest"] = counting  # simulate operator fixing the source
+    result = daemon.run_stage_once("ingest")
+    assert result == StageResult(processed=1)
+    assert daemon.status()["ingest"]["paused"] is False
+
+
+def test_run_stage_once_unknown_stage_raises(tmp_path: Path) -> None:
+    with pytest.raises(KeyError):
+        _daemon(tmp_path).run_stage_once("nonsense")
+
+
+def test_daemon_requeues_stale_running_jobs_on_startup(tmp_path: Path) -> None:
+    queue = AmbientQueue(tmp_path / "ambient.sqlite3")
+    queue.enqueue("ingest", "poll_source", {})
+    assert queue.claim("ingest") is not None  # simulate a crash mid-job
+    daemon = AmbientDaemon(
+        charter=_charter(),
+        queue=queue,
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+    assert daemon.status()["ingest"]["queue_depth"] == 1
+
+
+def test_run_forever_respects_max_cycles(tmp_path: Path) -> None:
+    counting = CountingStage(name="curate")
+    daemon = _daemon(tmp_path, stages={"curate": counting})
+    daemon.run_forever(poll_seconds=0.0, max_cycles=3)
+    assert counting.runs == 3

--- a/autocontext/tests/test_ambient_interview.py
+++ b/autocontext/tests/test_ambient_interview.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from autocontext.ambient.interview import InterviewAnswers, build_charter, run_interview
+
+
+def _answers(**overrides: object) -> InterviewAnswers:
+    base: dict[str, object] = dict(
+        tier="oss",
+        autonomy="train",
+        enable_otel=True,
+        enable_proxy=False,
+        first_target_role="competitor@grid_ctf",
+        base_model="Qwen/Qwen2.5-3B-Instruct",
+        gpu_hours_per_window=8.0,
+        window_hours=24,
+        disk_quota_gb=200.0,
+    )
+    base.update(overrides)
+    return InterviewAnswers(**base)  # type: ignore[arg-type]
+
+
+def test_build_charter_includes_native_source_always() -> None:
+    charter = build_charter(_answers(enable_otel=False, enable_proxy=False))
+    assert [s.kind for s in charter.sources] == ["autocontext"]
+
+
+def test_build_charter_adds_optional_sources() -> None:
+    charter = build_charter(_answers(enable_otel=True, enable_proxy=True))
+    assert [s.kind for s in charter.sources] == ["autocontext", "otel", "proxy"]
+
+
+def test_build_charter_first_target() -> None:
+    charter = build_charter(_answers())
+    target = charter.targets[0]
+    assert target.selector == "competitor@grid_ctf"
+    assert target.eval_suite == "competitor_holdout"
+    assert target.min_dataset_records == 500
+    assert charter.autonomy == "train"
+
+
+def test_run_interview_maps_prompts_to_answers() -> None:
+    scripted = {
+        "deployment tier": "oss",
+        "autonomy": "propose",
+        "enable otel source": "y",
+        "enable llm proxy source": "n",
+        "first target role": "competitor@grid_ctf",
+        "base model": "Qwen/Qwen2.5-3B-Instruct",
+        "gpu hours per window": "4",
+        "window hours": "24",
+        "disk quota gb": "100",
+    }
+
+    def prompt(question: str, default: str) -> str:
+        for key, value in scripted.items():
+            if key in question.lower():
+                return value
+        raise AssertionError(f"unexpected question: {question}")
+
+    answers = run_interview(prompt)
+    assert answers.autonomy == "propose"
+    assert answers.enable_otel is True
+    assert answers.enable_proxy is False
+    assert answers.gpu_hours_per_window == 4.0

--- a/autocontext/tests/test_ambient_policy.py
+++ b/autocontext/tests/test_ambient_policy.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.policy import PolicyDecision, budget_allows, decide, effective_autonomy
+
+
+def _charter(autonomy: str = "propose", target_autonomy: str | None = None) -> Charter:
+    return Charter(
+        tier="oss",
+        autonomy=autonomy,  # type: ignore[arg-type]
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="Qwen/Qwen2.5-3B-Instruct",
+                min_dataset_records=10,
+                eval_suite="grid_ctf_holdout",
+                autonomy=target_autonomy,  # type: ignore[arg-type]
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=8.0, window_hours=24, disk_quota_gb=10.0),
+    )
+
+
+def test_effective_autonomy_global_default() -> None:
+    assert effective_autonomy(_charter("train"), "t1") == "train"
+
+
+def test_effective_autonomy_target_override_wins() -> None:
+    assert effective_autonomy(_charter("propose", target_autonomy="full"), "t1") == "full"
+
+
+def test_effective_autonomy_unknown_target_raises() -> None:
+    with pytest.raises(KeyError):
+        effective_autonomy(_charter(), "missing")
+
+
+@pytest.mark.parametrize(
+    ("autonomy", "action", "allowed", "requires_approval"),
+    [
+        ("propose", "train", True, True),
+        ("propose", "promote", True, True),
+        ("train", "train", True, False),
+        ("train", "promote", True, True),
+        ("full", "train", True, False),
+        ("full", "promote", True, False),
+    ],
+)
+def test_decide_matrix(autonomy: str, action: str, allowed: bool, requires_approval: bool) -> None:
+    decision = decide(_charter(autonomy), action, "t1")  # type: ignore[arg-type]
+    assert isinstance(decision, PolicyDecision)
+    assert decision.allowed is allowed
+    assert decision.requires_approval is requires_approval
+    assert decision.reason
+
+
+def test_budget_allows_within_window() -> None:
+    budgets = CharterBudgets(gpu_hours_per_window=8.0, window_hours=24, disk_quota_gb=10.0)
+    assert budget_allows(budgets, used_gpu_hours_in_window=5.0, requested_gpu_hours=3.0) is True
+    assert budget_allows(budgets, used_gpu_hours_in_window=5.0, requested_gpu_hours=3.1) is False

--- a/autocontext/tests/test_ambient_proposals.py
+++ b/autocontext/tests/test_ambient_proposals.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.proposals import CharterProposal, ProposalError, ProposalStore, apply_proposal
+
+
+def _charter() -> Charter:
+    return Charter(
+        tier="oss",
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="Qwen/Qwen2.5-3B-Instruct",
+                min_dataset_records=10,
+                eval_suite="grid_ctf_holdout",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=1.0, window_hours=24, disk_quota_gb=10.0),
+    )
+
+
+def _add_target_proposal(name: str = "t2") -> CharterProposal:
+    return CharterProposal(
+        proposal_id="p-1",
+        kind="add_target",
+        payload=dict(
+            name=name,
+            kind="task_family",
+            selector="lean_putnam_proof",
+            base_model="Qwen/Qwen2.5-3B-Instruct",
+            method="sft-distill",
+            min_dataset_records=1000,
+            eval_suite="lean_holdout",
+        ),
+        rationale="4100 lean traces at 92 percent pass rate",
+    )
+
+
+def test_apply_add_target_returns_new_charter() -> None:
+    charter = _charter()
+    updated = apply_proposal(charter, _add_target_proposal())
+    assert [t.name for t in updated.targets] == ["t1", "t2"]
+    assert [t.name for t in charter.targets] == ["t1"]
+
+
+def test_apply_duplicate_target_name_raises() -> None:
+    with pytest.raises(ProposalError, match="already exists"):
+        apply_proposal(_charter(), _add_target_proposal(name="t1"))
+
+
+def test_apply_update_budgets() -> None:
+    proposal = CharterProposal(
+        proposal_id="p-2",
+        kind="update_budgets",
+        payload=dict(gpu_hours_per_window=4.0, window_hours=24, disk_quota_gb=50.0),
+        rationale="raise training budget",
+    )
+    updated = apply_proposal(_charter(), proposal)
+    assert updated.budgets.gpu_hours_per_window == pytest.approx(4.0)
+
+
+def test_store_append_pending_and_mark(tmp_path: Path) -> None:
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    store.append(_add_target_proposal())
+    assert [p.proposal_id for p in store.pending()] == ["p-1"]
+    store.mark("p-1", "applied")
+    assert store.pending() == []

--- a/autocontext/tests/test_ambient_proposals.py
+++ b/autocontext/tests/test_ambient_proposals.py
@@ -72,3 +72,13 @@ def test_store_append_pending_and_mark(tmp_path: Path) -> None:
     assert [p.proposal_id for p in store.pending()] == ["p-1"]
     store.mark("p-1", "applied")
     assert store.pending() == []
+
+
+def test_store_survives_torn_trailing_line(tmp_path: Path) -> None:
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    store.append(_add_target_proposal())
+    with store.path.open("a", encoding="utf-8") as handle:
+        handle.write('{"proposal_id": "p-torn", "kin')  # crash mid-append
+    assert [p.proposal_id for p in store.pending()] == ["p-1"]
+    store.mark("p-1", "applied")
+    assert store.pending() == []

--- a/autocontext/tests/test_ambient_queue.py
+++ b/autocontext/tests/test_ambient_queue.py
@@ -40,3 +40,24 @@ def test_queue_survives_reopen(tmp_path: Path) -> None:
     path = tmp_path / "ambient.sqlite3"
     AmbientQueue(path).enqueue("ingest", "poll_source", {})
     assert AmbientQueue(path).depth("ingest") == 1
+
+
+def test_claim_never_double_claims(tmp_path: Path) -> None:
+    path = tmp_path / "ambient.sqlite3"
+    queue_a = AmbientQueue(path)
+    queue_b = AmbientQueue(path)
+    queue_a.enqueue("ingest", "poll_source", {})
+    first = queue_a.claim("ingest")
+    second = queue_b.claim("ingest")
+    assert first is not None
+    assert second is None
+
+
+def test_requeue_stale_running(tmp_path: Path) -> None:
+    queue = AmbientQueue(tmp_path / "ambient.sqlite3")
+    queue.enqueue("train", "run_target", {})
+    assert queue.claim("train") is not None
+    assert queue.depth("train") == 0
+    assert queue.requeue_stale_running() == 1
+    assert queue.depth("train") == 1
+    assert queue.claim("train") is not None

--- a/autocontext/tests/test_ambient_queue.py
+++ b/autocontext/tests/test_ambient_queue.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.ambient.queue import AmbientQueue
+
+
+def test_enqueue_claim_complete(tmp_path: Path) -> None:
+    queue = AmbientQueue(tmp_path / "ambient.sqlite3")
+    job_id = queue.enqueue("ingest", "poll_source", {"source": "native"})
+    assert queue.depth("ingest") == 1
+    job = queue.claim("ingest")
+    assert job is not None
+    assert job.job_id == job_id
+    assert job.payload == {"source": "native"}
+    assert queue.depth("ingest") == 0
+    queue.complete(job.job_id)
+    assert queue.claim("ingest") is None
+
+
+def test_claim_is_stage_scoped(tmp_path: Path) -> None:
+    queue = AmbientQueue(tmp_path / "ambient.sqlite3")
+    queue.enqueue("train", "run_target", {"target": "t1"})
+    assert queue.claim("ingest") is None
+    assert queue.claim("train") is not None
+
+
+def test_fail_returns_job_to_pending_with_attempts(tmp_path: Path) -> None:
+    queue = AmbientQueue(tmp_path / "ambient.sqlite3")
+    queue.enqueue("curate", "rebuild", {})
+    job = queue.claim("curate")
+    assert job is not None and job.attempts == 0
+    queue.fail(job.job_id, "boom")
+    retried = queue.claim("curate")
+    assert retried is not None
+    assert retried.attempts == 1
+
+
+def test_queue_survives_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "ambient.sqlite3"
+    AmbientQueue(path).enqueue("ingest", "poll_source", {})
+    assert AmbientQueue(path).depth("ingest") == 1

--- a/autocontext/tests/test_ambient_stage.py
+++ b/autocontext/tests/test_ambient_stage.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from autocontext.ambient.stage import STAGE_NAMES, AutoPauseBreaker, NoOpStage, StageResult
+
+
+def test_stage_names_are_the_five_spec_stages() -> None:
+    assert STAGE_NAMES == ("ingest", "curate", "advise", "train", "evaluate")
+
+
+def test_breaker_pauses_after_threshold_consecutive_failures() -> None:
+    breaker = AutoPauseBreaker(threshold=3)
+    for _ in range(2):
+        breaker.record(StageResult(processed=0, errors=1))
+    assert breaker.paused is False
+    breaker.record_exception()
+    assert breaker.paused is True
+
+
+def test_breaker_resets_on_success() -> None:
+    breaker = AutoPauseBreaker(threshold=2)
+    breaker.record(StageResult(errors=1))
+    breaker.record(StageResult(processed=3, errors=0))
+    breaker.record(StageResult(errors=1))
+    assert breaker.paused is False
+
+
+def test_noop_stage_returns_empty_result() -> None:
+    stage = NoOpStage(name="ingest")
+    result = stage.run_once(ctx=None)  # type: ignore[arg-type]
+    assert result == StageResult()

--- a/autocontext/tests/test_cli_contract_parity.py
+++ b/autocontext/tests/test_cli_contract_parity.py
@@ -64,6 +64,7 @@ def contract() -> Contract:
 UNCONTRACTED_TOP_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
     {
         "ab-test",
+        "ambient",
         "analytics",
         "benchmark",
         "ecosystem",

--- a/docs/ambient-trainer-design.md
+++ b/docs/ambient-trainer-design.md
@@ -1,0 +1,232 @@
+# ambient trainer design
+
+Date: 2026-07-03
+Status: approved in brainstorming; pending written review
+Working name: `autoctx ambient`
+
+## Purpose
+
+A resident data-plane daemon for Linux GPU boxes that learns continuously from
+the reasoning traces flowing through it: it ingests traces, curates datasets,
+proposes and executes fine-tunes, evaluates candidates against a frozen anchor,
+and promotes winners into live serving so autocontext's own roles (and any
+user workload) progressively run on locally-trained models.
+
+It ships as a product feature of autocontext. The first dogfood is recursive:
+training local replacements for autocontext's generator roles on our own GPU
+box, with the cost and quality delta versus frontier APIs as the headline
+telemetry.
+
+## Decisions of record
+
+1. **Purpose**: product feature, dogfooded via recursive local role models.
+2. **Intent**: a declarative charter file is the daemon's only policy input;
+   an interview wizard bootstraps it; an autonomy dial governs how much the
+   daemon does without approval; an advisor proposes charter amendments.
+3. **Data scope is tiered**: the OSS package ingests autocontext-native runs,
+   the OTel/production-traces feed, and an LLM proxy tap. The hosted tier
+   (boxes we provision) adds a full-box collector (shell, editor, all LLM
+   calls). The hairiest privacy surface stays in the deployment where the
+   consent story is controlled.
+4. **Topology**: data-plane worker daemon on the GPU box plus a control
+   surface abstraction with two backends: local (charter file, CLI/TUI
+   approvals) for OSS/standalone, and the autowork control plane for managed
+   fleets. The engine stays a dumb worker; policy authority lives in the
+   control surface.
+5. **Architecture**: pipeline daemon (approach A): five loosely-coupled
+   stages around a durable queue. Longevity commitment: every stage runs both
+   resident and one-shot (`autoctx ambient <stage> --once`), so the system can
+   degrade into a cron-over-stages model without a rewrite and can later split
+   stages across machines by re-pointing queue endpoints.
+6. **V1 bar**: the full closed loop on our box: interview to charter, ingest,
+   advisor proposal, train, frozen-anchor eval, promotion, vLLM serving, with
+   autocontext roles actually using the promoted model.
+7. **Bias posture**: asymmetric trainability, frozen-anchor promotion,
+   provenance quarantine, drift canaries, and a minimum frontier-traffic
+   fraction. These are guardrails with a non-removable floor, not defaults.
+
+## System overview
+
+```
+sources -> [Ingest] -> trace store -> [Curate] -> dataset store -> [Train] -> checkpoints
+                |                          |                            |
+                v                          v                            v
+            redaction                  [Advise] -> proposals   [Evaluate/Promote/Serve]
+                                           ^                            |
+                                           |                            v
+                                        charter (policy) <------ vLLM + model registry
+```
+
+One Python process, five stages, one durable SQLite-backed work queue (the
+existing task-queue idiom). Python owns the daemon because it owns the
+training backends; the TypeScript side receives contract parity for charter,
+registry, and telemetry types per repo convention (contracts, not execution).
+
+### Stage: Ingest
+
+Pluggable trace sources, each opt-in per charter with a consent flag and a
+redaction profile:
+
+- autocontext-native: the loop's own runs, generations, matches, judgments
+  (richest labels; already structured).
+- OTel feed: anything shipping traces via the existing otel-bridge and
+  production-traces SDK (other agents, Claude Code hooks, instrumented apps).
+- LLM proxy tap: the daemon exposes an OpenAI/Anthropic-compatible gateway
+  endpoint; any tool pointed at it gets traced. Lowest-friction third-party
+  capture; lacks tool/execution context by nature.
+- full-box collector (hosted tier only, v2): shell sessions, editor activity,
+  all LLM calls on the box.
+
+Redaction (existing redactor) applies at ingest, before anything is persisted
+as training-eligible. Every record carries source, provenance, and lineage
+tags (`produced_by: frontier | finetune:<lineage-id>`). The trace store is
+append-only with retention driven by the charter's disk budget.
+
+### Stage: Curate
+
+Continuous dataset construction on the existing dataset adapters, manifests,
+and curation workflows. Maintains one dataset manifest per charter target with
+quality stats and freshness. Two guardrails are enforced here, mechanically:
+
+- **Eligibility filter (asymmetric trainability)**: a dataset for an
+  evaluative role (judge, curator, coach) may only include records whose
+  labels are externally anchored: human feedback, objective verifier
+  outcomes, or frontier-model annotations. A trained judge's own verdicts are
+  never eligible labels for a judge target. Generator-role datasets are
+  unrestricted beyond quarantine.
+- **Provenance quarantine**: records produced by fine-tune lineage N are
+  excluded (or down-weighted per charter) from lineage N+1's training set.
+  Drift cannot compound within a lineage.
+
+### Stage: Advise
+
+The hermes advisor generalized. Watches curation stats (volume, quality,
+pass-rates, novelty per task family) and emits **charter proposals**:
+structured charter diffs such as "4,100 Lean-verifier traces at 92% pass rate;
+propose a 3B prover target, estimated 6 GPU-hours." Proposals flow to the
+control surface; approval applies the diff. The charter's evolution is
+therefore an auditable sequence of applied diffs.
+
+### Stage: Train
+
+Executes charter targets through the existing backends (CUDA/TRL, MLX) when a
+target's minimum-dataset threshold and budget window trip. Methods: SFT
+distillation (v1), RLVR (flagged experimental in v1, automated in v2).
+GPU-aware scheduling: jobs declare VRAM needs from the existing scale
+profiles; the scheduler refuses to start a train that would evict serving
+unless the charter's priority says training wins.
+
+### Stage: Evaluate / Promote / Serve
+
+- **Frozen-anchor evaluation**: candidates are judged on a held-out suite by
+  the anchor pinned in the charter (a frontier API model or the frozen base),
+  versioned in the eval record. Promotion requires beating the incumbent
+  under the anchor, never under a trained sibling.
+- **Drift canaries**: a fixed bias-probe suite (the judge bias-probe and
+  rubric-calibration machinery) runs at every promotion; judge-score
+  inflation relative to the anchor must stay within tolerance.
+- **Promotion**: existing promotion-engine and registry workflows record the
+  checkpoint, lineage, eval evidence, and role binding.
+- **Serving**: a model server manager supervises vLLM (load, health-check,
+  hot-swap, rollback). Role binding lives in the registry ("competitor@
+  grid_ctf resolves to lineage-7 v3"), not in scenario code; the existing
+  vllm provider path routes role traffic. The previous checkpoint stays warm
+  through a probation window (charter-defined: N runs or M days within
+  quality-delta and error-rate bounds); rollback is one registry flip.
+- **Frontier fraction**: the router keeps the charter's minimum share of role
+  traffic on frontier APIs so the reference distribution never dries up and a
+  live comparison population always exists.
+
+## The charter
+
+`ambient-charter.yaml`, schema-validated, bootstrapped by `autoctx ambient
+init` (an interview wizard covering goals, sources, model families, budgets,
+autonomy). The charter is the daemon's only policy input; there are no other
+behavior flags. Schema groups:
+
+- **identity/tier**: deployment tier (`oss` | `hosted-box`), control surface
+  binding (`local` | `autowork`).
+- **sources[]**: enabled trace sources, consent flags, redaction profiles.
+- **targets[]**: role or task-family selector, base model and size, method
+  (`sft-distill` | `rlvr-experimental`), data filters, minimum-dataset
+  thresholds, eval suite, promotion criteria, optional per-target autonomy
+  override.
+- **budgets**: GPU-hours per window, disk quotas, serving-versus-training
+  priority.
+- **autonomy**: the dial: `propose` (advisor suggests, human approves
+  everything) | `train` (auto-train, human approves promotion) | `full`
+  (auto-promote within budgets and eval gates).
+- **guardrails**: asymmetric trainability, frozen-anchor promotion,
+  provenance quarantine, drift canaries, minimum frontier fraction. Values
+  are tunable above a floor; the floor is not removable through the charter.
+
+## Control surface
+
+One interface: charter read/write and diff application, proposal approval,
+telemetry and event subscription, manual stage triggers, promotion sign-off.
+Two backends: local (file plus CLI/TUI: `autoctx ambient status | proposals |
+approve | history`) and the autowork control plane (fleet view, RBAC, audit).
+V1 ships local; the interface is stubbed against the autowork shape from day
+one so v2 is a backend, not a redesign.
+
+## Error handling and operations
+
+- Per-stage auto-pause breaker: N consecutive failures pauses that stage
+  only, alerts the control surface, leaves the rest running.
+- Idempotent stage work against the durable queue; run-manifest locks prevent
+  double-training after crash-resume.
+- Disk pressure triggers retention compaction before it pauses ingest.
+- systemd supervision, health endpoints, `autoctx ambient status` parity
+  between standalone and fleet views.
+- Full reconstructibility: everything autonomous is explainable from the
+  event stream plus the charter-diff history.
+
+## Testing
+
+- Unit: charter schema and policy engine (autonomy dial, budget windows,
+  guardrail floors) as pure functions; eligibility filter with adversarial
+  fixtures (self-labeled judge records must be rejected; quarantine
+  violations must fail curation).
+- Integration: each stage one-shot against fixture stores.
+- End-to-end: a "miniature ambient" CI test using the deterministic provider
+  and a tiny CPU/MLX-trainable model running ingest through serve in minutes.
+- Guardrail regressions: a synthetic drifting judge must trip the canary.
+- Contract parity tests for the TS-side charter/registry/telemetry types.
+- The full ts-test and pytest CI gates apply as with any subsystem.
+
+## V1 slice
+
+In scope: the daemon with all five stages; charter, interview, autonomy dial;
+autocontext-native, OTel, and proxy-tap ingestion; SFT-distillation targets
+for generator roles; frozen-anchor eval, promotion, vLLM serving with
+rollback and probation; local control surface; telemetry events; the
+miniature-ambient CI test.
+
+Out of scope (v2+): the hosted full-box collector; the autowork control-plane
+backend (interface stubbed now); multi-box fleets; evaluative-role training;
+automated RLVR targets.
+
+Acceptance: on our GPU box, `autoctx ambient init` through to at least one
+generator role served by a locally-trained model that beat baseline under the
+anchor, with cost and quality deltas visible in telemetry.
+
+## Risks
+
+- Residency reliability (OOM, driver faults, disk pressure): mitigated by
+  breakers, idempotency, one-shot degradation, systemd; not by design novelty.
+- Reward hacking and drift despite guardrails: the frontier fraction and
+  anchor pinning keep an external reference; canaries are regression-tested.
+- GPU contention between serving and training: charter priority plus
+  VRAM-aware scheduling; worst case is delayed training, never broken serving.
+- Dataset quality plateaus (the cap-sets representation-ceiling lesson):
+  the advisor reports per-target marginal-gain trends so a stalling target is
+  visible rather than silently consuming budget.
+
+## Inspirations borrowed
+
+From ColeMurray/background-agents: durable per-session event streams,
+auto-pause after consecutive failures, lifecycle scripts, control-plane and
+data-plane separation. From our own history: verifier-driven training (RLVR
+at 3B+), "compiles is not proved" oracle discipline, provenance tagging in
+the dataset adapters, and the control-plane thesis (engine stays a dumb
+worker).

--- a/docs/ambient-trainer-design.md
+++ b/docs/ambient-trainer-design.md
@@ -35,7 +35,7 @@ telemetry.
    control surface.
 5. **Architecture**: pipeline daemon (approach A): five loosely-coupled
    stages around a durable queue. Longevity commitment: every stage runs both
-   resident and one-shot (`autoctx ambient <stage> --once`), so the system can
+   resident and one-shot (`autoctx ambient once <stage>`), so the system can
    degrade into a cron-over-stages model without a rewrite and can later split
    stages across machines by re-pointing queue endpoints.
 6. **V1 bar**: the full closed loop on our box: interview to charter, ingest,


### PR DESCRIPTION
Foundation slice of docs/ambient-trainer-design.md: charter models with guardrail floors, yaml io, policy engine (autonomy dial + budgets), proposal store, durable stage queue, five-stage daemon with auto-pause breakers and a one-shot manual lever, interview wizard, and the autoctx ambient cli (init, status, run, once). Stages are deliberate no-ops; plans 2-4 fill in ingest, curate/advise, and train/evaluate/serve.