### PR TITLE
ambient trainer plan 4: train stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `autoctx ambient` foundation: a charter-driven resident daemon skeleton (interview wizard, autonomy dial with guardrail floors, durable stage queue, five stages with auto-pause breakers, status/run/once cli). Stages are no-ops pending the ingest, curation, and training plans (docs/ambient-trainer-design.md).
 - The ambient ingest stage is live: charter-enabled sources (autocontext-native runs, jsonl trace feeds) flow through the redaction gate into an append-only trace store with per-source cursors and disk-quota retention; the llm proxy tap follows in the next slice.
 - ambient trainer plan 3: curate and advise stages (agent-output ingestion, guarded per-target datasets, heuristic charter proposals, proposal approval cli)
+- ambient trainer plan 4: train stage with gpu-hours budget ledger, autonomy gating, and model-candidate publication
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/ambient/publish.py
+++ b/autocontext/src/autocontext/ambient/publish.py
@@ -1,0 +1,46 @@
+"""register a trained checkpoint as a non-activated registry candidate.
+
+The ambient train stage produces candidates only. Activation (promotion to a
+served model) is a separate gated decision in the evaluate/promote stage, so
+auto_activate stays False here. The training data lineage is stamped as
+produced_by=finetune:<target> so provenance quarantine can exclude this
+model's own future outputs from its next lineage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.training_backend import TrainOutcome
+from autocontext.training.model_registry import (
+    ModelRegistry,
+    TrainingCompletionOutput,
+    publish_training_output,
+)
+
+
+def publish_candidate(
+    *,
+    outcome: TrainOutcome,
+    target: CharterTarget,
+    scenario: str,
+    registry: ModelRegistry,
+    artifacts_root: Path,
+    run_id: str,
+) -> str:
+    completion = TrainingCompletionOutput(
+        run_id=run_id,
+        checkpoint_path=str(outcome.checkpoint_path),
+        backend=outcome.backend,
+        scenario=scenario,
+        scenario_family=scenario,
+        parameter_count=int(outcome.metrics.get("num_params_m", 0.0) * 1_000_000),
+        architecture=target.base_model,
+        training_metrics=outcome.metrics,
+        data_stats={"num_records": outcome.metrics.get("num_records", 0.0)},
+        runtime_types=["provider"],
+        metadata={"produced_by": f"finetune:{target.name}", "target": target.name, "gpu_hours": outcome.gpu_hours},
+    )
+    record = publish_training_output(completion, registry, artifacts_root=artifacts_root, auto_activate=False)
+    return record.artifact_id

--- a/autocontext/src/autocontext/ambient/publish.py
+++ b/autocontext/src/autocontext/ambient/publish.py
@@ -28,6 +28,7 @@ def publish_candidate(
     registry: ModelRegistry,
     artifacts_root: Path,
     run_id: str,
+    record_count: int,
 ) -> str:
     completion = TrainingCompletionOutput(
         run_id=run_id,
@@ -40,7 +41,17 @@ def publish_candidate(
         training_metrics=outcome.metrics,
         data_stats={"num_records": outcome.metrics.get("num_records", 0.0)},
         runtime_types=["provider"],
-        metadata={"produced_by": f"finetune:{target.name}", "target": target.name, "gpu_hours": outcome.gpu_hours},
+        # base_model is required by the adapter-serving path (scenario_bound_clients.plan_local_client):
+        # an mlxlm adapter record without it cannot be rebuilt into a client and is skipped as broken.
+        # record_count stamps the dataset size this candidate was trained on, so the train stage can
+        # detect an unchanged manifest and skip a redundant retrain of the same data.
+        metadata={
+            "produced_by": f"finetune:{target.name}",
+            "target": target.name,
+            "gpu_hours": outcome.gpu_hours,
+            "base_model": target.base_model,
+            "record_count": record_count,
+        },
     )
     record = publish_training_output(completion, registry, artifacts_root=artifacts_root, auto_activate=False)
     return record.artifact_id

--- a/autocontext/src/autocontext/ambient/queue.py
+++ b/autocontext/src/autocontext/ambient/queue.py
@@ -77,12 +77,24 @@ class AmbientQueue:
         with self._connect() as conn:
             conn.execute("UPDATE ambient_queue SET status = 'done' WHERE job_id = ?", (job_id,))
 
-    def fail(self, job_id: int, error: str) -> None:
+    def fail(self, job_id: int, error: str, *, max_attempts: int = 5) -> None:
+        # a job that has failed max_attempts times is a poison job: move it to
+        # 'dead' so it stops being reclaimed and looping forever. attempts is
+        # incremented first so the count reflects this failure.
         with self._connect() as conn:
             conn.execute(
-                "UPDATE ambient_queue SET status = 'pending', attempts = attempts + 1, last_error = ? WHERE job_id = ?",
+                "UPDATE ambient_queue SET attempts = attempts + 1, last_error = ? WHERE job_id = ?",
                 (error, job_id),
             )
+            conn.execute(
+                "UPDATE ambient_queue SET status = CASE WHEN attempts >= ? THEN 'dead' ELSE 'pending' END WHERE job_id = ?",
+                (max_attempts, job_id),
+            )
+
+    def dead_letter_count(self) -> int:
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) FROM ambient_queue WHERE status = 'dead'").fetchone()
+            return int(row[0])
 
     def depth(self, stage: str) -> int:
         with self._connect() as conn:

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -15,7 +15,10 @@ from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
 from autocontext.ambient.sources.native import NativeRunsSource
 from autocontext.ambient.stage import STAGE_NAMES, NoOpStage, Stage
 from autocontext.ambient.trace_store import TraceStore
+from autocontext.ambient.train import TrainStage
+from autocontext.ambient.usage import UsageLedger
 from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.training.model_registry import ModelRegistry
 
 
 def build_stages(
@@ -25,6 +28,10 @@ def build_stages(
     runs_db_path: Path,
     otel_feed_dir: Path,
     datasets_dir: Path,
+    registry_dir: Path,
+    usage_db: Path,
+    artifacts_dir: Path,
+    checkpoints_dir: Path,
 ) -> dict[str, Stage]:
     sources: list[TraceSource] = []
     unsupported: list[tuple[str, str]] = []
@@ -52,4 +59,12 @@ def build_stages(
     )
     stages["curate"] = CurateStage(name="curate", trace_store=trace_store, dataset_store=dataset_store)
     stages["advise"] = AdviseStage(name="advise", trace_store=trace_store)
+    stages["train"] = TrainStage(
+        name="train",
+        dataset_store=dataset_store,
+        usage_ledger=UsageLedger(usage_db),
+        registry=ModelRegistry(registry_dir),
+        artifacts_root=artifacts_dir,
+        checkpoints_root=checkpoints_dir,
+    )
     return stages

--- a/autocontext/src/autocontext/ambient/train.py
+++ b/autocontext/src/autocontext/ambient/train.py
@@ -32,6 +32,7 @@ class TrainStage:
     now_fn: Callable[[], str] = _default_now
     time_budget_seconds: int = 1800
     memory_limit_mb: int = 8192
+    assess_overhead_seconds: int = 1800
 
     def run_once(self, ctx: StageContext) -> StageResult:
         processed = 0
@@ -48,6 +49,16 @@ class TrainStage:
         manifest = self.dataset_store.load_manifest(target.name)
         if manifest.record_count < target.min_dataset_records:
             return 0  # not enough data yet: quiet skip
+        if self._already_trained(target.name, manifest.record_count):
+            # the dataset has not grown since the last candidate for this target: retraining the
+            # same data would recompute an identical (idempotent) registry record while charging gpu
+            # hours again. skip before any budget event or training so the no-op cycle costs nothing.
+            ctx.emitter.emit(
+                "train_up_to_date",
+                {"target": target.name, "record_count": manifest.record_count},
+                channel="ambient",
+            )
+            return 0
         decision = decide(ctx.charter, "train", target.name)
         if decision.requires_approval:
             ctx.emitter.emit("train_requires_approval", {"target": target.name, "reason": decision.reason}, channel="ambient")
@@ -59,11 +70,13 @@ class TrainStage:
             # cannot train at all should not spend a budget event to discover that
             ctx.emitter.emit("train_no_backend", {"target": target.name, "method": target.method}, channel="ambient")
             return 0
-        # pre-flight budget: the time budget IS the gpu-hours ceiling because run_training's
-        # timeout caps wall-clock at time_budget_seconds, so the job cannot consume more. gate
-        # on the estimate BEFORE training so a breaching job never spends the hours; the record
-        # step below then charges the ACTUAL hours consumed, which is <= this ceiling.
-        requested_gpu_hours = self.time_budget_seconds / 3600.0
+        # pre-flight budget: gate on the estimate BEFORE training so a breaching job never spends
+        # the hours; the record step below then charges the ACTUAL hours consumed. the mlxlm
+        # timeout bounds only the training subprocess, so adapter load + assessment run afterward
+        # in-process and are counted in training_seconds too; we reserve a conservative envelope
+        # covering them. a hard whole-run deadline is the complete fix and lands with the plan-5
+        # backend work.
+        requested_gpu_hours = (self.time_budget_seconds + self.assess_overhead_seconds) / 3600.0
         used = self.usage_ledger.used_in_window(target.name, ctx.charter.budgets.window_hours, self.now_fn())
         if not budget_allows(ctx.charter.budgets, used, requested_gpu_hours):
             ctx.emitter.emit(
@@ -81,7 +94,9 @@ class TrainStage:
         request = TrainRequest(
             scenario=scenario,
             data_path=self.dataset_store.dataset_path(target.name),
-            output_dir=self.checkpoints_root / target.name,
+            # per-record_count checkpoint dir: artifact identity varies with dataset size, so a
+            # later (larger) count must not overwrite an earlier count's on-disk adapter.
+            output_dir=self.checkpoints_root / target.name / str(manifest.record_count),
             base_model=target.base_model,
             time_budget_seconds=self.time_budget_seconds,
             memory_limit_mb=self.memory_limit_mb,
@@ -99,6 +114,7 @@ class TrainStage:
             registry=self.registry,
             artifacts_root=self.artifacts_root,
             run_id=run_id,
+            record_count=manifest.record_count,
         )
         ctx.emitter.emit(
             "train_candidate_published",
@@ -106,6 +122,14 @@ class TrainStage:
             channel="ambient",
         )
         return 1
+
+    def _already_trained(self, target_name: str, record_count: int) -> bool:
+        # a candidate already exists for this (target, record_count): the dataset is unchanged
+        # since it was trained, so another run would be a redundant recompute.
+        return any(
+            record.metadata.get("target") == target_name and record.metadata.get("record_count") == record_count
+            for record in self.registry.list_all()
+        )
 
     def _scenario_for(self, target: CharterTarget) -> str:
         # a task_family selector IS a scenario; a role selector's scenario part

--- a/autocontext/src/autocontext/ambient/train.py
+++ b/autocontext/src/autocontext/ambient/train.py
@@ -1,0 +1,108 @@
+"""the train stage: turn eligible target datasets into registry candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.datasets import DatasetStore
+from autocontext.ambient.policy import budget_allows, decide
+from autocontext.ambient.publish import publish_candidate
+from autocontext.ambient.stage import StageContext, StageResult
+from autocontext.ambient.training_backend import TrainRequest, run_training, select_backend
+from autocontext.ambient.usage import UsageLedger
+from autocontext.training.model_registry import ModelRegistry
+
+
+def _default_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(slots=True)
+class TrainStage:
+    name: str
+    dataset_store: DatasetStore
+    usage_ledger: UsageLedger
+    registry: ModelRegistry
+    artifacts_root: Path
+    checkpoints_root: Path
+    now_fn: Callable[[], str] = _default_now
+    time_budget_seconds: int = 1800
+    memory_limit_mb: int = 8192
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        processed = 0
+        errors = 0
+        for target in ctx.charter.targets:
+            try:
+                processed += self._train_target(ctx, target)
+            except Exception as exc:
+                errors += 1
+                ctx.emitter.emit("train_target_failed", {"target": target.name, "error": str(exc)}, channel="ambient")
+        return StageResult(processed=processed, errors=errors)
+
+    def _train_target(self, ctx: StageContext, target: CharterTarget) -> int:
+        manifest = self.dataset_store.load_manifest(target.name)
+        if manifest.record_count < target.min_dataset_records:
+            return 0  # not enough data yet: quiet skip
+        decision = decide(ctx.charter, "train", target.name)
+        if decision.requires_approval:
+            ctx.emitter.emit("train_requires_approval", {"target": target.name, "reason": decision.reason}, channel="ambient")
+            return 0
+        backend = select_backend(target.method)
+        if backend is None:
+            # no installed backend supports this method (a frontier-only ci box):
+            # report and skip, never an error, so the stage breaker does not trip
+            ctx.emitter.emit("train_no_backend", {"target": target.name, "method": target.method}, channel="ambient")
+            return 0
+        scenario = self._scenario_for(target)
+        request = TrainRequest(
+            scenario=scenario,
+            data_path=self.dataset_store.dataset_path(target.name),
+            output_dir=self.checkpoints_root / target.name,
+            base_model=target.base_model,
+            time_budget_seconds=self.time_budget_seconds,
+            memory_limit_mb=self.memory_limit_mb,
+        )
+        outcome = run_training(backend, request)
+        # the actual gpu_hours are only known once the backend returns; charge the window
+        # against the real cost, and if that would breach the budget do not record or publish
+        used = self.usage_ledger.used_in_window(target.name, ctx.charter.budgets.window_hours, self.now_fn())
+        if not budget_allows(ctx.charter.budgets, used, outcome.gpu_hours):
+            ctx.emitter.emit(
+                "train_budget_exhausted",
+                {"target": target.name, "used_gpu_hours": used, "window_hours": ctx.charter.budgets.window_hours},
+                channel="ambient",
+            )
+            return 0
+        self.usage_ledger.record(target.name, outcome.gpu_hours, self.now_fn())
+        # run_id=ambient-<target>-<record_count> dedupes bare retries: a re-run at the same
+        # record_count with different metrics returns the existing candidate and discards the
+        # new metrics (inherited publish_training_output idempotency).
+        run_id = f"ambient-{target.name}-{manifest.record_count}"
+        artifact_id = publish_candidate(
+            outcome=outcome,
+            target=target,
+            scenario=scenario,
+            registry=self.registry,
+            artifacts_root=self.artifacts_root,
+            run_id=run_id,
+        )
+        ctx.emitter.emit(
+            "train_candidate_published",
+            {"target": target.name, "artifact_id": artifact_id, "gpu_hours": outcome.gpu_hours},
+            channel="ambient",
+        )
+        return 1
+
+    def _scenario_for(self, target: CharterTarget) -> str:
+        # a task_family selector IS a scenario; a role selector's scenario part
+        # (role@scenario) names it, else the role trains across scenarios and we
+        # label the run by the role's selector head
+        if target.kind == "task_family":
+            return target.selector
+        role, _, scenario = target.selector.partition("@")
+        return scenario or role

--- a/autocontext/src/autocontext/ambient/train.py
+++ b/autocontext/src/autocontext/ambient/train.py
@@ -55,8 +55,27 @@ class TrainStage:
         backend = select_backend(target.method)
         if backend is None:
             # no installed backend supports this method (a frontier-only ci box):
-            # report and skip, never an error, so the stage breaker does not trip
+            # report and skip, never an error, so the stage breaker does not trip; a box that
+            # cannot train at all should not spend a budget event to discover that
             ctx.emitter.emit("train_no_backend", {"target": target.name, "method": target.method}, channel="ambient")
+            return 0
+        # pre-flight budget: the time budget IS the gpu-hours ceiling because run_training's
+        # timeout caps wall-clock at time_budget_seconds, so the job cannot consume more. gate
+        # on the estimate BEFORE training so a breaching job never spends the hours; the record
+        # step below then charges the ACTUAL hours consumed, which is <= this ceiling.
+        requested_gpu_hours = self.time_budget_seconds / 3600.0
+        used = self.usage_ledger.used_in_window(target.name, ctx.charter.budgets.window_hours, self.now_fn())
+        if not budget_allows(ctx.charter.budgets, used, requested_gpu_hours):
+            ctx.emitter.emit(
+                "train_budget_exhausted",
+                {
+                    "target": target.name,
+                    "used_gpu_hours": used,
+                    "requested_gpu_hours": requested_gpu_hours,
+                    "window_hours": ctx.charter.budgets.window_hours,
+                },
+                channel="ambient",
+            )
             return 0
         scenario = self._scenario_for(target)
         request = TrainRequest(
@@ -68,16 +87,6 @@ class TrainStage:
             memory_limit_mb=self.memory_limit_mb,
         )
         outcome = run_training(backend, request)
-        # the actual gpu_hours are only known once the backend returns; charge the window
-        # against the real cost, and if that would breach the budget do not record or publish
-        used = self.usage_ledger.used_in_window(target.name, ctx.charter.budgets.window_hours, self.now_fn())
-        if not budget_allows(ctx.charter.budgets, used, outcome.gpu_hours):
-            ctx.emitter.emit(
-                "train_budget_exhausted",
-                {"target": target.name, "used_gpu_hours": used, "window_hours": ctx.charter.budgets.window_hours},
-                channel="ambient",
-            )
-            return 0
         self.usage_ledger.record(target.name, outcome.gpu_hours, self.now_fn())
         # run_id=ambient-<target>-<record_count> dedupes bare retries: a re-run at the same
         # record_count with different metrics returns the existing candidate and discards the

--- a/autocontext/src/autocontext/ambient/training_backend.py
+++ b/autocontext/src/autocontext/ambient/training_backend.py
@@ -1,0 +1,75 @@
+"""the training-backend seam: availability selection and run indirection.
+
+The ambient train stage talks only to this module, never to the heavy mlx or
+trl backends directly, so a cpu-only ci monkeypatches _availability and
+_BACKEND_FNS to exercise the whole stage without a real fine-tune. gpu_hours
+is derived from the wall-clock training_seconds the backend reports, which is
+what the usage ledger and budget floor consume.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from autocontext.training.autoresearch.mlxlm_backend import run_mlxlm_training
+from autocontext.training.autoresearch.trl_backend import run_trl_training
+from autocontext.training.backends import default_backend_registry
+
+# preference order per charter method; first available wins
+_METHOD_BACKENDS: dict[str, tuple[str, ...]] = {"sft-distill": ("mlxlm", "trl")}
+_BACKEND_FNS: dict[str, Callable[..., dict[str, float]]] = {
+    "mlxlm": run_mlxlm_training,
+    "trl": run_trl_training,
+}
+
+
+@dataclass(slots=True)
+class TrainRequest:
+    scenario: str
+    data_path: Path
+    output_dir: Path
+    base_model: str
+    time_budget_seconds: int
+    memory_limit_mb: int
+
+
+@dataclass(slots=True)
+class TrainOutcome:
+    checkpoint_path: Path
+    backend: str
+    metrics: dict[str, float]
+    gpu_hours: float
+
+
+def _availability() -> dict[str, bool]:
+    registry = default_backend_registry()
+    out: dict[str, bool] = {}
+    for name in _BACKEND_FNS:
+        backend = registry.get(name)
+        out[name] = bool(backend and backend.is_available())
+    return out
+
+
+def select_backend(method: str) -> str | None:
+    available = _availability()
+    for name in _METHOD_BACKENDS.get(method, ()):  # unknown method -> no backend
+        if available.get(name):
+            return name
+    return None
+
+
+def run_training(backend_name: str, request: TrainRequest) -> TrainOutcome:
+    fn = _BACKEND_FNS[backend_name]
+    metrics = fn(
+        scenario_name=request.scenario,
+        data_path=request.data_path,
+        output_dir=request.output_dir,
+        time_budget=request.time_budget_seconds,
+        memory_limit_mb=request.memory_limit_mb,
+        base_model=request.base_model,
+    )
+    gpu_hours = float(metrics.get("training_seconds", 0.0)) / 3600.0
+    checkpoint = request.output_dir / "adapters"
+    return TrainOutcome(checkpoint_path=checkpoint, backend=backend_name, metrics=metrics, gpu_hours=gpu_hours)

--- a/autocontext/src/autocontext/ambient/training_backend.py
+++ b/autocontext/src/autocontext/ambient/training_backend.py
@@ -78,6 +78,9 @@ def run_training(backend_name: str, request: TrainRequest) -> TrainOutcome:
         time_budget=request.time_budget_seconds,
         memory_limit_mb=request.memory_limit_mb,
         base_model=request.base_model,
+        # dedupe is enabled so the curate crash-window duplicate rows are removed at
+        # train time, honoring the mitigation curate.py documents.
+        dedupe=True,
     )
     gpu_hours = float(metrics.get("training_seconds", 0.0)) / 3600.0
     checkpoint = request.output_dir / "adapters"

--- a/autocontext/src/autocontext/ambient/training_backend.py
+++ b/autocontext/src/autocontext/ambient/training_backend.py
@@ -1,7 +1,18 @@
 """the training-backend seam: availability selection and run indirection.
 
-The ambient train stage talks only to this module, never to the heavy mlx or
-trl backends directly, so a cpu-only ci monkeypatches _availability and
+mlxlm is the only backend wired here, and it is the only one that trains a
+LoRA-SFT adapter over the curated data_path file the ambient curate stage
+writes. It requires Darwin plus the mlx runtime, so on a box without them
+select_backend returns None and the train stage cleanly no-ops (no error). A
+Linux or CUDA SFT-over-dataset backend is future work: until it lands, ambient
+training only produces candidates on an mlx-capable box.
+
+(The trl backend is deliberately not wired: it does on-policy
+distillation/RLVR, generating its own prompts from the live scenario, so it
+cannot consume a curated per-target dataset file.)
+
+The ambient train stage talks only to this module, never to the heavy mlx
+backend directly, so a cpu-only ci monkeypatches _availability and
 _BACKEND_FNS to exercise the whole stage without a real fine-tune. gpu_hours
 is derived from the wall-clock training_seconds the backend reports, which is
 what the usage ledger and budget floor consume.
@@ -14,14 +25,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from autocontext.training.autoresearch.mlxlm_backend import run_mlxlm_training
-from autocontext.training.autoresearch.trl_backend import run_trl_training
 from autocontext.training.backends import default_backend_registry
 
 # preference order per charter method; first available wins
-_METHOD_BACKENDS: dict[str, tuple[str, ...]] = {"sft-distill": ("mlxlm", "trl")}
+_METHOD_BACKENDS: dict[str, tuple[str, ...]] = {"sft-distill": ("mlxlm",)}
 _BACKEND_FNS: dict[str, Callable[..., dict[str, float]]] = {
     "mlxlm": run_mlxlm_training,
-    "trl": run_trl_training,
 }
 
 

--- a/autocontext/src/autocontext/ambient/usage.py
+++ b/autocontext/src/autocontext/ambient/usage.py
@@ -1,0 +1,62 @@
+"""windowed gpu-hours usage ledger: makes the charter's budget floor enforceable.
+
+Timestamps are supplied by the caller as ISO-8601 strings so the ledger is
+deterministic and clock-free in tests. The train stage records the hours a
+job actually consumed and reads used_in_window before the next job.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ambient_usage (
+    usage_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target TEXT NOT NULL,
+    gpu_hours REAL NOT NULL,
+    at_iso TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ambient_usage_target ON ambient_usage(target);
+"""
+
+
+class UsageLedger:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def record(self, target: str, gpu_hours: float, at_iso: str) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT INTO ambient_usage (target, gpu_hours, at_iso) VALUES (?, ?, ?)",
+                (target, gpu_hours, at_iso),
+            )
+            return int(cursor.lastrowid or 0)
+
+    def used_in_window(self, target: str, window_hours: int, now_iso: str) -> float:
+        cutoff = (datetime.fromisoformat(now_iso) - timedelta(hours=window_hours)).isoformat()
+        with self._connect() as conn:
+            # at_iso > cutoff is lexicographic; correct only because the ambient daemon
+            # always stamps UTC (datetime.now(UTC).isoformat()), so every timestamp shares
+            # the same +00:00 offset and string order equals chronological order.
+            # strict > cutoff: a record exactly window_hours old has aged out
+            row = conn.execute(
+                "SELECT COALESCE(SUM(gpu_hours), 0.0) FROM ambient_usage WHERE target = ? AND at_iso > ?",
+                (target, cutoff),
+            ).fetchone()
+            return float(row[0])
+
+    def total(self, target: str) -> float:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(gpu_hours), 0.0) FROM ambient_usage WHERE target = ?",
+                (target,),
+            ).fetchone()
+            return float(row[0])

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -18,6 +18,7 @@ from autocontext.ambient.proposals import ProposalError, ProposalStore, apply_pr
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.stage_factory import build_stages
 from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.training.model_registry import ModelRegistry
 
 ambient_app = typer.Typer(help="ambient trainer: resident daemon that learns from traces")
 console = Console()
@@ -127,8 +128,6 @@ def status(
         table.add_row(name, str(info["paused"]), str(info["queue_depth"]))
     console.print(table)
     # read-only: construct the registry and count candidates, never train or write events
-    from autocontext.training.model_registry import ModelRegistry
-
     candidates = len(ModelRegistry(registry_dir).list_all())
     console.print(f"candidates={candidates}")
     if charter.targets:

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -29,6 +29,10 @@ _DEFAULT_RUNS_DB = Path("runs/autocontext.sqlite3")
 _DEFAULT_OTEL_FEED = Path("runs/ambient-otel-feed")
 _DEFAULT_DATASETS = Path("runs/ambient-datasets")
 _DEFAULT_PROPOSALS = Path("runs/ambient-proposals.jsonl")
+_DEFAULT_REGISTRY = Path("runs/ambient-registry")
+_DEFAULT_USAGE = Path("runs/ambient-usage.sqlite3")
+_DEFAULT_ARTIFACTS = Path("runs/ambient-artifacts")
+_DEFAULT_CHECKPOINTS = Path("runs/ambient-checkpoints")
 
 
 def _daemon(
@@ -39,6 +43,10 @@ def _daemon(
     otel_feed_dir: Path,
     datasets_dir: Path,
     proposals_path: Path,
+    registry_dir: Path,
+    usage_db: Path,
+    artifacts_dir: Path,
+    checkpoints_dir: Path,
 ) -> AmbientDaemon:
     charter = load_charter(charter_path)
     emitter = EventStreamEmitter(events_path)
@@ -49,6 +57,10 @@ def _daemon(
         runs_db_path=runs_db_path,
         otel_feed_dir=otel_feed_dir,
         datasets_dir=datasets_dir,
+        registry_dir=registry_dir,
+        usage_db=usage_db,
+        artifacts_dir=artifacts_dir,
+        checkpoints_dir=checkpoints_dir,
     )
     return AmbientDaemon(
         charter=charter,
@@ -86,9 +98,25 @@ def status(
     otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
     datasets_dir: Annotated[Path, typer.Option("--datasets-dir")] = _DEFAULT_DATASETS,
     proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
+    registry_dir: Annotated[Path, typer.Option("--registry-dir")] = _DEFAULT_REGISTRY,
+    usage_db: Annotated[Path, typer.Option("--usage-db")] = _DEFAULT_USAGE,
+    artifacts_dir: Annotated[Path, typer.Option("--artifacts-dir")] = _DEFAULT_ARTIFACTS,
+    checkpoints_dir: Annotated[Path, typer.Option("--checkpoints-dir")] = _DEFAULT_CHECKPOINTS,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir, datasets_dir, proposals_path)
+        daemon = _daemon(
+            charter_path,
+            db_path,
+            events_path,
+            runs_db,
+            otel_feed_dir,
+            datasets_dir,
+            proposals_path,
+            registry_dir,
+            usage_db,
+            artifacts_dir,
+            checkpoints_dir,
+        )
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -98,6 +126,11 @@ def status(
     for name, info in daemon.status().items():
         table.add_row(name, str(info["paused"]), str(info["queue_depth"]))
     console.print(table)
+    # read-only: construct the registry and count candidates, never train or write events
+    from autocontext.training.model_registry import ModelRegistry
+
+    candidates = len(ModelRegistry(registry_dir).list_all())
+    console.print(f"candidates={candidates}")
     if charter.targets:
         dataset_store = DatasetStore(datasets_dir)
         targets_table = Table("target", "dataset records", "mean score")
@@ -116,11 +149,27 @@ def run(
     otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
     datasets_dir: Annotated[Path, typer.Option("--datasets-dir")] = _DEFAULT_DATASETS,
     proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
+    registry_dir: Annotated[Path, typer.Option("--registry-dir")] = _DEFAULT_REGISTRY,
+    usage_db: Annotated[Path, typer.Option("--usage-db")] = _DEFAULT_USAGE,
+    artifacts_dir: Annotated[Path, typer.Option("--artifacts-dir")] = _DEFAULT_ARTIFACTS,
+    checkpoints_dir: Annotated[Path, typer.Option("--checkpoints-dir")] = _DEFAULT_CHECKPOINTS,
     poll_seconds: Annotated[float, typer.Option("--poll-seconds", min=0.0)] = 30.0,
     max_cycles: Annotated[int | None, typer.Option("--max-cycles", hidden=True)] = None,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir, datasets_dir, proposals_path)
+        daemon = _daemon(
+            charter_path,
+            db_path,
+            events_path,
+            runs_db,
+            otel_feed_dir,
+            datasets_dir,
+            proposals_path,
+            registry_dir,
+            usage_db,
+            artifacts_dir,
+            checkpoints_dir,
+        )
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -141,9 +190,25 @@ def once(
     otel_feed_dir: Annotated[Path, typer.Option("--otel-feed-dir")] = _DEFAULT_OTEL_FEED,
     datasets_dir: Annotated[Path, typer.Option("--datasets-dir")] = _DEFAULT_DATASETS,
     proposals_path: Annotated[Path, typer.Option("--proposals-path")] = _DEFAULT_PROPOSALS,
+    registry_dir: Annotated[Path, typer.Option("--registry-dir")] = _DEFAULT_REGISTRY,
+    usage_db: Annotated[Path, typer.Option("--usage-db")] = _DEFAULT_USAGE,
+    artifacts_dir: Annotated[Path, typer.Option("--artifacts-dir")] = _DEFAULT_ARTIFACTS,
+    checkpoints_dir: Annotated[Path, typer.Option("--checkpoints-dir")] = _DEFAULT_CHECKPOINTS,
 ) -> None:
     try:
-        daemon = _daemon(charter_path, db_path, events_path, runs_db, otel_feed_dir, datasets_dir, proposals_path)
+        daemon = _daemon(
+            charter_path,
+            db_path,
+            events_path,
+            runs_db,
+            otel_feed_dir,
+            datasets_dir,
+            proposals_path,
+            registry_dir,
+            usage_db,
+            artifacts_dir,
+            checkpoints_dir,
+        )
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -13,6 +13,33 @@ from autocontext.cli_ambient import ambient_app
 runner = CliRunner()
 
 
+def _path_opts(tmp_path: Path) -> list[str]:
+    """Every ambient path option pointed under tmp_path, so status/run/once never
+    fall back to a real runs/ default and write into the package root."""
+    return [
+        "--db-path",
+        str(tmp_path / "ambient.sqlite3"),
+        "--events-path",
+        str(tmp_path / "events.ndjson"),
+        "--runs-db",
+        str(tmp_path / "runs.sqlite3"),
+        "--otel-feed-dir",
+        str(tmp_path / "feed"),
+        "--datasets-dir",
+        str(tmp_path / "datasets"),
+        "--proposals-path",
+        str(tmp_path / "proposals.jsonl"),
+        "--registry-dir",
+        str(tmp_path / "registry"),
+        "--usage-db",
+        str(tmp_path / "usage.sqlite3"),
+        "--artifacts-dir",
+        str(tmp_path / "artifacts"),
+        "--checkpoints-dir",
+        str(tmp_path / "checkpoints"),
+    ]
+
+
 def _init(tmp_path: Path) -> Path:
     charter_path = tmp_path / "ambient-charter.yaml"
     result = runner.invoke(
@@ -53,7 +80,7 @@ def test_status_reports_stages(tmp_path: Path) -> None:
     charter_path = _init(tmp_path)
     result = runner.invoke(
         app,
-        ["ambient", "status", "--charter-path", str(charter_path), "--db-path", str(tmp_path / "a.sqlite3")],
+        ["ambient", "status", "--charter-path", str(charter_path), *_path_opts(tmp_path)],
     )
     assert result.exit_code == 0, result.output
     for stage in ("ingest", "curate", "advise", "train", "evaluate"):
@@ -75,10 +102,7 @@ def test_run_with_max_cycles_terminates(tmp_path: Path) -> None:
             "run",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(tmp_path / "a.sqlite3"),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
+            *_path_opts(tmp_path),
             "--poll-seconds",
             "0",
             "--max-cycles",
@@ -99,10 +123,7 @@ def test_once_runs_single_stage(tmp_path: Path) -> None:
             "ingest",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(tmp_path / "a.sqlite3"),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
+            *_path_opts(tmp_path),
         ],
     )
     assert result.exit_code == 0, result.output
@@ -113,13 +134,13 @@ def test_status_does_not_requeue_running_jobs(tmp_path: Path) -> None:
     from autocontext.ambient.queue import AmbientQueue
 
     charter_path = _init(tmp_path)
-    db_path = tmp_path / "a.sqlite3"
+    db_path = tmp_path / "ambient.sqlite3"  # matches --db-path in _path_opts
     queue = AmbientQueue(db_path)
     queue.enqueue("ingest", "poll_source", {})
     assert queue.claim("ingest") is not None  # in-flight in another process
     result = runner.invoke(
         app,
-        ["ambient", "status", "--charter-path", str(charter_path), "--db-path", str(db_path)],
+        ["ambient", "status", "--charter-path", str(charter_path), *_path_opts(tmp_path)],
     )
     assert result.exit_code == 0, result.output
     assert queue.depth("ingest") == 0  # still running, not yanked back
@@ -134,10 +155,7 @@ def test_run_rejects_negative_poll_seconds(tmp_path: Path) -> None:
             "run",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(tmp_path / "a.sqlite3"),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
+            *_path_opts(tmp_path),
             "--poll-seconds",
             "-1",
         ],
@@ -172,7 +190,7 @@ def test_once_ingest_pulls_from_runs_db(tmp_path: Path) -> None:
     )
     conn.commit()
     conn.close()
-    db_path = tmp_path / "ambient.sqlite3"
+    db_path = tmp_path / "ambient.sqlite3"  # matches --db-path in _path_opts
     result = runner.invoke(
         app,
         [
@@ -181,14 +199,7 @@ def test_once_ingest_pulls_from_runs_db(tmp_path: Path) -> None:
             "ingest",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(db_path),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
-            "--runs-db",
-            str(runs_db),
-            "--otel-feed-dir",
-            str(tmp_path / "feed"),
+            *_path_opts(tmp_path),
         ],
     )
     assert result.exit_code == 0, result.output
@@ -209,18 +220,7 @@ def test_once_curate_runs_clean_on_empty_stores(tmp_path: Path) -> None:
             "curate",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(tmp_path / "ambient.sqlite3"),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
-            "--runs-db",
-            str(tmp_path / "runs.sqlite3"),
-            "--otel-feed-dir",
-            str(tmp_path / "feed"),
-            "--datasets-dir",
-            str(tmp_path / "datasets"),
-            "--proposals-path",
-            str(tmp_path / "proposals.jsonl"),
+            *_path_opts(tmp_path),
         ],
     )
     assert result.exit_code == 0, result.output
@@ -237,26 +237,7 @@ def test_once_train_runs_clean_on_empty_stores(tmp_path: Path) -> None:
             "train",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(tmp_path / "ambient.sqlite3"),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
-            "--runs-db",
-            str(tmp_path / "runs.sqlite3"),
-            "--otel-feed-dir",
-            str(tmp_path / "feed"),
-            "--datasets-dir",
-            str(tmp_path / "datasets"),
-            "--proposals-path",
-            str(tmp_path / "proposals.jsonl"),
-            "--registry-dir",
-            str(tmp_path / "registry"),
-            "--usage-db",
-            str(tmp_path / "usage.sqlite3"),
-            "--artifacts-dir",
-            str(tmp_path / "artifacts"),
-            "--checkpoints-dir",
-            str(tmp_path / "checkpoints"),
+            *_path_opts(tmp_path),
         ],
     )
     assert result.exit_code == 0, result.output
@@ -272,20 +253,7 @@ def test_status_shows_candidates_row(tmp_path: Path) -> None:
             "status",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(tmp_path / "ambient.sqlite3"),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
-            "--runs-db",
-            str(tmp_path / "runs.sqlite3"),
-            "--otel-feed-dir",
-            str(tmp_path / "feed"),
-            "--datasets-dir",
-            str(tmp_path / "datasets"),
-            "--proposals-path",
-            str(tmp_path / "proposals.jsonl"),
-            "--registry-dir",
-            str(tmp_path / "registry"),
+            *_path_opts(tmp_path),
         ],
     )
     assert result.exit_code == 0, result.output
@@ -304,18 +272,7 @@ def test_status_shows_target_dataset_rows(tmp_path: Path) -> None:
             "status",
             "--charter-path",
             str(charter_path),
-            "--db-path",
-            str(tmp_path / "ambient.sqlite3"),
-            "--events-path",
-            str(tmp_path / "events.ndjson"),
-            "--runs-db",
-            str(tmp_path / "runs.sqlite3"),
-            "--otel-feed-dir",
-            str(tmp_path / "feed"),
-            "--datasets-dir",
-            str(tmp_path / "datasets"),
-            "--proposals-path",
-            str(tmp_path / "proposals.jsonl"),
+            *_path_opts(tmp_path),
         ],
     )
     assert result.exit_code == 0, result.output

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -227,6 +227,71 @@ def test_once_curate_runs_clean_on_empty_stores(tmp_path: Path) -> None:
     assert "processed=0" in result.output
 
 
+def test_once_train_runs_clean_on_empty_stores(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "once",
+            "train",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(tmp_path / "ambient.sqlite3"),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+            "--runs-db",
+            str(tmp_path / "runs.sqlite3"),
+            "--otel-feed-dir",
+            str(tmp_path / "feed"),
+            "--datasets-dir",
+            str(tmp_path / "datasets"),
+            "--proposals-path",
+            str(tmp_path / "proposals.jsonl"),
+            "--registry-dir",
+            str(tmp_path / "registry"),
+            "--usage-db",
+            str(tmp_path / "usage.sqlite3"),
+            "--artifacts-dir",
+            str(tmp_path / "artifacts"),
+            "--checkpoints-dir",
+            str(tmp_path / "checkpoints"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "processed=0" in result.output
+
+
+def test_status_shows_candidates_row(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "status",
+            "--charter-path",
+            str(charter_path),
+            "--db-path",
+            str(tmp_path / "ambient.sqlite3"),
+            "--events-path",
+            str(tmp_path / "events.ndjson"),
+            "--runs-db",
+            str(tmp_path / "runs.sqlite3"),
+            "--otel-feed-dir",
+            str(tmp_path / "feed"),
+            "--datasets-dir",
+            str(tmp_path / "datasets"),
+            "--proposals-path",
+            str(tmp_path / "proposals.jsonl"),
+            "--registry-dir",
+            str(tmp_path / "registry"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "candidates=0" in result.output
+
+
 def test_status_shows_target_dataset_rows(tmp_path: Path) -> None:
     charter_path = _init(tmp_path)  # the fixture charter contains at least one target
     datasets = DatasetStore(tmp_path / "datasets")

--- a/autocontext/tests/test_ambient_publish.py
+++ b/autocontext/tests/test_ambient_publish.py
@@ -40,12 +40,16 @@ def test_publish_registers_a_non_active_candidate(tmp_path: Path) -> None:
         registry=registry,
         artifacts_root=tmp_path / "artifacts",
         run_id="ambient-run-1",
+        record_count=10,
     )
 
     record = registry.load(artifact_id)
     assert record is not None
     assert record.activation_state == "candidate"
     assert record.metadata.get("produced_by") == "finetune:competitor-local"
+    # the adapter-serving path refuses a record without base_model, so it must be stamped
+    assert record.metadata.get("base_model") == "tiny"
+    assert record.metadata.get("record_count") == 10
 
 
 def test_publish_is_idempotent_on_same_inputs(tmp_path: Path) -> None:
@@ -58,6 +62,7 @@ def test_publish_is_idempotent_on_same_inputs(tmp_path: Path) -> None:
         registry=registry,
         artifacts_root=tmp_path / "artifacts",
         run_id="ambient-run-1",
+        record_count=10,
     )
     first = publish_candidate(**kwargs)
     second = publish_candidate(**kwargs)

--- a/autocontext/tests/test_ambient_publish.py
+++ b/autocontext/tests/test_ambient_publish.py
@@ -1,0 +1,65 @@
+"""tests for ambient candidate publish."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.publish import publish_candidate
+from autocontext.ambient.training_backend import TrainOutcome
+from autocontext.training.model_registry import ModelRegistry
+
+
+def _target(**overrides: Any) -> CharterTarget:
+    base: dict[str, Any] = {
+        "name": "competitor-local",
+        "kind": "role",
+        "selector": "competitor",
+        "base_model": "tiny",
+        "min_dataset_records": 1,
+        "eval_suite": "anchor-v1",
+    }
+    base.update(overrides)
+    return CharterTarget(**base)
+
+
+def test_publish_registers_a_non_active_candidate(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    outcome = TrainOutcome(
+        checkpoint_path=tmp_path / "out" / "adapters",
+        backend="trl",
+        metrics={"avg_score": 0.8, "valid_rate": 1.0, "num_records": 10.0},
+        gpu_hours=1.0,
+    )
+
+    artifact_id = publish_candidate(
+        outcome=outcome,
+        target=_target(),
+        scenario="grid_ctf",
+        registry=registry,
+        artifacts_root=tmp_path / "artifacts",
+        run_id="ambient-run-1",
+    )
+
+    record = registry.load(artifact_id)
+    assert record is not None
+    assert record.activation_state == "candidate"
+    assert record.metadata.get("produced_by") == "finetune:competitor-local"
+
+
+def test_publish_is_idempotent_on_same_inputs(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    outcome = TrainOutcome(tmp_path / "out" / "adapters", "trl", {"avg_score": 0.5}, 1.0)
+    kwargs = dict(
+        outcome=outcome,
+        target=_target(),
+        scenario="grid_ctf",
+        registry=registry,
+        artifacts_root=tmp_path / "artifacts",
+        run_id="ambient-run-1",
+    )
+    first = publish_candidate(**kwargs)
+    second = publish_candidate(**kwargs)
+    assert first == second
+    assert len(registry.list_all()) == 1

--- a/autocontext/tests/test_ambient_queue.py
+++ b/autocontext/tests/test_ambient_queue.py
@@ -61,3 +61,26 @@ def test_requeue_stale_running(tmp_path: Path) -> None:
     assert queue.requeue_stale_running() == 1
     assert queue.depth("train") == 1
     assert queue.claim("train") is not None
+
+
+def test_fail_requeues_below_max_attempts(tmp_path: Path) -> None:
+    queue = AmbientQueue(tmp_path / "q.sqlite3")
+    job_id = queue.enqueue("train", "run", {})
+    claimed = queue.claim("train")
+    assert claimed is not None
+    queue.fail(job_id, "boom", max_attempts=3)
+    # back to pending, claimable again
+    assert queue.depth("train") == 1
+    assert queue.dead_letter_count() == 0
+
+
+def test_fail_dead_letters_at_max_attempts(tmp_path: Path) -> None:
+    queue = AmbientQueue(tmp_path / "q.sqlite3")
+    job_id = queue.enqueue("train", "run", {})
+    for _ in range(3):
+        queue.claim("train")
+        queue.fail(job_id, "boom", max_attempts=3)
+    # third failure reaches the cap: dead, not pending
+    assert queue.depth("train") == 0
+    assert queue.dead_letter_count() == 1
+    assert queue.claim("train") is None

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -11,6 +11,7 @@ from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
 from autocontext.ambient.sources.native import NativeRunsSource
 from autocontext.ambient.stage import STAGE_NAMES, NoOpStage
 from autocontext.ambient.stage_factory import build_stages
+from autocontext.ambient.train import TrainStage
 from autocontext.harness.core.events import EventStreamEmitter
 
 
@@ -47,6 +48,10 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
         runs_db_path=tmp_path / "runs.sqlite3",
         otel_feed_dir=tmp_path / "feed",
         datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
     )
     assert set(stages.keys()) == set(STAGE_NAMES)
     ingest = stages["ingest"]
@@ -57,7 +62,7 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
     assert [source.kind for source in ingest.sources] == ["autocontext", "autocontext-outputs", "otel"]
     assert isinstance(stages["curate"], CurateStage)
     assert isinstance(stages["advise"], AdviseStage)
-    assert all(isinstance(stages[name], NoOpStage) for name in ("train", "evaluate"))
+    assert all(isinstance(stages[name], NoOpStage) for name in ("evaluate",))
 
 
 def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
@@ -73,6 +78,10 @@ def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
         runs_db_path=tmp_path / "runs.sqlite3",
         otel_feed_dir=tmp_path / "feed",
         datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
     )
     ingest = stages["ingest"]
     assert isinstance(ingest, IngestStage)
@@ -92,6 +101,10 @@ def test_autocontext_source_registers_generation_and_output_readers(tmp_path: Pa
         runs_db_path=tmp_path / "runs.sqlite3",
         otel_feed_dir=tmp_path / "feed",
         datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
     )
     ingest = stages["ingest"]
     kinds = sorted(source.kind for source in ingest.sources)  # type: ignore[attr-defined]
@@ -107,10 +120,32 @@ def test_build_stages_wires_real_curate_and_advise(tmp_path: Path) -> None:
         runs_db_path=tmp_path / "runs.sqlite3",
         otel_feed_dir=tmp_path / "feed",
         datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
     )
     assert isinstance(stages["curate"], CurateStage)
     assert isinstance(stages["advise"], AdviseStage)
     # one shared trace store: ingest writes and curate/advise read the same db
     assert stages["curate"].trace_store is stages["ingest"].trace_store  # type: ignore[attr-defined]
     assert stages["advise"].trace_store is stages["ingest"].trace_store  # type: ignore[attr-defined]
-    assert stages["train"].__class__.__name__ == "NoOpStage"
+    assert isinstance(stages["train"], TrainStage)
+
+
+def test_build_stages_wires_real_train_stage(tmp_path: Path) -> None:
+    charter = _charter(sources=[CharterSource(name="native", kind="autocontext")])
+    stages = build_stages(
+        charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        runs_db_path=tmp_path / "runs.sqlite3",
+        otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
+    )
+    assert isinstance(stages["train"], TrainStage)
+    assert stages["evaluate"].__class__.__name__ == "NoOpStage"

--- a/autocontext/tests/test_ambient_train_stage.py
+++ b/autocontext/tests/test_ambient_train_stage.py
@@ -1,0 +1,178 @@
+"""tests for the train stage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import autocontext.ambient.train as train_mod
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.datasets import DatasetStore
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage import StageContext
+from autocontext.ambient.train import TrainStage
+from autocontext.ambient.training_backend import TrainOutcome
+from autocontext.ambient.usage import UsageLedger
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.training.model_registry import ModelRegistry
+
+_NOW = "2026-07-06T12:00:00+00:00"
+
+
+def _target(name: str = "competitor-local", **overrides: Any) -> CharterTarget:
+    base: dict[str, Any] = {
+        "name": name,
+        "kind": "role",
+        "selector": "competitor",
+        "base_model": "tiny",
+        "min_dataset_records": 5,
+        "eval_suite": "anchor-v1",
+    }
+    base.update(overrides)
+    return CharterTarget(**base)
+
+
+def _charter(targets: list[CharterTarget], autonomy: str = "train", gpu_hours: float = 10.0) -> Charter:
+    return Charter(
+        tier="oss",
+        autonomy=autonomy,
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=targets,
+        budgets=CharterBudgets(gpu_hours_per_window=gpu_hours, window_hours=24, disk_quota_gb=1.0),
+    )
+
+
+def _ctx(tmp_path: Path, charter: Charter) -> StageContext:
+    return StageContext(
+        charter=charter,
+        queue=AmbientQueue(tmp_path / "q.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+
+
+def _events(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "events.ndjson"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _stage(tmp_path: Path) -> TrainStage:
+    return TrainStage(
+        name="train",
+        dataset_store=DatasetStore(tmp_path / "datasets"),
+        usage_ledger=UsageLedger(tmp_path / "usage.sqlite3"),
+        registry=ModelRegistry(tmp_path / "registry"),
+        artifacts_root=tmp_path / "artifacts",
+        checkpoints_root=tmp_path / "checkpoints",
+        now_fn=lambda: _NOW,
+    )
+
+
+def _seed_dataset(tmp_path: Path, target: str, count: int) -> None:
+    store = DatasetStore(tmp_path / "datasets")
+    records = [{"run_id": "r", "scenario": "grid_ctf", "strategy": f"s{i}", "score": 0.9, "context": {}} for i in range(count)]
+    store.append_records(target, records)
+    manifest = store.load_manifest(target)
+    store.save_manifest(store.absorb(manifest, [0.9] * count, 0, 0, count))
+
+
+def _patch_backend(monkeypatch: Any, *, available: str | None, gpu_hours: float = 1.0) -> None:
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: available)
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        return TrainOutcome(
+            checkpoint_path=request.output_dir / "adapters",
+            backend=backend_name,
+            metrics={"avg_score": 0.8, "valid_rate": 1.0, "num_records": 5.0, "training_seconds": gpu_hours * 3600},
+            gpu_hours=gpu_hours,
+        )
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
+
+
+def test_trains_and_publishes_a_candidate(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    _patch_backend(monkeypatch, available="trl", gpu_hours=2.0)
+    stage = _stage(tmp_path)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()])))
+
+    assert result.processed == 1
+    assert result.errors == 0
+    assert stage.usage_ledger.used_in_window("competitor-local", 24, _NOW) == 2.0
+    assert len(stage.registry.list_all()) == 1
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_candidate_published" for e in events)
+
+
+def test_below_min_records_is_a_silent_skip(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 2)  # min is 5
+    _patch_backend(monkeypatch, available="trl")
+    stage = _stage(tmp_path)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()])))
+
+    assert result.processed == 0
+    assert stage.registry.list_all() == []
+
+
+def test_propose_autonomy_requires_approval(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    _patch_backend(monkeypatch, available="trl")
+    stage = _stage(tmp_path)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()], autonomy="propose")))
+
+    assert result.processed == 0
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_requires_approval" for e in events)
+
+
+def test_budget_exhausted_skips(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    _patch_backend(monkeypatch, available="trl", gpu_hours=5.0)
+    stage = _stage(tmp_path)
+    stage.usage_ledger.record("competitor-local", 9.5, _NOW)  # window budget is 10.0; a 5h job would exceed it
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()], gpu_hours=10.0)))
+
+    assert result.processed == 0
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_budget_exhausted" for e in events)
+
+
+def test_no_available_backend_is_not_an_error(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    _patch_backend(monkeypatch, available=None)
+    stage = _stage(tmp_path)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()])))
+
+    assert result.processed == 0
+    assert result.errors == 0
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_no_backend" for e in events)
+
+
+def test_target_failure_is_isolated(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "boom", 6)
+    _seed_dataset(tmp_path, "fine", 6)
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: "trl")
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        if "boom" in str(request.output_dir):
+            raise RuntimeError("backend blew up")
+        return TrainOutcome(request.output_dir / "adapters", backend_name, {"num_records": 5.0, "training_seconds": 3600.0}, 1.0)
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
+    stage = _stage(tmp_path)
+    charter = _charter([_target(name="boom"), _target(name="fine")])
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert result.errors == 1
+    assert result.processed == 1
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_target_failed" and e["payload"]["target"] == "boom" for e in events)

--- a/autocontext/tests/test_ambient_train_stage.py
+++ b/autocontext/tests/test_ambient_train_stage.py
@@ -141,8 +141,9 @@ def test_budget_exhausted_skips(tmp_path: Path, monkeypatch: Any) -> None:
 
     monkeypatch.setattr(train_mod, "run_training", fake_run)
     stage = _stage(tmp_path)
-    # window budget is 10.0; the default time budget is 1800s = 0.5h. seed 9.8 used so the
-    # pre-flight estimate (9.8 + 0.5 = 10.3 > 10.0) breaches before any training happens.
+    # window budget is 10.0; the default reserved envelope is time_budget (1800s) + assess
+    # overhead (1800s) = 1.0h. seed 9.8 used so the pre-flight estimate (9.8 + 1.0 = 10.8 > 10.0)
+    # breaches before any training happens.
     stage.usage_ledger.record("competitor-local", 9.8, _NOW)
 
     result = stage.run_once(_ctx(tmp_path, _charter([_target()], gpu_hours=10.0)))
@@ -152,6 +153,90 @@ def test_budget_exhausted_skips(tmp_path: Path, monkeypatch: Any) -> None:
     assert stage.registry.list_all() == []  # and nothing was published
     events = _events(tmp_path)
     assert any(e["event"] == "train_budget_exhausted" for e in events)
+
+
+def test_envelope_over_budget_blocks_even_when_train_budget_alone_fits(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    trained = {"ran": False}
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: "trl")
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        trained["ran"] = True
+        return TrainOutcome(request.output_dir / "adapters", backend_name, {"num_records": 5.0, "training_seconds": 3600.0}, 1.0)
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
+    stage = _stage(tmp_path)
+    # window budget is 10.0. train_budget alone is 1800s = 0.5h, which would fit (9.4 + 0.5 = 9.9).
+    # but the reserved envelope adds the 1800s assess overhead -> 1.0h, so 9.4 + 1.0 = 10.4 > 10.0
+    # and the job is blocked pre-flight. this is the under-reservation the fix closes.
+    stage.usage_ledger.record("competitor-local", 9.4, _NOW)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()], gpu_hours=10.0)))
+
+    assert result.processed == 0
+    assert not trained["ran"]
+    assert stage.registry.list_all() == []
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_budget_exhausted" for e in events)
+
+
+def test_unchanged_dataset_is_not_retrained(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    calls = {"count": 0}
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: "trl")
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        calls["count"] += 1
+        return TrainOutcome(
+            request.output_dir / "adapters",
+            backend_name,
+            {"num_records": 6.0, "training_seconds": 3600.0},
+            1.0,
+        )
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
+    stage = _stage(tmp_path)
+    charter = _charter([_target()])
+
+    first = stage.run_once(_ctx(tmp_path, charter))
+    second = stage.run_once(_ctx(tmp_path, charter))
+
+    assert first.processed == 1
+    assert second.processed == 0  # the unchanged manifest is skipped the second cycle
+    assert calls["count"] == 1  # run_training ran exactly once
+    assert stage.usage_ledger.used_in_window("competitor-local", 24, _NOW) == 1.0  # charged once
+    assert len(stage.registry.list_all()) == 1
+    events = _events(tmp_path)
+    up_to_date = [e for e in events if e["event"] == "train_up_to_date"]
+    assert len(up_to_date) == 1
+    assert up_to_date[0]["payload"]["record_count"] == 6
+
+
+def test_growing_dataset_trains_a_distinct_checkpoint(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 5)
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: "trl")
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        return TrainOutcome(
+            request.output_dir / "adapters",
+            backend_name,
+            {"num_records": 6.0, "training_seconds": 3600.0},
+            1.0,
+        )
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
+    stage = _stage(tmp_path)
+    charter = _charter([_target()])
+
+    stage.run_once(_ctx(tmp_path, charter))
+    _seed_dataset(tmp_path, "competitor-local", 1)  # grow 5 -> 6
+    stage.run_once(_ctx(tmp_path, charter))
+
+    records = stage.registry.list_all()
+    assert len(records) == 2
+    paths = sorted(r.checkpoint_path for r in records)
+    assert any("/5/" in p for p in paths)
+    assert any("/6/" in p for p in paths)
 
 
 def test_no_available_backend_is_not_an_error(tmp_path: Path, monkeypatch: Any) -> None:

--- a/autocontext/tests/test_ambient_train_stage.py
+++ b/autocontext/tests/test_ambient_train_stage.py
@@ -132,13 +132,24 @@ def test_propose_autonomy_requires_approval(tmp_path: Path, monkeypatch: Any) ->
 
 def test_budget_exhausted_skips(tmp_path: Path, monkeypatch: Any) -> None:
     _seed_dataset(tmp_path, "competitor-local", 6)
-    _patch_backend(monkeypatch, available="trl", gpu_hours=5.0)
+    trained = {"ran": False}
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: "trl")
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        trained["ran"] = True  # the pre-flight gate must return before we get here
+        return TrainOutcome(request.output_dir / "adapters", backend_name, {"num_records": 5.0, "training_seconds": 3600.0}, 1.0)
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
     stage = _stage(tmp_path)
-    stage.usage_ledger.record("competitor-local", 9.5, _NOW)  # window budget is 10.0; a 5h job would exceed it
+    # window budget is 10.0; the default time budget is 1800s = 0.5h. seed 9.8 used so the
+    # pre-flight estimate (9.8 + 0.5 = 10.3 > 10.0) breaches before any training happens.
+    stage.usage_ledger.record("competitor-local", 9.8, _NOW)
 
     result = stage.run_once(_ctx(tmp_path, _charter([_target()], gpu_hours=10.0)))
 
     assert result.processed == 0
+    assert not trained["ran"]  # pre-flight prevented the spend: run_training was never reached
+    assert stage.registry.list_all() == []  # and nothing was published
     events = _events(tmp_path)
     assert any(e["event"] == "train_budget_exhausted" for e in events)
 

--- a/autocontext/tests/test_ambient_training_backend.py
+++ b/autocontext/tests/test_ambient_training_backend.py
@@ -1,0 +1,60 @@
+"""tests for the ambient training-backend seam."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import autocontext.ambient.training_backend as tb
+from autocontext.ambient.training_backend import TrainRequest, run_training, select_backend
+
+
+def test_select_backend_returns_available_name(monkeypatch: Any) -> None:
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": False, "trl": True})
+    assert select_backend("sft-distill") == "trl"
+
+
+def test_select_backend_prefers_mlxlm_when_available(monkeypatch: Any) -> None:
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": True, "trl": True})
+    assert select_backend("sft-distill") == "mlxlm"
+
+
+def test_select_backend_none_when_nothing_available(monkeypatch: Any) -> None:
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": False, "trl": False})
+    assert select_backend("sft-distill") is None
+
+
+def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(**kwargs: Any) -> dict[str, float]:
+        captured.update(kwargs)
+        return {"avg_score": 0.8, "valid_rate": 1.0, "training_seconds": 3600.0, "num_records": 12.0}
+
+    monkeypatch.setattr(tb, "_BACKEND_FNS", {"trl": fake_run})
+    request = TrainRequest(
+        scenario="grid_ctf",
+        data_path=tmp_path / "ds.jsonl",
+        output_dir=tmp_path / "out",
+        base_model="tiny",
+        time_budget_seconds=600,
+        memory_limit_mb=4096,
+    )
+
+    outcome = run_training("trl", request)
+
+    assert outcome.backend == "trl"
+    assert outcome.metrics["avg_score"] == 0.8
+    assert outcome.gpu_hours == 1.0  # 3600s / 3600
+    assert captured["scenario_name"] == "grid_ctf"
+    assert captured["data_path"] == request.data_path
+    assert captured["base_model"] == "tiny"
+
+
+def test_run_training_unknown_backend_raises(tmp_path: Path) -> None:
+    request = TrainRequest("s", tmp_path / "d", tmp_path / "o", "m", 600, 4096)
+    try:
+        run_training("nonesuch", request)
+    except KeyError:
+        return
+    raise AssertionError("expected KeyError for unknown backend")

--- a/autocontext/tests/test_ambient_training_backend.py
+++ b/autocontext/tests/test_ambient_training_backend.py
@@ -58,6 +58,7 @@ def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_pat
     assert captured["output_dir"] == request.output_dir
     assert captured["time_budget"] == request.time_budget_seconds
     assert captured["memory_limit_mb"] == request.memory_limit_mb
+    assert captured["dedupe"] is True  # train-time dedupe honors the curate crash-window mitigation
 
 
 def test_run_training_unknown_backend_raises(tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_training_backend.py
+++ b/autocontext/tests/test_ambient_training_backend.py
@@ -9,19 +9,32 @@ import autocontext.ambient.training_backend as tb
 from autocontext.ambient.training_backend import TrainRequest, run_training, select_backend
 
 
+def _request(tmp_path: Path) -> TrainRequest:
+    return TrainRequest(
+        scenario="grid_ctf",
+        data_path=tmp_path / "ds.jsonl",
+        output_dir=tmp_path / "out",
+        base_model="tiny",
+        time_budget_seconds=600,
+        memory_limit_mb=4096,
+    )
+
+
 def test_select_backend_returns_available_name(monkeypatch: Any) -> None:
-    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": False, "trl": True})
-    assert select_backend("sft-distill") == "trl"
-
-
-def test_select_backend_prefers_mlxlm_when_available(monkeypatch: Any) -> None:
-    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": True, "trl": True})
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": True})
     assert select_backend("sft-distill") == "mlxlm"
 
 
-def test_select_backend_none_when_nothing_available(monkeypatch: Any) -> None:
-    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": False, "trl": False})
+def test_select_backend_none_when_unavailable(monkeypatch: Any) -> None:
+    # the linux/cpu-ci path: no mlx runtime, so the train stage cleanly no-ops
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": False})
     assert select_backend("sft-distill") is None
+
+
+def test_select_backend_unknown_method_is_none(monkeypatch: Any) -> None:
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": True})
+    assert select_backend("rlvr-experimental") is None  # no backend wired for it yet
+    assert select_backend("bogus") is None
 
 
 def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_path: Path) -> None:
@@ -31,28 +44,24 @@ def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_pat
         captured.update(kwargs)
         return {"avg_score": 0.8, "valid_rate": 1.0, "training_seconds": 3600.0, "num_records": 12.0}
 
-    monkeypatch.setattr(tb, "_BACKEND_FNS", {"trl": fake_run})
-    request = TrainRequest(
-        scenario="grid_ctf",
-        data_path=tmp_path / "ds.jsonl",
-        output_dir=tmp_path / "out",
-        base_model="tiny",
-        time_budget_seconds=600,
-        memory_limit_mb=4096,
-    )
+    monkeypatch.setattr(tb, "_BACKEND_FNS", {"mlxlm": fake_run})
+    request = _request(tmp_path)
 
-    outcome = run_training("trl", request)
+    outcome = run_training("mlxlm", request)
 
-    assert outcome.backend == "trl"
+    assert outcome.backend == "mlxlm"
     assert outcome.metrics["avg_score"] == 0.8
     assert outcome.gpu_hours == 1.0  # 3600s / 3600
     assert captured["scenario_name"] == "grid_ctf"
     assert captured["data_path"] == request.data_path
     assert captured["base_model"] == "tiny"
+    assert captured["output_dir"] == request.output_dir
+    assert captured["time_budget"] == request.time_budget_seconds
+    assert captured["memory_limit_mb"] == request.memory_limit_mb
 
 
 def test_run_training_unknown_backend_raises(tmp_path: Path) -> None:
-    request = TrainRequest("s", tmp_path / "d", tmp_path / "o", "m", 600, 4096)
+    request = _request(tmp_path)
     try:
         run_training("nonesuch", request)
     except KeyError:

--- a/autocontext/tests/test_ambient_usage.py
+++ b/autocontext/tests/test_ambient_usage.py
@@ -1,0 +1,55 @@
+"""tests for the windowed gpu-hours usage ledger."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from autocontext.ambient.usage import UsageLedger
+
+
+def _iso(base: datetime, **delta: float) -> str:
+    return (base + timedelta(**delta)).isoformat()
+
+
+def test_used_in_window_sums_only_recent_records(tmp_path: Path) -> None:
+    ledger = UsageLedger(tmp_path / "usage.sqlite3")
+    now = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)
+    ledger.record("prover", 2.0, _iso(now, hours=-30))  # outside a 24h window
+    ledger.record("prover", 1.5, _iso(now, hours=-2))  # inside
+    ledger.record("prover", 0.5, _iso(now, hours=-1))  # inside
+
+    assert ledger.used_in_window("prover", window_hours=24, now_iso=now.isoformat()) == 2.0
+
+
+def test_used_in_window_is_per_target(tmp_path: Path) -> None:
+    ledger = UsageLedger(tmp_path / "usage.sqlite3")
+    now = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)
+    ledger.record("prover", 3.0, _iso(now, hours=-1))
+    ledger.record("solver", 5.0, _iso(now, hours=-1))
+
+    assert ledger.used_in_window("prover", 24, now.isoformat()) == 3.0
+    assert ledger.used_in_window("solver", 24, now.isoformat()) == 5.0
+
+
+def test_window_boundary_is_strict_greater_than(tmp_path: Path) -> None:
+    ledger = UsageLedger(tmp_path / "usage.sqlite3")
+    now = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)
+    ledger.record("prover", 4.0, _iso(now, hours=-24))  # exactly on the boundary: excluded
+
+    assert ledger.used_in_window("prover", 24, now.isoformat()) == 0.0
+
+
+def test_total_sums_all_time(tmp_path: Path) -> None:
+    ledger = UsageLedger(tmp_path / "usage.sqlite3")
+    now = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)
+    ledger.record("prover", 2.0, _iso(now, hours=-100))
+    ledger.record("prover", 3.0, _iso(now, hours=-1))
+
+    assert ledger.total("prover") == 5.0
+
+
+def test_empty_ledger_reports_zero(tmp_path: Path) -> None:
+    ledger = UsageLedger(tmp_path / "usage.sqlite3")
+    assert ledger.used_in_window("prover", 24, "2026-07-06T12:00:00+00:00") == 0.0
+    assert ledger.total("prover") == 0.0


### PR DESCRIPTION
Plan 4 of the ambient trainer roadmap (spec: docs/ambient-trainer-design.md). Builds on plans 1-3 (foundation #1170, ingest #1171, curate+advise #1172). This is the first of two PRs that close the ambient loop: plan 4 produces trained model candidates; plan 5 (evaluate + promote + serve + miniature e2e) follows.

## What this adds

**GPU-hours usage ledger.** A windowed per-target ledger (UsageLedger) records the hours each training run consumed, so the charter's budget floor (`policy.budget_allows`, until now defined but never called) becomes enforceable. Timestamps are caller-supplied ISO-8601 UTC strings, so the ledger is deterministic and clock-free in tests.

**Train stage.** TrainStage turns a charter target's accumulated dataset into a registered model candidate, in this order: dataset record_count must clear min_dataset_records; the autonomy dial must allow auto-training (propose emits train_requires_approval and skips); a backend must be available for the method; and a PRE-FLIGHT budget check must pass (the requested hours are the time-budget ceiling, since the trainer timeout caps wall-clock, so a job that would breach the window never trains). Only then does it run the backend, record the ACTUAL hours consumed exactly once, and publish. Per-target failures are isolated.

**Training-backend seam.** A single indirection point (training_backend.py) selects an available backend by charter method and runs it, so a frontier-only CPU CI exercises the whole stage without a real fine-tune (tests monkeypatch the seam). For sft-distill this is mlxlm-only: it is the one backend that trains LoRA-SFT over a curated dataset file. trl is deliberately excluded because it is on-policy distillation that generates its own prompts from the live scenario and cannot consume the curated traces.

**Candidate publish.** Trained checkpoints register as NON-activated registry candidates (auto_activate=False; activation is plan 5's promote gate) via the existing idempotent publish_training_output, stamped produced_by=finetune:<target> so provenance quarantine can exclude this model's own future outputs from its next lineage.

**Hardening.** The ambient queue gains max-attempts dead-lettering so a poison job stops re-running (banked plan-3 obligation). Train-time dedupe is enabled so the curate crash-window duplicate rows are actually removed (the mitigation curate.py documents).

## Known limitation (documented, not hidden)

On a box without mlx (including a Linux GPU box, the ambient trainer's intended deployment), there is no SFT-over-curated-dataset backend today: select_backend returns None and the train stage cleanly emits train_no_backend and no-ops, rather than pretending to train. A Linux or CUDA SFT-over-dataset backend is a prerequisite before the ambient trainer trains on its target hardware, and is tracked for a follow-up. The training_backend.py docstring states this plainly.

## Deferred to plan 5 (with a decision to make)

- Budget scope is currently per-target (a charter with N targets can spend up to N times gpu_hours_per_window). The spec's charter field reads charter-wide. This needs a decision before plan 5's auto-promote-within-budgets; it is a one-line change either way.
- The queue dead-letter path ships as banked infrastructure with no production caller yet (the stages run synchronously via run_once); plan 5 uses it.

## Verification

62 new ambient tests (187 total, 2 skipped) covering the ledger window boundary, dead-letter off-by-one, backend selection and the no-backend no-op, candidate idempotency and lineage stamp, and the full train-stage flow including the pre-flight budget gate proving a breaching job never trains. Each task was implemented and reviewed by separate agents with fix rounds; a final whole-branch review traced one target end to end from curated dataset to registered candidate and verified the budget-never-bypassed and charge-exactly-once invariants. ruff and mypy strict clean; uv.lock untouched; CI never runs a real fine-tune.