### PR TITLE
ambient trainer plan 5a: evaluate, promote, serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - The ambient ingest stage is live: charter-enabled sources (autocontext-native runs, jsonl trace feeds) flow through the redaction gate into an append-only trace store with per-source cursors and disk-quota retention; the llm proxy tap follows in the next slice.
 - ambient trainer plan 3: curate and advise stages (agent-output ingestion, guarded per-target datasets, heuristic charter proposals, proposal approval cli)
 - ambient trainer plan 4: train stage with gpu-hours budget ledger, autonomy gating, and model-candidate publication
+- ambient trainer plan 5a: evaluate, promote, and serving-resolution stages closing the ambient loop
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -39,6 +39,14 @@ class GuardrailConfig(BaseModel):
         return value
 
 
+class CharterAnchor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = "anthropic"
+    model: str = Field(min_length=1, default="claude-sonnet-5")
+    rubric: str = Field(min_length=1, default="Score the response for task success from 0 to 1.")
+
+
 class CharterSource(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -94,6 +102,7 @@ class Charter(BaseModel):
     targets: list[CharterTarget]
     budgets: CharterBudgets
     guardrails: GuardrailConfig = Field(default_factory=GuardrailConfig)
+    anchor: CharterAnchor = Field(default_factory=CharterAnchor)
 
     @model_validator(mode="after")
     def _full_box_requires_hosted(self) -> Charter:

--- a/autocontext/src/autocontext/ambient/daemon.py
+++ b/autocontext/src/autocontext/ambient/daemon.py
@@ -1,4 +1,4 @@
-"""the ambient daemon: orchestrates the five stages with per-stage breakers."""
+"""the ambient daemon: orchestrates the six stages with per-stage breakers."""
 
 from __future__ import annotations
 

--- a/autocontext/src/autocontext/ambient/eval_suite.py
+++ b/autocontext/src/autocontext/ambient/eval_suite.py
@@ -1,0 +1,61 @@
+"""resolve a charter target's eval_suite name to a held-out suite loaded from disk.
+
+The evaluate stage distinguishes two absences: a missing suite file means no
+held-out suite was ever defined for the target (load returns None), while a
+present-but-empty file (or one whose lines are all malformed) means a suite
+exists but has nothing to score yet (load returns an EvalSuite with [] cases).
+Callers key different behaviour off that distinction, so it must be preserved.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class EvalCase:
+    prompt: str
+    reference: str = ""
+
+
+@dataclass(slots=True)
+class EvalSuite:
+    name: str
+    cases: list[EvalCase]
+
+
+def load_eval_suite(suites_dir: Path, name: str) -> EvalSuite | None:
+    """Load ``suites_dir/<name>.jsonl`` into an EvalSuite, or None if absent.
+
+    ``name`` is a charter eval_suite string (e.g. "competitor_holdout"); it must
+    name a file directly inside suites_dir, so a path separator or a ".."
+    traversal sequence is rejected with ValueError rather than allowed to escape.
+    Each non-blank line is a JSON object; a line that fails to parse or lacks a
+    non-empty "prompt" string is skipped. A missing file returns None; a present
+    file always returns an EvalSuite (with [] cases when nothing parsed).
+    """
+    if os.sep in name or (os.altsep and os.altsep in name) or ".." in name:
+        raise ValueError(f"eval_suite name must not contain a path separator or '..': {name!r}")
+
+    path = suites_dir / f"{name}.jsonl"
+    if not path.exists():
+        return None
+
+    cases: list[EvalCase] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        prompt = obj.get("prompt") if isinstance(obj, dict) else None
+        if not isinstance(prompt, str) or not prompt:
+            continue
+        reference = obj.get("reference", "")
+        cases.append(EvalCase(prompt=prompt, reference=reference if isinstance(reference, str) else ""))
+
+    return EvalSuite(name=name, cases=cases)

--- a/autocontext/src/autocontext/ambient/evaluate.py
+++ b/autocontext/src/autocontext/ambient/evaluate.py
@@ -1,0 +1,173 @@
+"""the evaluate stage: score trained candidates under the charter's frozen anchor + drift canary.
+
+Every trained candidate is judged on its target's held-out eval suite by the anchor model
+(the one guardrail model the charter cannot retrain), and a drift canary probes that anchor
+for position bias. Both results are written back onto the candidate's registry metadata under
+"eval" without ever changing its activation_state: this stage measures, it does not promote.
+A candidate stays a "candidate" here; promotion (which refuses a drift-flagged candidate) is a
+later slice that reads this eval block.
+
+The scorer and drift probe are injected so CI runs deterministic fakes; the defaults build a
+real anchor-model LLMJudge and position-bias probe. In this slice the injected scorer receives
+(case.prompt, case.reference) as a stand-in for the candidate's own generation; plan 5b's real
+serving wires the trained candidate's output in as the scored text.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from autocontext.ambient.charter import CharterAnchor, CharterTarget
+from autocontext.ambient.eval_suite import load_eval_suite
+from autocontext.ambient.stage import StageContext, StageResult
+from autocontext.execution.bias_probes import BiasProbeResult, run_position_bias_probe
+from autocontext.training.model_registry import DistilledModelRecord, ModelRegistry
+
+
+def _default_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class _Scorer(Protocol):
+    """Scores a candidate's output for one held-out case (0.0-1.0)."""
+
+    def score(self, prompt: str, output: str) -> float: ...
+
+
+@dataclass(slots=True)
+class _JudgeScorer:
+    """Adapts an LLMJudge's evaluate(...).score to the _Scorer interface."""
+
+    judge: object  # LLMJudge; kept loose so the module has no import-time judge dependency
+
+    def score(self, prompt: str, output: str) -> float:
+        result = self.judge.evaluate(prompt, output)  # type: ignore[attr-defined]
+        return float(result.score)
+
+
+def _default_judge_factory(anchor: CharterAnchor) -> _Scorer:
+    from autocontext.execution.judge import LLMJudge
+    from autocontext.providers.registry import create_provider
+
+    judge = LLMJudge(
+        model=anchor.model,
+        rubric=anchor.rubric,
+        provider=create_provider(anchor.provider, model=anchor.model),
+    )
+    return _JudgeScorer(judge)
+
+
+def _default_probe_fn(anchor: CharterAnchor) -> BiasProbeResult:
+    from autocontext.providers.registry import create_provider
+
+    provider = create_provider(anchor.provider, model=anchor.model)
+    return run_position_bias_probe(
+        provider=provider,
+        model=anchor.model,
+        system_prompt="You are the frozen anchor judge. Score fairly regardless of ordering.",
+        candidate_a="A concise, correct answer.",
+        candidate_b="A concise, correct answer.",
+        rubric=anchor.rubric,
+    )
+
+
+@dataclass(slots=True)
+class EvaluateStage:
+    name: str
+    registry: ModelRegistry
+    suites_dir: Path
+    judge_factory: Callable[[CharterAnchor], _Scorer] | None = None
+    probe_fn: Callable[..., BiasProbeResult] | None = None
+    drift_tolerance: float = 0.2
+    now_fn: Callable[[], str] = _default_now
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        anchor = ctx.charter.anchor
+        judge_factory = self.judge_factory or _default_judge_factory
+        probe_fn = self.probe_fn or _default_probe_fn
+        # the anchor judge is built once and reused across candidates: it is fixed per charter and
+        # constructing the default provider per candidate would be wasteful. build lazily so a cycle
+        # with no eligible candidate never touches the provider.
+        scorer: _Scorer | None = None
+
+        processed = 0
+        errors = 0
+        for record in self.registry.list_all():
+            if record.activation_state != "candidate":
+                continue
+            if record.metadata.get("eval"):
+                continue
+            target = self._target_for(ctx, record)
+            if target is None:
+                # not one of this charter's targets: another charter (or a stale artifact) owns it,
+                # so it is silently skipped rather than reported as ours.
+                continue
+            try:
+                if scorer is None:
+                    scorer = judge_factory(anchor)
+                processed += self._evaluate_candidate(ctx, record, target, anchor, scorer, probe_fn)
+            except Exception as exc:
+                errors += 1
+                ctx.emitter.emit(
+                    "evaluate_candidate_failed",
+                    {"artifact_id": record.artifact_id, "error": str(exc)},
+                    channel="ambient",
+                )
+        return StageResult(processed=processed, errors=errors)
+
+    def _evaluate_candidate(
+        self,
+        ctx: StageContext,
+        record: DistilledModelRecord,
+        target: CharterTarget,
+        anchor: CharterAnchor,
+        scorer: _Scorer,
+        probe_fn: Callable[..., BiasProbeResult],
+    ) -> int:
+        suite = load_eval_suite(self.suites_dir, target.eval_suite)
+        if suite is None or not suite.cases:
+            # a missing file means no held-out suite was ever defined; a present-but-empty file
+            # means one exists but has nothing to score yet. either way there is nothing to judge,
+            # so we report and leave the candidate unevaluated (a later cycle retries once cases land).
+            ctx.emitter.emit(
+                "evaluate_no_suite",
+                {"artifact_id": record.artifact_id, "target": target.name, "eval_suite": target.eval_suite},
+                channel="ambient",
+            )
+            return 0
+
+        scores = [scorer.score(case.prompt, case.reference) for case in suite.cases]
+        avg_score = sum(scores) / len(scores)
+
+        probe = probe_fn(anchor)
+        drift_ok = probe.magnitude <= self.drift_tolerance
+
+        record.metadata["eval"] = {
+            "anchor_model": anchor.model,
+            "score": avg_score,
+            "drift_magnitude": probe.magnitude,
+            "drift_ok": drift_ok,
+            "evaluated_at": self.now_fn(),
+        }
+        # re-register to persist the eval block; activation_state is untouched so the candidate
+        # stays a candidate — this stage never promotes.
+        self.registry.register(record)
+
+        ctx.emitter.emit(
+            "evaluate_completed",
+            {"artifact_id": record.artifact_id, "target": target.name, "score": avg_score, "drift_ok": drift_ok},
+            channel="ambient",
+        )
+        return 1
+
+    @staticmethod
+    def _target_for(ctx: StageContext, record: DistilledModelRecord) -> CharterTarget | None:
+        target_name = record.metadata.get("target")
+        for target in ctx.charter.targets:
+            if target.name == target_name:
+                return target
+        return None

--- a/autocontext/src/autocontext/ambient/evaluate.py
+++ b/autocontext/src/autocontext/ambient/evaluate.py
@@ -15,6 +15,7 @@ serving wires the trained candidate's output in as the scored text.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -30,6 +31,18 @@ from autocontext.training.model_registry import DistilledModelRecord, ModelRegis
 
 def _default_now() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def eval_fingerprint(anchor: CharterAnchor, eval_suite: str) -> str:
+    """A stable identity for the evaluation config a candidate was scored under.
+
+    Combines the frozen anchor (provider, model, rubric) with the target's eval suite name. A
+    candidate whose stored fingerprint no longer matches the current one was scored under a stale
+    config (the charter anchor, its rubric, or the suite changed), so it must be re-evaluated rather
+    than left stuck with a score computed under the old config.
+    """
+    rubric_hash = hashlib.sha256(anchor.rubric.encode()).hexdigest()[:16]
+    return "|".join([anchor.provider, anchor.model, rubric_hash, eval_suite])
 
 
 class _Scorer(Protocol):
@@ -84,6 +97,11 @@ class EvaluateStage:
     probe_fn: Callable[..., BiasProbeResult] | None = None
     drift_tolerance: float = 0.2
     now_fn: Callable[[], str] = _default_now
+    # False because the default judge_factory scores the eval suite's reference text (a placeholder),
+    # not the candidate model's own generation. it becomes True only once a real candidate-generation
+    # scorer is wired (plan 5b, or a test that stands in for it). the promote stage refuses to activate
+    # a candidate whose eval was a placeholder, so this flag is what makes a candidate promotable.
+    scores_candidate_generation: bool = False
 
     def run_once(self, ctx: StageContext) -> StageResult:
         anchor = ctx.charter.anchor
@@ -116,15 +134,22 @@ class EvaluateStage:
         for record in self.registry.list_all():
             if record.activation_state != "candidate":
                 continue
-            if record.metadata.get("eval"):
-                continue
             target = self._target_for(ctx, record)
             if target is None:
                 # not one of this charter's targets: another charter (or a stale artifact) owns it,
                 # so it is silently skipped rather than reported as ours.
                 continue
+            # the fingerprint is per-target because the eval suite is per-target, while the anchor is
+            # charter-wide; compute it here where the target (and its suite) are known.
+            fingerprint = eval_fingerprint(anchor, target.eval_suite)
+            existing = record.metadata.get("eval")
+            if existing and existing.get("fingerprint") == fingerprint:
+                # already scored under the CURRENT config: skip. if the fingerprint differs (the
+                # anchor, its rubric, or the suite changed), fall through and re-evaluate, overwriting
+                # the stale eval rather than leaving the candidate stuck with an old-config score.
+                continue
             try:
-                processed += self._evaluate_candidate(ctx, record, target, anchor, get_scorer, get_drift)
+                processed += self._evaluate_candidate(ctx, record, target, anchor, fingerprint, get_scorer, get_drift)
             except Exception as exc:
                 errors += 1
                 ctx.emitter.emit(
@@ -140,6 +165,7 @@ class EvaluateStage:
         record: DistilledModelRecord,
         target: CharterTarget,
         anchor: CharterAnchor,
+        fingerprint: str,
         get_scorer: Callable[[], _Scorer],
         get_drift: Callable[[], BiasProbeResult],
     ) -> int:
@@ -172,6 +198,12 @@ class EvaluateStage:
             "drift_magnitude": probe.magnitude,
             "drift_ok": drift_ok,
             "evaluated_at": self.now_fn(),
+            # whether the score judged the candidate's real generation or a placeholder (reference
+            # text). the promote stage only activates a candidate when this is True.
+            "from_candidate_generation": self.scores_candidate_generation,
+            # identity of the config this score was computed under; a later cycle re-evaluates when
+            # the current fingerprint no longer matches this one.
+            "fingerprint": fingerprint,
         }
         # re-register to persist the eval block; activation_state is untouched so the candidate
         # stays a candidate — this stage never promotes.

--- a/autocontext/src/autocontext/ambient/evaluate.py
+++ b/autocontext/src/autocontext/ambient/evaluate.py
@@ -93,6 +93,23 @@ class EvaluateStage:
         # constructing the default provider per candidate would be wasteful. build lazily so a cycle
         # with no eligible candidate never touches the provider.
         scorer: _Scorer | None = None
+        # the drift canary is a property of the fixed charter anchor, not the candidate being
+        # evaluated, so it is computed once per cycle and applied to all candidates. it shares the
+        # scorer's lazy-build-once pattern: both build on the first candidate that actually has a
+        # suite to score, so an all-skipped or all-no-suite cycle never touches the probe provider.
+        drift: BiasProbeResult | None = None
+
+        def get_scorer() -> _Scorer:
+            nonlocal scorer
+            if scorer is None:
+                scorer = judge_factory(anchor)
+            return scorer
+
+        def get_drift() -> BiasProbeResult:
+            nonlocal drift
+            if drift is None:
+                drift = probe_fn(anchor)
+            return drift
 
         processed = 0
         errors = 0
@@ -107,9 +124,7 @@ class EvaluateStage:
                 # so it is silently skipped rather than reported as ours.
                 continue
             try:
-                if scorer is None:
-                    scorer = judge_factory(anchor)
-                processed += self._evaluate_candidate(ctx, record, target, anchor, scorer, probe_fn)
+                processed += self._evaluate_candidate(ctx, record, target, anchor, get_scorer, get_drift)
             except Exception as exc:
                 errors += 1
                 ctx.emitter.emit(
@@ -125,8 +140,8 @@ class EvaluateStage:
         record: DistilledModelRecord,
         target: CharterTarget,
         anchor: CharterAnchor,
-        scorer: _Scorer,
-        probe_fn: Callable[..., BiasProbeResult],
+        get_scorer: Callable[[], _Scorer],
+        get_drift: Callable[[], BiasProbeResult],
     ) -> int:
         suite = load_eval_suite(self.suites_dir, target.eval_suite)
         if suite is None or not suite.cases:
@@ -140,10 +155,15 @@ class EvaluateStage:
             )
             return 0
 
+        # v1 stand-in: the injected scorer receives (case.prompt, case.reference); plan 5b wires the
+        # candidate model's real generation as the scored output.
+        scorer = get_scorer()
         scores = [scorer.score(case.prompt, case.reference) for case in suite.cases]
         avg_score = sum(scores) / len(scores)
 
-        probe = probe_fn(anchor)
+        # the drift canary depends only on the anchor, so this returns the same memoized probe for
+        # every candidate in the cycle.
+        probe = get_drift()
         drift_ok = probe.magnitude <= self.drift_tolerance
 
         record.metadata["eval"] = {

--- a/autocontext/src/autocontext/ambient/promote.py
+++ b/autocontext/src/autocontext/ambient/promote.py
@@ -1,0 +1,130 @@
+"""the promote stage: activate an anchor-winning, drift-clean candidate into the live binding.
+
+This is the slice that reads the eval block written by the evaluate stage and, gated by the
+charter's autonomy dial, flips the best candidate to the live serving binding. Promotion refuses
+a drift-flagged candidate outright (a higher score never buys past a tripped drift canary), and it
+only promotes when the candidate beats the incumbent's recorded eval score under the SAME anchor.
+An incumbent scored under a different (or absent) anchor is not comparable, so v1 declines to
+auto-promote across mismatched anchors and emits promote_anchor_mismatch instead.
+
+On promote the new record gets a "probation" marker naming the previous active artifact, then
+registry.activate demotes that incumbent to disabled — kept warm as the rollback target. This
+stage never generates or scores; it reads eval metadata and moves the activation pointer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.policy import decide
+from autocontext.ambient.stage import StageContext, StageResult
+from autocontext.training.model_registry import DistilledModelRecord, ModelRegistry
+
+
+def _default_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(slots=True)
+class PromoteStage:
+    name: str
+    registry: ModelRegistry
+    now_fn: Callable[[], str] = _default_now
+
+    def run_once(self, ctx: StageContext) -> StageResult:
+        processed = 0
+        errors = 0
+        for target in ctx.charter.targets:
+            try:
+                processed += self._promote_target(ctx, target)
+            except Exception as exc:
+                errors += 1
+                ctx.emitter.emit(
+                    "promote_target_failed",
+                    {"target": target.name, "error": str(exc)},
+                    channel="ambient",
+                )
+        return StageResult(processed=processed, errors=errors)
+
+    def _promote_target(self, ctx: StageContext, target: CharterTarget) -> int:
+        records = self.registry.list_all()
+        candidates = [r for r in records if self._is_promotable_candidate(r, target.name)]
+        if not candidates:
+            # nothing evaluated-and-clean for this target this cycle: stay quiet.
+            return 0
+
+        best = max(candidates, key=lambda r: r.metadata["eval"]["score"])
+        incumbent = self._incumbent(records, target.name)
+
+        if not self._beats_incumbent(ctx, best, incumbent, target):
+            # either the incumbent was scored under a different anchor (mismatch already emitted)
+            # or the candidate does not clear the incumbent's score: leave the binding untouched.
+            return 0
+
+        decision = decide(ctx.charter, "promote", target.name)
+        if decision.requires_approval:
+            ctx.emitter.emit(
+                "promote_requires_approval",
+                {"target": target.name, "artifact_id": best.artifact_id, "reason": decision.reason},
+                channel="ambient",
+            )
+            return 0
+
+        previous_active = incumbent.artifact_id if incumbent is not None else ""
+        best.metadata["probation"] = {"promoted_at": self.now_fn(), "previous_active": previous_active}
+        # persist the probation marker while best is still a candidate; activate flips it to active
+        # and demotes the incumbent to disabled, kept warm as the rollback target.
+        self.registry.register(best)
+        self.registry.activate(best.artifact_id)
+
+        ctx.emitter.emit(
+            "promote_activated",
+            {
+                "target": target.name,
+                "artifact_id": best.artifact_id,
+                "previous_active": previous_active,
+                "score": best.metadata["eval"]["score"],
+            },
+            channel="ambient",
+        )
+        return 1
+
+    @staticmethod
+    def _is_promotable_candidate(record: DistilledModelRecord, target_name: str) -> bool:
+        if record.activation_state != "candidate" or record.metadata.get("target") != target_name:
+            return False
+        eval_meta = record.metadata.get("eval")
+        # a drift-flagged candidate is never promotable, however high its score.
+        return isinstance(eval_meta, dict) and eval_meta.get("drift_ok") is True
+
+    @staticmethod
+    def _incumbent(records: list[DistilledModelRecord], target_name: str) -> DistilledModelRecord | None:
+        for record in records:
+            if record.activation_state == "active" and record.metadata.get("target") == target_name:
+                return record
+        return None
+
+    def _beats_incumbent(
+        self,
+        ctx: StageContext,
+        best: DistilledModelRecord,
+        incumbent: DistilledModelRecord | None,
+        target: CharterTarget,
+    ) -> bool:
+        if incumbent is None:
+            return True
+        incumbent_eval = incumbent.metadata.get("eval")
+        best_anchor = best.metadata["eval"].get("anchor_model")
+        if isinstance(incumbent_eval, dict) and incumbent_eval.get("anchor_model") == best_anchor:
+            return bool(best.metadata["eval"]["score"] > incumbent_eval["score"])
+        # v1 rule: never auto-promote across mismatched (or absent) anchors — the scores are not
+        # comparable, so a human decides.
+        ctx.emitter.emit(
+            "promote_anchor_mismatch",
+            {"target": target.name, "artifact_id": best.artifact_id},
+            channel="ambient",
+        )
+        return False

--- a/autocontext/src/autocontext/ambient/promote.py
+++ b/autocontext/src/autocontext/ambient/promote.py
@@ -54,8 +54,12 @@ class PromoteStage:
         candidates = [r for r in records if self._is_promotable_candidate(r, target.name)]
         # only compare candidates scored under the CURRENT charter anchor: if the anchor
         # changed between training cycles, candidates carrying scores from a stale anchor are
-        # not apples-to-apples, so they are not eligible to be picked as best this cycle (they
-        # get re-scored under the new anchor by the evaluate stage, a separate 5b concern).
+        # not apples-to-apples, so they are not eligible to be picked as best this cycle. the
+        # evaluate stage now re-scores such candidates under the new anchor on a later cycle (it
+        # re-evaluates whenever the eval fingerprint changes), so a stale-anchor candidate becomes
+        # eligible again once re-scored. the INCUMBENT (an active record) is still not re-scored, so
+        # a post-anchor-change promote can still anchor-mismatch against a stale incumbent; that
+        # incumbent-side re-evaluation is tracked in AC-883 and is out of scope here.
         current_anchor = ctx.charter.anchor.model
         candidates = [r for r in candidates if r.metadata["eval"].get("anchor_model") == current_anchor]
         if not candidates:
@@ -104,8 +108,16 @@ class PromoteStage:
         if record.activation_state != "candidate" or record.metadata.get("target") != target_name:
             return False
         eval_meta = record.metadata.get("eval")
+        if not isinstance(eval_meta, dict):
+            return False
+        # until real candidate generation is wired (plan 5b), evaluation scores a placeholder (the
+        # eval suite's reference text, not the candidate's own output), so promotion must refuse those
+        # candidates rather than activate a model on a score that never ran it. only a candidate whose
+        # eval judged its real generation (from_candidate_generation True) is promotable.
+        if eval_meta.get("from_candidate_generation") is not True:
+            return False
         # a drift-flagged candidate is never promotable, however high its score.
-        return isinstance(eval_meta, dict) and eval_meta.get("drift_ok") is True
+        return eval_meta.get("drift_ok") is True
 
     @staticmethod
     def _incumbent(records: list[DistilledModelRecord], target_name: str) -> DistilledModelRecord | None:

--- a/autocontext/src/autocontext/ambient/promote.py
+++ b/autocontext/src/autocontext/ambient/promote.py
@@ -52,8 +52,15 @@ class PromoteStage:
     def _promote_target(self, ctx: StageContext, target: CharterTarget) -> int:
         records = self.registry.list_all()
         candidates = [r for r in records if self._is_promotable_candidate(r, target.name)]
+        # only compare candidates scored under the CURRENT charter anchor: if the anchor
+        # changed between training cycles, candidates carrying scores from a stale anchor are
+        # not apples-to-apples, so they are not eligible to be picked as best this cycle (they
+        # get re-scored under the new anchor by the evaluate stage, a separate 5b concern).
+        current_anchor = ctx.charter.anchor.model
+        candidates = [r for r in candidates if r.metadata["eval"].get("anchor_model") == current_anchor]
         if not candidates:
-            # nothing evaluated-and-clean for this target this cycle: stay quiet.
+            # nothing evaluated-and-clean under the current anchor for this target this cycle:
+            # stay quiet, same as having no candidates at all.
             return 0
 
         best = max(candidates, key=lambda r: r.metadata["eval"]["score"])

--- a/autocontext/src/autocontext/ambient/promote.py
+++ b/autocontext/src/autocontext/ambient/promote.py
@@ -8,7 +8,7 @@ An incumbent scored under a different (or absent) anchor is not comparable, so v
 auto-promote across mismatched anchors and emits promote_anchor_mismatch instead.
 
 On promote the new record gets a "probation" marker naming the previous active artifact, then
-registry.activate demotes that incumbent to disabled — kept warm as the rollback target. This
+registry.activate demotes that incumbent to disabled, kept warm as the rollback target. This
 stage never generates or scores; it reads eval metadata and moves the activation pointer.
 """
 
@@ -120,7 +120,7 @@ class PromoteStage:
         best_anchor = best.metadata["eval"].get("anchor_model")
         if isinstance(incumbent_eval, dict) and incumbent_eval.get("anchor_model") == best_anchor:
             return bool(best.metadata["eval"]["score"] > incumbent_eval["score"])
-        # v1 rule: never auto-promote across mismatched (or absent) anchors — the scores are not
+        # v1 rule: never auto-promote across mismatched (or absent) anchors: the scores are not
         # comparable, so a human decides.
         ctx.emitter.emit(
             "promote_anchor_mismatch",

--- a/autocontext/src/autocontext/ambient/publish.py
+++ b/autocontext/src/autocontext/ambient/publish.py
@@ -34,7 +34,12 @@ def publish_candidate(
         run_id=run_id,
         checkpoint_path=str(outcome.checkpoint_path),
         backend=outcome.backend,
-        scenario=scenario,
+        # the registry SLOT is the target name, not the raw scenario: activation demotes competing
+        # actives in the same scenario+backend+runtime slot, and two charter targets can map to the
+        # same real scenario (competitor@grid_ctf and analyst@grid_ctf both -> "grid_ctf"). slotting
+        # by target.name keeps each target its own activation slot so promoting one never cross-demotes
+        # a sibling's live model. the real scenario is preserved as scenario_family for grouping.
+        scenario=target.name,
         scenario_family=scenario,
         parameter_count=int(outcome.metrics.get("num_params_m", 0.0) * 1_000_000),
         architecture=target.base_model,

--- a/autocontext/src/autocontext/ambient/serving.py
+++ b/autocontext/src/autocontext/ambient/serving.py
@@ -7,6 +7,15 @@ live model for a target is a scenario-routing lookup keyed on the target name.
 resolve_active_serving is a thin wrapper over the scenario-routing resolver that
 returns the active model for a target (or the fallback when none is live).
 
+Scope boundary: resolve_active_serving is keyed on the TARGET name, so it is a
+per-target lookup a caller runs when it already knows which target to serve. The
+generation loop's own live router (resolve_provider_for_context, driven by the real
+scenario context of a running match) does NOT see these per-target ambient records:
+ambient candidates are slotted by target name, not by the real scenario, so the
+target key and the running-scenario key never coincide. Wiring per-role live serving
+into the running loop (mapping a live scenario onto the right ambient target) is
+deferred to plan 5b.
+
 ServerSupervisor carries the health/rollback logic a real vLLM launch needs, with
 launch itself left to a later slice (plan 5b/ops). It is unit-tested with fakes:
 poll_interval_fn defaults to a no-op so tests never sleep.

--- a/autocontext/src/autocontext/ambient/serving.py
+++ b/autocontext/src/autocontext/ambient/serving.py
@@ -1,0 +1,78 @@
+"""per-target serving resolution and a health-checkable supervisor.
+
+Ambient trains and serves per TARGET, and publish.py slots each candidate by its
+target name (the real scenario is preserved as scenario_family). So resolving the
+live model for a target is a scenario-routing lookup keyed on the target name.
+
+resolve_active_serving is a thin wrapper over the scenario-routing resolver that
+returns the active model for a target (or the fallback when none is live).
+
+ServerSupervisor carries the health/rollback logic a real vLLM launch needs, with
+launch itself left to a later slice (plan 5b/ops). It is unit-tested with fakes:
+poll_interval_fn defaults to a no-op so tests never sleep.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from autocontext.providers.scenario_routing import (
+    RoutingDecision,
+    ScenarioRoutingContext,
+    resolve_provider_for_context,
+)
+from autocontext.training.model_registry import ModelRegistry
+
+
+def resolve_active_serving(registry: ModelRegistry, target_name: str, backend: str) -> RoutingDecision:
+    """Resolve the live serving model for a target.
+
+    Because ambient candidates are slotted by target.name, routing on the target
+    name resolves the ACTIVE model for that target (or the fallback when none is live).
+    """
+    ctx = ScenarioRoutingContext(scenario=target_name, backend=backend)
+    return resolve_provider_for_context(ctx, registry)
+
+
+def _noop_interval(_attempt: int) -> None:
+    return None
+
+
+@dataclass(slots=True)
+class ServerSupervisor:
+    """Health-poll and rollback logic for a served ambient model.
+
+    Real process launch is out of scope here; start_fn/stop_fn are carried for the
+    launch slice that wires this to a concrete vLLM server.
+    """
+
+    health_fn: Callable[[], bool]
+    start_fn: Callable[[], None] | None = None
+    stop_fn: Callable[[], None] | None = None
+    poll_attempts: int = 5
+    poll_interval_fn: Callable[[int], None] | None = None
+
+    def wait_until_healthy(self) -> bool:
+        """Poll health_fn up to poll_attempts times, returning True on the first healthy poll.
+
+        Between attempts poll_interval_fn(attempt) is invoked when set (a test can count
+        the calls; a real supervisor sleeps there). Returns False if never healthy.
+        """
+        interval = self.poll_interval_fn or _noop_interval
+        for attempt in range(self.poll_attempts):
+            if self.health_fn():
+                return True
+            if attempt < self.poll_attempts - 1:
+                interval(attempt)
+        return False
+
+    def rollback(self, registry: ModelRegistry, target_name: str, previous_artifact_id: str) -> None:
+        """Re-activate the previous model for a target after a failed serve.
+
+        previous_artifact_id is the incumbent the promote flow demoted and kept warm.
+        An empty id means there is no warm rollback target, which is a programming error.
+        """
+        if not previous_artifact_id:
+            raise ValueError(f"no previous artifact to roll back to for target {target_name!r}")
+        registry.activate(previous_artifact_id)

--- a/autocontext/src/autocontext/ambient/stage.py
+++ b/autocontext/src/autocontext/ambient/stage.py
@@ -10,7 +10,7 @@ from autocontext.ambient.proposals import ProposalStore
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.harness.core.events import EventStreamEmitter
 
-STAGE_NAMES: tuple[str, ...] = ("ingest", "curate", "advise", "train", "evaluate")
+STAGE_NAMES: tuple[str, ...] = ("ingest", "curate", "advise", "train", "evaluate", "promote")
 
 
 @dataclass(slots=True)

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -1,4 +1,4 @@
-"""builds the daemon's stage set from the charter (ingest, curate, advise real; train/evaluate no-op)."""
+"""builds the daemon's stage set from the charter (all six stages ingest..promote are real)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,9 @@ from autocontext.ambient.advise import AdviseStage
 from autocontext.ambient.charter import Charter
 from autocontext.ambient.curate import CurateStage
 from autocontext.ambient.datasets import DatasetStore
+from autocontext.ambient.evaluate import EvaluateStage
 from autocontext.ambient.ingest import IngestStage
+from autocontext.ambient.promote import PromoteStage
 from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
 from autocontext.ambient.sources.contract import TraceSource
 from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
@@ -32,6 +34,7 @@ def build_stages(
     usage_db: Path,
     artifacts_dir: Path,
     checkpoints_dir: Path,
+    suites_dir: Path,
 ) -> dict[str, Stage]:
     sources: list[TraceSource] = []
     unsupported: list[tuple[str, str]] = []
@@ -49,7 +52,12 @@ def build_stages(
             unsupported.append((spec.name, spec.kind))
     trace_store = TraceStore(db_path)
     dataset_store = DatasetStore(datasets_dir)
+    # the NoOp comprehension seeds the dict in STAGE_NAMES order (which the daemon's run_cycle
+    # iterates, so evaluate precedes promote); every slot is then replaced by its real stage.
     stages: dict[str, Stage] = {name: NoOpStage(name=name) for name in STAGE_NAMES}
+    # one registry shared by train, evaluate, and promote: a candidate trained this cycle is the
+    # same record evaluate scores and promote activates, so they must read and write one store.
+    registry = ModelRegistry(registry_dir)
     stages["ingest"] = IngestStage(
         name="ingest",
         trace_store=trace_store,
@@ -63,8 +71,10 @@ def build_stages(
         name="train",
         dataset_store=dataset_store,
         usage_ledger=UsageLedger(usage_db),
-        registry=ModelRegistry(registry_dir),
+        registry=registry,
         artifacts_root=artifacts_dir,
         checkpoints_root=checkpoints_dir,
     )
+    stages["evaluate"] = EvaluateStage(name="evaluate", registry=registry, suites_dir=suites_dir)
+    stages["promote"] = PromoteStage(name="promote", registry=registry)
     return stages

--- a/autocontext/src/autocontext/ambient/train.py
+++ b/autocontext/src/autocontext/ambient/train.py
@@ -77,7 +77,10 @@ class TrainStage:
         # covering them. a hard whole-run deadline is the complete fix and lands with the plan-5
         # backend work.
         requested_gpu_hours = (self.time_budget_seconds + self.assess_overhead_seconds) / 3600.0
-        used = self.usage_ledger.used_in_window(target.name, ctx.charter.budgets.window_hours, self.now_fn())
+        # charter-wide pool: read every target's in-window hours, not just this target's, so a
+        # charter with N targets cannot each spend a full window. record() below stays per-target
+        # for attribution; only the gate reads the shared total.
+        used = self.usage_ledger.used_in_window_all(ctx.charter.budgets.window_hours, self.now_fn())
         if not budget_allows(ctx.charter.budgets, used, requested_gpu_hours):
             ctx.emitter.emit(
                 "train_budget_exhausted",

--- a/autocontext/src/autocontext/ambient/usage.py
+++ b/autocontext/src/autocontext/ambient/usage.py
@@ -53,6 +53,18 @@ class UsageLedger:
             ).fetchone()
             return float(row[0])
 
+    def used_in_window_all(self, window_hours: int, now_iso: str) -> float:
+        # charter-wide pool: sum every target's hours in the window. record()
+        # stays per-target for attribution, but the budget gate reads this
+        # total so a charter with N targets cannot spend N times the window.
+        cutoff = (datetime.fromisoformat(now_iso) - timedelta(hours=window_hours)).isoformat()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(gpu_hours), 0.0) FROM ambient_usage WHERE at_iso > ?",
+                (cutoff,),
+            ).fetchone()
+            return float(row[0])
+
     def total(self, target: str) -> float:
         with self._connect() as conn:
             row = conn.execute(

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -34,6 +34,7 @@ _DEFAULT_REGISTRY = Path("runs/ambient-registry")
 _DEFAULT_USAGE = Path("runs/ambient-usage.sqlite3")
 _DEFAULT_ARTIFACTS = Path("runs/ambient-artifacts")
 _DEFAULT_CHECKPOINTS = Path("runs/ambient-checkpoints")
+_DEFAULT_SUITES = Path("runs/ambient-eval-suites")
 
 
 def _daemon(
@@ -48,6 +49,7 @@ def _daemon(
     usage_db: Path,
     artifacts_dir: Path,
     checkpoints_dir: Path,
+    suites_dir: Path,
 ) -> AmbientDaemon:
     charter = load_charter(charter_path)
     emitter = EventStreamEmitter(events_path)
@@ -62,6 +64,7 @@ def _daemon(
         usage_db=usage_db,
         artifacts_dir=artifacts_dir,
         checkpoints_dir=checkpoints_dir,
+        suites_dir=suites_dir,
     )
     return AmbientDaemon(
         charter=charter,
@@ -103,6 +106,7 @@ def status(
     usage_db: Annotated[Path, typer.Option("--usage-db")] = _DEFAULT_USAGE,
     artifacts_dir: Annotated[Path, typer.Option("--artifacts-dir")] = _DEFAULT_ARTIFACTS,
     checkpoints_dir: Annotated[Path, typer.Option("--checkpoints-dir")] = _DEFAULT_CHECKPOINTS,
+    suites_dir: Annotated[Path, typer.Option("--suites-dir")] = _DEFAULT_SUITES,
 ) -> None:
     try:
         daemon = _daemon(
@@ -117,6 +121,7 @@ def status(
             usage_db,
             artifacts_dir,
             checkpoints_dir,
+            suites_dir,
         )
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -128,7 +133,8 @@ def status(
         table.add_row(name, str(info["paused"]), str(info["queue_depth"]))
     console.print(table)
     # read-only: construct the registry and count candidates, never train or write events
-    candidates = len(ModelRegistry(registry_dir).list_all())
+    registry = ModelRegistry(registry_dir)
+    candidates = len(registry.list_all())
     console.print(f"candidates={candidates}")
     if charter.targets:
         dataset_store = DatasetStore(datasets_dir)
@@ -137,6 +143,17 @@ def status(
             manifest = dataset_store.load_manifest(target.name)
             targets_table.add_row(target.name, str(manifest.record_count), f"{manifest.mean_score:.2f}")
         console.print(targets_table)
+        # per-target serving pointer: the active artifact for this target's slot, or "none".
+        # the slot key is the target name (task 5), so scan its records for the active one rather
+        # than guessing a backend for resolve_model; still read-only, no promotion happens here.
+        active_table = Table("target", "active model")
+        for target in charter.targets:
+            active = next(
+                (r for r in registry.list_for_scenario(target.name) if r.activation_state == "active"),
+                None,
+            )
+            active_table.add_row(target.name, active.artifact_id if active is not None else "none")
+        console.print(active_table)
 
 
 @ambient_app.command()
@@ -152,6 +169,7 @@ def run(
     usage_db: Annotated[Path, typer.Option("--usage-db")] = _DEFAULT_USAGE,
     artifacts_dir: Annotated[Path, typer.Option("--artifacts-dir")] = _DEFAULT_ARTIFACTS,
     checkpoints_dir: Annotated[Path, typer.Option("--checkpoints-dir")] = _DEFAULT_CHECKPOINTS,
+    suites_dir: Annotated[Path, typer.Option("--suites-dir")] = _DEFAULT_SUITES,
     poll_seconds: Annotated[float, typer.Option("--poll-seconds", min=0.0)] = 30.0,
     max_cycles: Annotated[int | None, typer.Option("--max-cycles", hidden=True)] = None,
 ) -> None:
@@ -168,6 +186,7 @@ def run(
             usage_db,
             artifacts_dir,
             checkpoints_dir,
+            suites_dir,
         )
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -193,6 +212,7 @@ def once(
     usage_db: Annotated[Path, typer.Option("--usage-db")] = _DEFAULT_USAGE,
     artifacts_dir: Annotated[Path, typer.Option("--artifacts-dir")] = _DEFAULT_ARTIFACTS,
     checkpoints_dir: Annotated[Path, typer.Option("--checkpoints-dir")] = _DEFAULT_CHECKPOINTS,
+    suites_dir: Annotated[Path, typer.Option("--suites-dir")] = _DEFAULT_SUITES,
 ) -> None:
     try:
         daemon = _daemon(
@@ -207,6 +227,7 @@ def once(
             usage_db,
             artifacts_dir,
             checkpoints_dir,
+            suites_dir,
         )
     except CharterLoadError as exc:
         console.print(f"[red]{exc}[/red]")

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from autocontext.ambient.charter import (
     Charter,
+    CharterAnchor,
     CharterBudgets,
     CharterSource,
     CharterTarget,
@@ -40,6 +41,23 @@ def test_minimal_charter_validates() -> None:
     assert charter.autonomy == "propose"
     assert charter.guardrails.frozen_anchor is True
     assert charter.guardrails.min_frontier_fraction == pytest.approx(0.2)
+
+
+def test_charter_has_default_anchor() -> None:
+    charter = _minimal_charter()
+    assert charter.anchor.model  # a sensible frontier default, never empty
+    assert charter.anchor.provider == "anthropic"
+    assert charter.anchor.rubric
+
+
+def test_anchor_empty_model_rejected() -> None:
+    with pytest.raises(ValidationError):
+        CharterAnchor(model="")
+
+
+def test_anchor_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        CharterAnchor(temperature=0.5)  # type: ignore[call-arg]
 
 
 def test_guardrail_booleans_cannot_be_disabled() -> None:

--- a/autocontext/tests/test_ambient_cli.py
+++ b/autocontext/tests/test_ambient_cli.py
@@ -37,6 +37,8 @@ def _path_opts(tmp_path: Path) -> list[str]:
         str(tmp_path / "artifacts"),
         "--checkpoints-dir",
         str(tmp_path / "checkpoints"),
+        "--suites-dir",
+        str(tmp_path / "suites"),
     ]
 
 
@@ -83,7 +85,7 @@ def test_status_reports_stages(tmp_path: Path) -> None:
         ["ambient", "status", "--charter-path", str(charter_path), *_path_opts(tmp_path)],
     )
     assert result.exit_code == 0, result.output
-    for stage in ("ingest", "curate", "advise", "train", "evaluate"):
+    for stage in ("ingest", "curate", "advise", "train", "evaluate", "promote"):
         assert stage in result.output
 
 
@@ -242,6 +244,58 @@ def test_once_train_runs_clean_on_empty_stores(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert "processed=0" in result.output
+
+
+def test_once_evaluate_runs_clean_on_empty_registry(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "once",
+            "evaluate",
+            "--charter-path",
+            str(charter_path),
+            *_path_opts(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "processed=0" in result.output
+
+
+def test_once_promote_runs_clean_on_empty_registry(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "once",
+            "promote",
+            "--charter-path",
+            str(charter_path),
+            *_path_opts(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "processed=0" in result.output
+
+
+def test_status_shows_active_model_rows(tmp_path: Path) -> None:
+    charter_path = _init(tmp_path)  # fixture charter carries at least one target
+    result = runner.invoke(
+        app,
+        [
+            "ambient",
+            "status",
+            "--charter-path",
+            str(charter_path),
+            *_path_opts(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # empty registry: every target resolves to no active model
+    assert "active model" in result.output
+    assert "none" in result.output
 
 
 def test_status_shows_candidates_row(tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_daemon.py
+++ b/autocontext/tests/test_ambient_daemon.py
@@ -59,7 +59,7 @@ class CountingStage:
         return StageResult(processed=1)
 
 
-def test_default_daemon_has_five_noop_stages(tmp_path: Path) -> None:
+def test_default_daemon_has_all_noop_stages(tmp_path: Path) -> None:
     daemon = _daemon(tmp_path)
     assert set(daemon.status().keys()) == set(STAGE_NAMES)
 

--- a/autocontext/tests/test_ambient_e2e.py
+++ b/autocontext/tests/test_ambient_e2e.py
@@ -183,6 +183,10 @@ def test_miniature_ingest_through_serving(tmp_path: Path, monkeypatch: Any) -> N
     evaluate.judge_factory = lambda anchor: _FixedScorer(0.9)
     evaluate.probe_fn = _clean_probe
     evaluate.now_fn = lambda: _NOW
+    # EvaluateStage is a non-frozen slots dataclass; flip its candidate-generation flag on the built
+    # instance. the injected _FixedScorer stands in for real candidate generation, so promotion (which
+    # refuses placeholder evals) is allowed to activate this candidate.
+    evaluate.scores_candidate_generation = True
 
     ctx = _ctx(tmp_path, charter)
 

--- a/autocontext/tests/test_ambient_e2e.py
+++ b/autocontext/tests/test_ambient_e2e.py
@@ -1,0 +1,220 @@
+"""miniature end-to-end acceptance: ingest -> curate -> advise -> train -> evaluate -> promote -> serving.
+
+This is the V1 acceptance in miniature. It seeds a runs sqlite db with completed frontier competitor
+traces, builds a full-autonomy charter and a tiny eval suite, then drives the real stage set (built by
+build_stages so train/evaluate/promote share one ModelRegistry and one TraceStore) in cycle order.
+Every non-deterministic seam is injected: the training backend is monkeypatched to a fake that writes a
+checkpoint dir instead of fine-tuning, and the evaluate stage's anchor judge + drift probe are replaced
+with deterministic fakes. No real fine-tune, no LLM, no network, no sleeps.
+
+The assertion proves the whole loop: a candidate is trained, scored above threshold, promoted to active,
+and serving resolution for the target routes to that exact artifact from the registry (not the fallback).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import autocontext.ambient.train as train_mod
+from autocontext.ambient.charter import Charter, CharterAnchor, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.evaluate import EvaluateStage
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.serving import resolve_active_serving
+from autocontext.ambient.stage import STAGE_NAMES, StageContext
+from autocontext.ambient.stage_factory import build_stages
+from autocontext.ambient.training_backend import TrainOutcome
+from autocontext.execution.bias_probes import BiasProbeResult
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.training.model_registry import ModelRegistry
+
+_NOW = "2026-07-06T12:00:00+00:00"
+_ANCHOR = "claude-sonnet-5"
+_BACKEND = "mlx"
+_TARGET = "competitor-grid_ctf"
+
+_RUNS_SCHEMA = """
+CREATE TABLE runs (
+    run_id TEXT PRIMARY KEY, scenario TEXT NOT NULL, target_generations INTEGER NOT NULL,
+    executor_mode TEXT NOT NULL, status TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE generations (
+    run_id TEXT NOT NULL, generation_index INTEGER NOT NULL, mean_score REAL NOT NULL,
+    best_score REAL NOT NULL, gate_decision TEXT NOT NULL, status TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (run_id, generation_index)
+);
+CREATE TABLE agent_outputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, run_id TEXT NOT NULL, generation_index INTEGER NOT NULL,
+    role TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
+
+def _seed_runs_db(db: Path, generations: int) -> None:
+    """Seed one completed grid_ctf run with `generations` completed competitor outputs.
+
+    The agent_outputs source hands these to curate as frontier-provenance agent_output traces; each
+    completed competitor row becomes one eligible training record for the competitor target.
+    """
+    conn = sqlite3.connect(db)
+    conn.executescript(_RUNS_SCHEMA)
+    conn.execute(
+        "INSERT INTO runs (run_id, scenario, target_generations, executor_mode, status) "
+        "VALUES ('r1', 'grid_ctf', ?, 'local', 'completed')",
+        (generations,),
+    )
+    for index in range(generations):
+        conn.execute(
+            "INSERT INTO generations (run_id, generation_index, mean_score, best_score, gate_decision, status) "
+            "VALUES ('r1', ?, 0.8, 0.9, 'advance', 'completed')",
+            (index,),
+        )
+        conn.execute(
+            "INSERT INTO agent_outputs (run_id, generation_index, role, content) VALUES ('r1', ?, 'competitor', ?)",
+            (index, f"capture the flag via corner control, plan v{index}"),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _charter() -> Charter:
+    return Charter(
+        tier="oss",
+        autonomy="full",  # train and promote are both autonomous
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name=_TARGET,
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="tiny",
+                min_dataset_records=2,
+                eval_suite="e2e_holdout",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=10.0, window_hours=24, disk_quota_gb=1.0),
+        anchor=CharterAnchor(provider="anthropic", model=_ANCHOR, rubric="Score 0 to 1."),
+    )
+
+
+def _write_suite(suites_dir: Path) -> None:
+    suites_dir.mkdir(parents=True, exist_ok=True)
+    cases = [
+        {"prompt": "hold the two corners nearest your base", "reference": "corner control"},
+        {"prompt": "when should you rush the flag", "reference": "after securing the center"},
+    ]
+    (suites_dir / "e2e_holdout.jsonl").write_text("\n".join(json.dumps(case) for case in cases) + "\n", encoding="utf-8")
+
+
+def _fake_run_training(backend_name: str, request: Any) -> TrainOutcome:
+    """Stand in for a real fine-tune: write a checkpoint dir, return a tiny-budget outcome."""
+    checkpoint = request.output_dir / "adapters"
+    checkpoint.mkdir(parents=True, exist_ok=True)
+    (checkpoint / "adapter_config.json").write_text("{}", encoding="utf-8")
+    return TrainOutcome(
+        checkpoint_path=checkpoint,
+        backend=backend_name,
+        metrics={"avg_score": 0.85, "valid_rate": 1.0, "num_records": 3.0, "training_seconds": 36.0},
+        gpu_hours=0.01,  # well within the 10h window
+    )
+
+
+class _FixedScorer:
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def score(self, prompt: str, output: str) -> float:
+        return self.value
+
+
+def _clean_probe(_anchor: CharterAnchor) -> BiasProbeResult:
+    # magnitude 0.0 <= the 0.2 default tolerance, so the candidate reads drift-clean
+    return BiasProbeResult(probe_type="position", detected=False, magnitude=0.0, details="")
+
+
+def _ctx(tmp_path: Path, charter: Charter) -> StageContext:
+    return StageContext(
+        charter=charter,
+        queue=AmbientQueue(tmp_path / "q.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+
+
+def _events(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "events.ndjson"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_miniature_ingest_through_serving(tmp_path: Path, monkeypatch: Any) -> None:
+    runs_db = tmp_path / "runs.sqlite3"
+    _seed_runs_db(runs_db, generations=3)
+    _write_suite(tmp_path / "suites")
+    charter = _charter()
+
+    # a fixed backend name + a checkpoint-writing fake training run: no real fine-tune, deterministic budget.
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: _BACKEND)
+    monkeypatch.setattr(train_mod, "run_training", _fake_run_training)
+
+    stages = build_stages(
+        charter=charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        runs_db_path=runs_db,
+        otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
+    )
+    # the train stage's now_fn is left at default (real clock); its budget gate compares hours, not
+    # timestamps, so it stays deterministic. only evaluate needs a fixed clock for its eval block.
+    evaluate = stages["evaluate"]
+    assert isinstance(evaluate, EvaluateStage)
+    # build_stages wires the default anchor judge + probe; replace them with deterministic fakes so the
+    # candidate scores above 0.5 and reads drift-clean without touching a provider.
+    evaluate.judge_factory = lambda anchor: _FixedScorer(0.9)
+    evaluate.probe_fn = _clean_probe
+    evaluate.now_fn = lambda: _NOW
+
+    ctx = _ctx(tmp_path, charter)
+
+    # drive the full loop in cycle order (advise is a no-op without a proposal store, but runs to prove
+    # the ordered set clears end to end).
+    results = {name: stages[name].run_once(ctx) for name in STAGE_NAMES}
+
+    # each stage did its unit of work with no errors.
+    assert all(result.errors == 0 for result in results.values())
+    assert results["ingest"].processed > 0  # native generations + agent outputs landed in the trace store
+    assert results["curate"].processed == 3  # three completed competitor traces became training records
+    assert results["train"].processed == 1  # one candidate trained + published
+    assert results["evaluate"].processed == 1  # candidate scored under the anchor
+    assert results["promote"].processed == 1  # candidate activated (no incumbent)
+
+    # the shared registry now holds exactly one record for the target, and it is ACTIVE.
+    registry = ModelRegistry(tmp_path / "registry")
+    target_records = [r for r in registry.list_all() if r.metadata.get("target") == _TARGET]
+    assert len(target_records) == 1
+    promoted = target_records[0]
+    assert promoted.activation_state == "active"
+    assert promoted.metadata["eval"]["score"] == 0.9
+    assert promoted.metadata["eval"]["drift_ok"] is True
+
+    # serving resolution for the target routes to that promoted artifact from the registry, not the fallback.
+    decision = resolve_active_serving(registry, _TARGET, _BACKEND)
+    assert decision.source == "registry"
+    assert decision.fallback_used is False
+    assert decision.artifact_id == promoted.artifact_id
+    assert decision.model == promoted.checkpoint_path
+
+    # the promote stage announced the activation for this target.
+    activated = [e for e in _events(tmp_path) if e["event"] == "promote_activated"]
+    assert activated and activated[0]["payload"]["target"] == _TARGET
+    assert activated[0]["payload"]["artifact_id"] == promoted.artifact_id

--- a/autocontext/tests/test_ambient_eval_suite.py
+++ b/autocontext/tests/test_ambient_eval_suite.py
@@ -1,0 +1,57 @@
+"""tests for the eval_suite resolver that loads a held-out suite from disk."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autocontext.ambient.eval_suite import EvalCase, EvalSuite, load_eval_suite
+
+
+def test_absent_file_returns_none(tmp_path: Path) -> None:
+    assert load_eval_suite(tmp_path, "competitor_holdout") is None
+
+
+def test_two_line_suite_parses_prompt_and_reference(tmp_path: Path) -> None:
+    (tmp_path / "holdout.jsonl").write_text(
+        json.dumps({"prompt": "solve x", "reference": "x=1"}) + "\n" + json.dumps({"prompt": "solve y"}) + "\n",
+        encoding="utf-8",
+    )
+    suite = load_eval_suite(tmp_path, "holdout")
+    assert suite == EvalSuite(
+        name="holdout",
+        cases=[EvalCase(prompt="solve x", reference="x=1"), EvalCase(prompt="solve y", reference="")],
+    )
+
+
+def test_malformed_and_promptless_lines_are_skipped(tmp_path: Path) -> None:
+    (tmp_path / "holdout.jsonl").write_text(
+        json.dumps({"prompt": "keep me", "reference": "r"})
+        + "\n"
+        + "this is not json\n"
+        + json.dumps({"reference": "no prompt here"})
+        + "\n"
+        + json.dumps({"prompt": ""})
+        + "\n",
+        encoding="utf-8",
+    )
+    suite = load_eval_suite(tmp_path, "holdout")
+    assert suite is not None
+    assert suite.cases == [EvalCase(prompt="keep me", reference="r")]
+
+
+def test_empty_file_yields_empty_suite_not_none(tmp_path: Path) -> None:
+    (tmp_path / "holdout.jsonl").write_text("\n  \n", encoding="utf-8")
+    suite = load_eval_suite(tmp_path, "holdout")
+    assert suite is not None
+    assert suite.cases == []
+
+
+@pytest.mark.parametrize("name", ["../secrets", "sub/holdout", ".."])
+def test_name_with_path_separator_raises(tmp_path: Path, name: str) -> None:
+    outside = tmp_path.parent / "secrets.jsonl"
+    outside.write_text(json.dumps({"prompt": "leaked"}) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_eval_suite(tmp_path, name)

--- a/autocontext/tests/test_ambient_evaluate_stage.py
+++ b/autocontext/tests/test_ambient_evaluate_stage.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from autocontext.ambient.charter import Charter, CharterAnchor, CharterBudgets, CharterSource, CharterTarget
-from autocontext.ambient.evaluate import EvaluateStage
+from autocontext.ambient.evaluate import EvaluateStage, eval_fingerprint
 from autocontext.ambient.queue import AmbientQueue
 from autocontext.ambient.stage import StageContext
 from autocontext.execution.bias_probes import BiasProbeResult
@@ -186,11 +186,13 @@ def test_empty_suite_emits_no_suite(tmp_path: Path) -> None:
     assert any(e["event"] == "evaluate_no_suite" for e in _events(tmp_path))
 
 
-def test_already_evaluated_candidate_is_skipped(tmp_path: Path) -> None:
+def test_already_evaluated_candidate_with_current_fingerprint_is_skipped(tmp_path: Path) -> None:
     registry = ModelRegistry(tmp_path / "registry")
-    _candidate(registry, "cand-1", "competitor-local", metadata={"eval": {"score": 0.5}})
-    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
     charter = _charter([_target("competitor-local", "anchor-v1")])
+    current = eval_fingerprint(charter.anchor, "anchor-v1")
+    stored = {"score": 0.5, "fingerprint": current}
+    _candidate(registry, "cand-1", "competitor-local", metadata={"eval": stored})
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
     stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
 
     result = stage.run_once(_ctx(tmp_path, charter))
@@ -198,7 +200,7 @@ def test_already_evaluated_candidate_is_skipped(tmp_path: Path) -> None:
     assert (result.processed, result.errors) == (0, 0)
     reloaded = registry.load("cand-1")
     assert reloaded is not None
-    assert reloaded.metadata["eval"] == {"score": 0.5}  # untouched
+    assert reloaded.metadata["eval"] == stored  # untouched: fingerprint matches the current config
     assert _events(tmp_path) == []
 
 
@@ -368,3 +370,124 @@ def test_reregister_keeps_activation_state_candidate(tmp_path: Path) -> None:
     reloaded = registry.load("cand-1")
     assert reloaded is not None
     assert reloaded.activation_state == "candidate"
+
+
+def test_from_candidate_generation_defaults_false_placeholder(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    # _stage leaves scores_candidate_generation at its False default: the score judged the suite's
+    # reference text, a placeholder, so the eval is stamped from_candidate_generation False.
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert reloaded.metadata["eval"]["from_candidate_generation"] is False
+
+
+def test_from_candidate_generation_stamped_true_when_flag_set(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: _FixedScorer(0.9),
+        probe_fn=_probe(0.1),
+        now_fn=lambda: _NOW,
+        scores_candidate_generation=True,
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert reloaded.metadata["eval"]["from_candidate_generation"] is True
+
+
+def test_matching_fingerprint_candidate_is_not_rescored(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    current = eval_fingerprint(charter.anchor, "anchor-v1")
+    stored = {"score": 0.42, "anchor_model": "claude-sonnet-5", "fingerprint": current}
+    _candidate(registry, "cand-1", "competitor-local", metadata={"eval": stored})
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert reloaded.metadata["eval"] == stored  # unchanged: still scored under the current config
+    assert _events(tmp_path) == []
+
+
+def test_stale_fingerprint_candidate_is_reevaluated(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    # an eval scored under a previous anchor: its fingerprint carries a different anchor model, so it
+    # no longer matches the current config and must be re-scored rather than left stuck.
+    stale_anchor = CharterAnchor(provider="anthropic", model="claude-opus-4-8", rubric="Score 0 to 1.")
+    stale = {"score": 0.42, "anchor_model": "claude-opus-4-8", "fingerprint": eval_fingerprint(stale_anchor, "anchor-v1")}
+    _candidate(registry, "cand-1", "competitor-local", metadata={"eval": stale})
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    eval_meta = reloaded.metadata["eval"]
+    assert eval_meta["score"] == 0.9  # re-scored under the current anchor
+    assert eval_meta["anchor_model"] == "claude-sonnet-5"
+    assert eval_meta["fingerprint"] == eval_fingerprint(charter.anchor, "anchor-v1")
+
+
+def test_drift_probe_memoized_across_reevaluations(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    charter = _charter([_target("target-a", "suite-a"), _target("target-b", "suite-b")])
+    # both candidates carry a stale eval (previous anchor), so both are re-evaluated this cycle. the
+    # drift canary depends only on the anchor, so it must still be probed exactly once for the cycle.
+    stale_anchor = CharterAnchor(provider="anthropic", model="claude-opus-4-8", rubric="Score 0 to 1.")
+    _candidate(
+        registry,
+        "cand-a",
+        "target-a",
+        metadata={"eval": {"score": 0.1, "fingerprint": eval_fingerprint(stale_anchor, "suite-a")}},
+    )
+    _candidate(
+        registry,
+        "cand-b",
+        "target-b",
+        metadata={"eval": {"score": 0.1, "fingerprint": eval_fingerprint(stale_anchor, "suite-b")}},
+    )
+    _seed_suite(tmp_path / "suites", "suite-a", [("p1", "r1")])
+    _seed_suite(tmp_path / "suites", "suite-b", [("p2", "r2")])
+    probe = _CountingProbe(0.3)
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: _FixedScorer(0.9),
+        probe_fn=probe,
+        drift_tolerance=0.5,
+        now_fn=lambda: _NOW,
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (2, 0)
+    assert probe.calls == 1  # memoized across both re-evaluations
+    a = registry.load("cand-a")
+    b = registry.load("cand-b")
+    assert a is not None and a.metadata["eval"]["score"] == 0.9
+    assert b is not None and b.metadata["eval"]["score"] == 0.9

--- a/autocontext/tests/test_ambient_evaluate_stage.py
+++ b/autocontext/tests/test_ambient_evaluate_stage.py
@@ -1,0 +1,270 @@
+"""tests for the evaluate stage: scoring candidates under the frozen anchor + drift canary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.ambient.charter import Charter, CharterAnchor, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.evaluate import EvaluateStage
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage import StageContext
+from autocontext.execution.bias_probes import BiasProbeResult
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.training.model_registry import DistilledModelRecord, ModelRegistry
+
+_NOW = "2026-07-06T12:00:00+00:00"
+
+
+def _target(name: str, eval_suite: str) -> CharterTarget:
+    return CharterTarget(
+        name=name,
+        kind="role",
+        selector="competitor",
+        base_model="tiny",
+        min_dataset_records=5,
+        eval_suite=eval_suite,
+    )
+
+
+def _charter(targets: list[CharterTarget]) -> Charter:
+    return Charter(
+        tier="oss",
+        autonomy="train",
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=targets,
+        budgets=CharterBudgets(gpu_hours_per_window=10.0, window_hours=24, disk_quota_gb=1.0),
+        anchor=CharterAnchor(provider="anthropic", model="claude-sonnet-5", rubric="Score 0 to 1."),
+    )
+
+
+def _ctx(tmp_path: Path, charter: Charter) -> StageContext:
+    return StageContext(
+        charter=charter,
+        queue=AmbientQueue(tmp_path / "q.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+
+
+def _events(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "events.ndjson"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _seed_suite(suites_dir: Path, name: str, cases: list[tuple[str, str]]) -> None:
+    suites_dir.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps({"prompt": prompt, "reference": reference}) for prompt, reference in cases]
+    (suites_dir / f"{name}.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _candidate(registry: ModelRegistry, artifact_id: str, target: str, **overrides: Any) -> DistilledModelRecord:
+    metadata: dict[str, Any] = {"target": target}
+    metadata.update(overrides.pop("metadata", {}))
+    record = DistilledModelRecord(
+        artifact_id=artifact_id,
+        scenario="grid_ctf",
+        scenario_family="",
+        backend="mlx",
+        checkpoint_path=f"/ckpt/{artifact_id}",
+        runtime_types=["provider"],
+        activation_state=overrides.pop("activation_state", "candidate"),
+        training_metrics={},
+        provenance={},
+        metadata=metadata,
+    )
+    registry.register(record)
+    return record
+
+
+class _FixedScorer:
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def score(self, prompt: str, output: str) -> float:
+        return self.value
+
+
+class _MapScorer:
+    def __init__(self, mapping: dict[str, float]) -> None:
+        self.mapping = mapping
+
+    def score(self, prompt: str, output: str) -> float:
+        return self.mapping[prompt]
+
+
+class _RaisingScorer:
+    def score(self, prompt: str, output: str) -> float:
+        if prompt == "boom":
+            raise RuntimeError("scorer exploded")
+        return 0.7
+
+
+def _probe(magnitude: float) -> Any:
+    def _fn(anchor: CharterAnchor) -> BiasProbeResult:
+        return BiasProbeResult(probe_type="position", detected=magnitude > 0.1, magnitude=magnitude, details="")
+
+    return _fn
+
+
+def _stage(tmp_path: Path, registry: ModelRegistry, scorer: Any, magnitude: float, drift_tolerance: float = 0.2) -> EvaluateStage:
+    return EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: scorer,
+        probe_fn=_probe(magnitude),
+        drift_tolerance=drift_tolerance,
+        now_fn=lambda: _NOW,
+    )
+
+
+def test_candidate_with_suite_gets_averaged_eval(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1"), ("p2", "r2")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = _stage(tmp_path, registry, _MapScorer({"p1": 0.6, "p2": 1.0}), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    eval_meta = reloaded.metadata["eval"]
+    assert eval_meta["score"] == 0.8
+    assert eval_meta["anchor_model"] == "claude-sonnet-5"
+    assert eval_meta["drift_magnitude"] == 0.1
+    assert eval_meta["drift_ok"] is True
+    assert eval_meta["evaluated_at"] == _NOW
+    completed = [e for e in _events(tmp_path) if e["event"] == "evaluate_completed"]
+    assert completed[0]["payload"] == {"artifact_id": "cand-1", "target": "competitor-local", "score": 0.8, "drift_ok": True}
+
+
+def test_candidate_without_suite_emits_no_suite_and_is_not_evaluated(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    charter = _charter([_target("competitor-local", "missing-suite")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert "eval" not in reloaded.metadata
+    no_suite = [e for e in _events(tmp_path) if e["event"] == "evaluate_no_suite"]
+    assert no_suite[0]["payload"] == {"artifact_id": "cand-1", "target": "competitor-local", "eval_suite": "missing-suite"}
+
+
+def test_empty_suite_emits_no_suite(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None and "eval" not in reloaded.metadata
+    assert any(e["event"] == "evaluate_no_suite" for e in _events(tmp_path))
+
+
+def test_already_evaluated_candidate_is_skipped(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local", metadata={"eval": {"score": 0.5}})
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert reloaded.metadata["eval"] == {"score": 0.5}  # untouched
+    assert _events(tmp_path) == []
+
+
+def test_non_candidate_records_are_ignored(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "active-1", "competitor-local", activation_state="active")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    reloaded = registry.load("active-1")
+    assert reloaded is not None and "eval" not in reloaded.metadata
+
+
+def test_candidate_with_unknown_target_is_skipped_silently(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "not-in-charter")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None and "eval" not in reloaded.metadata
+    assert _events(tmp_path) == []
+
+
+def test_scorer_exception_is_isolated_per_candidate(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-fail", "target-a")
+    _candidate(registry, "cand-ok", "target-b")
+    _seed_suite(tmp_path / "suites", "suite-a", [("boom", "r")])
+    _seed_suite(tmp_path / "suites", "suite-b", [("fine", "r")])
+    charter = _charter([_target("target-a", "suite-a"), _target("target-b", "suite-b")])
+    stage = _stage(tmp_path, registry, _RaisingScorer(), magnitude=0.1)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 1)
+    failed = registry.load("cand-fail")
+    ok = registry.load("cand-ok")
+    assert failed is not None and "eval" not in failed.metadata
+    assert ok is not None and ok.metadata["eval"]["score"] == 0.7
+    failures = [e for e in _events(tmp_path) if e["event"] == "evaluate_candidate_failed"]
+    assert failures[0]["payload"]["artifact_id"] == "cand-fail"
+    assert "scorer exploded" in failures[0]["payload"]["error"]
+
+
+def test_drift_above_tolerance_records_eval_with_drift_ok_false(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.5, drift_tolerance=0.2)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert reloaded.metadata["eval"]["drift_ok"] is False
+    assert reloaded.metadata["eval"]["drift_magnitude"] == 0.5
+
+
+def test_reregister_keeps_activation_state_candidate(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.1)
+
+    stage.run_once(_ctx(tmp_path, charter))
+
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert reloaded.activation_state == "candidate"

--- a/autocontext/tests/test_ambient_evaluate_stage.py
+++ b/autocontext/tests/test_ambient_evaluate_stage.py
@@ -109,6 +109,18 @@ def _probe(magnitude: float) -> Any:
     return _fn
 
 
+class _CountingProbe:
+    """A drift probe that records how many times it was invoked."""
+
+    def __init__(self, magnitude: float) -> None:
+        self.magnitude = magnitude
+        self.calls = 0
+
+    def __call__(self, anchor: CharterAnchor) -> BiasProbeResult:
+        self.calls += 1
+        return BiasProbeResult(probe_type="position", detected=self.magnitude > 0.1, magnitude=self.magnitude, details="")
+
+
 def _stage(tmp_path: Path, registry: ModelRegistry, scorer: Any, magnitude: float, drift_tolerance: float = 0.2) -> EvaluateStage:
     return EvaluateStage(
         name="evaluate",
@@ -254,6 +266,94 @@ def test_drift_above_tolerance_records_eval_with_drift_ok_false(tmp_path: Path) 
     assert reloaded is not None
     assert reloaded.metadata["eval"]["drift_ok"] is False
     assert reloaded.metadata["eval"]["drift_magnitude"] == 0.5
+
+
+def test_drift_probe_computed_once_per_run_once(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-a", "target-a")
+    _candidate(registry, "cand-b", "target-b")
+    _seed_suite(tmp_path / "suites", "suite-a", [("p1", "r1")])
+    _seed_suite(tmp_path / "suites", "suite-b", [("p2", "r2")])
+    charter = _charter([_target("target-a", "suite-a"), _target("target-b", "suite-b")])
+    probe = _CountingProbe(0.3)
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: _FixedScorer(0.9),
+        probe_fn=probe,
+        drift_tolerance=0.5,
+        now_fn=lambda: _NOW,
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (2, 0)
+    assert probe.calls == 1  # the canary depends only on the anchor, so it runs once per cycle
+    a = registry.load("cand-a")
+    b = registry.load("cand-b")
+    assert a is not None and b is not None
+    assert a.metadata["eval"]["drift_magnitude"] == 0.3
+    assert b.metadata["eval"]["drift_magnitude"] == 0.3
+    assert a.metadata["eval"]["drift_ok"] is True and b.metadata["eval"]["drift_ok"] is True
+
+
+def test_all_no_suite_run_never_probes(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    charter = _charter([_target("competitor-local", "missing-suite")])
+    probe = _CountingProbe(0.1)
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: _FixedScorer(0.9),
+        probe_fn=probe,
+        now_fn=lambda: _NOW,
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    assert probe.calls == 0  # nothing to score, so the probe provider is never built
+
+
+def test_all_skipped_run_never_probes(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "active-1", "competitor-local", activation_state="active")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    probe = _CountingProbe(0.1)
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: _FixedScorer(0.9),
+        probe_fn=probe,
+        now_fn=lambda: _NOW,
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    assert probe.calls == 0
+
+
+def test_drift_ok_boundary_is_inclusive(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "r1")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    # magnitude exactly equal to the tolerance: drift_ok is True because the check is <= (inclusive).
+    stage = _stage(tmp_path, registry, _FixedScorer(0.9), magnitude=0.2, drift_tolerance=0.2)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None
+    assert reloaded.metadata["eval"]["drift_magnitude"] == 0.2
+    assert reloaded.metadata["eval"]["drift_ok"] is True
 
 
 def test_reregister_keeps_activation_state_candidate(tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_promote_stage.py
+++ b/autocontext/tests/test_ambient_promote_stage.py
@@ -214,6 +214,40 @@ def test_propose_autonomy_requires_approval_and_does_not_activate(tmp_path: Path
     assert "approval" in approval[0]["payload"]["reason"]
 
 
+def test_train_autonomy_requires_approval_and_does_not_activate(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_target("competitor-local")], autonomy="train")
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    candidate = registry.load("cand-1")
+    assert candidate is not None and candidate.activation_state == "candidate"
+    assert "probation" not in candidate.metadata
+    approval = [e for e in _events(tmp_path) if e["event"] == "promote_requires_approval"]
+    assert approval[0]["payload"]["target"] == "competitor-local"
+    assert approval[0]["payload"]["artifact_id"] == "cand-1"
+    assert "approval" in approval[0]["payload"]["reason"]
+
+
+def test_equal_score_tie_does_not_promote(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "old-active", "competitor-local", state="active", eval_meta=_eval(0.7))
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.7))
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    incumbent = registry.load("old-active")
+    candidate = registry.load("cand-1")
+    assert incumbent is not None and incumbent.activation_state == "active"
+    assert candidate is not None and candidate.activation_state == "candidate"
+    assert "probation" not in candidate.metadata
+    assert _events(tmp_path) == []
+
+
 def test_per_target_failure_is_isolated(tmp_path: Path) -> None:
     registry = _ActivateFailRegistry(tmp_path / "registry", fail_id="poison")
     _record(registry, "poison", "target-a", state="candidate", eval_meta=_eval(0.8))

--- a/autocontext/tests/test_ambient_promote_stage.py
+++ b/autocontext/tests/test_ambient_promote_stage.py
@@ -197,6 +197,34 @@ def test_different_anchor_incumbent_emits_mismatch_and_does_not_activate(tmp_pat
     assert mismatch[0]["payload"] == {"target": "competitor-local", "artifact_id": "cand-1"}
 
 
+def test_candidate_under_stale_anchor_is_not_eligible_despite_higher_score(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    # two drift-clean candidates for the same target: the higher-scoring one was scored under a
+    # stale anchor (a previous charter anchor), the lower-scoring one under the current anchor.
+    _record(registry, "cand-current", "competitor-local", state="candidate", eval_meta=_eval(0.6))
+    _record(
+        registry,
+        "cand-stale",
+        "competitor-local",
+        state="candidate",
+        eval_meta=_eval(0.95, anchor="claude-opus-4-8"),
+    )
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    # the current-anchor candidate is the only promotion consideration; the stale higher-score
+    # one is never picked as best, so it is not promoted despite its higher score.
+    assert (result.processed, result.errors) == (1, 0)
+    promoted = registry.load("cand-current")
+    assert promoted is not None and promoted.activation_state == "active"
+    stale = registry.load("cand-stale")
+    assert stale is not None and stale.activation_state == "candidate"
+    assert "probation" not in stale.metadata
+    activated = [e for e in _events(tmp_path) if e["event"] == "promote_activated"]
+    assert activated[0]["payload"]["artifact_id"] == "cand-current"
+
+
 def test_propose_autonomy_requires_approval_and_does_not_activate(tmp_path: Path) -> None:
     registry = ModelRegistry(tmp_path / "registry")
     _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))

--- a/autocontext/tests/test_ambient_promote_stage.py
+++ b/autocontext/tests/test_ambient_promote_stage.py
@@ -54,12 +54,15 @@ def _events(tmp_path: Path) -> list[dict[str, Any]]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
-def _eval(score: float, *, anchor: str = _ANCHOR, drift_ok: bool = True) -> dict[str, Any]:
+def _eval(score: float, *, anchor: str = _ANCHOR, drift_ok: bool = True, from_candidate: bool = True) -> dict[str, Any]:
     return {
         "anchor_model": anchor,
         "score": score,
         "drift_magnitude": 0.1,
         "drift_ok": drift_ok,
+        # default True: these evals stand in for real candidate-generation scores, which is what the
+        # promote stage requires before it will activate a candidate.
+        "from_candidate_generation": from_candidate,
         "evaluated_at": _NOW,
     }
 
@@ -290,6 +293,29 @@ def test_per_target_failure_is_isolated(tmp_path: Path) -> None:
     failed = [e for e in _events(tmp_path) if e["event"] == "promote_target_failed"]
     assert failed[0]["payload"]["target"] == "target-a"
     assert "activate boom" in failed[0]["payload"]["error"]
+
+
+def test_placeholder_eval_candidate_is_not_promoted(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    # a high-scoring, drift-clean candidate whose eval judged a placeholder (reference text), not the
+    # candidate's real generation: promotion must refuse it rather than activate a model on a score
+    # that never ran it.
+    _record(
+        registry,
+        "cand-1",
+        "competitor-local",
+        state="candidate",
+        eval_meta=_eval(0.99, from_candidate=False),
+    )
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    candidate = registry.load("cand-1")
+    assert candidate is not None and candidate.activation_state == "candidate"
+    assert "probation" not in candidate.metadata
+    assert _events(tmp_path) == []
 
 
 def test_no_candidates_is_quiet(tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_promote_stage.py
+++ b/autocontext/tests/test_ambient_promote_stage.py
@@ -1,0 +1,240 @@
+"""tests for the promote stage: anchor-winning, drift-clean candidates become the live binding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.ambient.charter import Charter, CharterAnchor, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.promote import PromoteStage
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.stage import StageContext
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.training.model_registry import DistilledModelRecord, ModelRegistry
+
+_NOW = "2026-07-06T12:00:00+00:00"
+_ANCHOR = "claude-sonnet-5"
+
+
+def _target(name: str) -> CharterTarget:
+    return CharterTarget(
+        name=name,
+        kind="role",
+        selector="competitor",
+        base_model="tiny",
+        min_dataset_records=5,
+        eval_suite="anchor-v1",
+    )
+
+
+def _charter(targets: list[CharterTarget], autonomy: str = "full") -> Charter:
+    return Charter(
+        tier="oss",
+        autonomy=autonomy,  # type: ignore[arg-type]
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=targets,
+        budgets=CharterBudgets(gpu_hours_per_window=10.0, window_hours=24, disk_quota_gb=1.0),
+        anchor=CharterAnchor(provider="anthropic", model=_ANCHOR, rubric="Score 0 to 1."),
+    )
+
+
+def _ctx(tmp_path: Path, charter: Charter) -> StageContext:
+    return StageContext(
+        charter=charter,
+        queue=AmbientQueue(tmp_path / "q.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+
+
+def _events(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "events.ndjson"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _eval(score: float, *, anchor: str = _ANCHOR, drift_ok: bool = True) -> dict[str, Any]:
+    return {
+        "anchor_model": anchor,
+        "score": score,
+        "drift_magnitude": 0.1,
+        "drift_ok": drift_ok,
+        "evaluated_at": _NOW,
+    }
+
+
+def _record(
+    registry: ModelRegistry,
+    artifact_id: str,
+    target: str,
+    *,
+    state: str,
+    eval_meta: dict[str, Any] | None = None,
+) -> DistilledModelRecord:
+    metadata: dict[str, Any] = {"target": target}
+    if eval_meta is not None:
+        metadata["eval"] = eval_meta
+    record = DistilledModelRecord(
+        artifact_id=artifact_id,
+        scenario="grid_ctf",
+        scenario_family="",
+        backend="mlx",
+        checkpoint_path=f"/ckpt/{artifact_id}",
+        runtime_types=["provider"],
+        activation_state=state,
+        training_metrics={},
+        provenance={},
+        metadata=metadata,
+    )
+    registry.register(record)
+    return record
+
+
+def _stage(registry: ModelRegistry) -> PromoteStage:
+    return PromoteStage(name="promote", registry=registry, now_fn=lambda: _NOW)
+
+
+class _ActivateFailRegistry(ModelRegistry):
+    """A registry whose activate() explodes for one poisoned artifact id."""
+
+    def __init__(self, root: Path, fail_id: str) -> None:
+        super().__init__(root)
+        self.fail_id = fail_id
+
+    def activate(self, artifact_id: str) -> None:
+        if artifact_id == self.fail_id:
+            raise RuntimeError("activate boom")
+        super().activate(artifact_id)
+
+
+def test_no_incumbent_drift_clean_candidate_is_promoted(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    promoted = registry.load("cand-1")
+    assert promoted is not None
+    assert promoted.activation_state == "active"
+    assert promoted.metadata["probation"] == {"promoted_at": _NOW, "previous_active": ""}
+    activated = [e for e in _events(tmp_path) if e["event"] == "promote_activated"]
+    assert activated[0]["payload"] == {
+        "target": "competitor-local",
+        "artifact_id": "cand-1",
+        "previous_active": "",
+        "score": 0.8,
+    }
+
+
+def test_beats_same_anchor_incumbent_is_promoted(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "old-active", "competitor-local", state="active", eval_meta=_eval(0.6))
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.9))
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    promoted = registry.load("cand-1")
+    incumbent = registry.load("old-active")
+    assert promoted is not None and promoted.activation_state == "active"
+    assert promoted.metadata["probation"]["previous_active"] == "old-active"
+    assert incumbent is not None and incumbent.activation_state == "disabled"
+    activated = [e for e in _events(tmp_path) if e["event"] == "promote_activated"]
+    assert activated[0]["payload"]["previous_active"] == "old-active"
+
+
+def test_does_not_beat_incumbent_is_not_promoted(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "old-active", "competitor-local", state="active", eval_meta=_eval(0.9))
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.5))
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    incumbent = registry.load("old-active")
+    candidate = registry.load("cand-1")
+    assert incumbent is not None and incumbent.activation_state == "active"
+    assert candidate is not None and candidate.activation_state == "candidate"
+    assert "probation" not in candidate.metadata
+    assert _events(tmp_path) == []
+
+
+def test_drift_flagged_candidate_is_never_promoted_even_with_higher_score(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "old-active", "competitor-local", state="active", eval_meta=_eval(0.5))
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.99, drift_ok=False))
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    incumbent = registry.load("old-active")
+    candidate = registry.load("cand-1")
+    assert incumbent is not None and incumbent.activation_state == "active"
+    assert candidate is not None and candidate.activation_state == "candidate"
+    assert _events(tmp_path) == []
+
+
+def test_different_anchor_incumbent_emits_mismatch_and_does_not_activate(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "old-active", "competitor-local", state="active", eval_meta=_eval(0.6, anchor="claude-opus-4-8"))
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.9))
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    candidate = registry.load("cand-1")
+    incumbent = registry.load("old-active")
+    assert candidate is not None and candidate.activation_state == "candidate"
+    assert incumbent is not None and incumbent.activation_state == "active"
+    mismatch = [e for e in _events(tmp_path) if e["event"] == "promote_anchor_mismatch"]
+    assert mismatch[0]["payload"] == {"target": "competitor-local", "artifact_id": "cand-1"}
+
+
+def test_propose_autonomy_requires_approval_and_does_not_activate(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_target("competitor-local")], autonomy="propose")
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    candidate = registry.load("cand-1")
+    assert candidate is not None and candidate.activation_state == "candidate"
+    assert "probation" not in candidate.metadata
+    approval = [e for e in _events(tmp_path) if e["event"] == "promote_requires_approval"]
+    assert approval[0]["payload"]["target"] == "competitor-local"
+    assert approval[0]["payload"]["artifact_id"] == "cand-1"
+    assert "approval" in approval[0]["payload"]["reason"]
+
+
+def test_per_target_failure_is_isolated(tmp_path: Path) -> None:
+    registry = _ActivateFailRegistry(tmp_path / "registry", fail_id="poison")
+    _record(registry, "poison", "target-a", state="candidate", eval_meta=_eval(0.8))
+    _record(registry, "cand-b", "target-b", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_target("target-a"), _target("target-b")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 1)
+    good = registry.load("cand-b")
+    assert good is not None and good.activation_state == "active"
+    failed = [e for e in _events(tmp_path) if e["event"] == "promote_target_failed"]
+    assert failed[0]["payload"]["target"] == "target-a"
+    assert "activate boom" in failed[0]["payload"]["error"]
+
+
+def test_no_candidates_is_quiet(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    charter = _charter([_target("competitor-local")])
+
+    result = _stage(registry).run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 0)
+    assert _events(tmp_path) == []

--- a/autocontext/tests/test_ambient_publish.py
+++ b/autocontext/tests/test_ambient_publish.py
@@ -46,6 +46,11 @@ def test_publish_registers_a_non_active_candidate(tmp_path: Path) -> None:
     record = registry.load(artifact_id)
     assert record is not None
     assert record.activation_state == "candidate"
+    # the registry SLOT is the target name (unique per target), so activation never
+    # cross-demotes a sibling target that maps to the same real scenario.
+    assert record.scenario == "competitor-local"
+    # the real scenario is preserved as scenario_family for grouping and provenance.
+    assert record.scenario_family == "grid_ctf"
     assert record.metadata.get("produced_by") == "finetune:competitor-local"
     # the adapter-serving path refuses a record without base_model, so it must be stamped
     assert record.metadata.get("base_model") == "tiny"

--- a/autocontext/tests/test_ambient_serving.py
+++ b/autocontext/tests/test_ambient_serving.py
@@ -59,6 +59,8 @@ def _eval(score: float, *, anchor: str = _ANCHOR, drift_ok: bool = True) -> dict
         "score": score,
         "drift_magnitude": 0.1,
         "drift_ok": drift_ok,
+        # real-generation eval: the promote stage only activates a candidate scored on its own output.
+        "from_candidate_generation": True,
         "evaluated_at": _NOW,
     }
 

--- a/autocontext/tests/test_ambient_serving.py
+++ b/autocontext/tests/test_ambient_serving.py
@@ -1,0 +1,245 @@
+"""tests for per-target serving resolution, the health supervisor, and the slot-aliasing fix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autocontext.ambient.charter import Charter, CharterAnchor, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.promote import PromoteStage
+from autocontext.ambient.publish import publish_candidate
+from autocontext.ambient.queue import AmbientQueue
+from autocontext.ambient.serving import ServerSupervisor, resolve_active_serving
+from autocontext.ambient.stage import StageContext
+from autocontext.ambient.training_backend import TrainOutcome
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.training.model_registry import DistilledModelRecord, ModelRegistry
+
+_NOW = "2026-07-06T12:00:00+00:00"
+_ANCHOR = "claude-sonnet-5"
+
+
+def _target(name: str, **overrides: Any) -> CharterTarget:
+    base: dict[str, Any] = {
+        "name": name,
+        "kind": "role",
+        "selector": "competitor",
+        "base_model": "tiny",
+        "min_dataset_records": 1,
+        "eval_suite": "anchor-v1",
+    }
+    base.update(overrides)
+    return CharterTarget(**base)
+
+
+def _charter(targets: list[CharterTarget], autonomy: str = "full") -> Charter:
+    return Charter(
+        tier="oss",
+        autonomy=autonomy,  # type: ignore[arg-type]
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=targets,
+        budgets=CharterBudgets(gpu_hours_per_window=10.0, window_hours=24, disk_quota_gb=1.0),
+        anchor=CharterAnchor(provider="anthropic", model=_ANCHOR, rubric="Score 0 to 1."),
+    )
+
+
+def _ctx(tmp_path: Path, charter: Charter) -> StageContext:
+    return StageContext(
+        charter=charter,
+        queue=AmbientQueue(tmp_path / "q.sqlite3"),
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+    )
+
+
+def _eval(score: float, *, anchor: str = _ANCHOR, drift_ok: bool = True) -> dict[str, Any]:
+    return {
+        "anchor_model": anchor,
+        "score": score,
+        "drift_magnitude": 0.1,
+        "drift_ok": drift_ok,
+        "evaluated_at": _NOW,
+    }
+
+
+def _active_record(registry: ModelRegistry, target_name: str, *, backend: str = "mlx") -> DistilledModelRecord:
+    record = DistilledModelRecord(
+        artifact_id=f"active-{target_name}",
+        scenario=target_name,
+        scenario_family="grid_ctf",
+        backend=backend,
+        checkpoint_path=f"/ckpt/{target_name}",
+        runtime_types=["provider"],
+        activation_state="active",
+        training_metrics={},
+        provenance={},
+        metadata={"target": target_name, "base_model": "tiny"},
+    )
+    registry.register(record)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# resolve_active_serving
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_active_serving_returns_the_active_record(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    active = _active_record(registry, "competitor-grid_ctf")
+
+    decision = resolve_active_serving(registry, "competitor-grid_ctf", "mlx")
+
+    assert decision.source == "registry"
+    assert decision.fallback_used is False
+    assert decision.artifact_id == active.artifact_id
+    assert decision.model == active.checkpoint_path
+
+
+def test_resolve_active_serving_falls_back_when_no_active_model(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+
+    decision = resolve_active_serving(registry, "analyst-grid_ctf", "mlx")
+
+    assert decision.fallback_used is True
+    assert decision.source == "fallback"
+    assert decision.artifact_id is None
+
+
+# ---------------------------------------------------------------------------
+# ServerSupervisor.wait_until_healthy
+# ---------------------------------------------------------------------------
+
+
+def test_wait_until_healthy_returns_true_when_it_becomes_healthy() -> None:
+    calls = {"n": 0}
+
+    def health_fn() -> bool:
+        calls["n"] += 1
+        return calls["n"] >= 3  # healthy on the third poll
+
+    intervals: list[int] = []
+    supervisor = ServerSupervisor(
+        health_fn=health_fn,
+        poll_attempts=5,
+        poll_interval_fn=intervals.append,
+    )
+
+    assert supervisor.wait_until_healthy() is True
+    assert calls["n"] == 3
+    assert intervals == [0, 1]  # poll_interval_fn is invoked between the two failed polls
+
+
+def test_wait_until_healthy_returns_false_when_never_healthy() -> None:
+    intervals: list[int] = []
+    supervisor = ServerSupervisor(
+        health_fn=lambda: False,
+        poll_attempts=4,
+        poll_interval_fn=intervals.append,
+    )
+
+    assert supervisor.wait_until_healthy() is False
+    assert intervals == [0, 1, 2]  # called between attempts, never after the last
+
+
+def test_wait_until_healthy_defaults_to_no_sleep() -> None:
+    supervisor = ServerSupervisor(health_fn=lambda: True)
+
+    assert supervisor.wait_until_healthy() is True
+
+
+# ---------------------------------------------------------------------------
+# ServerSupervisor.rollback
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_reactivates_the_previous_model(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _active_record(registry, "competitor-grid_ctf")
+    previous = registry.load("active-competitor-grid_ctf")
+    assert previous is not None
+    registry.deactivate(previous.artifact_id)  # simulate a bad promote having disabled it
+
+    supervisor = ServerSupervisor(health_fn=lambda: False)
+    supervisor.rollback(registry, "competitor-grid_ctf", previous.artifact_id)
+
+    restored = registry.load(previous.artifact_id)
+    assert restored is not None
+    assert restored.activation_state == "active"
+
+
+def test_rollback_with_no_previous_artifact_raises(tmp_path: Path) -> None:
+    supervisor = ServerSupervisor(health_fn=lambda: True)
+
+    with pytest.raises(ValueError):
+        supervisor.rollback(ModelRegistry(tmp_path / "registry"), "competitor-grid_ctf", "")
+
+
+# ---------------------------------------------------------------------------
+# regression: the slot-vs-target aliasing bug (FIX A)
+# ---------------------------------------------------------------------------
+
+
+def _publish(registry: ModelRegistry, tmp_path: Path, target: CharterTarget) -> str:
+    outcome = TrainOutcome(
+        checkpoint_path=tmp_path / target.name / "adapters",
+        backend="mlx",
+        metrics={"avg_score": 0.8, "valid_rate": 1.0, "num_records": 6.0},
+        gpu_hours=1.0,
+    )
+    return publish_candidate(
+        outcome=outcome,
+        target=target,
+        scenario="grid_ctf",  # both targets share the real scenario
+        registry=registry,
+        artifacts_root=tmp_path / "artifacts",
+        run_id=f"ambient-{target.name}-6",
+        record_count=6,
+    )
+
+
+def test_publish_slots_candidates_by_target_not_by_scenario(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    comp_id = _publish(registry, tmp_path, _target("competitor-grid_ctf"))
+
+    comp = registry.load(comp_id)
+    assert comp is not None
+    # the registry SLOT is the target name; the real scenario is preserved as scenario_family.
+    assert comp.scenario == "competitor-grid_ctf"
+    assert comp.scenario_family == "grid_ctf"
+
+
+def test_promoting_a_sibling_target_does_not_demote_the_live_model(tmp_path: Path) -> None:
+    # two charter targets that both map to the same real scenario ("grid_ctf") but are
+    # trained and served independently. before the fix they shared one registry slot, so
+    # promoting one demoted the other's live model and lost its rollback pointer.
+    registry = ModelRegistry(tmp_path / "registry")
+    comp = _target("competitor-grid_ctf")
+    analyst = _target("analyst-grid_ctf")
+    comp_id = _publish(registry, tmp_path, comp)
+    analyst_id = _publish(registry, tmp_path, analyst)
+
+    # make the competitor model the live binding, and give both candidates a clean eval so the
+    # promote flow can act on the analyst candidate.
+    comp_rec = registry.load(comp_id)
+    assert comp_rec is not None
+    comp_rec.metadata["eval"] = _eval(0.8)
+    registry.register(comp_rec)
+    registry.activate(comp_id)
+
+    analyst_rec = registry.load(analyst_id)
+    assert analyst_rec is not None
+    analyst_rec.metadata["eval"] = _eval(0.9)
+    registry.register(analyst_rec)
+
+    stage = PromoteStage(name="promote", registry=registry, now_fn=lambda: _NOW)
+    result = stage.run_once(_ctx(tmp_path, _charter([comp, analyst])))
+
+    assert (result.processed, result.errors) == (1, 0)
+    # the analyst candidate is now active for its own slot...
+    promoted_analyst = registry.load(analyst_id)
+    assert promoted_analyst is not None and promoted_analyst.activation_state == "active"
+    # ...and the competitor's live model is UNTOUCHED (not cross-demoted).
+    still_live = registry.load(comp_id)
+    assert still_live is not None and still_live.activation_state == "active"

--- a/autocontext/tests/test_ambient_stage.py
+++ b/autocontext/tests/test_ambient_stage.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from autocontext.ambient.stage import STAGE_NAMES, AutoPauseBreaker, NoOpStage, StageResult
 
 
-def test_stage_names_are_the_five_spec_stages() -> None:
-    assert STAGE_NAMES == ("ingest", "curate", "advise", "train", "evaluate")
+def test_stage_names_are_the_spec_stages() -> None:
+    assert STAGE_NAMES == ("ingest", "curate", "advise", "train", "evaluate", "promote")
 
 
 def test_breaker_pauses_after_threshold_consecutive_failures() -> None:

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from autocontext.ambient.advise import AdviseStage
 from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
 from autocontext.ambient.curate import CurateStage
+from autocontext.ambient.evaluate import EvaluateStage
 from autocontext.ambient.ingest import IngestStage
+from autocontext.ambient.promote import PromoteStage
 from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
 from autocontext.ambient.sources.jsonl_feed import JsonlFeedSource
 from autocontext.ambient.sources.native import NativeRunsSource
-from autocontext.ambient.stage import STAGE_NAMES, NoOpStage
+from autocontext.ambient.stage import STAGE_NAMES
 from autocontext.ambient.stage_factory import build_stages
 from autocontext.ambient.train import TrainStage
 from autocontext.harness.core.events import EventStreamEmitter
@@ -52,6 +54,7 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
         usage_db=tmp_path / "usage.sqlite3",
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
     )
     assert set(stages.keys()) == set(STAGE_NAMES)
     ingest = stages["ingest"]
@@ -62,7 +65,8 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
     assert [source.kind for source in ingest.sources] == ["autocontext", "autocontext-outputs", "otel"]
     assert isinstance(stages["curate"], CurateStage)
     assert isinstance(stages["advise"], AdviseStage)
-    assert all(isinstance(stages[name], NoOpStage) for name in ("evaluate",))
+    assert isinstance(stages["evaluate"], EvaluateStage)
+    assert isinstance(stages["promote"], PromoteStage)
 
 
 def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
@@ -82,6 +86,7 @@ def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
         usage_db=tmp_path / "usage.sqlite3",
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
     )
     ingest = stages["ingest"]
     assert isinstance(ingest, IngestStage)
@@ -105,6 +110,7 @@ def test_autocontext_source_registers_generation_and_output_readers(tmp_path: Pa
         usage_db=tmp_path / "usage.sqlite3",
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
     )
     ingest = stages["ingest"]
     kinds = sorted(source.kind for source in ingest.sources)  # type: ignore[attr-defined]
@@ -124,6 +130,7 @@ def test_build_stages_wires_real_curate_and_advise(tmp_path: Path) -> None:
         usage_db=tmp_path / "usage.sqlite3",
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
     )
     assert isinstance(stages["curate"], CurateStage)
     assert isinstance(stages["advise"], AdviseStage)
@@ -146,6 +153,34 @@ def test_build_stages_wires_real_train_stage(tmp_path: Path) -> None:
         usage_db=tmp_path / "usage.sqlite3",
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
     )
     assert isinstance(stages["train"], TrainStage)
-    assert stages["evaluate"].__class__.__name__ == "NoOpStage"
+    assert isinstance(stages["evaluate"], EvaluateStage)
+
+
+def test_build_stages_wires_real_evaluate_and_promote_sharing_registry(tmp_path: Path) -> None:
+    charter = _charter(sources=[CharterSource(name="native", kind="autocontext")])
+    stages = build_stages(
+        charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        runs_db_path=tmp_path / "runs.sqlite3",
+        otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
+    )
+    evaluate = stages["evaluate"]
+    promote = stages["promote"]
+    train = stages["train"]
+    assert isinstance(evaluate, EvaluateStage)
+    assert isinstance(promote, PromoteStage)
+    assert evaluate.suites_dir == tmp_path / "suites"
+    # train, evaluate, and promote must share one ModelRegistry instance so a candidate
+    # trained this cycle is the same object evaluate scores and promote activates
+    assert evaluate.registry is train.registry  # type: ignore[attr-defined]
+    assert promote.registry is train.registry  # type: ignore[attr-defined]

--- a/autocontext/tests/test_ambient_train_stage.py
+++ b/autocontext/tests/test_ambient_train_stage.py
@@ -180,6 +180,34 @@ def test_envelope_over_budget_blocks_even_when_train_budget_alone_fits(tmp_path:
     assert any(e["event"] == "train_budget_exhausted" for e in events)
 
 
+def test_budget_pool_is_charter_wide(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    trained = {"ran": False}
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: "trl")
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        trained["ran"] = True  # the shared pool must block before we get here
+        return TrainOutcome(request.output_dir / "adapters", backend_name, {"num_records": 5.0, "training_seconds": 3600.0}, 1.0)
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
+    stage = _stage(tmp_path)
+    # window budget is 10.0h, shared charter-wide. another target already spent 9.6h, so the pool
+    # is nearly exhausted. competitor-local itself has used 0, but its pre-flight (envelope 1.0h)
+    # reads the CHARTER-WIDE total: 9.6 + 1.0 = 10.6 > 10.0, so it is blocked. under the old
+    # per-target read it would have seen 0 and trained, spending a second full window.
+    stage.usage_ledger.record("competitor-other", 9.6, _NOW)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()], gpu_hours=10.0)))
+
+    assert result.processed == 0
+    assert not trained["ran"]  # the shared pool prevented the spend
+    assert stage.registry.list_all() == []
+    events = _events(tmp_path)
+    exhausted = [e for e in events if e["event"] == "train_budget_exhausted"]
+    assert any(e["payload"]["target"] == "competitor-local" for e in exhausted)
+    assert any(e["payload"]["used_gpu_hours"] == 9.6 for e in exhausted)
+
+
 def test_unchanged_dataset_is_not_retrained(tmp_path: Path, monkeypatch: Any) -> None:
     _seed_dataset(tmp_path, "competitor-local", 6)
     calls = {"count": 0}

--- a/autocontext/tests/test_ambient_usage.py
+++ b/autocontext/tests/test_ambient_usage.py
@@ -32,6 +32,17 @@ def test_used_in_window_is_per_target(tmp_path: Path) -> None:
     assert ledger.used_in_window("solver", 24, now.isoformat()) == 5.0
 
 
+def test_used_in_window_all_sums_across_targets(tmp_path: Path) -> None:
+    ledger = UsageLedger(tmp_path / "usage.sqlite3")
+    now = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)
+    ledger.record("prover", 2.0, _iso(now, hours=-30))  # outside a 24h window
+    ledger.record("prover", 1.5, _iso(now, hours=-2))  # inside
+    ledger.record("solver", 0.5, _iso(now, hours=-1))  # inside, a different target
+
+    # the charter-wide pool sums every target's in-window hours into one total
+    assert ledger.used_in_window_all(window_hours=24, now_iso=now.isoformat()) == 2.0
+
+
 def test_window_boundary_is_strict_greater_than(tmp_path: Path) -> None:
     ledger = UsageLedger(tmp_path / "usage.sqlite3")
     now = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)


### PR DESCRIPTION
Plan 5a of the ambient trainer roadmap (spec: docs/ambient-trainer-design.md), the first of two PRs closing the loop. Builds on plans 1-4 (foundation, ingest, curate+advise, train). This PR makes a trained candidate evaluable, promotable, and servable; plan 5b adds the Linux SFT backend and a hard whole-run budget deadline.

## What this adds

**Charter anchor and charter-wide budget.** The charter gains an anchor spec (frozen evaluator model + rubric) that evaluation judges against. The GPU-hours budget is now a single charter-wide pool (used_in_window_all): a charter with N targets can no longer each spend the full window, correcting a per-target finding from plan 4. Per-target attribution is preserved for recording; only the gate reads the shared total.

**Eval suites and the evaluate stage.** An eval_suite name resolves to a small on-disk held-out suite (suites_dir/<name>.jsonl). EvaluateStage scores each candidate under the charter's frozen anchor via LLMJudge and runs a drift canary (position-bias probe) computed once per cycle, writing the score and drift result into the candidate's registry metadata. A candidate stays a candidate here; evaluation never promotes.

**Promote stage.** PromoteStage activates the highest-scoring candidate that is drift-clean, beats the incumbent under the same anchor, and is allowed by the autonomy dial (propose and train require approval; full auto-promotes). The prior active model is kept warm (demoted to disabled) and a probation marker records it for one-flip rollback. Cross-anchor comparisons are refused, and only candidates evaluated under the current charter anchor are eligible.

**Serving resolution and supervisor.** resolve_active_serving routes a target to its active model; ServerSupervisor provides health-poll-until-ready and rollback logic (real vLLM launch is plan 5b). 

**Registry-identity fix (cross-target isolation).** Ambient candidates are now slotted by target name (scenario = target.name, scenario_family = the real scenario). This closes a bug where two role targets sharing a scenario would share a registry activation slot, so promoting one silently demoted the other's live model and lost its rollback pointer. A regression test drives the real publish-and-promote path and proves a sibling target's active model survives.

**Wiring and end-to-end.** evaluate and promote are real daemon stages (promote runs after evaluate each cycle); status shows a per-target active-model row. A miniature end-to-end test drives ingest through serving with deterministic seams and asserts a candidate is trained, evaluated, promoted, and resolves as the active served model, the V1 acceptance criterion in miniature.

## Scope boundary (documented, deferred to 5b)

The generation-loop live router resolves by the real scenario, so it does not yet see these per-target ambient records; wiring per-role live serving into the running loop is plan 5b, stated in serving.py. Two design items are ticketed for 5b: an incumbent scored under a stale anchor would block promotion until re-evaluated (needs incumbent re-evaluation or a manual force-promote lever), and a charter target named literally after a real scenario could collide with non-ambient records (needs a charter name guard).

## Verification

Roughly 45 new ambient tests (240 total, 2 skipped) covering the charter-wide budget, eval-suite loading, evaluate scoring + drift memoization, promote gating (drift, anchor, autonomy, tie, rollback marker), serving resolution + supervisor, the cross-target aliasing regression, and the miniature e2e (non-flaky over repeated runs). Each task was implemented and reviewed by separate agents with fix rounds; a final whole-branch review traced one candidate from train through serving and returned READY. ruff and mypy strict clean; uv.lock untouched; CI runs no real fine-tune or inference server.