### PR TITLE
ambient trainer plan 3: curate and advise stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `autoctx ambient` foundation: a charter-driven resident daemon skeleton (interview wizard, autonomy dial with guardrail floors, durable stage queue, five stages with auto-pause breakers, status/run/once cli). Stages are no-ops pending the ingest, curation, and training plans (docs/ambient-trainer-design.md).
 - The ambient ingest stage is live: charter-enabled sources (autocontext-native runs, jsonl trace feeds) flow through the redaction gate into an append-only trace store with per-source cursors and disk-quota retention; the llm proxy tap follows in the next slice.
+- ambient trainer plan 3: curate and advise stages (agent-output ingestion, guarded per-target datasets, heuristic charter proposals, proposal approval cli)
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/ambient/advise.py
+++ b/autocontext/src/autocontext/ambient/advise.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 from pydantic import ValidationError
 
 from autocontext.ambient.charter import Charter, CharterTarget
+from autocontext.ambient.eligibility import split_role_selector
 from autocontext.ambient.proposals import CharterProposal, ProposalStore
 from autocontext.ambient.stage import StageContext, StageResult
 from autocontext.ambient.trace_store import TraceStore
@@ -32,15 +33,28 @@ class _ScenarioStats:
 def _covered_scenarios(charter: Charter, store: ProposalStore) -> tuple[bool, set[str]]:
     """Returns (role_coverage, covered_selectors).
 
-    A competitor role target trains on every scenario its role appears in, so
-    it covers everything; task-family targets and pending add_target proposals
-    cover their specific selector.
+    An unscoped competitor role target trains on every scenario its role
+    appears in, so it covers everything; task-family targets, competitor role
+    targets bound to a single scenario (competitor@grid_ctf), and pending
+    add_target proposals cover their specific selector.
     """
-    # only a competitor role target covers all scenarios: the advisor's signal
-    # is competitor-only, so any other role target (e.g. analyst) trains on a
-    # different slice and must not permanently suppress scenario proposals
-    role_coverage = any(target.kind == "role" and target.selector == "competitor" for target in charter.targets)
+    # only an unscoped competitor role target covers all scenarios: the
+    # advisor's signal is competitor-only, so any other role target (e.g.
+    # analyst) trains on a different slice and must not permanently suppress
+    # scenario proposals. a competitor binding scoped to one scenario
+    # (competitor@grid_ctf) covers only that scenario, not the rest.
+    role_coverage = False
     covered = {target.selector for target in charter.targets if target.kind == "task_family"}
+    for target in charter.targets:
+        if target.kind != "role":
+            continue
+        role, scenario = split_role_selector(target.selector)
+        if role != "competitor":
+            continue
+        if scenario is None:
+            role_coverage = True
+        else:
+            covered.add(scenario)
     # only pending proposals count as coverage: a rejected proposal's scenario is
     # deliberately eligible to be re-proposed on a later scan (rejection is a
     # decision about that proposal, not a permanent suppression of the scenario).

--- a/autocontext/src/autocontext/ambient/advise.py
+++ b/autocontext/src/autocontext/ambient/advise.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 from pydantic import ValidationError
 
 from autocontext.ambient.charter import Charter, CharterTarget
-from autocontext.ambient.eligibility import is_evaluative_target
 from autocontext.ambient.proposals import CharterProposal, ProposalStore
 from autocontext.ambient.stage import StageContext, StageResult
 from autocontext.ambient.trace_store import TraceStore
@@ -33,11 +32,14 @@ class _ScenarioStats:
 def _covered_scenarios(charter: Charter, store: ProposalStore) -> tuple[bool, set[str]]:
     """Returns (role_coverage, covered_selectors).
 
-    A non-evaluative role target trains on every scenario its role appears
-    in, so it covers everything; task-family targets and pending add_target
-    proposals cover their specific selector.
+    A competitor role target trains on every scenario its role appears in, so
+    it covers everything; task-family targets and pending add_target proposals
+    cover their specific selector.
     """
-    role_coverage = any(target.kind == "role" and not is_evaluative_target(target) for target in charter.targets)
+    # only a competitor role target covers all scenarios: the advisor's signal
+    # is competitor-only, so any other role target (e.g. analyst) trains on a
+    # different slice and must not permanently suppress scenario proposals
+    role_coverage = any(target.kind == "role" and target.selector == "competitor" for target in charter.targets)
     covered = {target.selector for target in charter.targets if target.kind == "task_family"}
     # only pending proposals count as coverage: a rejected proposal's scenario is
     # deliberately eligible to be re-proposed on a later scan (rejection is a
@@ -73,7 +75,8 @@ class AdviseStage:
                 continue
             entry = stats.setdefault(scenario, _ScenarioStats())
             entry.count += 1
-            entry.score_total += float(payload.get("best_score") or 0.0)
+            best_score = payload.get("best_score")
+            entry.score_total += float(best_score) if best_score is not None else 0.0
         role_coverage, covered = _covered_scenarios(ctx.charter, store)
         emitted = 0
         for scenario in sorted(stats):

--- a/autocontext/src/autocontext/ambient/advise.py
+++ b/autocontext/src/autocontext/ambient/advise.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import uuid4
 
+from pydantic import ValidationError
+
 from autocontext.ambient.charter import Charter, CharterTarget
 from autocontext.ambient.eligibility import is_evaluative_target
 from autocontext.ambient.proposals import CharterProposal, ProposalStore
@@ -37,6 +39,9 @@ def _covered_scenarios(charter: Charter, store: ProposalStore) -> tuple[bool, se
     """
     role_coverage = any(target.kind == "role" and not is_evaluative_target(target) for target in charter.targets)
     covered = {target.selector for target in charter.targets if target.kind == "task_family"}
+    # only pending proposals count as coverage: a rejected proposal's scenario is
+    # deliberately eligible to be re-proposed on a later scan (rejection is a
+    # decision about that proposal, not a permanent suppression of the scenario).
     for proposal in store.pending():
         selector = proposal.payload.get("selector")
         if proposal.kind == "add_target" and isinstance(selector, str):
@@ -87,10 +92,12 @@ class AdviseStage:
                     channel="ambient",
                 )
                 continue
-            proposal = CharterProposal(
-                proposal_id=f"add-target-{scenario}-{uuid4().hex[:8]}",
-                kind="add_target",
-                payload=CharterTarget(
+            # scenario names flow in from trace payloads and are not slug-validated
+            # upstream, so a name the charter would reject must be skipped here
+            # rather than allowed to trip the stage breaker (three raised cycles
+            # auto-pause the advise stage).
+            try:
+                target = CharterTarget(
                     name=f"{scenario}-auto",
                     kind="task_family",
                     selector=scenario,
@@ -98,7 +105,18 @@ class AdviseStage:
                     method="sft-distill",
                     min_dataset_records=template.min_dataset_records,
                     eval_suite=template.eval_suite,
-                ).model_dump(mode="json"),
+                )
+            except ValidationError as exc:
+                ctx.emitter.emit(
+                    "advise_invalid_scenario",
+                    {"scenario": scenario, "error": str(exc)},
+                    channel="ambient",
+                )
+                continue
+            proposal = CharterProposal(
+                proposal_id=f"add-target-{scenario}-{uuid4().hex[:8]}",
+                kind="add_target",
+                payload=target.model_dump(mode="json"),
                 rationale=(
                     f"{entry.count} eligible frontier traces for scenario {scenario} "
                     f"at mean score {entry.mean_score:.2f}; propose an sft-distill target"

--- a/autocontext/src/autocontext/ambient/advise.py
+++ b/autocontext/src/autocontext/ambient/advise.py
@@ -1,0 +1,119 @@
+"""the advise stage: heuristic charter proposals from observed trace quality.
+
+Deliberately LLM-free (matching the hermes advisor's offline posture): the
+rules are deterministic aggregates over recent traces. Advise only ever
+EMITS proposals; applying one to the charter is a control-surface action
+(autoctx ambient approve) at every autonomy level.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from autocontext.ambient.charter import Charter, CharterTarget
+from autocontext.ambient.eligibility import is_evaluative_target
+from autocontext.ambient.proposals import CharterProposal, ProposalStore
+from autocontext.ambient.stage import StageContext, StageResult
+from autocontext.ambient.trace_store import TraceStore
+
+
+@dataclass(slots=True)
+class _ScenarioStats:
+    count: int = 0
+    score_total: float = 0.0
+
+    @property
+    def mean_score(self) -> float:
+        return self.score_total / self.count if self.count else 0.0
+
+
+def _covered_scenarios(charter: Charter, store: ProposalStore) -> tuple[bool, set[str]]:
+    """Returns (role_coverage, covered_selectors).
+
+    A non-evaluative role target trains on every scenario its role appears
+    in, so it covers everything; task-family targets and pending add_target
+    proposals cover their specific selector.
+    """
+    role_coverage = any(target.kind == "role" and not is_evaluative_target(target) for target in charter.targets)
+    covered = {target.selector for target in charter.targets if target.kind == "task_family"}
+    for proposal in store.pending():
+        selector = proposal.payload.get("selector")
+        if proposal.kind == "add_target" and isinstance(selector, str):
+            covered.add(selector)
+    return role_coverage, covered
+
+
+@dataclass(slots=True)
+class AdviseStage:
+    name: str
+    trace_store: TraceStore
+    scan_limit: int = 2000
+    min_traces: int = 50
+    min_mean_score: float = 0.5
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        store = ctx.proposal_store
+        if store is None:
+            return StageResult()
+        stats: dict[str, _ScenarioStats] = {}
+        for trace in self.trace_store.recent(self.scan_limit):
+            if trace.kind != "agent_output" or trace.produced_by != "frontier":
+                continue
+            payload = trace.payload
+            if payload.get("role") != "competitor" or payload.get("status") != "completed":
+                continue
+            scenario = payload.get("scenario")
+            if not isinstance(scenario, str) or not scenario:
+                continue
+            entry = stats.setdefault(scenario, _ScenarioStats())
+            entry.count += 1
+            entry.score_total += float(payload.get("best_score") or 0.0)
+        role_coverage, covered = _covered_scenarios(ctx.charter, store)
+        emitted = 0
+        for scenario in sorted(stats):
+            entry = stats[scenario]
+            if entry.count < self.min_traces or entry.mean_score < self.min_mean_score:
+                continue
+            if role_coverage or scenario in covered:
+                continue
+            template = next(iter(ctx.charter.targets), None)
+            if template is None:
+                # a proposal must not invent a base model or eval suite; ask
+                # the human to seed the first target instead
+                ctx.emitter.emit(
+                    "advise_no_template",
+                    {"scenario": scenario, "traces": entry.count, "mean_score": entry.mean_score},
+                    channel="ambient",
+                )
+                continue
+            proposal = CharterProposal(
+                proposal_id=f"add-target-{scenario}-{uuid4().hex[:8]}",
+                kind="add_target",
+                payload=CharterTarget(
+                    name=f"{scenario}-auto",
+                    kind="task_family",
+                    selector=scenario,
+                    base_model=template.base_model,
+                    method="sft-distill",
+                    min_dataset_records=template.min_dataset_records,
+                    eval_suite=template.eval_suite,
+                ).model_dump(mode="json"),
+                rationale=(
+                    f"{entry.count} eligible frontier traces for scenario {scenario} "
+                    f"at mean score {entry.mean_score:.2f}; propose an sft-distill target"
+                ),
+            )
+            store.append(proposal)
+            ctx.emitter.emit(
+                "advise_proposal_emitted",
+                {
+                    "proposal_id": proposal.proposal_id,
+                    "selector": scenario,
+                    "traces": entry.count,
+                    "mean_score": entry.mean_score,
+                },
+                channel="ambient",
+            )
+            emitted += 1
+        return StageResult(processed=emitted)

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -60,7 +60,12 @@ class CharterSource(BaseModel):
 class CharterTarget(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    name: str = Field(min_length=1)
+    # target names become dataset and manifest filenames under the store root
+    # (DatasetStore builds root / f"{name}.jsonl"), so path separators and
+    # traversal sequences must be impossible. the pattern forbids a leading dot
+    # (so ".." can never start a name) and excludes "/" everywhere; a slug this
+    # shape stays inside the store root, so no separate path validator is needed.
+    name: str = Field(min_length=1, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
     kind: Literal["role", "task_family"]
     selector: str = Field(min_length=1)
     base_model: str = Field(min_length=1)

--- a/autocontext/src/autocontext/ambient/curate.py
+++ b/autocontext/src/autocontext/ambient/curate.py
@@ -63,7 +63,12 @@ class CurateStage:
                 skipped += 1
         appended = self.dataset_store.append_records(target.name, records)
         # the cursor advances past ineligible traces too; they were assessed
-        # and must not be re-assessed every cycle. Crash ordering note: the
+        # and must not be re-assessed every cycle. KNOWN v1 lose-data window:
+        # read_after silently skips ids it can no longer find, so if ingest's
+        # disk-quota prune deletes the oldest traces (it ignores per-target
+        # cursors) before this cursor reaches them, those un-curated traces are
+        # lost, not duplicated; a later slice can floor that prune at the minimum
+        # manifest cursor. Crash ordering note: the
         # dataset append lands before the manifest (cursor) save, so a crash
         # between them can duplicate this batch's records in the jsonl on the
         # next cycle; dedupe at train time (data_selection.dedupe_records)

--- a/autocontext/src/autocontext/ambient/curate.py
+++ b/autocontext/src/autocontext/ambient/curate.py
@@ -1,0 +1,90 @@
+"""the curate stage: continuous per-target dataset construction with guardrails."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.datasets import DatasetStore
+from autocontext.ambient.eligibility import assess, is_evaluative_target, to_training_record
+from autocontext.ambient.stage import StageContext, StageResult
+from autocontext.ambient.trace_store import TraceStore
+
+
+@dataclass(slots=True)
+class CurateStage:
+    name: str
+    trace_store: TraceStore
+    dataset_store: DatasetStore
+    batch_size: int = 500
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        processed = 0
+        errors = 0
+        for target in ctx.charter.targets:
+            if is_evaluative_target(target):
+                # asymmetric trainability: v1 has no externally anchored
+                # labels, so evaluative-role datasets are refused outright
+                ctx.emitter.emit(
+                    "curate_target_skipped",
+                    {"target": target.name, "reason": "evaluative_role"},
+                    channel="ambient",
+                )
+                continue
+            try:
+                processed += self._curate_target(ctx, target)
+            except Exception as exc:
+                errors += 1
+                ctx.emitter.emit(
+                    "curate_target_failed",
+                    {"target": target.name, "error": str(exc)},
+                    channel="ambient",
+                )
+        return StageResult(processed=processed, errors=errors)
+
+    def _curate_target(self, ctx: StageContext, target: CharterTarget) -> int:
+        manifest = self.dataset_store.load_manifest(target.name)
+        traces = self.trace_store.read_after(manifest.last_record_id, self.batch_size, kind="agent_output")
+        if not traces:
+            return 0
+        records = []
+        scores: list[float] = []
+        quarantined = 0
+        skipped = 0
+        for trace in traces:
+            decision = assess(trace, target)
+            if decision.eligible:
+                record = to_training_record(trace)
+                records.append(record)
+                scores.append(float(record["score"]))
+            elif decision.reason == "quarantined_provenance":
+                quarantined += 1
+            else:
+                skipped += 1
+        appended = self.dataset_store.append_records(target.name, records)
+        # the cursor advances past ineligible traces too; they were assessed
+        # and must not be re-assessed every cycle. Crash ordering note: the
+        # dataset append lands before the manifest (cursor) save, so a crash
+        # between them can duplicate this batch's records in the jsonl on the
+        # next cycle; dedupe at train time (data_selection.dedupe_records)
+        # absorbs that, and the manifest itself never goes torn (atomic replace).
+        updated = self.dataset_store.absorb(
+            manifest,
+            appended_scores=scores,
+            quarantined=quarantined,
+            skipped=skipped,
+            last_record_id=traces[-1].record_id,
+        )
+        self.dataset_store.save_manifest(updated)
+        ctx.emitter.emit(
+            "curate_target_updated",
+            {
+                "target": target.name,
+                "appended": appended,
+                "quarantined": quarantined,
+                "skipped": skipped,
+                "record_count": updated.record_count,
+            },
+            channel="ambient",
+        )
+        return appended

--- a/autocontext/src/autocontext/ambient/daemon.py
+++ b/autocontext/src/autocontext/ambient/daemon.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 
 from autocontext.ambient.charter import Charter
+from autocontext.ambient.proposals import ProposalStore
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.stage import (
     STAGE_NAMES,
@@ -27,18 +28,25 @@ class AmbientDaemon:
         queue: AmbientQueue,
         emitter: EventStreamEmitter,
         stages: dict[str, Stage] | None = None,
+        proposal_store: ProposalStore | None = None,
         breaker_threshold: int = 3,
     ) -> None:
         self.charter = charter
         self.queue = queue
         self.emitter = emitter
+        self.proposal_store = proposal_store
         self._stages: dict[str, Stage] = stages if stages is not None else {name: NoOpStage(name=name) for name in STAGE_NAMES}
         self._breakers: dict[str, AutoPauseBreaker] = {
             name: AutoPauseBreaker(threshold=breaker_threshold) for name in self._stages
         }
 
     def _context(self) -> StageContext:
-        return StageContext(charter=self.charter, queue=self.queue, emitter=self.emitter)
+        return StageContext(
+            charter=self.charter,
+            queue=self.queue,
+            emitter=self.emitter,
+            proposal_store=self.proposal_store,
+        )
 
     def run_stage_once(self, stage_name: str) -> StageResult:
         stage = self._stages[stage_name]

--- a/autocontext/src/autocontext/ambient/datasets.py
+++ b/autocontext/src/autocontext/ambient/datasets.py
@@ -1,0 +1,87 @@
+"""per-target dataset files and manifests: curate's continuous output."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DatasetManifest(BaseModel):
+    """quality and freshness stats for one charter target's dataset.
+
+    last_record_id doubles as curate's per-target cursor into the trace
+    store, so the manifest write and the cursor advance are one atomic
+    file replace.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target: str
+    record_count: int = 0
+    last_record_id: int = 0
+    mean_score: float = 0.0
+    quarantined_total: int = 0
+    skipped_total: int = 0
+    updated_at: str = ""
+
+
+class DatasetStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        root.mkdir(parents=True, exist_ok=True)
+
+    def dataset_path(self, target: str) -> Path:
+        return self.root / f"{target}.jsonl"
+
+    def _manifest_path(self, target: str) -> Path:
+        return self.root / f"{target}.manifest.json"
+
+    def load_manifest(self, target: str) -> DatasetManifest:
+        path = self._manifest_path(target)
+        if not path.exists():
+            return DatasetManifest(target=target)
+        return DatasetManifest(**json.loads(path.read_text(encoding="utf-8")))
+
+    def save_manifest(self, manifest: DatasetManifest) -> None:
+        # atomic replace: a crash mid-write must never leave a torn manifest,
+        # because a reset manifest would rewind the cursor and duplicate records
+        path = self._manifest_path(manifest.target)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(manifest.model_dump(mode="json")), encoding="utf-8")
+        os.replace(tmp, path)
+
+    def append_records(self, target: str, records: list[dict[str, Any]]) -> int:
+        if not records:
+            return 0
+        with self.dataset_path(target).open("a", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record) + "\n")
+        return len(records)
+
+    def absorb(
+        self,
+        manifest: DatasetManifest,
+        appended_scores: list[float],
+        quarantined: int,
+        skipped: int,
+        last_record_id: int,
+    ) -> DatasetManifest:
+        new_count = manifest.record_count + len(appended_scores)
+        if appended_scores:
+            mean = (manifest.mean_score * manifest.record_count + sum(appended_scores)) / new_count
+        else:
+            mean = manifest.mean_score
+        return DatasetManifest(
+            target=manifest.target,
+            record_count=new_count,
+            last_record_id=last_record_id,
+            mean_score=mean,
+            quarantined_total=manifest.quarantined_total + quarantined,
+            skipped_total=manifest.skipped_total + skipped,
+            updated_at=datetime.now(UTC).isoformat(),
+        )

--- a/autocontext/src/autocontext/ambient/eligibility.py
+++ b/autocontext/src/autocontext/ambient/eligibility.py
@@ -38,8 +38,15 @@ def assess(trace: TraceRecord, target: CharterTarget) -> EligibilityDecision:
         return EligibilityDecision(eligible=False, reason="not_completed")
     if target.kind == "role" and trace.payload.get("role") != target.selector:
         return EligibilityDecision(eligible=False, reason="selector_mismatch")
-    if target.kind == "task_family" and trace.payload.get("scenario") != target.selector:
-        return EligibilityDecision(eligible=False, reason="selector_mismatch")
+    if target.kind == "task_family":
+        if trace.payload.get("scenario") != target.selector:
+            return EligibilityDecision(eligible=False, reason="selector_mismatch")
+        # a task-family dataset is a generator dataset, and only competitor
+        # output is the generator signal; other roles' text would sidestep the
+        # evaluative-role refusal (which only guards kind="role" targets) and
+        # desynchronize dataset stats from the advisor's competitor-only rationale
+        if trace.payload.get("role") != "competitor":
+            return EligibilityDecision(eligible=False, reason="non_competitor_role")
     if not trace.payload.get("content"):
         return EligibilityDecision(eligible=False, reason="missing_content")
     return EligibilityDecision(eligible=True, reason="ok")
@@ -54,11 +61,13 @@ def to_training_record(trace: TraceRecord) -> dict[str, Any]:
     unchanged.
     """
     payload = trace.payload
+    best_score = payload.get("best_score")
+    score = float(best_score) if best_score is not None else 0.0
     return {
         "run_id": payload.get("run_id", ""),
         "scenario": payload.get("scenario", ""),
         "strategy": payload.get("content", ""),
-        "score": float(payload.get("best_score") or 0.0),
+        "score": score,
         "context": {
             "generation_index": payload.get("generation_index"),
             "role": payload.get("role"),

--- a/autocontext/src/autocontext/ambient/eligibility.py
+++ b/autocontext/src/autocontext/ambient/eligibility.py
@@ -25,8 +25,23 @@ class EligibilityDecision:
     reason: str
 
 
+def split_role_selector(selector: str) -> tuple[str, str | None]:
+    """Split a role selector in the role@scenario binding notation.
+
+    A bare role ("competitor") selects that role in every scenario; a
+    scoped binding ("competitor@grid_ctf") selects the role only in the
+    named scenario. This is the same notation the interview wizard and the
+    registry role bindings use, so selectors written in either form work.
+    """
+    role, _, scenario = selector.partition("@")
+    return role, scenario or None
+
+
 def is_evaluative_target(target: CharterTarget) -> bool:
-    return target.kind == "role" and target.selector in EVALUATIVE_ROLES
+    if target.kind != "role":
+        return False
+    role, _ = split_role_selector(target.selector)
+    return role in EVALUATIVE_ROLES
 
 
 def assess(trace: TraceRecord, target: CharterTarget) -> EligibilityDecision:
@@ -36,8 +51,12 @@ def assess(trace: TraceRecord, target: CharterTarget) -> EligibilityDecision:
         return EligibilityDecision(eligible=False, reason="wrong_kind")
     if trace.payload.get("status") != "completed":
         return EligibilityDecision(eligible=False, reason="not_completed")
-    if target.kind == "role" and trace.payload.get("role") != target.selector:
-        return EligibilityDecision(eligible=False, reason="selector_mismatch")
+    if target.kind == "role":
+        role, scenario = split_role_selector(target.selector)
+        if trace.payload.get("role") != role:
+            return EligibilityDecision(eligible=False, reason="selector_mismatch")
+        if scenario is not None and trace.payload.get("scenario") != scenario:
+            return EligibilityDecision(eligible=False, reason="selector_mismatch")
     if target.kind == "task_family":
         if trace.payload.get("scenario") != target.selector:
             return EligibilityDecision(eligible=False, reason="selector_mismatch")

--- a/autocontext/src/autocontext/ambient/eligibility.py
+++ b/autocontext/src/autocontext/ambient/eligibility.py
@@ -1,0 +1,69 @@
+"""curate's eligibility guardrails: quarantine, asymmetric trainability, selector match.
+
+These are the mechanical enforcement points for two charter guardrails
+(spec: docs/ambient-trainer-design.md, "Stage: Curate"): provenance
+quarantine (fine-tune-produced records never feed the next lineage's
+training set; v1 quarantines all non-frontier provenance) and asymmetric
+trainability (datasets for evaluative roles need externally anchored
+labels, which v1 does not have, so evaluative-role targets are refused).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.trace_store import TraceRecord
+
+EVALUATIVE_ROLES = frozenset({"judge", "curator", "coach"})
+
+
+@dataclass(slots=True)
+class EligibilityDecision:
+    eligible: bool
+    reason: str
+
+
+def is_evaluative_target(target: CharterTarget) -> bool:
+    return target.kind == "role" and target.selector in EVALUATIVE_ROLES
+
+
+def assess(trace: TraceRecord, target: CharterTarget) -> EligibilityDecision:
+    if trace.produced_by != "frontier":
+        return EligibilityDecision(eligible=False, reason="quarantined_provenance")
+    if trace.kind != "agent_output":
+        return EligibilityDecision(eligible=False, reason="wrong_kind")
+    if trace.payload.get("status") != "completed":
+        return EligibilityDecision(eligible=False, reason="not_completed")
+    if target.kind == "role" and trace.payload.get("role") != target.selector:
+        return EligibilityDecision(eligible=False, reason="selector_mismatch")
+    if target.kind == "task_family" and trace.payload.get("scenario") != target.selector:
+        return EligibilityDecision(eligible=False, reason="selector_mismatch")
+    if not trace.payload.get("content"):
+        return EligibilityDecision(eligible=False, reason="missing_content")
+    return EligibilityDecision(eligible=True, reason="ok")
+
+
+def to_training_record(trace: TraceRecord) -> dict[str, Any]:
+    """Shape one eligible trace as an autoresearch training record.
+
+    Matches the JSONL schema consumed by training/autoresearch/prepare.py
+    (run_id, scenario, strategy, score, context) so plan 4's train stage can
+    feed these files to the existing curate_records + backend pipeline
+    unchanged.
+    """
+    payload = trace.payload
+    return {
+        "run_id": payload.get("run_id", ""),
+        "scenario": payload.get("scenario", ""),
+        "strategy": payload.get("content", ""),
+        "score": float(payload.get("best_score") or 0.0),
+        "context": {
+            "generation_index": payload.get("generation_index"),
+            "role": payload.get("role"),
+            "gate_decision": payload.get("gate_decision"),
+            "trace_record_id": trace.record_id,
+            "produced_by": trace.produced_by,
+        },
+    }

--- a/autocontext/src/autocontext/ambient/ingest.py
+++ b/autocontext/src/autocontext/ambient/ingest.py
@@ -54,6 +54,13 @@ class IngestStage:
                 errors += 1
                 ctx.emitter.emit("ingest_source_failed", {"source": source.name, "error": str(exc)}, channel="ambient")
         if self.trace_store.db_size_bytes() > self.disk_quota_gb * 1024**3:
+            # KNOWN v1 lose-data window: this prune deletes the oldest traces by
+            # age with no regard for per-target curate cursors, and curate's
+            # read_after silently skips ids it can no longer find, so under
+            # sustained backlog plus disk pressure an un-curated trace can be
+            # pruned before curate reaches it (lost, not duplicated). A later
+            # slice can floor the prune at the minimum manifest cursor across
+            # targets so nothing un-curated is ever deleted.
             deleted = self.trace_store.prune_oldest(_PRUNE_FRACTION)
             ctx.emitter.emit("trace_retention_pruned", {"deleted": deleted}, channel="ambient")
         ctx.emitter.emit("ingest_completed", {"appended": appended, "sources": len(self.sources)}, channel="ambient")

--- a/autocontext/src/autocontext/ambient/sources/agent_outputs.py
+++ b/autocontext/src/autocontext/ambient/sources/agent_outputs.py
@@ -47,12 +47,13 @@ class AgentOutputsSource:
                 (watermark, self.batch_size),
             ).fetchall()
         except sqlite3.OperationalError as exc:
-            # A runs database created before the agent_outputs table existed
-            # is a legitimate older layout, not an error: there is simply
-            # nothing for this source to read, so poll empty and never trip
-            # the ingest breaker. Any other operational failure (locked db,
-            # corruption) is real and must propagate.
-            if "no such table" in str(exc):
+            # A runs database without an agent_outputs table (hand-built
+            # fixtures, manually assembled dbs) is a legitimate layout, not an
+            # error: there is simply nothing for this source to read, so poll
+            # empty and never trip the ingest breaker. The match is pinned to
+            # this table: a db missing generations or runs is corruption and,
+            # like any other operational failure (locked db), must propagate.
+            if "no such table: agent_outputs" in str(exc):
                 return SourcePoll()
             raise
         finally:

--- a/autocontext/src/autocontext/ambient/sources/agent_outputs.py
+++ b/autocontext/src/autocontext/ambient/sources/agent_outputs.py
@@ -1,0 +1,78 @@
+"""agent-outputs source: incremental reader over a loop runs database's full output text."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from autocontext.ambient.sources.contract import TERMINAL_GENERATION_STATUSES, RawTrace, SourcePoll
+
+
+@dataclass(slots=True)
+class AgentOutputsSource:
+    """incremental reader over agent_outputs joined to its parent generation.
+
+    Watermarks on agent_outputs.id (AUTOINCREMENT, append-only). Output rows
+    are inserted while their parent generation is still "running" and only the
+    parent row's terminal UPDATE makes the labels final, so this source
+    consumes only the contiguous prefix whose parent generation is terminal:
+    it stops at the first row with an in-flight parent and re-reads it, with
+    final labels, on a later poll. Known v1 tradeoff (same as
+    NativeRunsSource): one crashed, forever-running generation holds the
+    cursor for every later row until the loop's idempotent rerun marks it
+    terminal.
+    """
+
+    name: str
+    runs_db_path: Path
+    kind: str = "autocontext-outputs"
+    batch_size: int = 500
+
+    def poll(self, cursor: str | None) -> SourcePoll:
+        if not self.runs_db_path.exists():
+            return SourcePoll()
+        watermark = int(cursor or 0)
+        # read-only open: least privilege for a pure reader, and it can
+        # never take a write lock against the live loop
+        conn = sqlite3.connect(f"{self.runs_db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                "SELECT ao.id, ao.run_id, r.scenario, ao.generation_index, ao.role, ao.content, "
+                "ao.created_at, g.status, g.mean_score, g.best_score, g.gate_decision "
+                "FROM agent_outputs ao "
+                "JOIN generations g ON g.run_id = ao.run_id AND g.generation_index = ao.generation_index "
+                "JOIN runs r ON r.run_id = ao.run_id "
+                "WHERE ao.id > ? ORDER BY ao.id LIMIT ?",
+                (watermark, self.batch_size),
+            ).fetchall()
+        finally:
+            conn.close()
+        if not rows:
+            return SourcePoll()
+        terminal_prefix = []
+        for row in rows:
+            if row[7] not in TERMINAL_GENERATION_STATUSES:
+                break
+            terminal_prefix.append(row)
+        if not terminal_prefix:
+            return SourcePoll()
+        records = [
+            RawTrace(
+                kind="agent_output",
+                payload={
+                    "run_id": row[1],
+                    "scenario": row[2],
+                    "generation_index": row[3],
+                    "role": row[4],
+                    "content": row[5],
+                    "created_at": row[6],
+                    "status": row[7],
+                    "mean_score": row[8],
+                    "best_score": row[9],
+                    "gate_decision": row[10],
+                },
+            )
+            for row in terminal_prefix
+        ]
+        return SourcePoll(records=records, next_cursor=str(terminal_prefix[-1][0]))

--- a/autocontext/src/autocontext/ambient/sources/agent_outputs.py
+++ b/autocontext/src/autocontext/ambient/sources/agent_outputs.py
@@ -46,6 +46,15 @@ class AgentOutputsSource:
                 "WHERE ao.id > ? ORDER BY ao.id LIMIT ?",
                 (watermark, self.batch_size),
             ).fetchall()
+        except sqlite3.OperationalError as exc:
+            # A runs database created before the agent_outputs table existed
+            # is a legitimate older layout, not an error: there is simply
+            # nothing for this source to read, so poll empty and never trip
+            # the ingest breaker. Any other operational failure (locked db,
+            # corruption) is real and must propagate.
+            if "no such table" in str(exc):
+                return SourcePoll()
+            raise
         finally:
             conn.close()
         if not rows:

--- a/autocontext/src/autocontext/ambient/sources/agent_outputs.py
+++ b/autocontext/src/autocontext/ambient/sources/agent_outputs.py
@@ -67,6 +67,10 @@ class AgentOutputsSource:
             terminal_prefix.append(row)
         if not terminal_prefix:
             return SourcePoll()
+        # produced_by is hardcoded "frontier" because v1 only ever reads a loop
+        # driven by a frontier model. Plan 4 must derive provenance from the
+        # run's lineage instead, once fine-tuned models serve the loop and their
+        # output must be quarantined from the next lineage's training set.
         records = [
             RawTrace(
                 kind="agent_output",

--- a/autocontext/src/autocontext/ambient/sources/contract.py
+++ b/autocontext/src/autocontext/ambient/sources/contract.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+# terminal generation states, shared by every reader of a loop runs database.
+# The loop upserts a "running" placeholder row at generation start
+# (loop/generation_runner.py:1173; also cli.py:298 and
+# knowledge/solve_task_execution.py:211) and completion is an in-place,
+# rowid-preserving UPDATE to "completed" (loop/stages.py:1101,
+# knowledge/package.py:268, cli.py:366, solve_task_execution.py:319) or
+# "failed" (loop/generation_runner.py:992/1272/1301, cli.py:316,
+# solve_task_execution.py:280). Only terminal rows carry final values.
+TERMINAL_GENERATION_STATUSES = frozenset({"completed", "failed"})
+
 
 @dataclass(slots=True)
 class RawTrace:

--- a/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
+++ b/autocontext/src/autocontext/ambient/sources/jsonl_feed.py
@@ -22,6 +22,13 @@ class JsonlFeedSource:
     the completed record is never lost. A terminated malformed or blank
     line is genuine garbage: it is skipped and the cursor advances past
     it (skipped again, never duplicated).
+
+    Provenance is default-closed: a line that omits produced_by (or gives a
+    non-string) is stamped f"external:{name}" rather than inheriting the
+    RawTrace "frontier" default, so an external feed cannot become
+    quarantine-exempt by omission. A line that explicitly declares its
+    provenance keeps it: enabling a feed is the operator's consent flag
+    (per the charter), so an explicit "frontier" declaration is on them.
     """
 
     name: str
@@ -65,11 +72,15 @@ class JsonlFeedSource:
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                declared = obj.get("produced_by")
+                # default-closed: an omitted or non-string provenance is stamped
+                # external so it cannot dodge the quarantine gate by omission
+                produced_by = declared if isinstance(declared, str) and declared else f"external:{self.name}"
                 records.append(
                     RawTrace(
                         kind=str(obj.get("kind", "trace")),
                         payload=obj,
-                        produced_by=str(obj.get("produced_by", "frontier")),
+                        produced_by=produced_by,
                     )
                 )
         if not records:

--- a/autocontext/src/autocontext/ambient/sources/native.py
+++ b/autocontext/src/autocontext/ambient/sources/native.py
@@ -6,16 +6,7 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
-from autocontext.ambient.sources.contract import RawTrace, SourcePoll
-
-# terminal generation states. The loop upserts a "running" placeholder row at
-# generation start (loop/generation_runner.py:1173; also cli.py:298 and
-# knowledge/solve_task_execution.py:211) and completion is an in-place,
-# rowid-preserving UPDATE that flips status to a terminal value: "completed"
-# (loop/stages.py:1101, knowledge/package.py:268, cli.py:366,
-# solve_task_execution.py:319) or "failed" (loop/generation_runner.py:992/1272/1301,
-# cli.py:316, solve_task_execution.py:280). Only terminal rows carry final scores.
-_TERMINAL_STATUSES = frozenset({"completed", "failed"})
+from autocontext.ambient.sources.contract import TERMINAL_GENERATION_STATUSES, RawTrace, SourcePoll
 
 
 @dataclass(slots=True)
@@ -65,7 +56,7 @@ class NativeRunsSource:
         # in-flight row blocks the watermark instead of being skipped
         terminal_prefix = []
         for row in rows:
-            if row[7] not in _TERMINAL_STATUSES:
+            if row[7] not in TERMINAL_GENERATION_STATUSES:
                 break
             terminal_prefix.append(row)
         if not terminal_prefix:

--- a/autocontext/src/autocontext/ambient/stage.py
+++ b/autocontext/src/autocontext/ambient/stage.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 from autocontext.ambient.charter import Charter
+from autocontext.ambient.proposals import ProposalStore
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.harness.core.events import EventStreamEmitter
 
@@ -23,6 +24,7 @@ class StageContext:
     charter: Charter
     queue: AmbientQueue
     emitter: EventStreamEmitter
+    proposal_store: ProposalStore | None = None
 
 
 class Stage(Protocol):

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -1,10 +1,13 @@
-"""builds the daemon's stage set from the charter (real ingest, no-op others for now)."""
+"""builds the daemon's stage set from the charter (ingest, curate, advise real; train/evaluate no-op)."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from autocontext.ambient.advise import AdviseStage
 from autocontext.ambient.charter import Charter
+from autocontext.ambient.curate import CurateStage
+from autocontext.ambient.datasets import DatasetStore
 from autocontext.ambient.ingest import IngestStage
 from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
 from autocontext.ambient.sources.contract import TraceSource
@@ -21,6 +24,7 @@ def build_stages(
     emitter: EventStreamEmitter,
     runs_db_path: Path,
     otel_feed_dir: Path,
+    datasets_dir: Path,
 ) -> dict[str, Stage]:
     sources: list[TraceSource] = []
     unsupported: list[tuple[str, str]] = []
@@ -36,12 +40,16 @@ def build_stages(
             sources.append(JsonlFeedSource(name=spec.name, feed_dir=otel_feed_dir))
         else:
             unsupported.append((spec.name, spec.kind))
+    trace_store = TraceStore(db_path)
+    dataset_store = DatasetStore(datasets_dir)
     stages: dict[str, Stage] = {name: NoOpStage(name=name) for name in STAGE_NAMES}
     stages["ingest"] = IngestStage(
         name="ingest",
-        trace_store=TraceStore(db_path),
+        trace_store=trace_store,
         sources=sources,
         disk_quota_gb=charter.budgets.disk_quota_gb,
         unsupported=unsupported,
     )
+    stages["curate"] = CurateStage(name="curate", trace_store=trace_store, dataset_store=dataset_store)
+    stages["advise"] = AdviseStage(name="advise", trace_store=trace_store)
     return stages

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from autocontext.ambient.charter import Charter
 from autocontext.ambient.ingest import IngestStage
+from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
 from autocontext.ambient.sources.contract import TraceSource
 from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
 from autocontext.ambient.sources.native import NativeRunsSource
@@ -28,6 +29,9 @@ def build_stages(
             continue
         if spec.kind == "autocontext":
             sources.append(NativeRunsSource(name=spec.name, runs_db_path=runs_db_path))
+            # full output text rides its own source so it passes the redaction
+            # gate at ingest; curate never reads the runs db directly
+            sources.append(AgentOutputsSource(name=spec.name, runs_db_path=runs_db_path))
         elif spec.kind == "otel":
             sources.append(JsonlFeedSource(name=spec.name, feed_dir=otel_feed_dir))
         else:

--- a/autocontext/src/autocontext/ambient/trace_store.py
+++ b/autocontext/src/autocontext/ambient/trace_store.py
@@ -23,6 +23,9 @@ CREATE TABLE IF NOT EXISTS ambient_source_cursors (
     source TEXT PRIMARY KEY,
     cursor TEXT NOT NULL
 );
+CREATE INDEX IF NOT EXISTS idx_ambient_traces_source ON ambient_traces(source);
+CREATE INDEX IF NOT EXISTS idx_ambient_traces_kind ON ambient_traces(kind);
+CREATE INDEX IF NOT EXISTS idx_ambient_traces_produced_by ON ambient_traces(produced_by);
 """
 
 
@@ -104,6 +107,38 @@ class TraceStore:
                 "SELECT record_id, source, kind, payload, produced_by, redaction_findings, created_at "
                 "FROM ambient_traces ORDER BY record_id DESC LIMIT ?",
                 (limit,),
+            ).fetchall()
+        return [TraceRecord(r[0], r[1], r[2], json.loads(r[3]), r[4], r[5], r[6]) for r in rows]
+
+    def read_after(
+        self,
+        after_record_id: int,
+        limit: int,
+        *,
+        source: str | None = None,
+        kind: str | None = None,
+        produced_by: str | None = None,
+    ) -> list[TraceRecord]:
+        """Forward pagination for curate/advise readers: ascending record_id,
+        strictly after the given watermark, with optional column filters.
+        """
+        clauses = ["record_id > ?"]
+        params: list[Any] = [after_record_id]
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+        if kind is not None:
+            clauses.append("kind = ?")
+            params.append(kind)
+        if produced_by is not None:
+            clauses.append("produced_by = ?")
+            params.append(produced_by)
+        params.append(limit)
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT record_id, source, kind, payload, produced_by, redaction_findings, created_at "
+                f"FROM ambient_traces WHERE {' AND '.join(clauses)} ORDER BY record_id ASC LIMIT ?",
+                params,
             ).fetchall()
         return [TraceRecord(r[0], r[1], r[2], json.loads(r[3]), r[4], r[5], r[6]) for r in rows]
 

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -12,7 +12,9 @@ from rich.table import Table
 
 from autocontext.ambient.charter_io import CharterLoadError, load_charter, save_charter
 from autocontext.ambient.daemon import AmbientDaemon
+from autocontext.ambient.datasets import DatasetStore
 from autocontext.ambient.interview import build_charter, run_interview
+from autocontext.ambient.proposals import ProposalStore
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.stage_factory import build_stages
 from autocontext.harness.core.events import EventStreamEmitter
@@ -25,6 +27,8 @@ _DEFAULT_DB = Path("runs/ambient.sqlite3")
 _DEFAULT_EVENTS = Path("runs/ambient-events.ndjson")
 _DEFAULT_RUNS_DB = Path("runs/autocontext.sqlite3")
 _DEFAULT_OTEL_FEED = Path("runs/ambient-otel-feed")
+_DEFAULT_DATASETS = Path("runs/ambient-datasets")
+_DEFAULT_PROPOSALS = Path("runs/ambient-proposals.jsonl")
 
 
 def _daemon(
@@ -33,6 +37,8 @@ def _daemon(
     events_path: Path,
     runs_db_path: Path,
     otel_feed_dir: Path,
+    datasets_dir: Path,
+    proposals_path: Path,
 ) -> AmbientDaemon:
     charter = load_charter(charter_path)
     emitter = EventStreamEmitter(events_path)
@@ -42,12 +48,14 @@ def _daemon(
         emitter=emitter,
         runs_db_path=runs_db_path,
         otel_feed_dir=otel_feed_dir,
+        datasets_dir=datasets_dir,
     )
     return AmbientDaemon(
         charter=charter,
         queue=AmbientQueue(db_path),
         emitter=emitter,
         stages=stages,
+        proposal_store=ProposalStore(proposals_path),
     )
 
 
@@ -76,9 +84,11 @@ def status(
     events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
     runs_db: Annotated[Path, typer.Option("--runs-db")] = _DEFAULT_RUNS_DB,
     otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
+    datasets_dir: Annotated[Path, typer.Option("--datasets-dir")] = _DEFAULT_DATASETS,
+    proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir)
+        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir, datasets_dir, proposals_path)
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -88,6 +98,13 @@ def status(
     for name, info in daemon.status().items():
         table.add_row(name, str(info["paused"]), str(info["queue_depth"]))
     console.print(table)
+    if charter.targets:
+        dataset_store = DatasetStore(datasets_dir)
+        targets_table = Table("target", "dataset records", "mean score")
+        for target in charter.targets:
+            manifest = dataset_store.load_manifest(target.name)
+            targets_table.add_row(target.name, str(manifest.record_count), f"{manifest.mean_score:.2f}")
+        console.print(targets_table)
 
 
 @ambient_app.command()
@@ -97,11 +114,13 @@ def run(
     events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
     runs_db: Annotated[Path, typer.Option("--runs-db")] = _DEFAULT_RUNS_DB,
     otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
+    datasets_dir: Annotated[Path, typer.Option("--datasets-dir")] = _DEFAULT_DATASETS,
+    proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
     poll_seconds: Annotated[float, typer.Option("--poll-seconds", min=0.0)] = 30.0,
     max_cycles: Annotated[int | None, typer.Option("--max-cycles", hidden=True)] = None,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir)
+        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir, datasets_dir, proposals_path)
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -120,9 +139,11 @@ def once(
     events_path: Annotated[Path, typer.Option("--events-path")] = _DEFAULT_EVENTS,
     runs_db: Annotated[Path, typer.Option("--runs-db")] = _DEFAULT_RUNS_DB,
     otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
+    datasets_dir: Annotated[Path, typer.Option("--datasets-dir")] = _DEFAULT_DATASETS,
+    proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir)
+        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir, datasets_dir, proposals_path)
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -191,6 +191,12 @@ def approve(
         # the proposal stays pending: nothing was applied, so nothing is marked
         console.print(f"[red]could not apply proposal: {exc}[/red]")
         raise typer.Exit(code=1) from exc
+    # save-then-mark crash window: if the process dies between saving the
+    # charter and marking the proposal applied, the charter change is durable
+    # but the proposal stays pending. This never loses data: the operator sees a
+    # still-pending proposal whose target the charter already carries and
+    # rejects the stale proposal by hand (re-approving is also safe, apply is
+    # idempotent on an already-present target).
     save_charter(updated, charter_path)
     store.mark(proposal_id, "applied")
     console.print(f"applied {proposal_id} to {charter_path}")

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -1,4 +1,4 @@
-"""cli for the ambient trainer daemon: init, status, run, once."""
+"""cli for the ambient trainer daemon: init, status, run, once, proposals, approve, reject."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from autocontext.ambient.charter_io import CharterLoadError, load_charter, save_
 from autocontext.ambient.daemon import AmbientDaemon
 from autocontext.ambient.datasets import DatasetStore
 from autocontext.ambient.interview import build_charter, run_interview
-from autocontext.ambient.proposals import ProposalStore
+from autocontext.ambient.proposals import ProposalError, ProposalStore, apply_proposal
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.stage_factory import build_stages
 from autocontext.harness.core.events import EventStreamEmitter
@@ -155,3 +155,57 @@ def once(
     console.print(f"processed={result.processed} errors={result.errors}")
     if result.errors > 0:
         raise typer.Exit(code=1)
+
+
+@ambient_app.command()
+def proposals(
+    charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
+    proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
+) -> None:
+    store = ProposalStore(proposals_path)
+    pending = store.pending()
+    if not pending:
+        console.print("no pending proposals")
+        return
+    table = Table("proposal id", "kind", "rationale")
+    for proposal in pending:
+        table.add_row(proposal.proposal_id, proposal.kind, proposal.rationale)
+    console.print(table)
+
+
+@ambient_app.command()
+def approve(
+    proposal_id: Annotated[str, typer.Argument()],
+    charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
+    proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
+) -> None:
+    store = ProposalStore(proposals_path)
+    match = next((p for p in store.pending() if p.proposal_id == proposal_id), None)
+    if match is None:
+        console.print(f"[red]no pending proposal with id {proposal_id}[/red]")
+        raise typer.Exit(code=1)
+    try:
+        charter = load_charter(charter_path)
+        updated = apply_proposal(charter, match)
+    except (CharterLoadError, ProposalError, ValidationError, ValueError) as exc:
+        # the proposal stays pending: nothing was applied, so nothing is marked
+        console.print(f"[red]could not apply proposal: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    save_charter(updated, charter_path)
+    store.mark(proposal_id, "applied")
+    console.print(f"applied {proposal_id} to {charter_path}")
+
+
+@ambient_app.command()
+def reject(
+    proposal_id: Annotated[str, typer.Argument()],
+    charter_path: Annotated[Path, typer.Option("--charter-path")] = _DEFAULT_CHARTER,
+    proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
+) -> None:
+    store = ProposalStore(proposals_path)
+    try:
+        store.mark(proposal_id, "rejected")
+    except ProposalError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    console.print(f"rejected {proposal_id}")

--- a/autocontext/tests/test_ambient_advise_stage.py
+++ b/autocontext/tests/test_ambient_advise_stage.py
@@ -150,6 +150,25 @@ def test_non_competitor_role_target_does_not_cover_scenarios(tmp_path: Path) -> 
     assert store.pending()[0].payload["selector"] == "lean_prover"
 
 
+def test_scoped_competitor_role_covers_only_its_scenario(tmp_path: Path) -> None:
+    # a competitor role bound to one scenario (competitor@othello) covers only
+    # othello: it must not suppress an otherwise-qualifying lean_prover
+    # proposal, and othello itself stays covered
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    _seed_scenario(traces, "othello", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    charter = _charter([_target(name="competitor-othello", selector="competitor@othello")])
+    result = stage.run_once(_ctx(tmp_path, charter, store))
+
+    assert result.processed == 1
+    pending = store.pending()
+    assert len(pending) == 1
+    assert pending[0].payload["selector"] == "lean_prover"
+
+
 def test_pending_proposal_is_not_duplicated(tmp_path: Path) -> None:
     traces = TraceStore(tmp_path / "traces.sqlite3")
     _seed_scenario(traces, "lean_prover", count=5, score=0.9)

--- a/autocontext/tests/test_ambient_advise_stage.py
+++ b/autocontext/tests/test_ambient_advise_stage.py
@@ -135,6 +135,21 @@ def test_generator_role_target_covers_all_scenarios(tmp_path: Path) -> None:
     assert stage.run_once(_ctx(tmp_path, _charter([_target()]), store)).processed == 0
 
 
+def test_non_competitor_role_target_does_not_cover_scenarios(tmp_path: Path) -> None:
+    # the advisor's signal is competitor-only, so a lone analyst role target
+    # must not permanently suppress an otherwise-qualifying scenario proposal
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    charter = _charter([_target(name="analyst-local", selector="analyst")])
+    result = stage.run_once(_ctx(tmp_path, charter, store))
+
+    assert result.processed == 1
+    assert store.pending()[0].payload["selector"] == "lean_prover"
+
+
 def test_pending_proposal_is_not_duplicated(tmp_path: Path) -> None:
     traces = TraceStore(tmp_path / "traces.sqlite3")
     _seed_scenario(traces, "lean_prover", count=5, score=0.9)

--- a/autocontext/tests/test_ambient_advise_stage.py
+++ b/autocontext/tests/test_ambient_advise_stage.py
@@ -1,0 +1,175 @@
+"""tests for the advise stage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.ambient.advise import AdviseStage
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.proposals import ProposalStore, apply_proposal
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage import StageContext
+from autocontext.ambient.trace_store import TraceStore
+from autocontext.harness.core.events import EventStreamEmitter
+
+
+def _target(name: str = "competitor-local", **overrides: Any) -> CharterTarget:
+    base: dict[str, Any] = {
+        "name": name,
+        "kind": "role",
+        "selector": "competitor",
+        "base_model": "qwen2.5-3b",
+        "min_dataset_records": 10,
+        "eval_suite": "anchor-v1",
+    }
+    base.update(overrides)
+    return CharterTarget(**base)
+
+
+def _charter(targets: list[CharterTarget]) -> Charter:
+    return Charter(
+        tier="oss",
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=targets,
+        budgets=CharterBudgets(gpu_hours_per_window=1.0, window_hours=24, disk_quota_gb=1.0),
+    )
+
+
+def _ctx(tmp_path: Path, charter: Charter, store: ProposalStore | None) -> StageContext:
+    return StageContext(
+        charter=charter,
+        queue=AmbientQueue(tmp_path / "queue.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        proposal_store=store,
+    )
+
+
+def _seed_scenario(traces: TraceStore, scenario: str, count: int, score: float) -> None:
+    for index in range(count):
+        traces.append(
+            "autocontext-outputs:native",
+            "agent_output",
+            {
+                "run_id": f"run_{scenario}",
+                "scenario": scenario,
+                "generation_index": index,
+                "role": "competitor",
+                "content": f"strategy {index}",
+                "status": "completed",
+                "mean_score": score,
+                "best_score": score,
+                "gate_decision": "advance",
+                "created_at": "t",
+            },
+            "frontier",
+            0,
+        )
+
+
+def test_uncovered_high_quality_scenario_yields_a_proposal(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    # template target is evaluative-free but role-kind targets count as
+    # coverage, so template from a task_family target here
+    template = _target(name="othello-target", kind="task_family", selector="othello")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([template]), store))
+
+    assert result.processed == 1
+    pending = store.pending()
+    assert len(pending) == 1
+    proposal = pending[0]
+    assert proposal.kind == "add_target"
+    assert proposal.payload["selector"] == "lean_prover"
+    assert proposal.payload["kind"] == "task_family"
+    assert proposal.payload["base_model"] == "qwen2.5-3b"
+    assert "lean_prover" in proposal.rationale
+    # the emitted payload must survive the plan-1 apply path end to end
+    updated = apply_proposal(_charter([template]), proposal)
+    assert any(t.selector == "lean_prover" for t in updated.targets)
+
+
+def test_below_volume_floor_yields_nothing(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=3, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target(kind="task_family", selector="othello")]), store))
+
+    assert result.processed == 0
+    assert store.pending() == []
+
+
+def test_low_mean_score_yields_nothing(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.2)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target(kind="task_family", selector="othello")]), store))
+
+    assert result.processed == 0
+
+
+def test_task_family_target_covers_its_scenario(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    covered = _charter([_target(name="prover", kind="task_family", selector="lean_prover")])
+    assert stage.run_once(_ctx(tmp_path, covered, store)).processed == 0
+
+
+def test_generator_role_target_covers_all_scenarios(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    assert stage.run_once(_ctx(tmp_path, _charter([_target()]), store)).processed == 0
+
+
+def test_pending_proposal_is_not_duplicated(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    charter = _charter([_target(name="othello-target", kind="task_family", selector="othello")])
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    first = stage.run_once(_ctx(tmp_path, charter, store))
+    second = stage.run_once(_ctx(tmp_path, charter, store))
+
+    assert first.processed == 1
+    assert second.processed == 0
+    assert len(store.pending()) == 1
+
+
+def test_no_template_target_emits_event_not_proposal(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([]), store))
+
+    assert result.processed == 0
+    assert store.pending() == []
+    events = [json.loads(line) for line in (tmp_path / "events.ndjson").read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert any(e["event"] == "advise_no_template" for e in events)
+
+
+def test_missing_proposal_store_is_a_quiet_skip(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([]), None))
+
+    assert result.processed == 0
+    assert result.errors == 0

--- a/autocontext/tests/test_ambient_advise_stage.py
+++ b/autocontext/tests/test_ambient_advise_stage.py
@@ -164,6 +164,29 @@ def test_no_template_target_emits_event_not_proposal(tmp_path: Path) -> None:
     assert any(e["event"] == "advise_no_template" for e in events)
 
 
+def test_pattern_invalid_scenario_is_skipped_not_raised(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    # "_probe" leads with an underscore, which violates the CharterTarget.name
+    # slug pattern; it must be skipped without tripping the stage breaker while
+    # a valid sibling scenario still yields its proposal
+    _seed_scenario(traces, "_probe", count=5, score=0.9)
+    _seed_scenario(traces, "lean_prover", count=5, score=0.9)
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    template = _target(name="othello-target", kind="task_family", selector="othello")
+    stage = AdviseStage(name="advise", trace_store=traces, min_traces=5)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([template]), store))
+
+    assert result.processed == 1
+    pending = store.pending()
+    assert len(pending) == 1
+    assert pending[0].payload["selector"] == "lean_prover"
+    events = [json.loads(line) for line in (tmp_path / "events.ndjson").read_text(encoding="utf-8").splitlines() if line.strip()]
+    invalid = [e for e in events if e["event"] == "advise_invalid_scenario"]
+    assert len(invalid) == 1
+    assert invalid[0]["payload"]["scenario"] == "_probe"
+
+
 def test_missing_proposal_store_is_a_quiet_skip(tmp_path: Path) -> None:
     traces = TraceStore(tmp_path / "traces.sqlite3")
     _seed_scenario(traces, "lean_prover", count=5, score=0.9)

--- a/autocontext/tests/test_ambient_agent_outputs_source.py
+++ b/autocontext/tests/test_ambient_agent_outputs_source.py
@@ -37,6 +37,27 @@ def _make_runs_db(path: Path) -> None:
     conn.close()
 
 
+def _make_runs_db_without_agent_outputs(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE runs (run_id TEXT PRIMARY KEY, scenario TEXT NOT NULL);
+        CREATE TABLE generations (
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            mean_score REAL NOT NULL,
+            best_score REAL NOT NULL,
+            gate_decision TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (run_id, generation_index)
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
 def _insert(path: Path, sql: str, params: tuple) -> None:
     conn = sqlite3.connect(path)
     conn.execute(sql, params)
@@ -69,6 +90,17 @@ def _add_output(path: Path, run_id: str, index: int, role: str, content: str) ->
 def test_missing_db_yields_empty_poll(tmp_path: Path) -> None:
     source = AgentOutputsSource(name="native", runs_db_path=tmp_path / "absent.sqlite3")
     poll = source.poll(None)
+    assert poll.records == []
+    assert poll.next_cursor is None
+
+
+def test_runs_db_without_agent_outputs_table_yields_empty_poll(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _make_runs_db_without_agent_outputs(db)
+    _add_generation(db, "run_a", 0, "completed")
+
+    poll = AgentOutputsSource(name="native", runs_db_path=db).poll(None)
+
     assert poll.records == []
     assert poll.next_cursor is None
 

--- a/autocontext/tests/test_ambient_agent_outputs_source.py
+++ b/autocontext/tests/test_ambient_agent_outputs_source.py
@@ -1,0 +1,135 @@
+"""tests for the agent-outputs native source."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
+
+
+def _make_runs_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE runs (run_id TEXT PRIMARY KEY, scenario TEXT NOT NULL);
+        CREATE TABLE generations (
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            mean_score REAL NOT NULL,
+            best_score REAL NOT NULL,
+            gate_decision TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (run_id, generation_index)
+        );
+        CREATE TABLE agent_outputs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert(path: Path, sql: str, params: tuple) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(sql, params)
+    conn.commit()
+    conn.close()
+
+
+def _add_generation(path: Path, run_id: str, index: int, status: str) -> None:
+    _insert(
+        path,
+        "INSERT OR IGNORE INTO runs (run_id, scenario) VALUES (?, ?)",
+        (run_id, "grid_ctf"),
+    )
+    _insert(
+        path,
+        "INSERT INTO generations (run_id, generation_index, mean_score, best_score, gate_decision, status) "
+        "VALUES (?, ?, 0.5, 0.9, 'advance', ?)",
+        (run_id, index, status),
+    )
+
+
+def _add_output(path: Path, run_id: str, index: int, role: str, content: str) -> None:
+    _insert(
+        path,
+        "INSERT INTO agent_outputs (run_id, generation_index, role, content) VALUES (?, ?, ?, ?)",
+        (run_id, index, role, content),
+    )
+
+
+def test_missing_db_yields_empty_poll(tmp_path: Path) -> None:
+    source = AgentOutputsSource(name="native", runs_db_path=tmp_path / "absent.sqlite3")
+    poll = source.poll(None)
+    assert poll.records == []
+    assert poll.next_cursor is None
+
+
+def test_emits_agent_output_traces_with_generation_labels(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _make_runs_db(db)
+    _add_generation(db, "run_a", 0, "completed")
+    _add_output(db, "run_a", 0, "competitor", "the strategy text")
+
+    poll = AgentOutputsSource(name="native", runs_db_path=db).poll(None)
+
+    assert len(poll.records) == 1
+    record = poll.records[0]
+    assert record.kind == "agent_output"
+    assert record.payload["run_id"] == "run_a"
+    assert record.payload["scenario"] == "grid_ctf"
+    assert record.payload["role"] == "competitor"
+    assert record.payload["content"] == "the strategy text"
+    assert record.payload["status"] == "completed"
+    assert record.payload["best_score"] == 0.9
+    assert record.payload["gate_decision"] == "advance"
+    assert poll.next_cursor == "1"
+
+
+def test_holds_at_first_output_of_a_running_generation(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _make_runs_db(db)
+    _add_generation(db, "run_a", 0, "completed")
+    _add_output(db, "run_a", 0, "competitor", "done text")
+    _add_generation(db, "run_a", 1, "running")
+    _add_output(db, "run_a", 1, "competitor", "in flight text")
+    _add_generation(db, "run_a", 2, "completed")
+    _add_output(db, "run_a", 2, "competitor", "later text")
+
+    source = AgentOutputsSource(name="native", runs_db_path=db)
+    poll = source.poll(None)
+
+    # only the contiguous terminal prefix: the running generation blocks
+    # everything at and after its first output row
+    assert [r.payload["content"] for r in poll.records] == ["done text"]
+    assert poll.next_cursor == "1"
+
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE generations SET status = 'completed' WHERE run_id = 'run_a' AND generation_index = 1")
+    conn.commit()
+    conn.close()
+
+    resumed = source.poll(poll.next_cursor)
+    assert [r.payload["content"] for r in resumed.records] == ["in flight text", "later text"]
+    assert resumed.next_cursor == "3"
+
+
+def test_cursor_advances_and_no_reread(tmp_path: Path) -> None:
+    db = tmp_path / "runs.sqlite3"
+    _make_runs_db(db)
+    _add_generation(db, "run_a", 0, "completed")
+    _add_output(db, "run_a", 0, "competitor", "text one")
+
+    source = AgentOutputsSource(name="native", runs_db_path=db)
+    first = source.poll(None)
+    assert first.next_cursor == "1"
+    second = source.poll(first.next_cursor)
+    assert second.records == []

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -96,6 +96,32 @@ def test_duplicate_target_names_rejected() -> None:
         _minimal_charter(targets=[target, target.model_copy()])
 
 
+@pytest.mark.parametrize("unsafe_name", ["../../etc/foo", "sub/evil"])
+def test_target_name_path_traversal_rejected(unsafe_name: str) -> None:
+    with pytest.raises(ValidationError):
+        CharterTarget(
+            name=unsafe_name,
+            kind="role",
+            selector="competitor@grid_ctf",
+            base_model="Qwen/Qwen2.5-3B-Instruct",
+            min_dataset_records=1,
+            eval_suite="s",
+        )
+
+
+@pytest.mark.parametrize("safe_name", ["grid_ctf-auto", "competitor-local"])
+def test_target_name_slug_accepted(safe_name: str) -> None:
+    target = CharterTarget(
+        name=safe_name,
+        kind="role",
+        selector="competitor@grid_ctf",
+        base_model="Qwen/Qwen2.5-3B-Instruct",
+        min_dataset_records=1,
+        eval_suite="s",
+    )
+    assert target.name == safe_name
+
+
 def test_unknown_charter_keys_rejected() -> None:
     with pytest.raises(ValidationError):
         _minimal_charter(autonmy="full")  # typo'd key must fail loudly

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from autocontext.ambient.datasets import DatasetStore
 from autocontext.cli import app
 
 runner = CliRunner()
@@ -190,3 +191,65 @@ def test_once_ingest_pulls_from_runs_db(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert "processed=1" in result.output
     assert TraceStore(db_path).count() == 1
+
+
+_FIXTURE_TARGET_NAME = "competitor-grid_ctf"
+
+
+def test_once_curate_runs_clean_on_empty_stores(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "once",
+            "curate",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(tmp_path / "ambient.sqlite3"),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+            "--runs-db",
+            str(tmp_path / "runs.sqlite3"),
+            "--otel-feed-dir",
+            str(tmp_path / "feed"),
+            "--datasets-dir",
+            str(tmp_path / "datasets"),
+            "--proposals-path",
+            str(tmp_path / "proposals.jsonl"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "processed=0" in result.output
+
+
+def test_status_shows_target_dataset_rows(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)  # the fixture charter contains at least one target
+    datasets = DatasetStore(tmp_path / "datasets")
+    manifest = datasets.load_manifest(_FIXTURE_TARGET_NAME)
+    datasets.save_manifest(manifest.model_copy(update={"record_count": 4, "mean_score": 0.75}))
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "status",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(tmp_path / "ambient.sqlite3"),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+            "--runs-db",
+            str(tmp_path / "runs.sqlite3"),
+            "--otel-feed-dir",
+            str(tmp_path / "feed"),
+            "--datasets-dir",
+            str(tmp_path / "datasets"),
+            "--proposals-path",
+            str(tmp_path / "proposals.jsonl"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert _FIXTURE_TARGET_NAME in result.output
+    assert "4" in result.output

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -4,8 +4,11 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from autocontext.ambient.charter_io import load_charter
 from autocontext.ambient.datasets import DatasetStore
+from autocontext.ambient.proposals import CharterProposal, ProposalStore
 from autocontext.cli import app
+from autocontext.cli_ambient import ambient_app
 
 runner = CliRunner()
 
@@ -253,3 +256,131 @@ def test_status_shows_target_dataset_rows(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert _FIXTURE_TARGET_NAME in result.output
     assert "4" in result.output
+
+
+def _pending_proposal(tmp_path: Path, proposal_id: str = "add-target-lean-1234") -> ProposalStore:
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    store.append(
+        CharterProposal(
+            proposal_id=proposal_id,
+            kind="add_target",
+            payload={
+                "name": "lean-auto",
+                "kind": "task_family",
+                "selector": "lean_prover",
+                "base_model": "qwen2.5-3b",
+                "method": "sft-distill",
+                "min_dataset_records": 10,
+                "eval_suite": "anchor-v1",
+            },
+            rationale="5 eligible frontier traces for scenario lean_prover at mean score 0.90",
+        )
+    )
+    return store
+
+
+def test_proposals_lists_pending(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    _pending_proposal(tmp_path)
+    result = runner.invoke(
+        ambient_app,
+        ["proposals", "--charter-path", str(charter_path), "--proposals-path", str(tmp_path / "proposals.jsonl")],
+    )
+    assert result.exit_code == 0
+    assert "add-target-lean-1234" in result.output
+
+
+def test_proposals_reports_when_empty(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        ambient_app,
+        ["proposals", "--charter-path", str(charter_path), "--proposals-path", str(tmp_path / "proposals.jsonl")],
+    )
+    assert result.exit_code == 0
+    assert "no pending proposals" in result.output
+
+
+def test_approve_applies_and_marks(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    store = _pending_proposal(tmp_path)
+    result = runner.invoke(
+        ambient_app,
+        [
+            "approve",
+            "add-target-lean-1234",
+            "--charter-path",
+            str(charter_path),
+            "--proposals-path",
+            str(tmp_path / "proposals.jsonl"),
+        ],
+    )
+    assert result.exit_code == 0
+    updated = load_charter(charter_path)
+    assert any(target.name == "lean-auto" for target in updated.targets)
+    assert store.pending() == []
+
+
+def test_approve_unknown_id_exits_one(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        ambient_app,
+        ["approve", "nope", "--charter-path", str(charter_path), "--proposals-path", str(tmp_path / "proposals.jsonl")],
+    )
+    assert result.exit_code == 1
+
+
+def test_approve_failure_leaves_proposal_pending(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    store = _pending_proposal(tmp_path)
+    # first approval consumes it; re-adding the same target must fail
+    runner.invoke(
+        ambient_app,
+        [
+            "approve",
+            "add-target-lean-1234",
+            "--charter-path",
+            str(charter_path),
+            "--proposals-path",
+            str(tmp_path / "proposals.jsonl"),
+        ],
+    )
+    store.append(
+        CharterProposal(
+            proposal_id="dup-1",
+            kind="add_target",
+            payload={
+                "name": "lean-auto",
+                "kind": "task_family",
+                "selector": "lean_prover",
+                "base_model": "qwen2.5-3b",
+                "method": "sft-distill",
+                "min_dataset_records": 10,
+                "eval_suite": "anchor-v1",
+            },
+            rationale="duplicate",
+        )
+    )
+    result = runner.invoke(
+        ambient_app,
+        ["approve", "dup-1", "--charter-path", str(charter_path), "--proposals-path", str(tmp_path / "proposals.jsonl")],
+    )
+    assert result.exit_code == 1
+    assert len(store.pending()) == 1  # dup-1 stays pending, nothing was marked
+
+
+def test_reject_marks_rejected(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    store = _pending_proposal(tmp_path)
+    result = runner.invoke(
+        ambient_app,
+        [
+            "reject",
+            "add-target-lean-1234",
+            "--charter-path",
+            str(charter_path),
+            "--proposals-path",
+            str(tmp_path / "proposals.jsonl"),
+        ],
+    )
+    assert result.exit_code == 0
+    assert store.pending() == []

--- a/autocontext/tests/test_ambient_curate_stage.py
+++ b/autocontext/tests/test_ambient_curate_stage.py
@@ -1,0 +1,178 @@
+"""tests for the curate stage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.curate import CurateStage
+from autocontext.ambient.datasets import DatasetStore
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage import StageContext
+from autocontext.ambient.trace_store import TraceStore
+from autocontext.harness.core.events import EventStreamEmitter
+
+
+def _charter(targets: list[CharterTarget]) -> Charter:
+    return Charter(
+        tier="oss",
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=targets,
+        budgets=CharterBudgets(gpu_hours_per_window=1.0, window_hours=24, disk_quota_gb=1.0),
+    )
+
+
+def _target(name: str = "competitor-local", **overrides: Any) -> CharterTarget:
+    base: dict[str, Any] = {
+        "name": name,
+        "kind": "role",
+        "selector": "competitor",
+        "base_model": "qwen2.5-3b",
+        "min_dataset_records": 10,
+        "eval_suite": "anchor-v1",
+    }
+    base.update(overrides)
+    return CharterTarget(**base)
+
+
+def _ctx(tmp_path: Path, charter: Charter) -> StageContext:
+    return StageContext(
+        charter=charter,
+        queue=AmbientQueue(tmp_path / "queue.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+
+
+def _output_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "run_id": "run_a",
+        "scenario": "grid_ctf",
+        "generation_index": 0,
+        "role": "competitor",
+        "content": "strategy text",
+        "status": "completed",
+        "mean_score": 0.5,
+        "best_score": 0.9,
+        "gate_decision": "advance",
+        "created_at": "t",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _events(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "events.ndjson"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_eligible_traces_land_in_the_target_dataset(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(), "frontier", 0)
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(role="analyst"), "frontier", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()])))
+
+    assert result.processed == 1
+    assert result.errors == 0
+    lines = datasets.dataset_path("competitor-local").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["strategy"] == "strategy text"
+    manifest = datasets.load_manifest("competitor-local")
+    assert manifest.record_count == 1
+    assert manifest.skipped_total == 1
+    assert manifest.last_record_id == 2  # the cursor passed the ineligible trace too
+
+
+def test_quarantined_provenance_counts_but_never_lands(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(), "finetune:lineage-1", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()])))
+
+    assert result.processed == 0
+    assert not datasets.dataset_path("competitor-local").exists()
+    manifest = datasets.load_manifest("competitor-local")
+    assert manifest.quarantined_total == 1
+    assert manifest.last_record_id == 1
+
+
+def test_second_run_consumes_nothing_new(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(), "frontier", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+    charter = _charter([_target()])
+
+    stage.run_once(_ctx(tmp_path, charter))
+    second = stage.run_once(_ctx(tmp_path, charter))
+
+    assert second.processed == 0
+    assert len(datasets.dataset_path("competitor-local").read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_two_targets_hold_independent_cursors(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(), "frontier", 0)
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(scenario="othello"), "frontier", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+    charter = _charter(
+        [
+            _target(),
+            _target(name="grid-only", kind="task_family", selector="grid_ctf"),
+        ]
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    # role target takes both outputs; task-family target takes only grid_ctf
+    assert result.processed == 3
+    assert datasets.load_manifest("competitor-local").record_count == 2
+    assert datasets.load_manifest("grid-only").record_count == 1
+    assert datasets.load_manifest("grid-only").skipped_total == 1
+
+
+def test_evaluative_target_is_skipped_with_event(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(role="curator"), "frontier", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target(name="curator-local", selector="curator")])))
+
+    assert result.processed == 0
+    assert not datasets.dataset_path("curator-local").exists()
+    events = _events(tmp_path)
+    assert any(e["event"] == "curate_target_skipped" and e["payload"]["reason"] == "evaluative_role" for e in events)
+
+
+def test_target_failure_is_isolated(tmp_path: Path, monkeypatch: Any) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(), "frontier", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+    charter = _charter([_target(name="boom"), _target(name="fine")])
+
+    original = datasets.load_manifest
+
+    def exploding(target: str) -> Any:
+        if target == "boom":
+            raise RuntimeError("manifest io failure")
+        return original(target)
+
+    monkeypatch.setattr(datasets, "load_manifest", exploding)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert result.errors == 1
+    assert result.processed == 1
+    events = _events(tmp_path)
+    assert any(e["event"] == "curate_target_failed" and e["payload"]["target"] == "boom" for e in events)

--- a/autocontext/tests/test_ambient_curate_stage.py
+++ b/autocontext/tests/test_ambient_curate_stage.py
@@ -140,6 +140,25 @@ def test_two_targets_hold_independent_cursors(tmp_path: Path) -> None:
     assert datasets.load_manifest("grid-only").skipped_total == 1
 
 
+def test_task_family_target_takes_only_competitor_traces(tmp_path: Path) -> None:
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(), "frontier", 0)
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(role="coach"), "frontier", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+    charter = _charter([_target(name="grid-only", kind="task_family", selector="grid_ctf")])
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    # only the competitor row is the generator signal; the coach row is skipped
+    assert result.processed == 1
+    lines = datasets.dataset_path("grid-only").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    manifest = datasets.load_manifest("grid-only")
+    assert manifest.record_count == 1
+    assert manifest.skipped_total == 1
+
+
 def test_evaluative_target_is_skipped_with_event(tmp_path: Path) -> None:
     traces = TraceStore(tmp_path / "traces.sqlite3")
     traces.append("autocontext-outputs:native", "agent_output", _output_payload(role="curator"), "frontier", 0)

--- a/autocontext/tests/test_ambient_curate_stage.py
+++ b/autocontext/tests/test_ambient_curate_stage.py
@@ -9,6 +9,7 @@ from typing import Any
 from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
 from autocontext.ambient.curate import CurateStage
 from autocontext.ambient.datasets import DatasetStore
+from autocontext.ambient.interview import InterviewAnswers, build_charter
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.stage import StageContext
 from autocontext.ambient.trace_store import TraceStore
@@ -87,6 +88,38 @@ def test_eligible_traces_land_in_the_target_dataset(tmp_path: Path) -> None:
     assert manifest.record_count == 1
     assert manifest.skipped_total == 1
     assert manifest.last_record_id == 2  # the cursor passed the ineligible trace too
+
+
+def test_default_interview_charter_curates_matching_traces(tmp_path: Path) -> None:
+    # regression for the role@scenario selector finding: the interview wizard's
+    # default first target binds "competitor@grid_ctf", and a matching frontier
+    # competitor grid_ctf trace must land in that target's dataset (the bare
+    # role comparison used to skip every trace and curate zero records).
+    answers = InterviewAnswers(
+        tier="oss",
+        autonomy="propose",
+        enable_otel=False,
+        enable_proxy=False,
+        first_target_role="competitor@grid_ctf",
+        base_model="qwen2.5-3b",
+        gpu_hours_per_window=1.0,
+        window_hours=24,
+        disk_quota_gb=1.0,
+    )
+    charter = build_charter(answers)
+    traces = TraceStore(tmp_path / "traces.sqlite3")
+    traces.append("autocontext-outputs:native", "agent_output", _output_payload(), "frontier", 0)
+    datasets = DatasetStore(tmp_path / "datasets")
+    stage = CurateStage(name="curate", trace_store=traces, dataset_store=datasets)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert result.processed == 1
+    assert result.errors == 0
+    lines = datasets.dataset_path("competitor-grid_ctf").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["strategy"] == "strategy text"
+    assert datasets.load_manifest("competitor-grid_ctf").record_count == 1
 
 
 def test_quarantined_provenance_counts_but_never_lands(tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_daemon.py
+++ b/autocontext/tests/test_ambient_daemon.py
@@ -7,6 +7,7 @@ import pytest
 
 from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
 from autocontext.ambient.daemon import AmbientDaemon
+from autocontext.ambient.proposals import ProposalStore
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.stage import STAGE_NAMES, StageContext, StageResult
 from autocontext.harness.core.events import EventStreamEmitter
@@ -174,3 +175,26 @@ def test_lock_releases_after_run_forever(tmp_path: Path) -> None:
     daemon = _daemon(tmp_path)
     daemon.run_forever(poll_seconds=0.0, max_cycles=1)
     daemon.run_forever(poll_seconds=0.0, max_cycles=1)  # second sequential run acquires cleanly
+
+
+def test_daemon_threads_proposal_store_into_stage_context(tmp_path: Path) -> None:
+    seen: list[object] = []
+
+    @dataclass(slots=True)
+    class Capture:
+        name: str = "advise"
+
+        def run_once(self, ctx: StageContext) -> StageResult:
+            seen.append(ctx.proposal_store)
+            return StageResult()
+
+    store = ProposalStore(tmp_path / "proposals.jsonl")
+    daemon = AmbientDaemon(
+        charter=_charter(),
+        queue=AmbientQueue(tmp_path / "ambient.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        stages={"advise": Capture()},
+        proposal_store=store,
+    )
+    daemon.run_stage_once("advise")
+    assert seen == [store]

--- a/autocontext/tests/test_ambient_datasets.py
+++ b/autocontext/tests/test_ambient_datasets.py
@@ -1,0 +1,64 @@
+"""tests for the per-target dataset store and manifest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.ambient.datasets import DatasetManifest, DatasetStore
+
+
+def test_load_manifest_defaults_when_missing(tmp_path: Path) -> None:
+    store = DatasetStore(tmp_path / "datasets")
+    manifest = store.load_manifest("prover")
+    assert manifest.target == "prover"
+    assert manifest.record_count == 0
+    assert manifest.last_record_id == 0
+
+
+def test_append_records_writes_jsonl_lines(tmp_path: Path) -> None:
+    store = DatasetStore(tmp_path / "datasets")
+    written = store.append_records("prover", [{"strategy": "a", "score": 1.0}, {"strategy": "b", "score": 0.5}])
+    assert written == 2
+
+    lines = store.dataset_path("prover").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["strategy"] for line in lines] == ["a", "b"]
+
+    more = store.append_records("prover", [{"strategy": "c", "score": 0.2}])
+    assert more == 1
+    assert len(store.dataset_path("prover").read_text(encoding="utf-8").splitlines()) == 3
+
+
+def test_manifest_round_trip_is_atomic(tmp_path: Path) -> None:
+    store = DatasetStore(tmp_path / "datasets")
+    manifest = DatasetManifest(target="prover", record_count=3, last_record_id=17, mean_score=0.5, updated_at="t")
+    store.save_manifest(manifest)
+
+    assert store.load_manifest("prover") == manifest
+    leftovers = [p for p in (tmp_path / "datasets").iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+def test_absorb_updates_incremental_mean_and_counters(tmp_path: Path) -> None:
+    store = DatasetStore(tmp_path / "datasets")
+    manifest = DatasetManifest(target="prover", record_count=2, mean_score=0.5)
+
+    updated = store.absorb(manifest, appended_scores=[1.0, 1.0], quarantined=1, skipped=2, last_record_id=42)
+
+    assert updated.record_count == 4
+    assert updated.mean_score == 0.75
+    assert updated.quarantined_total == 1
+    assert updated.skipped_total == 2
+    assert updated.last_record_id == 42
+    assert updated.updated_at != ""
+    # absorb returns a new object; the input is untouched
+    assert manifest.record_count == 2
+
+
+def test_absorb_with_no_new_scores_keeps_mean(tmp_path: Path) -> None:
+    store = DatasetStore(tmp_path / "datasets")
+    manifest = DatasetManifest(target="prover", record_count=2, mean_score=0.5)
+    updated = store.absorb(manifest, appended_scores=[], quarantined=0, skipped=1, last_record_id=9)
+    assert updated.mean_score == 0.5
+    assert updated.record_count == 2
+    assert updated.last_record_id == 9

--- a/autocontext/tests/test_ambient_eligibility.py
+++ b/autocontext/tests/test_ambient_eligibility.py
@@ -1,0 +1,104 @@
+"""tests for curate's eligibility guardrails."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.eligibility import (
+    EVALUATIVE_ROLES,
+    assess,
+    is_evaluative_target,
+    to_training_record,
+)
+from autocontext.ambient.trace_store import TraceRecord
+
+
+def _target(**overrides: Any) -> CharterTarget:
+    base: dict[str, Any] = {
+        "name": "competitor-local",
+        "kind": "role",
+        "selector": "competitor",
+        "base_model": "qwen2.5-3b",
+        "min_dataset_records": 10,
+        "eval_suite": "anchor-v1",
+    }
+    base.update(overrides)
+    return CharterTarget(**base)
+
+
+def _trace(**payload_overrides: Any) -> TraceRecord:
+    payload: dict[str, Any] = {
+        "run_id": "run_a",
+        "scenario": "grid_ctf",
+        "generation_index": 3,
+        "role": "competitor",
+        "content": "the strategy",
+        "status": "completed",
+        "mean_score": 0.5,
+        "best_score": 0.9,
+        "gate_decision": "advance",
+        "created_at": "t",
+    }
+    produced_by = payload_overrides.pop("produced_by", "frontier")
+    kind = payload_overrides.pop("kind", "agent_output")
+    payload.update(payload_overrides)
+    return TraceRecord(7, "autocontext-outputs:native", kind, payload, produced_by, 0, "t")
+
+
+def test_frontier_completed_matching_trace_is_eligible() -> None:
+    decision = assess(_trace(), _target())
+    assert decision.eligible is True
+    assert decision.reason == "ok"
+
+
+def test_finetune_provenance_is_quarantined() -> None:
+    decision = assess(_trace(produced_by="finetune:lineage-3"), _target())
+    assert decision.eligible is False
+    assert decision.reason == "quarantined_provenance"
+
+
+def test_non_output_kind_is_rejected() -> None:
+    decision = assess(_trace(kind="generation"), _target())
+    assert decision.reason == "wrong_kind"
+
+
+def test_failed_generation_is_rejected() -> None:
+    decision = assess(_trace(status="failed"), _target())
+    assert decision.reason == "not_completed"
+
+
+def test_role_selector_mismatch_is_rejected() -> None:
+    decision = assess(_trace(role="analyst"), _target())
+    assert decision.reason == "selector_mismatch"
+
+
+def test_task_family_selector_matches_scenario() -> None:
+    target = _target(kind="task_family", selector="grid_ctf")
+    assert assess(_trace(), target).eligible is True
+    assert assess(_trace(scenario="othello"), target).reason == "selector_mismatch"
+
+
+def test_empty_content_is_rejected() -> None:
+    decision = assess(_trace(content=""), _target())
+    assert decision.reason == "missing_content"
+
+
+def test_evaluative_role_targets_are_flagged() -> None:
+    assert EVALUATIVE_ROLES == frozenset({"judge", "curator", "coach"})
+    assert is_evaluative_target(_target(selector="curator")) is True
+    assert is_evaluative_target(_target(selector="competitor")) is False
+    # task-family targets are generator datasets regardless of name
+    assert is_evaluative_target(_target(kind="task_family", selector="curator")) is False
+
+
+def test_training_record_matches_autoresearch_schema() -> None:
+    record = to_training_record(_trace())
+    assert record["run_id"] == "run_a"
+    assert record["scenario"] == "grid_ctf"
+    assert record["strategy"] == "the strategy"
+    assert record["score"] == 0.9
+    assert record["context"]["role"] == "competitor"
+    assert record["context"]["gate_decision"] == "advance"
+    assert record["context"]["trace_record_id"] == 7
+    assert record["context"]["produced_by"] == "frontier"

--- a/autocontext/tests/test_ambient_eligibility.py
+++ b/autocontext/tests/test_ambient_eligibility.py
@@ -79,6 +79,36 @@ def test_task_family_selector_matches_scenario() -> None:
     assert assess(_trace(scenario="othello"), target).reason == "selector_mismatch"
 
 
+def test_task_family_non_competitor_role_is_rejected() -> None:
+    # a task-family dataset is a generator dataset: only competitor output is
+    # the generator signal, so a matching-scenario analyst trace is refused
+    target = _target(kind="task_family", selector="grid_ctf")
+    decision = assess(_trace(role="analyst"), target)
+    assert decision.eligible is False
+    assert decision.reason == "non_competitor_role"
+
+
+def test_task_family_coach_role_is_rejected() -> None:
+    # coach text would otherwise sidestep the evaluative-role refusal, which
+    # only guards kind="role" targets
+    target = _target(kind="task_family", selector="grid_ctf")
+    decision = assess(_trace(role="coach"), target)
+    assert decision.eligible is False
+    assert decision.reason == "non_competitor_role"
+
+
+def test_task_family_competitor_role_is_eligible() -> None:
+    target = _target(kind="task_family", selector="grid_ctf")
+    assert assess(_trace(role="competitor"), target).eligible is True
+
+
+def test_role_target_still_accepts_its_own_role() -> None:
+    # the competitor-only rule is task-family-scoped: a role-kind target keeps
+    # training on its own role's traces
+    target = _target(kind="role", selector="analyst")
+    assert assess(_trace(role="analyst"), target).eligible is True
+
+
 def test_empty_content_is_rejected() -> None:
     decision = assess(_trace(content=""), _target())
     assert decision.reason == "missing_content"

--- a/autocontext/tests/test_ambient_eligibility.py
+++ b/autocontext/tests/test_ambient_eligibility.py
@@ -109,6 +109,31 @@ def test_role_target_still_accepts_its_own_role() -> None:
     assert assess(_trace(role="analyst"), target).eligible is True
 
 
+def test_scoped_role_selector_accepts_matching_role_and_scenario() -> None:
+    target = _target(name="competitor-grid_ctf", selector="competitor@grid_ctf")
+    assert assess(_trace(), target).eligible is True
+
+
+def test_scoped_role_selector_rejects_wrong_scenario() -> None:
+    target = _target(name="competitor-grid_ctf", selector="competitor@grid_ctf")
+    decision = assess(_trace(scenario="othello"), target)
+    assert decision.eligible is False
+    assert decision.reason == "selector_mismatch"
+
+
+def test_scoped_role_selector_rejects_wrong_role() -> None:
+    target = _target(name="competitor-grid_ctf", selector="competitor@grid_ctf")
+    decision = assess(_trace(role="analyst"), target)
+    assert decision.eligible is False
+    assert decision.reason == "selector_mismatch"
+
+
+def test_scoped_evaluative_role_is_flagged() -> None:
+    # the role part decides: a curator@grid_ctf target is evaluative and must
+    # be refused just like a bare curator target
+    assert is_evaluative_target(_target(name="curator-grid_ctf", selector="curator@grid_ctf")) is True
+
+
 def test_empty_content_is_rejected() -> None:
     decision = assess(_trace(content=""), _target())
     assert decision.reason == "missing_content"

--- a/autocontext/tests/test_ambient_jsonl_feed_source.py
+++ b/autocontext/tests/test_ambient_jsonl_feed_source.py
@@ -74,6 +74,32 @@ def test_batch_size_and_missing_dir(tmp_path: Path) -> None:
     assert [r.payload["n"] for r in second.records] == [2, 3]
 
 
+def test_missing_produced_by_defaults_to_external(tmp_path: Path) -> None:
+    feed = tmp_path / "feed"
+    _write(feed, "a.jsonl", [{"n": 1}])
+    source = JsonlFeedSource(name="prod-otel", feed_dir=feed)
+    result = source.poll(None)
+    # default-closed: an omitted provenance is stamped external, never frontier
+    assert result.records[0].produced_by == "external:prod-otel"
+
+
+def test_explicit_frontier_produced_by_is_kept(tmp_path: Path) -> None:
+    feed = tmp_path / "feed"
+    _write(feed, "a.jsonl", [{"n": 1, "produced_by": "frontier"}])
+    source = JsonlFeedSource(name="prod-otel", feed_dir=feed)
+    result = source.poll(None)
+    # an explicit declaration is the operator's call (enabling the feed is consent)
+    assert result.records[0].produced_by == "frontier"
+
+
+def test_explicit_finetune_produced_by_is_kept(tmp_path: Path) -> None:
+    feed = tmp_path / "feed"
+    _write(feed, "a.jsonl", [{"n": 1, "produced_by": "finetune:x"}])
+    source = JsonlFeedSource(name="prod-otel", feed_dir=feed)
+    result = source.poll(None)
+    assert result.records[0].produced_by == "finetune:x"
+
+
 def test_zero_batch_size_rejected(tmp_path: Path) -> None:
     import pytest
 

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
 from autocontext.ambient.ingest import IngestStage
+from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
 from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
 from autocontext.ambient.sources.native import NativeRunsSource
 from autocontext.ambient.stage import STAGE_NAMES, NoOpStage
@@ -49,8 +50,8 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
     assert isinstance(ingest, IngestStage)
     assert ingest.disk_quota_gb == 7.0
     kinds = [type(source) for source in ingest.sources]
-    assert kinds == [NativeRunsSource, JsonlFeedSource]
-    assert [source.kind for source in ingest.sources] == ["autocontext", "otel"]
+    assert kinds == [NativeRunsSource, AgentOutputsSource, JsonlFeedSource]
+    assert [source.kind for source in ingest.sources] == ["autocontext", "autocontext-outputs", "otel"]
     assert all(isinstance(stages[name], NoOpStage) for name in ("curate", "advise", "train", "evaluate"))
 
 
@@ -69,7 +70,22 @@ def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
     )
     ingest = stages["ingest"]
     assert isinstance(ingest, IngestStage)
-    assert len(ingest.sources) == 1
+    # the one enabled autocontext source registers both readers; the full-box source is skipped
+    assert len(ingest.sources) == 2
     assert ingest.unsupported == [("box", "full-box")]
     # construction is event-silent; the announcement happens on first run
     assert not events_path.exists() or "ingest_source_unsupported" not in events_path.read_text(encoding="utf-8")
+
+
+def test_autocontext_source_registers_generation_and_output_readers(tmp_path: Path) -> None:
+    charter = _charter(sources=[CharterSource(name="native", kind="autocontext")])
+    stages = build_stages(
+        charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        runs_db_path=tmp_path / "runs.sqlite3",
+        otel_feed_dir=tmp_path / "feed",
+    )
+    ingest = stages["ingest"]
+    kinds = sorted(source.kind for source in ingest.sources)  # type: ignore[attr-defined]
+    assert kinds == ["autocontext", "autocontext-outputs"]

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from autocontext.ambient.advise import AdviseStage
 from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.curate import CurateStage
 from autocontext.ambient.ingest import IngestStage
 from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
 from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
@@ -44,6 +46,7 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
         emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
         runs_db_path=tmp_path / "runs.sqlite3",
         otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
     )
     assert set(stages.keys()) == set(STAGE_NAMES)
     ingest = stages["ingest"]
@@ -52,7 +55,9 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
     kinds = [type(source) for source in ingest.sources]
     assert kinds == [NativeRunsSource, AgentOutputsSource, JsonlFeedSource]
     assert [source.kind for source in ingest.sources] == ["autocontext", "autocontext-outputs", "otel"]
-    assert all(isinstance(stages[name], NoOpStage) for name in ("curate", "advise", "train", "evaluate"))
+    assert isinstance(stages["curate"], CurateStage)
+    assert isinstance(stages["advise"], AdviseStage)
+    assert all(isinstance(stages[name], NoOpStage) for name in ("train", "evaluate"))
 
 
 def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
@@ -67,6 +72,7 @@ def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
         emitter=EventStreamEmitter(events_path),
         runs_db_path=tmp_path / "runs.sqlite3",
         otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
     )
     ingest = stages["ingest"]
     assert isinstance(ingest, IngestStage)
@@ -85,7 +91,26 @@ def test_autocontext_source_registers_generation_and_output_readers(tmp_path: Pa
         emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
         runs_db_path=tmp_path / "runs.sqlite3",
         otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
     )
     ingest = stages["ingest"]
     kinds = sorted(source.kind for source in ingest.sources)  # type: ignore[attr-defined]
     assert kinds == ["autocontext", "autocontext-outputs"]
+
+
+def test_build_stages_wires_real_curate_and_advise(tmp_path: Path) -> None:
+    charter = _charter(sources=[CharterSource(name="native", kind="autocontext")])
+    stages = build_stages(
+        charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        runs_db_path=tmp_path / "runs.sqlite3",
+        otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
+    )
+    assert isinstance(stages["curate"], CurateStage)
+    assert isinstance(stages["advise"], AdviseStage)
+    # one shared trace store: ingest writes and curate/advise read the same db
+    assert stages["curate"].trace_store is stages["ingest"].trace_store  # type: ignore[attr-defined]
+    assert stages["advise"].trace_store is stages["ingest"].trace_store  # type: ignore[attr-defined]
+    assert stages["train"].__class__.__name__ == "NoOpStage"

--- a/autocontext/tests/test_ambient_trace_store.py
+++ b/autocontext/tests/test_ambient_trace_store.py
@@ -76,3 +76,46 @@ def test_prune_oldest_removes_oldest_fraction(tmp_path: Path) -> None:
     remaining = {record.record_id for record in store.recent(limit=100)}
     assert set(ids[3:]) == remaining
     assert store.db_size_bytes() > 0
+
+
+def test_read_after_returns_ascending_records_after_id(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "traces.sqlite3")
+    first = store.append("autocontext:native", "generation", {"n": 1}, "frontier", 0)
+    store.append("autocontext:native", "generation", {"n": 2}, "frontier", 0)
+    store.append("autocontext:native", "generation", {"n": 3}, "frontier", 0)
+
+    records = store.read_after(first, limit=10)
+
+    assert [r.payload["n"] for r in records] == [2, 3]
+    assert records[0].record_id < records[1].record_id
+
+
+def test_read_after_respects_limit(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "traces.sqlite3")
+    for n in range(5):
+        store.append("s", "generation", {"n": n}, "frontier", 0)
+
+    assert len(store.read_after(0, limit=2)) == 2
+
+
+def test_read_after_filters_by_kind_source_and_produced_by(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "traces.sqlite3")
+    store.append("autocontext:native", "generation", {"n": 1}, "frontier", 0)
+    store.append("autocontext-outputs:native", "agent_output", {"n": 2}, "frontier", 0)
+    store.append("autocontext-outputs:native", "agent_output", {"n": 3}, "finetune:lineage-1", 0)
+
+    by_kind = store.read_after(0, limit=10, kind="agent_output")
+    assert [r.payload["n"] for r in by_kind] == [2, 3]
+
+    by_source = store.read_after(0, limit=10, source="autocontext:native")
+    assert [r.payload["n"] for r in by_source] == [1]
+
+    by_producer = store.read_after(0, limit=10, kind="agent_output", produced_by="frontier")
+    assert [r.payload["n"] for r in by_producer] == [2]
+
+
+def test_read_after_empty_when_nothing_newer(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path / "traces.sqlite3")
+    last = store.append("s", "generation", {}, "frontier", 0)
+
+    assert store.read_after(last, limit=10) == []


### PR DESCRIPTION
Plan 3 of the ambient trainer roadmap (spec: docs/ambient-trainer-design.md). Builds on plan 1 (foundation, #1170) and plan 2 (ingest, #1171).

## What this adds

**Agent-output ingestion.** A second native reader, AgentOutputsSource, ingests full agent output text from the loop runs db (agent_outputs joined to its parent generation) through the redaction gate, using the same contiguous terminal-prefix watermark as the generation reader. Curate never reads the runs db directly, preserving the redaction-before-persistence invariant. The terminal-status constant is promoted to the source contract, and a runs db without an agent_outputs table yields an empty poll instead of tripping the ingest breaker.

**Curate stage.** Continuous per-target dataset construction: TraceStore.read_after (forward pagination with source/kind/produced_by filters plus indexes) feeds eligibility guardrails enforced mechanically per the spec: provenance quarantine (non-frontier records never enter a dataset), asymmetric trainability (evaluative-role targets are refused; task_family datasets accept competitor output only), and selector matching. Eligible traces become autoresearch-schema JSONL records (run_id, scenario, strategy, score, context), so plan 4's train stage feeds the existing pipeline unchanged. Each target has an atomically-replaced manifest whose last_record_id doubles as its cursor, making stats update and cursor advance one atomic file replace. Per-target failures are isolated.

**Advise stage.** Deliberately LLM-free heuristics: recent frontier competitor traces are aggregated by scenario, and an uncovered scenario clearing volume and mean-score floors yields one add_target CharterProposal (templated from the charter's first target) through the plan 1 ProposalStore. Coverage counts competitor role targets, task_family selectors, and pending proposals; pattern-invalid scenario names are skipped with an event rather than tripping the stage breaker. Advise only ever proposes; applying a diff is a control-surface action at every autonomy level.

**Control surface.** `autoctx ambient proposals | approve <id> | reject <id>` close the propose-autonomy loop: approve applies the diff through full charter re-validation, saves, then marks applied (any failure leaves the proposal pending). status gains per-target dataset rows; status/run/once gain --datasets-dir and --proposals-path.

**Hardening from reviews.** Charter target names are constrained to filesystem-safe slugs (they become dataset filenames); external jsonl feeds get default-closed provenance (omitted produced_by becomes external:<name>, quarantined by curate); the prune-vs-curate retention window is documented; advise proposal rationales use explicit None handling for scores.

## Scope notes

- The LLM proxy tap (tagged plan 3 in the spec's ingest section) is deferred to its own slice: it is a full gateway server and would have doubled this plan.
- Known v1 tradeoffs documented in code: a crashed forever-running generation holds the output watermark; disk-quota prune can drop un-curated traces under sustained backlog plus disk pressure; a crash between charter save and proposal mark leaves a stuck pending proposal (operator rejects manually).

## Verification

62 new ambient tests (158 total, 2 skipped) covering guardrail rejection reasons, cursor independence, crash-ordering contracts, proposal round-trips through apply_proposal, and CLI flows. Each task was implemented and reviewed by separate agents with fix rounds; a final whole-branch review traced one competitor output end to end from agent_outputs row to approved charter target and its required finding (task_family role gate) is fixed and re-verified. ruff and mypy strict clean; uv.lock untouched.