### PR TITLE
ambient trainer plan 2: live ingest (trace store, redaction gate, sources)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `autoctx ambient` foundation: a charter-driven resident daemon skeleton (interview wizard, autonomy dial with guardrail floors, durable stage queue, five stages with auto-pause breakers, status/run/once cli). Stages are no-ops pending the ingest, curation, and training plans (docs/ambient-trainer-design.md).
+- The ambient ingest stage is live: charter-enabled sources (autocontext-native runs, jsonl trace feeds) flow through the redaction gate into an append-only trace store with per-source cursors and disk-quota retention; the llm proxy tap follows in the next slice.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -45,7 +45,16 @@ class CharterSource(BaseModel):
     name: str = Field(min_length=1)
     kind: SourceKind
     enabled: bool = True
+    # reserved: only "default" is accepted today; alternate redaction
+    # profiles are a future slice and rejected by the validator below
     redaction_profile: str = "default"
+
+    @field_validator("redaction_profile")
+    @classmethod
+    def _reserved_redaction_profile(cls, value: str) -> str:
+        if value != "default":
+            raise ValueError("redaction profiles beyond default are reserved for a future slice")
+        return value
 
 
 class CharterTarget(BaseModel):

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -89,6 +89,16 @@ class Charter(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def _source_names_unique(self) -> Charter:
+        # the trace store keys ingest cursors by source name; duplicates
+        # would clobber each other's watermarks and silently skip records
+        names = [source.name for source in self.sources]
+        duplicates = {name for name in names if names.count(name) > 1}
+        if duplicates:
+            raise ValueError(f"duplicate source names: {sorted(duplicates)}")
+        return self
+
+    @model_validator(mode="after")
     def _target_names_unique(self) -> Charter:
         # policy lookups and proposal keying treat target name as a unique key
         names = [target.name for target in self.targets]

--- a/autocontext/src/autocontext/ambient/ingest.py
+++ b/autocontext/src/autocontext/ambient/ingest.py
@@ -26,14 +26,15 @@ class IngestStage:
             # announced at run time, not construction, so read-only commands
             # (status builds the stage set too) never write events
             for source_name, kind in self.unsupported:
-                ctx.emitter.emit(
-                    "ingest_source_unsupported", {"source": source_name, "kind": kind}, channel="ambient"
-                )
+                ctx.emitter.emit("ingest_source_unsupported", {"source": source_name, "kind": kind}, channel="ambient")
             self._announced = True
         appended = 0
         errors = 0
         for source in self.sources:
-            cursor = self.trace_store.get_cursor(source.name)
+            # kind-namespacing means a charter kind change restarts that
+            # source's cursor cleanly instead of cross-reading a foreign format
+            cursor_key = f"{source.kind}:{source.name}"
+            cursor = self.trace_store.get_cursor(cursor_key)
             try:
                 poll = source.poll(cursor)
                 for record in poll.records:
@@ -41,7 +42,7 @@ class IngestStage:
                     self.trace_store.append(source.name, record.kind, payload, record.produced_by, findings)
                     appended += 1
                 if poll.next_cursor is not None:
-                    self.trace_store.set_cursor(source.name, poll.next_cursor)
+                    self.trace_store.set_cursor(cursor_key, poll.next_cursor)
             except Exception as exc:
                 errors += 1
                 ctx.emitter.emit("ingest_source_failed", {"source": source.name, "error": str(exc)}, channel="ambient")

--- a/autocontext/src/autocontext/ambient/ingest.py
+++ b/autocontext/src/autocontext/ambient/ingest.py
@@ -1,0 +1,42 @@
+"""the ingest stage: poll charter sources, redact, append to the trace store."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.ambient.redaction_gate import redact_payload
+from autocontext.ambient.sources.contract import TraceSource
+from autocontext.ambient.stage import StageContext, StageResult
+from autocontext.ambient.trace_store import TraceStore
+
+_PRUNE_FRACTION = 0.1
+
+
+@dataclass(slots=True)
+class IngestStage:
+    name: str
+    trace_store: TraceStore
+    sources: list[TraceSource]
+    disk_quota_gb: float
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        appended = 0
+        errors = 0
+        for source in self.sources:
+            cursor = self.trace_store.get_cursor(source.name)
+            try:
+                poll = source.poll(cursor)
+                for record in poll.records:
+                    payload, findings = redact_payload(record.payload)
+                    self.trace_store.append(source.name, record.kind, payload, record.produced_by, findings)
+                    appended += 1
+                if poll.next_cursor is not None:
+                    self.trace_store.set_cursor(source.name, poll.next_cursor)
+            except Exception as exc:
+                errors += 1
+                ctx.emitter.emit("ingest_source_failed", {"source": source.name, "error": str(exc)}, channel="ambient")
+        if self.trace_store.db_size_bytes() > self.disk_quota_gb * 1024**3:
+            deleted = self.trace_store.prune_oldest(_PRUNE_FRACTION)
+            ctx.emitter.emit("trace_retention_pruned", {"deleted": deleted}, channel="ambient")
+        ctx.emitter.emit("ingest_completed", {"appended": appended, "sources": len(self.sources)}, channel="ambient")
+        return StageResult(processed=appended, errors=errors)

--- a/autocontext/src/autocontext/ambient/ingest.py
+++ b/autocontext/src/autocontext/ambient/ingest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from autocontext.ambient.redaction_gate import redact_payload
 from autocontext.ambient.sources.contract import TraceSource
@@ -18,8 +18,18 @@ class IngestStage:
     trace_store: TraceStore
     sources: list[TraceSource]
     disk_quota_gb: float
+    unsupported: list[tuple[str, str]] = field(default_factory=list)
+    _announced: bool = False
 
     def run_once(self, ctx: StageContext) -> StageResult:
+        if not self._announced:
+            # announced at run time, not construction, so read-only commands
+            # (status builds the stage set too) never write events
+            for source_name, kind in self.unsupported:
+                ctx.emitter.emit(
+                    "ingest_source_unsupported", {"source": source_name, "kind": kind}, channel="ambient"
+                )
+            self._announced = True
         appended = 0
         errors = 0
         for source in self.sources:

--- a/autocontext/src/autocontext/ambient/ingest.py
+++ b/autocontext/src/autocontext/ambient/ingest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from autocontext.ambient.redaction_gate import redact_payload
 from autocontext.ambient.sources.contract import TraceSource
@@ -10,6 +11,8 @@ from autocontext.ambient.stage import StageContext, StageResult
 from autocontext.ambient.trace_store import TraceStore
 
 _PRUNE_FRACTION = 0.1
+# (kind, payload, produced_by, redaction_findings) as consumed by append_batch
+_BatchRecord = tuple[str, dict[str, Any], str, int]
 
 
 @dataclass(slots=True)
@@ -37,12 +40,16 @@ class IngestStage:
             cursor = self.trace_store.get_cursor(cursor_key)
             try:
                 poll = source.poll(cursor)
+                batch: list[_BatchRecord] = []
                 for record in poll.records:
                     payload, findings = redact_payload(record.payload)
-                    self.trace_store.append(source.name, record.kind, payload, record.produced_by, findings)
-                    appended += 1
-                if poll.next_cursor is not None:
-                    self.trace_store.set_cursor(cursor_key, poll.next_cursor)
+                    batch.append((record.kind, payload, record.produced_by, findings))
+                # store-side failures are now atomic per batch (nothing
+                # persisted, cursor unchanged), so a replay would need the
+                # process to die between the source poll and this call, which
+                # persists nothing; duplicates thus require a repeated poll of
+                # the same source data, which the cursors prevent
+                appended += self.trace_store.append_batch(cursor_key, batch, poll.next_cursor)
             except Exception as exc:
                 errors += 1
                 ctx.emitter.emit("ingest_source_failed", {"source": source.name, "error": str(exc)}, channel="ambient")

--- a/autocontext/src/autocontext/ambient/redaction_gate.py
+++ b/autocontext/src/autocontext/ambient/redaction_gate.py
@@ -20,6 +20,8 @@ def _redact_value(value: Any, counter: list[int]) -> Any:
 
 
 def redact_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    # dict keys are structural and not redacted; payloads are JSON-origin so
+    # keys are strings and never carry content.
     counter = [0]
     redacted = {key: _redact_value(value, counter) for key, value in payload.items()}
     return redacted, counter[0]

--- a/autocontext/src/autocontext/ambient/redaction_gate.py
+++ b/autocontext/src/autocontext/ambient/redaction_gate.py
@@ -1,0 +1,25 @@
+"""redaction applies at ingest, before anything is persisted as training-eligible."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.sharing.redactor import redact_content_with_report
+
+
+def _redact_value(value: Any, counter: list[int]) -> Any:
+    if isinstance(value, str):
+        cleaned, report = redact_content_with_report(value)
+        counter[0] += report.total_count
+        return cleaned
+    if isinstance(value, dict):
+        return {key: _redact_value(item, counter) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item, counter) for item in value]
+    return value
+
+
+def redact_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    counter = [0]
+    redacted = {key: _redact_value(value, counter) for key, value in payload.items()}
+    return redacted, counter[0]

--- a/autocontext/src/autocontext/ambient/sources/__init__.py
+++ b/autocontext/src/autocontext/ambient/sources/__init__.py
@@ -1,0 +1,1 @@
+"""trace sources: pluggable feeds the ingest stage polls (spec: Stage: Ingest)."""

--- a/autocontext/src/autocontext/ambient/sources/contract.py
+++ b/autocontext/src/autocontext/ambient/sources/contract.py
@@ -1,0 +1,25 @@
+"""the source contract: poll with a cursor, get records and the next cursor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(slots=True)
+class RawTrace:
+    kind: str
+    payload: dict[str, Any]
+    produced_by: str = "frontier"
+
+
+@dataclass(slots=True)
+class SourcePoll:
+    records: list[RawTrace] = field(default_factory=list)
+    next_cursor: str | None = None
+
+
+class TraceSource(Protocol):
+    name: str
+
+    def poll(self, cursor: str | None) -> SourcePoll: ...

--- a/autocontext/src/autocontext/ambient/sources/contract.py
+++ b/autocontext/src/autocontext/ambient/sources/contract.py
@@ -21,5 +21,11 @@ class SourcePoll:
 
 class TraceSource(Protocol):
     name: str
+    kind: str
 
-    def poll(self, cursor: str | None) -> SourcePoll: ...
+    def poll(self, cursor: str | None) -> SourcePoll:
+        """A poll that returns records must also return a next_cursor;
+        returning records with next_cursor None would re-ingest the same
+        batch every poll.
+        """
+        ...

--- a/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
+++ b/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
@@ -23,6 +23,7 @@ class JsonlFeedSource:
 
     name: str
     feed_dir: Path
+    kind: str = "otel"
     batch_size: int = 500
 
     def _files(self) -> list[Path]:

--- a/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
+++ b/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
@@ -16,9 +16,12 @@ class JsonlFeedSource:
     Assumes the writer names files in monotonic sort order (the
     production-traces sdk's date/ulid layout satisfies this); a file
     sorting before the cursor is treated as fully consumed, so
-    out-of-order or backfilled files are not re-read. A malformed or
-    blank tail after the last valid record is re-scanned each poll
-    (skipped again, never duplicated).
+    out-of-order or backfilled files are not re-read. A file whose text
+    does not end in a newline has a possibly-partial final line (a writer
+    mid-append); that line is held unconsumed until a newline arrives, so
+    the completed record is never lost. A terminated malformed or blank
+    line is genuine garbage: it is skipped and the cursor advances past
+    it (skipped again, never duplicated).
     """
 
     name: str
@@ -45,11 +48,16 @@ class JsonlFeedSource:
             if cursor_file is not None and rel < cursor_file:
                 continue
             start = cursor_line if rel == cursor_file else 0
-            lines = path.read_text(encoding="utf-8").splitlines()
-            for index in range(start, len(lines)):
+            text = path.read_text(encoding="utf-8")
+            terminated = text.endswith("\n")
+            lines = text.splitlines()
+            # an unterminated final line may be a writer mid-append; hold it
+            # (do not consume, do not advance the cursor) until a newline arrives
+            consumable = lines if terminated else lines[:-1]
+            for index in range(start, len(consumable)):
                 if len(records) >= self.batch_size:
                     return SourcePoll(records=records, next_cursor=f"{last_file}:{last_line}")
-                line = lines[index].strip()
+                line = consumable[index].strip()
                 last_file, last_line = rel, index + 1
                 if not line:
                     continue

--- a/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
+++ b/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
@@ -11,6 +11,16 @@ from autocontext.ambient.sources.contract import RawTrace, SourcePoll
 
 @dataclass(slots=True)
 class JsonlFeedSource:
+    """consumes jsonl trace files in sorted-path order with a file-and-line cursor.
+
+    Assumes the writer names files in monotonic sort order (the
+    production-traces sdk's date/ulid layout satisfies this); a file
+    sorting before the cursor is treated as fully consumed, so
+    out-of-order or backfilled files are not re-read. A malformed or
+    blank tail after the last valid record is re-scanned each poll
+    (skipped again, never duplicated).
+    """
+
     name: str
     feed_dir: Path
     batch_size: int = 500
@@ -21,6 +31,8 @@ class JsonlFeedSource:
         return sorted(self.feed_dir.rglob("*.jsonl"))
 
     def poll(self, cursor: str | None) -> SourcePoll:
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be at least 1")
         cursor_file, cursor_line = None, 0
         if cursor:
             rel, _, line = cursor.rpartition(":")
@@ -51,8 +63,6 @@ class JsonlFeedSource:
                         produced_by=str(obj.get("produced_by", "frontier")),
                     )
                 )
-        if not records and (last_file == cursor_file and last_line == cursor_line):
-            return SourcePoll()
         if not records:
-            return SourcePoll(records=[], next_cursor=None)
+            return SourcePoll()
         return SourcePoll(records=records, next_cursor=f"{last_file}:{last_line}")

--- a/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
+++ b/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
@@ -1,0 +1,58 @@
+"""jsonl feed source: consumes production-traces sdk / otel-bridge output directories."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from autocontext.ambient.sources.contract import RawTrace, SourcePoll
+
+
+@dataclass(slots=True)
+class JsonlFeedSource:
+    name: str
+    feed_dir: Path
+    batch_size: int = 500
+
+    def _files(self) -> list[Path]:
+        if not self.feed_dir.exists():
+            return []
+        return sorted(self.feed_dir.rglob("*.jsonl"))
+
+    def poll(self, cursor: str | None) -> SourcePoll:
+        cursor_file, cursor_line = None, 0
+        if cursor:
+            rel, _, line = cursor.rpartition(":")
+            cursor_file, cursor_line = rel, int(line)
+        records: list[RawTrace] = []
+        last_file, last_line = cursor_file, cursor_line
+        for path in self._files():
+            rel = str(path.relative_to(self.feed_dir))
+            if cursor_file is not None and rel < cursor_file:
+                continue
+            start = cursor_line if rel == cursor_file else 0
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for index in range(start, len(lines)):
+                if len(records) >= self.batch_size:
+                    return SourcePoll(records=records, next_cursor=f"{last_file}:{last_line}")
+                line = lines[index].strip()
+                last_file, last_line = rel, index + 1
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                records.append(
+                    RawTrace(
+                        kind=str(obj.get("kind", "trace")),
+                        payload=obj,
+                        produced_by=str(obj.get("produced_by", "frontier")),
+                    )
+                )
+        if not records and (last_file == cursor_file and last_line == cursor_line):
+            return SourcePoll()
+        if not records:
+            return SourcePoll(records=[], next_cursor=None)
+        return SourcePoll(records=records, next_cursor=f"{last_file}:{last_line}")

--- a/autocontext/src/autocontext/ambient/sources/native.py
+++ b/autocontext/src/autocontext/ambient/sources/native.py
@@ -11,6 +11,14 @@ from autocontext.ambient.sources.contract import RawTrace, SourcePoll
 
 @dataclass(slots=True)
 class NativeRunsSource:
+    """incremental reader over a loop runs database.
+
+    Watermarks on the generations rowid, which assumes the runs db is
+    append-only and never VACUUMed directly (loop code neither deletes
+    generations nor vacuums; a manual VACUUM could renumber rowids and
+    silently skip rows below the cursor).
+    """
+
     name: str
     runs_db_path: Path
     batch_size: int = 500
@@ -19,7 +27,9 @@ class NativeRunsSource:
         if not self.runs_db_path.exists():
             return SourcePoll()
         watermark = int(cursor or 0)
-        conn = sqlite3.connect(self.runs_db_path)
+        # read-only open: least privilege for a pure reader, and it can
+        # never take a write lock against the live loop
+        conn = sqlite3.connect(f"{self.runs_db_path.resolve().as_uri()}?mode=ro", uri=True)
         try:
             rows = conn.execute(
                 "SELECT g.rowid, g.run_id, r.scenario, g.generation_index, g.mean_score, "

--- a/autocontext/src/autocontext/ambient/sources/native.py
+++ b/autocontext/src/autocontext/ambient/sources/native.py
@@ -1,0 +1,51 @@
+"""autocontext-native source: incremental reader over a loop runs database."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from autocontext.ambient.sources.contract import RawTrace, SourcePoll
+
+
+@dataclass(slots=True)
+class NativeRunsSource:
+    name: str
+    runs_db_path: Path
+    batch_size: int = 500
+
+    def poll(self, cursor: str | None) -> SourcePoll:
+        if not self.runs_db_path.exists():
+            return SourcePoll()
+        watermark = int(cursor or 0)
+        conn = sqlite3.connect(self.runs_db_path)
+        try:
+            rows = conn.execute(
+                "SELECT g.rowid, g.run_id, r.scenario, g.generation_index, g.mean_score, "
+                "g.best_score, g.gate_decision, g.status, g.created_at "
+                "FROM generations g JOIN runs r ON r.run_id = g.run_id "
+                "WHERE g.rowid > ? ORDER BY g.rowid LIMIT ?",
+                (watermark, self.batch_size),
+            ).fetchall()
+        finally:
+            conn.close()
+        if not rows:
+            return SourcePoll()
+        records = [
+            RawTrace(
+                kind="generation",
+                payload={
+                    "run_id": row[1],
+                    "scenario": row[2],
+                    "generation_index": row[3],
+                    "mean_score": row[4],
+                    "best_score": row[5],
+                    "gate_decision": row[6],
+                    "status": row[7],
+                    "created_at": row[8],
+                },
+            )
+            for row in rows
+        ]
+        return SourcePoll(records=records, next_cursor=str(rows[-1][0]))

--- a/autocontext/src/autocontext/ambient/sources/native.py
+++ b/autocontext/src/autocontext/ambient/sources/native.py
@@ -8,19 +8,37 @@ from pathlib import Path
 
 from autocontext.ambient.sources.contract import RawTrace, SourcePoll
 
+# terminal generation states. The loop upserts a "running" placeholder row at
+# generation start (loop/generation_runner.py:1173; also cli.py:298 and
+# knowledge/solve_task_execution.py:211) and completion is an in-place,
+# rowid-preserving UPDATE that flips status to a terminal value: "completed"
+# (loop/stages.py:1101, knowledge/package.py:268, cli.py:366,
+# solve_task_execution.py:319) or "failed" (loop/generation_runner.py:992/1272/1301,
+# cli.py:316, solve_task_execution.py:280). Only terminal rows carry final scores.
+_TERMINAL_STATUSES = frozenset({"completed", "failed"})
+
 
 @dataclass(slots=True)
 class NativeRunsSource:
     """incremental reader over a loop runs database.
 
-    Watermarks on the generations rowid, which assumes the runs db is
-    append-only and never VACUUMed directly (loop code neither deletes
-    generations nor vacuums; a manual VACUUM could renumber rowids and
-    silently skip rows below the cursor).
+    Watermarks on the generations rowid. rowids are stable (the loop neither
+    deletes generations nor VACUUMs; a manual VACUUM could renumber rowids and
+    silently skip rows below the cursor), but a generation row mutates in place
+    until terminal: it is upserted as a "running" placeholder at generation
+    start and the same rowid is UPDATEd to a terminal status ("completed" or
+    "failed") on completion. Because a rowid is read past the watermark exactly
+    once, this source only consumes the contiguous terminal prefix of a batch:
+    it stops at the first non-terminal row so an in-flight generation blocks the
+    watermark (and is re-read with its final values on a later poll) rather than
+    being captured forever as a placeholder. Known v1 tradeoff: a crashed,
+    forever-"running" row holds the cursor until the loop's idempotent rerun
+    marks it terminal.
     """
 
     name: str
     runs_db_path: Path
+    kind: str = "autocontext"
     batch_size: int = 500
 
     def poll(self, cursor: str | None) -> SourcePoll:
@@ -42,6 +60,16 @@ class NativeRunsSource:
             conn.close()
         if not rows:
             return SourcePoll()
+        # truncate at the first non-terminal (in-flight) row: only the
+        # contiguous terminal prefix is safe to ingest and advance past, so an
+        # in-flight row blocks the watermark instead of being skipped
+        terminal_prefix = []
+        for row in rows:
+            if row[7] not in _TERMINAL_STATUSES:
+                break
+            terminal_prefix.append(row)
+        if not terminal_prefix:
+            return SourcePoll()
         records = [
             RawTrace(
                 kind="generation",
@@ -56,6 +84,6 @@ class NativeRunsSource:
                     "created_at": row[8],
                 },
             )
-            for row in rows
+            for row in terminal_prefix
         ]
-        return SourcePoll(records=records, next_cursor=str(rows[-1][0]))
+        return SourcePoll(records=records, next_cursor=str(terminal_prefix[-1][0]))

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -1,0 +1,41 @@
+"""builds the daemon's stage set from the charter (real ingest, no-op others for now)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.ambient.charter import Charter
+from autocontext.ambient.ingest import IngestStage
+from autocontext.ambient.sources.contract import TraceSource
+from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
+from autocontext.ambient.sources.native import NativeRunsSource
+from autocontext.ambient.stage import STAGE_NAMES, NoOpStage, Stage
+from autocontext.ambient.trace_store import TraceStore
+from autocontext.harness.core.events import EventStreamEmitter
+
+
+def build_stages(
+    charter: Charter,
+    db_path: Path,
+    emitter: EventStreamEmitter,
+    runs_db_path: Path,
+    otel_feed_dir: Path,
+) -> dict[str, Stage]:
+    sources: list[TraceSource] = []
+    for spec in charter.sources:
+        if not spec.enabled:
+            continue
+        if spec.kind == "autocontext":
+            sources.append(NativeRunsSource(name=spec.name, runs_db_path=runs_db_path))
+        elif spec.kind == "otel":
+            sources.append(JsonlFeedSource(name=spec.name, feed_dir=otel_feed_dir))
+        else:
+            emitter.emit("ingest_source_unsupported", {"source": spec.name, "kind": spec.kind}, channel="ambient")
+    stages: dict[str, Stage] = {name: NoOpStage(name=name) for name in STAGE_NAMES}
+    stages["ingest"] = IngestStage(
+        name="ingest",
+        trace_store=TraceStore(db_path),
+        sources=sources,
+        disk_quota_gb=charter.budgets.disk_quota_gb,
+    )
+    return stages

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -22,6 +22,7 @@ def build_stages(
     otel_feed_dir: Path,
 ) -> dict[str, Stage]:
     sources: list[TraceSource] = []
+    unsupported: list[tuple[str, str]] = []
     for spec in charter.sources:
         if not spec.enabled:
             continue
@@ -30,12 +31,13 @@ def build_stages(
         elif spec.kind == "otel":
             sources.append(JsonlFeedSource(name=spec.name, feed_dir=otel_feed_dir))
         else:
-            emitter.emit("ingest_source_unsupported", {"source": spec.name, "kind": spec.kind}, channel="ambient")
+            unsupported.append((spec.name, spec.kind))
     stages: dict[str, Stage] = {name: NoOpStage(name=name) for name in STAGE_NAMES}
     stages["ingest"] = IngestStage(
         name="ingest",
         trace_store=TraceStore(db_path),
         sources=sources,
         disk_quota_gb=charter.budgets.disk_quota_gb,
+        unsupported=unsupported,
     )
     return stages

--- a/autocontext/src/autocontext/ambient/trace_store.py
+++ b/autocontext/src/autocontext/ambient/trace_store.py
@@ -57,6 +57,39 @@ class TraceStore:
             )
             return int(cursor.lastrowid or 0)
 
+    def append_batch(
+        self,
+        source_key: str,
+        records: list[tuple[str, dict[str, Any], str, int]],
+        cursor: str | None,
+    ) -> int:
+        """Insert every record and upsert the cursor in one transaction.
+
+        Each tuple is (kind, payload, produced_by, redaction_findings). All
+        inserts plus the cursor upsert (when cursor is not None) run on one
+        connection in one transaction, so a mid-batch failure (including a
+        payload that fails to serialize) persists nothing and leaves the
+        cursor unchanged. Returns the number of rows inserted. The trace
+        source column and the cursor row are both keyed by source_key.
+        """
+        created_at = datetime.now(UTC).isoformat()
+        with self._connect() as conn:
+            inserted = 0
+            for kind, payload, produced_by, redaction_findings in records:
+                conn.execute(
+                    "INSERT INTO ambient_traces (source, kind, payload, produced_by, redaction_findings, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (source_key, kind, json.dumps(payload), produced_by, redaction_findings, created_at),
+                )
+                inserted += 1
+            if cursor is not None:
+                conn.execute(
+                    "INSERT INTO ambient_source_cursors (source, cursor) VALUES (?, ?) "
+                    "ON CONFLICT(source) DO UPDATE SET cursor = excluded.cursor",
+                    (source_key, cursor),
+                )
+        return inserted
+
     def count(self, source: str | None = None) -> int:
         with self._connect() as conn:
             if source is None:

--- a/autocontext/src/autocontext/ambient/trace_store.py
+++ b/autocontext/src/autocontext/ambient/trace_store.py
@@ -1,0 +1,105 @@
+"""append-only trace store: every training-eligible record lands here after redaction."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ambient_traces (
+    record_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    produced_by TEXT NOT NULL,
+    redaction_findings INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ambient_source_cursors (
+    source TEXT PRIMARY KEY,
+    cursor TEXT NOT NULL
+);
+"""
+
+
+@dataclass(slots=True)
+class TraceRecord:
+    record_id: int
+    source: str
+    kind: str
+    payload: dict[str, Any]
+    produced_by: str
+    redaction_findings: int
+    created_at: str
+
+
+class TraceStore:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def append(self, source: str, kind: str, payload: dict[str, Any], produced_by: str, redaction_findings: int) -> int:
+        created_at = datetime.now(UTC).isoformat()
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT INTO ambient_traces (source, kind, payload, produced_by, redaction_findings, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (source, kind, json.dumps(payload), produced_by, redaction_findings, created_at),
+            )
+            return int(cursor.lastrowid or 0)
+
+    def count(self, source: str | None = None) -> int:
+        with self._connect() as conn:
+            if source is None:
+                row = conn.execute("SELECT COUNT(*) FROM ambient_traces").fetchone()
+            else:
+                row = conn.execute("SELECT COUNT(*) FROM ambient_traces WHERE source = ?", (source,)).fetchone()
+            return int(row[0])
+
+    def recent(self, limit: int) -> list[TraceRecord]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT record_id, source, kind, payload, produced_by, redaction_findings, created_at "
+                "FROM ambient_traces ORDER BY record_id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [TraceRecord(r[0], r[1], r[2], json.loads(r[3]), r[4], r[5], r[6]) for r in rows]
+
+    def get_cursor(self, source: str) -> str | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT cursor FROM ambient_source_cursors WHERE source = ?", (source,)).fetchone()
+            return None if row is None else str(row[0])
+
+    def set_cursor(self, source: str, cursor: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO ambient_source_cursors (source, cursor) VALUES (?, ?) "
+                "ON CONFLICT(source) DO UPDATE SET cursor = excluded.cursor",
+                (source, cursor),
+            )
+
+    def db_size_bytes(self) -> int:
+        return self.db_path.stat().st_size if self.db_path.exists() else 0
+
+    def prune_oldest(self, fraction: float) -> int:
+        total = self.count()
+        to_delete = int(total * fraction)
+        if to_delete <= 0:
+            return 0
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM ambient_traces WHERE record_id IN (SELECT record_id FROM ambient_traces ORDER BY record_id LIMIT ?)",
+                (to_delete,),
+            )
+        with self._connect() as conn:
+            conn.execute("VACUUM")
+        return to_delete

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -14,6 +14,7 @@ from autocontext.ambient.charter_io import CharterLoadError, load_charter, save_
 from autocontext.ambient.daemon import AmbientDaemon
 from autocontext.ambient.interview import build_charter, run_interview
 from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage_factory import build_stages
 from autocontext.harness.core.events import EventStreamEmitter
 
 ambient_app = typer.Typer(help="ambient trainer: resident daemon that learns from traces")
@@ -22,14 +23,31 @@ console = Console()
 _DEFAULT_CHARTER = Path("ambient-charter.yaml")
 _DEFAULT_DB = Path("runs/ambient.sqlite3")
 _DEFAULT_EVENTS = Path("runs/ambient-events.ndjson")
+_DEFAULT_RUNS_DB = Path("runs/autocontext.sqlite3")
+_DEFAULT_OTEL_FEED = Path("runs/ambient-otel-feed")
 
 
-def _daemon(charter_path: Path, db_path: Path, events_path: Path) -> AmbientDaemon:
+def _daemon(
+    charter_path: Path,
+    db_path: Path,
+    events_path: Path,
+    runs_db_path: Path,
+    otel_feed_dir: Path,
+) -> AmbientDaemon:
     charter = load_charter(charter_path)
+    emitter = EventStreamEmitter(events_path)
+    stages = build_stages(
+        charter,
+        db_path=db_path,
+        emitter=emitter,
+        runs_db_path=runs_db_path,
+        otel_feed_dir=otel_feed_dir,
+    )
     return AmbientDaemon(
         charter=charter,
         queue=AmbientQueue(db_path),
-        emitter=EventStreamEmitter(events_path),
+        emitter=emitter,
+        stages=stages,
     )
 
 
@@ -56,9 +74,11 @@ def status(
     charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
     db_path: Annotated[Path, typer.Option("--db-path")] = _DEFAULT_DB,
     events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
+    runs_db: Annotated[Path, typer.Option("--runs-db")] = _DEFAULT_RUNS_DB,
+    otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path)
+        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir)
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -75,11 +95,13 @@ def run(
     charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
     db_path: Annotated[Path, typer.Option("--db-path")] = _DEFAULT_DB,
     events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
+    runs_db: Annotated[Path, typer.Option("--runs-db")] = _DEFAULT_RUNS_DB,
+    otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
     poll_seconds: Annotated[float, typer.Option("--poll-seconds", min=0.0)] = 30.0,
     max_cycles: Annotated[int | None, typer.Option("--max-cycles", hidden=True)] = None,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path)
+        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir)
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -96,9 +118,11 @@ def once(
     charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
     db_path: Annotated[Path, typer.Option("--db-path")] = _DEFAULT_DB,
     events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
+    runs_db: Annotated[Path, typer.Option("--runs-db")] = _DEFAULT_RUNS_DB,
+    otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path)
+        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir)
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -111,6 +111,11 @@ def test_unknown_charter_keys_rejected() -> None:
         )
 
 
+def test_non_default_redaction_profile_rejected() -> None:
+    with pytest.raises(ValidationError, match="reserved"):
+        CharterSource(name="native", kind="autocontext", redaction_profile="strict")
+
+
 def test_duplicate_source_names_rejected() -> None:
     with pytest.raises(ValidationError, match="duplicate source names"):
         _minimal_charter(

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -109,3 +109,13 @@ def test_unknown_charter_keys_rejected() -> None:
             eval_suite="e",
             autonmy="full",
         )
+
+
+def test_duplicate_source_names_rejected() -> None:
+    with pytest.raises(ValidationError, match="duplicate source names"):
+        _minimal_charter(
+            sources=[
+                CharterSource(name="main", kind="autocontext"),
+                CharterSource(name="main", kind="otel"),
+            ]
+        )

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -126,11 +126,67 @@ def test_run_rejects_negative_poll_seconds(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         [
-            "ambient", "run",
-            "--charter-path", str(charter_path),
-            "--db-path", str(tmp_path / "a.sqlite3"),
-            "--events-path", str(tmp_path / "events.ndjson"),
-            "--poll-seconds", "-1",
+            "ambient",
+            "run",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(tmp_path / "a.sqlite3"),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+            "--poll-seconds",
+            "-1",
         ],
     )
     assert result.exit_code != 0
+
+
+def test_once_ingest_pulls_from_runs_db(tmp_path: Path) -> None:
+    import sqlite3
+
+    from autocontext.ambient.trace_store import TraceStore
+
+    charter_path = _init(tmp_path)
+    runs_db = tmp_path / "runs.sqlite3"
+    conn = sqlite3.connect(runs_db)
+    conn.executescript(
+        "CREATE TABLE runs (run_id TEXT PRIMARY KEY, scenario TEXT NOT NULL, target_generations INTEGER NOT NULL, "
+        "executor_mode TEXT NOT NULL, status TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')), "
+        "updated_at TEXT NOT NULL DEFAULT (datetime('now')));"
+        "CREATE TABLE generations (run_id TEXT NOT NULL, generation_index INTEGER NOT NULL, mean_score REAL NOT NULL, "
+        "best_score REAL NOT NULL, gate_decision TEXT NOT NULL, status TEXT NOT NULL, "
+        "created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')), "
+        "PRIMARY KEY (run_id, generation_index));"
+    )
+    conn.execute(
+        "INSERT INTO runs (run_id, scenario, target_generations, executor_mode, status) "
+        "VALUES ('r1', 'grid_ctf', 1, 'local', 'completed')"
+    )
+    conn.execute(
+        "INSERT INTO generations (run_id, generation_index, mean_score, best_score, gate_decision, status) "
+        "VALUES ('r1', 0, 1.0, 2.0, 'advance', 'completed')"
+    )
+    conn.commit()
+    conn.close()
+    db_path = tmp_path / "ambient.sqlite3"
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "once",
+            "ingest",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(db_path),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+            "--runs-db",
+            str(runs_db),
+            "--otel-feed-dir",
+            str(tmp_path / "feed"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "processed=1" in result.output
+    assert TraceStore(db_path).count() == 1

--- a/autocontext/tests/test_ambient_ingest_stage.py
+++ b/autocontext/tests/test_ambient_ingest_stage.py
@@ -44,6 +44,7 @@ def _ctx(tmp_path: Path) -> StageContext:
 class ScriptedSource:
     name: str
     polls: list[SourcePoll]
+    kind: str = "autocontext"
     seen_cursors: list[str | None] = field(default_factory=list)
 
     def poll(self, cursor: str | None) -> SourcePoll:
@@ -54,6 +55,7 @@ class ScriptedSource:
 @dataclass
 class ExplodingSource:
     name: str
+    kind: str = "autocontext"
 
     def poll(self, cursor: str | None) -> SourcePoll:
         raise RuntimeError("feed offline")
@@ -69,7 +71,7 @@ def test_ingest_appends_redacts_and_advances_cursor(tmp_path: Path) -> None:
     result = stage.run_once(_ctx(tmp_path))
     assert result.processed == 1 and result.errors == 0
     assert source.seen_cursors == [None]
-    assert store.get_cursor("native") == "5"
+    assert store.get_cursor("autocontext:native") == "5"
     record = store.recent(limit=1)[0]
     assert _FAKE_KEY not in str(record.payload)
     assert record.redaction_findings >= 1
@@ -110,7 +112,10 @@ def test_disk_quota_triggers_prune(tmp_path: Path) -> None:
 def test_unsupported_kinds_announced_once_at_run_time(tmp_path: Path) -> None:
     store = TraceStore(tmp_path / "ambient.sqlite3")
     stage = IngestStage(
-        name="ingest", trace_store=store, sources=[], disk_quota_gb=10.0,
+        name="ingest",
+        trace_store=store,
+        sources=[],
+        disk_quota_gb=10.0,
         unsupported=[("box", "full-box")],
     )
     ctx = _ctx(tmp_path)

--- a/autocontext/tests/test_ambient_ingest_stage.py
+++ b/autocontext/tests/test_ambient_ingest_stage.py
@@ -105,3 +105,16 @@ def test_disk_quota_triggers_prune(tmp_path: Path) -> None:
     assert store.count() < before
     events = (tmp_path / "events.ndjson").read_text(encoding="utf-8")
     assert "trace_retention_pruned" in events
+
+
+def test_unsupported_kinds_announced_once_at_run_time(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    stage = IngestStage(
+        name="ingest", trace_store=store, sources=[], disk_quota_gb=10.0,
+        unsupported=[("box", "full-box")],
+    )
+    ctx = _ctx(tmp_path)
+    stage.run_once(ctx)
+    stage.run_once(ctx)
+    events = (tmp_path / "events.ndjson").read_text(encoding="utf-8")
+    assert events.count("ingest_source_unsupported") == 1

--- a/autocontext/tests/test_ambient_ingest_stage.py
+++ b/autocontext/tests/test_ambient_ingest_stage.py
@@ -80,6 +80,25 @@ def test_ingest_appends_redacts_and_advances_cursor(tmp_path: Path) -> None:
     assert source.seen_cursors[-1] == "5"
 
 
+def test_batch_failure_leaves_no_records_and_no_cursor(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    source = ScriptedSource(
+        name="native",
+        polls=[SourcePoll(records=[RawTrace(kind="generation", payload={"n": 1})], next_cursor="5")],
+    )
+
+    def _boom(*args: object, **kwargs: object) -> int:
+        raise RuntimeError("store down")
+
+    monkeypatch.setattr(TraceStore, "append_batch", _boom)
+    stage = IngestStage(name="ingest", trace_store=store, sources=[source], disk_quota_gb=10.0)
+    result = stage.run_once(_ctx(tmp_path))
+    assert result.errors == 1
+    assert result.processed == 0
+    assert store.count() == 0
+    assert store.get_cursor("autocontext:native") is None
+
+
 def test_failing_source_isolated_and_counted(tmp_path: Path) -> None:
     store = TraceStore(tmp_path / "ambient.sqlite3")
     good = ScriptedSource(name="ok", polls=[SourcePoll(records=[RawTrace(kind="x", payload={})], next_cursor="1")])

--- a/autocontext/tests/test_ambient_ingest_stage.py
+++ b/autocontext/tests/test_ambient_ingest_stage.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.ingest import IngestStage
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.sources.contract import RawTrace, SourcePoll
+from autocontext.ambient.stage import StageContext
+from autocontext.ambient.trace_store import TraceStore
+from autocontext.harness.core.events import EventStreamEmitter
+
+_FAKE_KEY = "sk-ant-api03-" + "a" * 32
+
+
+def _charter() -> Charter:
+    return Charter(
+        tier="oss",
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="m",
+                min_dataset_records=1,
+                eval_suite="e",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=1.0, window_hours=24, disk_quota_gb=10.0),
+    )
+
+
+def _ctx(tmp_path: Path) -> StageContext:
+    return StageContext(
+        charter=_charter(),
+        queue=AmbientQueue(tmp_path / "ambient.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+
+
+@dataclass
+class ScriptedSource:
+    name: str
+    polls: list[SourcePoll]
+    seen_cursors: list[str | None] = field(default_factory=list)
+
+    def poll(self, cursor: str | None) -> SourcePoll:
+        self.seen_cursors.append(cursor)
+        return self.polls.pop(0) if self.polls else SourcePoll()
+
+
+@dataclass
+class ExplodingSource:
+    name: str
+
+    def poll(self, cursor: str | None) -> SourcePoll:
+        raise RuntimeError("feed offline")
+
+
+def test_ingest_appends_redacts_and_advances_cursor(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    source = ScriptedSource(
+        name="native",
+        polls=[SourcePoll(records=[RawTrace(kind="generation", payload={"note": f"key {_FAKE_KEY}"})], next_cursor="5")],
+    )
+    stage = IngestStage(name="ingest", trace_store=store, sources=[source], disk_quota_gb=10.0)
+    result = stage.run_once(_ctx(tmp_path))
+    assert result.processed == 1 and result.errors == 0
+    assert source.seen_cursors == [None]
+    assert store.get_cursor("native") == "5"
+    record = store.recent(limit=1)[0]
+    assert _FAKE_KEY not in str(record.payload)
+    assert record.redaction_findings >= 1
+    again = stage.run_once(_ctx(tmp_path))
+    assert again.processed == 0
+    assert source.seen_cursors[-1] == "5"
+
+
+def test_failing_source_isolated_and_counted(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    good = ScriptedSource(name="ok", polls=[SourcePoll(records=[RawTrace(kind="x", payload={})], next_cursor="1")])
+    stage = IngestStage(
+        name="ingest",
+        trace_store=store,
+        sources=[ExplodingSource(name="bad"), good],
+        disk_quota_gb=10.0,
+    )
+    result = stage.run_once(_ctx(tmp_path))
+    assert result.errors == 1
+    assert result.processed == 1
+    events = (tmp_path / "events.ndjson").read_text(encoding="utf-8")
+    assert "ingest_source_failed" in events
+    assert "ingest_completed" in events
+
+
+def test_disk_quota_triggers_prune(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    for i in range(50):
+        store.append("native", "generation", {"pad": "x" * 200, "i": i}, "frontier", 0)
+    stage = IngestStage(name="ingest", trace_store=store, sources=[], disk_quota_gb=1e-9)
+    before = store.count()
+    stage.run_once(_ctx(tmp_path))
+    assert store.count() < before
+    events = (tmp_path / "events.ndjson").read_text(encoding="utf-8")
+    assert "trace_retention_pruned" in events

--- a/autocontext/tests/test_ambient_jsonl_feed_source.py
+++ b/autocontext/tests/test_ambient_jsonl_feed_source.py
@@ -47,6 +47,21 @@ def test_malformed_lines_are_skipped_but_advance(tmp_path: Path) -> None:
     assert result.next_cursor == "a.jsonl:3"
 
 
+def test_unterminated_tail_is_held_until_complete(tmp_path: Path) -> None:
+    feed = tmp_path / "feed"
+    feed.mkdir(parents=True)
+    (feed / "a.jsonl").write_text('{"n": 1}\n{"n": 2', encoding="utf-8")
+    source = JsonlFeedSource(name="otel", feed_dir=feed)
+    first = source.poll(None)
+    assert [r.payload["n"] for r in first.records] == [1]
+    assert first.next_cursor == "a.jsonl:1"
+    with (feed / "a.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write("3}\n")
+    second = source.poll(first.next_cursor)
+    assert [r.payload["n"] for r in second.records] == [23]
+    assert second.next_cursor == "a.jsonl:2"
+
+
 def test_batch_size_and_missing_dir(tmp_path: Path) -> None:
     source = JsonlFeedSource(name="otel", feed_dir=tmp_path / "absent")
     assert source.poll(None).records == []

--- a/autocontext/tests/test_ambient_jsonl_feed_source.py
+++ b/autocontext/tests/test_ambient_jsonl_feed_source.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
+
+
+def _write(feed: Path, name: str, objs: list[dict]) -> None:
+    feed.mkdir(parents=True, exist_ok=True)
+    (feed / name).write_text("".join(json.dumps(o) + "\n" for o in objs), encoding="utf-8")
+
+
+def test_reads_files_in_order_with_cursor(tmp_path: Path) -> None:
+    feed = tmp_path / "feed"
+    _write(feed, "a.jsonl", [{"kind": "llm_call", "n": 1}, {"n": 2}])
+    _write(feed, "b.jsonl", [{"n": 3, "produced_by": "finetune:l1"}])
+    source = JsonlFeedSource(name="otel", feed_dir=feed)
+    first = source.poll(None)
+    assert [r.payload["n"] for r in first.records] == [1, 2, 3]
+    assert first.records[0].kind == "llm_call"
+    assert first.records[1].kind == "trace"
+    assert first.records[2].produced_by == "finetune:l1"
+    assert first.next_cursor == "b.jsonl:1"
+    again = source.poll(first.next_cursor)
+    assert again.records == []
+    assert again.next_cursor is None
+
+
+def test_new_data_after_cursor_is_picked_up(tmp_path: Path) -> None:
+    feed = tmp_path / "feed"
+    _write(feed, "a.jsonl", [{"n": 1}])
+    source = JsonlFeedSource(name="otel", feed_dir=feed)
+    first = source.poll(None)
+    _write(feed, "a.jsonl", [{"n": 1}, {"n": 2}])
+    second = source.poll(first.next_cursor)
+    assert [r.payload["n"] for r in second.records] == [2]
+
+
+def test_malformed_lines_are_skipped_but_advance(tmp_path: Path) -> None:
+    feed = tmp_path / "feed"
+    feed.mkdir(parents=True)
+    (feed / "a.jsonl").write_text('{"n": 1}\nnot json\n{"n": 3}\n', encoding="utf-8")
+    source = JsonlFeedSource(name="otel", feed_dir=feed)
+    result = source.poll(None)
+    assert [r.payload["n"] for r in result.records] == [1, 3]
+    assert result.next_cursor == "a.jsonl:3"
+
+
+def test_batch_size_and_missing_dir(tmp_path: Path) -> None:
+    source = JsonlFeedSource(name="otel", feed_dir=tmp_path / "absent")
+    assert source.poll(None).records == []
+    feed = tmp_path / "feed"
+    _write(feed, "a.jsonl", [{"n": i} for i in range(5)])
+    limited = JsonlFeedSource(name="otel", feed_dir=feed, batch_size=2)
+    first = limited.poll(None)
+    assert len(first.records) == 2
+    second = limited.poll(first.next_cursor)
+    assert [r.payload["n"] for r in second.records] == [2, 3]

--- a/autocontext/tests/test_ambient_jsonl_feed_source.py
+++ b/autocontext/tests/test_ambient_jsonl_feed_source.py
@@ -57,3 +57,11 @@ def test_batch_size_and_missing_dir(tmp_path: Path) -> None:
     assert len(first.records) == 2
     second = limited.poll(first.next_cursor)
     assert [r.payload["n"] for r in second.records] == [2, 3]
+
+
+def test_zero_batch_size_rejected(tmp_path: Path) -> None:
+    import pytest
+
+    source = JsonlFeedSource(name="otel", feed_dir=tmp_path, batch_size=0)
+    with pytest.raises(ValueError, match="at least 1"):
+        source.poll(None)

--- a/autocontext/tests/test_ambient_native_source.py
+++ b/autocontext/tests/test_ambient_native_source.py
@@ -20,18 +20,18 @@ CREATE TABLE generations (
 """
 
 
-def _seed(db: Path, generations: int) -> None:
+def _seed(db: Path, statuses: list[str]) -> None:
     conn = sqlite3.connect(db)
     conn.executescript(_SCHEMA)
     conn.execute(
         "INSERT INTO runs (run_id, scenario, target_generations, executor_mode, status) "
         "VALUES ('r1', 'grid_ctf', 3, 'local', 'completed')"
     )
-    for index in range(generations):
+    for index, status in enumerate(statuses):
         conn.execute(
             "INSERT INTO generations (run_id, generation_index, mean_score, best_score, gate_decision, status) "
-            "VALUES ('r1', ?, 1.0, 2.0, 'advance', 'completed')",
-            (index,),
+            "VALUES ('r1', ?, 1.0, 2.0, 'advance', ?)",
+            (index, status),
         )
     conn.commit()
     conn.close()
@@ -39,7 +39,7 @@ def _seed(db: Path, generations: int) -> None:
 
 def test_poll_reads_generations_with_run_context(tmp_path: Path) -> None:
     db = tmp_path / "runs.sqlite3"
-    _seed(db, generations=2)
+    _seed(db, ["completed", "completed"])
     source = NativeRunsSource(name="native", runs_db_path=db)
     result = source.poll(None)
     assert len(result.records) == 2
@@ -54,7 +54,7 @@ def test_poll_reads_generations_with_run_context(tmp_path: Path) -> None:
 
 def test_poll_is_incremental(tmp_path: Path) -> None:
     db = tmp_path / "runs.sqlite3"
-    _seed(db, generations=3)
+    _seed(db, ["completed", "completed", "completed"])
     source = NativeRunsSource(name="native", runs_db_path=db)
     first = source.poll(None)
     second = source.poll(first.next_cursor)
@@ -64,7 +64,7 @@ def test_poll_is_incremental(tmp_path: Path) -> None:
 
 def test_batch_size_limits_poll(tmp_path: Path) -> None:
     db = tmp_path / "runs.sqlite3"
-    _seed(db, generations=5)
+    _seed(db, ["completed"] * 5)
     source = NativeRunsSource(name="native", runs_db_path=db, batch_size=2)
     result = source.poll(None)
     assert len(result.records) == 2
@@ -74,6 +74,48 @@ def test_batch_size_limits_poll(tmp_path: Path) -> None:
 
 def test_missing_db_returns_empty_poll(tmp_path: Path) -> None:
     source = NativeRunsSource(name="native", runs_db_path=tmp_path / "absent.sqlite3")
+    result = source.poll(None)
+    assert result.records == []
+    assert result.next_cursor is None
+
+
+def test_failed_status_is_terminal_and_ingested(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _seed(db, ["completed", "failed"])
+    source = NativeRunsSource(name="native", runs_db_path=db)
+    result = source.poll(None)
+    assert [r.payload["status"] for r in result.records] == ["completed", "failed"]
+    assert result.next_cursor == "2"
+
+
+def test_in_flight_row_blocks_cursor_then_advances_when_terminal(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _seed(db, ["completed", "running", "completed"])
+    source = NativeRunsSource(name="native", runs_db_path=db)
+
+    # the in-flight ("running") row at rowid 2 truncates the batch: only the
+    # first row is returned and the cursor stops before the in-flight row
+    first = source.poll(None)
+    assert len(first.records) == 1
+    assert first.records[0].payload["generation_index"] == 0
+    assert first.next_cursor == "1"
+
+    # the placeholder completes in place (rowid-preserving UPDATE, same rowid 2)
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE generations SET status = 'completed' WHERE generation_index = 1")
+    conn.commit()
+    conn.close()
+
+    # a later poll from the held cursor now picks up rows 2 and 3 with finals
+    second = source.poll(first.next_cursor)
+    assert [r.payload["generation_index"] for r in second.records] == [1, 2]
+    assert second.next_cursor == "3"
+
+
+def test_all_running_seed_returns_empty_poll(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _seed(db, ["running", "running"])
+    source = NativeRunsSource(name="native", runs_db_path=db)
     result = source.poll(None)
     assert result.records == []
     assert result.next_cursor is None

--- a/autocontext/tests/test_ambient_native_source.py
+++ b/autocontext/tests/test_ambient_native_source.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from autocontext.ambient.sources.native import NativeRunsSource
+
+_SCHEMA = """
+CREATE TABLE runs (
+    run_id TEXT PRIMARY KEY, scenario TEXT NOT NULL, target_generations INTEGER NOT NULL,
+    executor_mode TEXT NOT NULL, status TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE generations (
+    run_id TEXT NOT NULL, generation_index INTEGER NOT NULL, mean_score REAL NOT NULL,
+    best_score REAL NOT NULL, gate_decision TEXT NOT NULL, status TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (run_id, generation_index)
+);
+"""
+
+
+def _seed(db: Path, generations: int) -> None:
+    conn = sqlite3.connect(db)
+    conn.executescript(_SCHEMA)
+    conn.execute(
+        "INSERT INTO runs (run_id, scenario, target_generations, executor_mode, status) "
+        "VALUES ('r1', 'grid_ctf', 3, 'local', 'completed')"
+    )
+    for index in range(generations):
+        conn.execute(
+            "INSERT INTO generations (run_id, generation_index, mean_score, best_score, gate_decision, status) "
+            "VALUES ('r1', ?, 1.0, 2.0, 'advance', 'completed')",
+            (index,),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_poll_reads_generations_with_run_context(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _seed(db, generations=2)
+    source = NativeRunsSource(name="native", runs_db_path=db)
+    result = source.poll(None)
+    assert len(result.records) == 2
+    first = result.records[0]
+    assert first.kind == "generation"
+    assert first.payload["run_id"] == "r1"
+    assert first.payload["scenario"] == "grid_ctf"
+    assert first.payload["generation_index"] == 0
+    assert first.payload["best_score"] == 2.0
+    assert result.next_cursor == "2"
+
+
+def test_poll_is_incremental(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _seed(db, generations=3)
+    source = NativeRunsSource(name="native", runs_db_path=db)
+    first = source.poll(None)
+    second = source.poll(first.next_cursor)
+    assert second.records == []
+    assert second.next_cursor is None
+
+
+def test_batch_size_limits_poll(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _seed(db, generations=5)
+    source = NativeRunsSource(name="native", runs_db_path=db, batch_size=2)
+    result = source.poll(None)
+    assert len(result.records) == 2
+    rest = source.poll(result.next_cursor)
+    assert len(rest.records) == 2
+
+
+def test_missing_db_returns_empty_poll(tmp_path: Path) -> None:
+    source = NativeRunsSource(name="native", runs_db_path=tmp_path / "absent.sqlite3")
+    result = source.poll(None)
+    assert result.records == []
+    assert result.next_cursor is None

--- a/autocontext/tests/test_ambient_redaction_gate.py
+++ b/autocontext/tests/test_ambient_redaction_gate.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from autocontext.ambient.redaction_gate import redact_payload
+
+_FAKE_KEY = "sk-ant-api03-" + "a" * 32
+
+
+def test_redacts_nested_strings_and_counts() -> None:
+    payload = {
+        "prompt": f"use key {_FAKE_KEY} please",
+        "meta": {"notes": [f"backup {_FAKE_KEY}", "clean"]},
+        "score": 1.5,
+    }
+    redacted, findings = redact_payload(payload)
+    assert findings >= 2
+    assert _FAKE_KEY not in str(redacted)
+    assert redacted["score"] == 1.5
+    assert redacted["meta"]["notes"][1] == "clean"
+
+
+def test_clean_payload_zero_findings_and_not_mutated() -> None:
+    payload = {"prompt": "hello", "n": 1}
+    redacted, findings = redact_payload(payload)
+    assert findings == 0
+    assert redacted == payload
+    payload["prompt"] = "changed"
+    assert redacted["prompt"] == "hello"

--- a/autocontext/tests/test_ambient_source_contract.py
+++ b/autocontext/tests/test_ambient_source_contract.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.ambient.sources.contract import RawTrace, SourcePoll, TraceSource
+
+
+@dataclass
+class FakeSource:
+    name: str
+
+    def poll(self, cursor: str | None) -> SourcePoll:
+        return SourcePoll(records=[RawTrace(kind="x", payload={"cursor": cursor})], next_cursor="1")
+
+
+def test_contract_shapes() -> None:
+    source: TraceSource = FakeSource(name="fake")
+    result = source.poll(None)
+    assert result.records[0].payload == {"cursor": None}
+    assert result.records[0].produced_by == "frontier"
+    assert result.next_cursor == "1"

--- a/autocontext/tests/test_ambient_source_contract.py
+++ b/autocontext/tests/test_ambient_source_contract.py
@@ -8,6 +8,7 @@ from autocontext.ambient.sources.contract import RawTrace, SourcePoll, TraceSour
 @dataclass
 class FakeSource:
     name: str
+    kind: str = "autocontext"
 
     def poll(self, cursor: str | None) -> SourcePoll:
         return SourcePoll(records=[RawTrace(kind="x", payload={"cursor": cursor})], next_cursor="1")
@@ -19,3 +20,4 @@ def test_contract_shapes() -> None:
     assert result.records[0].payload == {"cursor": None}
     assert result.records[0].produced_by == "frontier"
     assert result.next_cursor == "1"
+    assert source.kind == "autocontext"

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.ingest import IngestStage
+from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
+from autocontext.ambient.sources.native import NativeRunsSource
+from autocontext.ambient.stage import STAGE_NAMES, NoOpStage
+from autocontext.ambient.stage_factory import build_stages
+from autocontext.harness.core.events import EventStreamEmitter
+
+
+def _charter(sources: list[CharterSource], tier: str = "oss") -> Charter:
+    return Charter(
+        tier=tier,  # type: ignore[arg-type]
+        sources=sources,
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="m",
+                min_dataset_records=1,
+                eval_suite="e",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=1.0, window_hours=24, disk_quota_gb=7.0),
+    )
+
+
+def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
+    charter = _charter(
+        [
+            CharterSource(name="native", kind="autocontext"),
+            CharterSource(name="feed", kind="otel"),
+            CharterSource(name="off", kind="otel", enabled=False),
+        ]
+    )
+    stages = build_stages(
+        charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        runs_db_path=tmp_path / "runs.sqlite3",
+        otel_feed_dir=tmp_path / "feed",
+    )
+    assert set(stages.keys()) == set(STAGE_NAMES)
+    ingest = stages["ingest"]
+    assert isinstance(ingest, IngestStage)
+    assert ingest.disk_quota_gb == 7.0
+    kinds = [type(source) for source in ingest.sources]
+    assert kinds == [NativeRunsSource, JsonlFeedSource]
+    assert all(isinstance(stages[name], NoOpStage) for name in ("curate", "advise", "train", "evaluate"))
+
+
+def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.ndjson"
+    charter = _charter(
+        [CharterSource(name="native", kind="autocontext"), CharterSource(name="box", kind="full-box")],
+        tier="hosted-box",
+    )
+    stages = build_stages(
+        charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(events_path),
+        runs_db_path=tmp_path / "runs.sqlite3",
+        otel_feed_dir=tmp_path / "feed",
+    )
+    ingest = stages["ingest"]
+    assert isinstance(ingest, IngestStage)
+    assert len(ingest.sources) == 1
+    assert "ingest_source_unsupported" in events_path.read_text(encoding="utf-8")

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -69,4 +69,6 @@ def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
     ingest = stages["ingest"]
     assert isinstance(ingest, IngestStage)
     assert len(ingest.sources) == 1
-    assert "ingest_source_unsupported" in events_path.read_text(encoding="utf-8")
+    assert ingest.unsupported == [("box", "full-box")]
+    # construction is event-silent; the announcement happens on first run
+    assert not events_path.exists() or "ingest_source_unsupported" not in events_path.read_text(encoding="utf-8")

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -50,6 +50,7 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
     assert ingest.disk_quota_gb == 7.0
     kinds = [type(source) for source in ingest.sources]
     assert kinds == [NativeRunsSource, JsonlFeedSource]
+    assert [source.kind for source in ingest.sources] == ["autocontext", "otel"]
     assert all(isinstance(stages[name], NoOpStage) for name in ("curate", "advise", "train", "evaluate"))
 
 

--- a/autocontext/tests/test_ambient_trace_store.py
+++ b/autocontext/tests/test_ambient_trace_store.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.trace_store import TraceStore
 
@@ -36,6 +38,34 @@ def test_shares_db_file_with_queue(tmp_path: Path) -> None:
     store.append("native", "generation", {}, "frontier", 0)
     assert queue.depth("ingest") == 1
     assert store.count() == 1
+
+
+def test_append_batch_commits_records_and_cursor_together(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    inserted = store.append_batch(
+        "autocontext:native",
+        [("generation", {"n": 1}, "frontier", 0), ("llm_call", {"n": 2}, "frontier", 1)],
+        "7",
+    )
+    assert inserted == 2
+    assert store.count() == 2
+    assert store.get_cursor("autocontext:native") == "7"
+
+
+def test_append_batch_rolls_back_on_serialization_failure(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    store.set_cursor("autocontext:native", "3")
+    with pytest.raises(TypeError):
+        store.append_batch(
+            "autocontext:native",
+            [
+                ("generation", {"n": 1}, "frontier", 0),
+                ("generation", {"bad": object()}, "frontier", 0),
+            ],
+            "9",
+        )
+    assert store.count() == 0
+    assert store.get_cursor("autocontext:native") == "3"
 
 
 def test_prune_oldest_removes_oldest_fraction(tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_trace_store.py
+++ b/autocontext/tests/test_ambient_trace_store.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.trace_store import TraceStore
+
+
+def test_append_and_recent(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    first = store.append("native", "generation", {"score": 1.0}, "frontier", 0)
+    second = store.append("otel", "llm_call", {"prompt": "hi"}, "frontier", 2)
+    assert second > first
+    assert store.count() == 2
+    assert store.count("native") == 1
+    newest = store.recent(limit=1)[0]
+    assert newest.record_id == second
+    assert newest.payload == {"prompt": "hi"}
+    assert newest.redaction_findings == 2
+    assert newest.created_at
+
+
+def test_cursor_roundtrip_and_upsert(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    assert store.get_cursor("native") is None
+    store.set_cursor("native", "41")
+    store.set_cursor("native", "42")
+    assert store.get_cursor("native") == "42"
+
+
+def test_shares_db_file_with_queue(tmp_path: Path) -> None:
+    db = tmp_path / "ambient.sqlite3"
+    queue = AmbientQueue(db)
+    store = TraceStore(db)
+    queue.enqueue("ingest", "poll_source", {})
+    store.append("native", "generation", {}, "frontier", 0)
+    assert queue.depth("ingest") == 1
+    assert store.count() == 1
+
+
+def test_prune_oldest_removes_oldest_fraction(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "ambient.sqlite3")
+    ids = [store.append("native", "generation", {"i": i}, "frontier", 0) for i in range(10)]
+    deleted = store.prune_oldest(0.3)
+    assert deleted == 3
+    remaining = {record.record_id for record in store.recent(limit=100)}
+    assert set(ids[3:]) == remaining
+    assert store.db_size_bytes() > 0

--- a/docs/ambient-trainer-design.md
+++ b/docs/ambient-trainer-design.md
@@ -71,7 +71,7 @@ redaction profile:
   (richest labels; already structured).
 - OTel feed: anything shipping traces via the existing otel-bridge and
   production-traces SDK (other agents, Claude Code hooks, instrumented apps).
-- LLM proxy tap: the daemon exposes an OpenAI/Anthropic-compatible gateway
+- LLM proxy tap (plan 3): the daemon exposes an OpenAI/Anthropic-compatible gateway
   endpoint; any tool pointed at it gets traced. Lowest-friction third-party
   capture; lacks tool/execution context by nature.
 - full-box collector (hosted tier only, v2): shell sessions, editor activity,


### PR DESCRIPTION
Second slice of docs/ambient-trainer-design.md: an append-only trace store with per-source cursors and disk-quota retention, a recursive redaction gate over the existing sharing redactor, the trace-source contract, two sources (autocontext-native incremental runs reader, jsonl feed directory for production-traces/otel output), the live ingest stage with per-source failure isolation, and stage-factory wiring into the daemon and cli (--runs-db, --otel-feed-dir). The llm proxy tap and the remaining no-op stages land in plan 3.