### PR TITLE
ambient trainer plan 5b: linux sft backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - ambient trainer plan 3: curate and advise stages (agent-output ingestion, guarded per-target datasets, heuristic charter proposals, proposal approval cli)
 - ambient trainer plan 4: train stage with gpu-hours budget ledger, autonomy gating, and model-candidate publication
 - ambient trainer plan 5a: evaluate, promote, and serving-resolution stages closing the ambient loop
+- ambient trainer plan 5b: linux trl sft-trainer backend over the curated dataset, whole-run budget deadline, and charter name-collision guard
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -129,3 +129,26 @@ class Charter(BaseModel):
         if duplicates:
             raise ValueError(f"duplicate target names: {sorted(duplicates)}")
         return self
+
+    @model_validator(mode="after")
+    def _target_names_do_not_collide_with_scenarios(self) -> Charter:
+        # ambient candidates are slotted in the model registry by scenario=target.name,
+        # so a target named like a real scenario would share the activation slot with the
+        # non-ambient records the training runner publishes under that scenario, and
+        # registry.activate() could cross-demote them. imported lazily to avoid an import
+        # cycle (charter must not pull scenarios at module load); a minimal environment
+        # without the registry skips the check rather than hard-failing construction.
+        try:
+            from autocontext.scenarios import SCENARIO_REGISTRY
+        except ImportError:
+            return self
+        scenario_names = set(SCENARIO_REGISTRY)
+        for target in self.targets:
+            name = target.name
+            if name in scenario_names:
+                raise ValueError(
+                    f"charter target name {name!r} collides with a registered scenario name; "
+                    f"ambient candidates are slotted by target name and would cross-demote "
+                    f"non-ambient {name!r} models. Rename the target."
+                )
+        return self

--- a/autocontext/src/autocontext/ambient/train.py
+++ b/autocontext/src/autocontext/ambient/train.py
@@ -12,7 +12,7 @@ from autocontext.ambient.datasets import DatasetStore
 from autocontext.ambient.policy import budget_allows, decide
 from autocontext.ambient.publish import publish_candidate
 from autocontext.ambient.stage import StageContext, StageResult
-from autocontext.ambient.training_backend import _DEADLINE_CAPABLE, TrainRequest, run_training, select_backend
+from autocontext.ambient.training_backend import TrainRequest, is_deadline_capable, run_training, select_backend
 from autocontext.ambient.usage import UsageLedger
 from autocontext.training.model_registry import ModelRegistry
 
@@ -72,13 +72,17 @@ class TrainStage:
             return 0
         # pre-flight budget: gate on the estimate BEFORE training so a breaching job never spends
         # the hours; the record step below then charges the ACTUAL hours consumed. the reservation
-        # is asymmetric by backend: a deadline-capable backend (sft) enforces a real whole-run
-        # wall-clock deadline (run_sft_training's DeadlineCallback stops the run at time_budget), so
-        # its wall clock cannot exceed the ceiling and we reserve time_budget exactly. mlxlm has no
-        # in-run deadline: its timeout bounds only the training subprocess, so adapter load +
-        # assessment run afterward in-process and are counted in training_seconds too, so it keeps a
-        # conservative envelope covering that assess overhead.
-        if backend in _DEADLINE_CAPABLE:
+        # is asymmetric by backend: a deadline-capable backend (sft) enforces a real wall-clock
+        # deadline (run_sft_training's DeadlineCallback stops the run at time_budget), so its
+        # TRAINING COMPUTE cannot exceed the ceiling and we reserve time_budget exactly. that is what
+        # the recorded gpu_hours measures (training_seconds), so recorded usage stays within the
+        # reservation. note the deadline bounds compute only, not model download/load: a first run
+        # pulling a large base model does that load OUTSIDE the deadline and it is not charged to the
+        # ledger, so total box-occupancy for such a run can exceed the window even though recorded
+        # usage does not. mlxlm has no in-run deadline: its timeout bounds only the training
+        # subprocess, so adapter load + assessment run afterward in-process and are counted in
+        # training_seconds too, so it keeps a conservative envelope covering that assess overhead.
+        if is_deadline_capable(backend):
             requested_gpu_hours = self.time_budget_seconds / 3600.0
         else:
             requested_gpu_hours = (self.time_budget_seconds + self.assess_overhead_seconds) / 3600.0

--- a/autocontext/src/autocontext/ambient/train.py
+++ b/autocontext/src/autocontext/ambient/train.py
@@ -12,7 +12,7 @@ from autocontext.ambient.datasets import DatasetStore
 from autocontext.ambient.policy import budget_allows, decide
 from autocontext.ambient.publish import publish_candidate
 from autocontext.ambient.stage import StageContext, StageResult
-from autocontext.ambient.training_backend import TrainRequest, run_training, select_backend
+from autocontext.ambient.training_backend import _DEADLINE_CAPABLE, TrainRequest, run_training, select_backend
 from autocontext.ambient.usage import UsageLedger
 from autocontext.training.model_registry import ModelRegistry
 
@@ -71,12 +71,17 @@ class TrainStage:
             ctx.emitter.emit("train_no_backend", {"target": target.name, "method": target.method}, channel="ambient")
             return 0
         # pre-flight budget: gate on the estimate BEFORE training so a breaching job never spends
-        # the hours; the record step below then charges the ACTUAL hours consumed. the mlxlm
-        # timeout bounds only the training subprocess, so adapter load + assessment run afterward
-        # in-process and are counted in training_seconds too; we reserve a conservative envelope
-        # covering them. a hard whole-run deadline is the complete fix and lands with the plan-5
-        # backend work.
-        requested_gpu_hours = (self.time_budget_seconds + self.assess_overhead_seconds) / 3600.0
+        # the hours; the record step below then charges the ACTUAL hours consumed. the reservation
+        # is asymmetric by backend: a deadline-capable backend (sft) enforces a real whole-run
+        # wall-clock deadline (run_sft_training's DeadlineCallback stops the run at time_budget), so
+        # its wall clock cannot exceed the ceiling and we reserve time_budget exactly. mlxlm has no
+        # in-run deadline: its timeout bounds only the training subprocess, so adapter load +
+        # assessment run afterward in-process and are counted in training_seconds too, so it keeps a
+        # conservative envelope covering that assess overhead.
+        if backend in _DEADLINE_CAPABLE:
+            requested_gpu_hours = self.time_budget_seconds / 3600.0
+        else:
+            requested_gpu_hours = (self.time_budget_seconds + self.assess_overhead_seconds) / 3600.0
         # charter-wide pool: read every target's in-window hours, not just this target's, so a
         # charter with N targets cannot each spend a full window. record() below stays per-target
         # for attribution; only the gate reads the shared total.

--- a/autocontext/src/autocontext/ambient/training_backend.py
+++ b/autocontext/src/autocontext/ambient/training_backend.py
@@ -12,10 +12,15 @@ distillation/RLVR, generating its own prompts from the live scenario, so it
 cannot consume a curated per-target dataset file.)
 
 The ambient train stage talks only to this module, never to the heavy mlx
-backend directly, so a cpu-only ci monkeypatches _availability and
-_BACKEND_FNS to exercise the whole stage without a real fine-tune. gpu_hours
-is derived from the wall-clock training_seconds the backend reports, which is
-what the usage ledger and budget floor consume.
+backend directly, so a cpu-only ci monkeypatches _availability and the
+_BACKEND registry to exercise the whole stage without a real fine-tune.
+gpu_hours is derived from the wall-clock training_seconds the backend reports,
+which is what the usage ledger and budget floor consume.
+
+Each backend in the registry carries its own arg-adapter mapping a TrainRequest
+to that backend's exact kwargs, so a second backend with a different signature
+can never be handed foreign kwargs: run_training dispatches through the adapter
+rather than a fixed kwarg set.
 """
 
 from __future__ import annotations
@@ -23,15 +28,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from autocontext.training.autoresearch.mlxlm_backend import run_mlxlm_training
 from autocontext.training.backends import default_backend_registry
-
-# preference order per charter method; first available wins
-_METHOD_BACKENDS: dict[str, tuple[str, ...]] = {"sft-distill": ("mlxlm",)}
-_BACKEND_FNS: dict[str, Callable[..., dict[str, float]]] = {
-    "mlxlm": run_mlxlm_training,
-}
 
 
 @dataclass(slots=True)
@@ -45,6 +45,35 @@ class TrainRequest:
 
 
 @dataclass(slots=True)
+class BackendEntry:
+    """a registry record pairing a backend fn with its request->kwargs adapter."""
+
+    fn: Callable[..., dict[str, float]]
+    adapt: Callable[[TrainRequest], dict[str, Any]]
+
+
+def _adapt_mlxlm(request: TrainRequest) -> dict[str, Any]:
+    return {
+        "scenario_name": request.scenario,
+        "data_path": request.data_path,
+        "output_dir": request.output_dir,
+        "time_budget": request.time_budget_seconds,
+        "memory_limit_mb": request.memory_limit_mb,
+        "base_model": request.base_model,
+        # dedupe is enabled so the curate crash-window duplicate rows are removed at
+        # train time, honoring the mitigation curate.py documents.
+        "dedupe": True,
+    }
+
+
+# preference order per charter method; first available wins
+_METHOD_BACKENDS: dict[str, tuple[str, ...]] = {"sft-distill": ("mlxlm",)}
+_BACKEND: dict[str, BackendEntry] = {
+    "mlxlm": BackendEntry(fn=run_mlxlm_training, adapt=_adapt_mlxlm),
+}
+
+
+@dataclass(slots=True)
 class TrainOutcome:
     checkpoint_path: Path
     backend: str
@@ -55,7 +84,7 @@ class TrainOutcome:
 def _availability() -> dict[str, bool]:
     registry = default_backend_registry()
     out: dict[str, bool] = {}
-    for name in _BACKEND_FNS:
+    for name in _BACKEND:
         backend = registry.get(name)
         out[name] = bool(backend and backend.is_available())
     return out
@@ -70,18 +99,8 @@ def select_backend(method: str) -> str | None:
 
 
 def run_training(backend_name: str, request: TrainRequest) -> TrainOutcome:
-    fn = _BACKEND_FNS[backend_name]
-    metrics = fn(
-        scenario_name=request.scenario,
-        data_path=request.data_path,
-        output_dir=request.output_dir,
-        time_budget=request.time_budget_seconds,
-        memory_limit_mb=request.memory_limit_mb,
-        base_model=request.base_model,
-        # dedupe is enabled so the curate crash-window duplicate rows are removed at
-        # train time, honoring the mitigation curate.py documents.
-        dedupe=True,
-    )
+    entry = _BACKEND[backend_name]
+    metrics = entry.fn(**entry.adapt(request))
     gpu_hours = float(metrics.get("training_seconds", 0.0)) / 3600.0
     checkpoint = request.output_dir / "adapters"
     return TrainOutcome(checkpoint_path=checkpoint, backend=backend_name, metrics=metrics, gpu_hours=gpu_hours)

--- a/autocontext/src/autocontext/ambient/training_backend.py
+++ b/autocontext/src/autocontext/ambient/training_backend.py
@@ -97,6 +97,17 @@ _BACKEND: dict[str, BackendEntry] = {
 _DEADLINE_CAPABLE: frozenset[str] = frozenset({"sft"})
 
 
+def is_deadline_capable(backend_name: str) -> bool:
+    """True when this backend enforces a real in-run wall-clock deadline.
+
+    The train stage reads this to decide the budget reservation: a deadline-capable backend passes
+    a deadline through its adapter (see the ``deadline_seconds`` invariant test), so its training
+    compute cannot exceed time_budget_seconds and the exact ceiling is reserved. A backend without
+    an in-run deadline (mlxlm) is reserved a conservative assess envelope instead.
+    """
+    return backend_name in _DEADLINE_CAPABLE
+
+
 @dataclass(slots=True)
 class TrainOutcome:
     checkpoint_path: Path

--- a/autocontext/src/autocontext/ambient/training_backend.py
+++ b/autocontext/src/autocontext/ambient/training_backend.py
@@ -1,18 +1,18 @@
 """the training-backend seam: availability selection and run indirection.
 
-mlxlm is the only backend wired here, and it is the only one that trains a
-LoRA-SFT adapter over the curated data_path file the ambient curate stage
-writes. It requires Darwin plus the mlx runtime, so on a box without them
-select_backend returns None and the train stage cleanly no-ops (no error). A
-Linux or CUDA SFT-over-dataset backend is future work: until it lands, ambient
-training only produces candidates on an mlx-capable box.
+Two backends are wired, both training a LoRA-SFT adapter over the curated
+data_path file the ambient curate stage writes: mlxlm (Darwin + mlx runtime)
+and sft (cross-platform trl + torch, the linux/cuda path). For the sft-distill
+method mlxlm is preferred and sft is the fallback, so select_backend returns
+mlxlm where the mlx runtime is present and sft where only trl + torch are; on a
+box with neither it returns None and the train stage cleanly no-ops (no error).
 
 (The trl backend is deliberately not wired: it does on-policy
 distillation/RLVR, generating its own prompts from the live scenario, so it
 cannot consume a curated per-target dataset file.)
 
-The ambient train stage talks only to this module, never to the heavy mlx
-backend directly, so a cpu-only ci monkeypatches _availability and the
+The ambient train stage talks only to this module, never to the heavy backend
+implementations directly, so a cpu-only ci monkeypatches _availability and the
 _BACKEND registry to exercise the whole stage without a real fine-tune.
 gpu_hours is derived from the wall-clock training_seconds the backend reports,
 which is what the usage ledger and budget floor consume.
@@ -20,7 +20,9 @@ which is what the usage ledger and budget floor consume.
 Each backend in the registry carries its own arg-adapter mapping a TrainRequest
 to that backend's exact kwargs, so a second backend with a different signature
 can never be handed foreign kwargs: run_training dispatches through the adapter
-rather than a fixed kwarg set.
+rather than a fixed kwarg set. The sft backend additionally enforces a real
+in-run wall-clock deadline (_DEADLINE_CAPABLE), which the train stage reads to
+reserve an exact budget ceiling rather than a conservative envelope.
 """
 
 from __future__ import annotations
@@ -31,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from autocontext.training.autoresearch.mlxlm_backend import run_mlxlm_training
+from autocontext.training.autoresearch.sft_backend import run_sft_training
 from autocontext.training.backends import default_backend_registry
 
 
@@ -66,11 +69,32 @@ def _adapt_mlxlm(request: TrainRequest) -> dict[str, Any]:
     }
 
 
-# preference order per charter method; first available wins
-_METHOD_BACKENDS: dict[str, tuple[str, ...]] = {"sft-distill": ("mlxlm",)}
+def _adapt_sft(request: TrainRequest) -> dict[str, Any]:
+    return {
+        "scenario_name": request.scenario,
+        "data_path": request.data_path,
+        "output_dir": request.output_dir,
+        "base_model": request.base_model,
+        "time_budget": request.time_budget_seconds,
+        "memory_limit_mb": request.memory_limit_mb,
+        # the whole-run wall-clock ceiling: run_sft_training's DeadlineCallback stops the run at
+        # this many seconds, so the pre-flight can reserve time_budget_seconds exactly (no assess
+        # envelope). run_sft_training's deadline_seconds is in SECONDS, matching time_budget_seconds.
+        "deadline_seconds": float(request.time_budget_seconds),
+    }
+
+
+# preference order per charter method; first available wins. mlxlm is preferred on mac; sft is the
+# linux/cuda fallback (select_backend returns the first AVAILABLE, so mlxlm wins where installed).
+_METHOD_BACKENDS: dict[str, tuple[str, ...]] = {"sft-distill": ("mlxlm", "sft")}
 _BACKEND: dict[str, BackendEntry] = {
     "mlxlm": BackendEntry(fn=run_mlxlm_training, adapt=_adapt_mlxlm),
+    "sft": BackendEntry(fn=run_sft_training, adapt=_adapt_sft),
 }
+# backends that enforce a real in-run wall-clock deadline: their whole-run wall clock cannot exceed
+# time_budget_seconds, so the train stage reserves the true ceiling for them instead of the
+# conservative assess envelope. mlxlm has no in-run deadline, so it is deliberately absent.
+_DEADLINE_CAPABLE: frozenset[str] = frozenset({"sft"})
 
 
 @dataclass(slots=True)

--- a/autocontext/src/autocontext/training/autoresearch/sft_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/sft_backend.py
@@ -14,11 +14,18 @@ reason-then-construct completions).
 
 from __future__ import annotations
 
+import importlib.util
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from autocontext.training.autoresearch.mlxlm_backend import records_to_completions
+
+# Runtime deps the TRL SFT ``run`` path needs; all imported lazily so the module (and its
+# pure-helper tests) load without them. The preflight checks these up front so a missing one
+# fails fast with an actionable message rather than tens of seconds into a fine-tune.
+_SFT_RUNTIME_DEPS = ("trl", "transformers", "peft", "torch", "datasets")
 
 
 def sft_pairs_from_records(records: list[dict[str, Any]]) -> list[dict[str, str]]:
@@ -75,3 +82,174 @@ class DeadlineCallback:
     def should_stop(self) -> bool:
         """True once the clock has advanced past the deadline since construction."""
         return self.should_stop_at(self._clock() - self._start)
+
+
+# ---------------------------------------------------------------------------
+# Heavy run path (gated; needs trl + transformers + peft + torch + datasets)
+# ---------------------------------------------------------------------------
+
+
+def _preflight_sft_deps() -> None:
+    """Fail fast if any TRL-SFT runtime dependency is missing (mirrors ``_preflight_backend_deps``).
+
+    A real fine-tune does tens of seconds of work before the adapter is written, so a
+    dependency missing only at save time would crash after all of it. Check every heavy import
+    up front and raise an actionable ``RuntimeError`` naming exactly what is missing.
+    """
+    missing = [name for name in _SFT_RUNTIME_DEPS if importlib.util.find_spec(name) is None]
+    if missing:
+        raise RuntimeError(
+            "trl SFT fine-tuning requires trl + transformers + peft + torch + datasets; "
+            f"missing: {', '.join(missing)}. Install with: uv pip install trl peft transformers datasets torch"
+        )
+
+
+def _load_sft_runtime() -> tuple[Any, Any, Any, Any, Any, Any, Any]:
+    """Lazily import the heavy TRL/transformers/peft/datasets classes behind one seam.
+
+    Returns ``(SFTConfig, SFTTrainer, LoraConfig, Dataset, AutoModelForCausalLM, AutoTokenizer,
+    TrainerCallback)``. Isolating every heavy import here lets the mock-the-run test patch this
+    single function with fakes and exercise the whole runner on a machine without ``trl``.
+    """
+    from datasets import Dataset  # type: ignore[import-not-found]
+    from peft import LoraConfig  # type: ignore[import-not-found]
+    from transformers import (  # type: ignore[import-not-found]
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        TrainerCallback,
+    )
+    from trl import SFTConfig, SFTTrainer  # type: ignore[import-not-found]
+
+    return SFTConfig, SFTTrainer, LoraConfig, Dataset, AutoModelForCausalLM, AutoTokenizer, TrainerCallback
+
+
+def _make_deadline_callback(trainer_callback_cls: Any, deadline_seconds: float) -> Any:
+    """Wrap :class:`DeadlineCallback` in a real ``transformers.TrainerCallback``.
+
+    ``transformers`` loops run to ``max_steps`` with no wall-clock cap; this stops training at
+    the next step boundary once the deadline passes. The pure comparison lives in
+    :class:`DeadlineCallback` so it stays unit-testable without ``transformers``; this thin
+    subclass only bridges it onto the trainer's ``control.should_training_stop``.
+    """
+    deadline = DeadlineCallback(deadline_seconds, clock=time.perf_counter)
+
+    class _DeadlineTrainerCallback(trainer_callback_cls):  # type: ignore[misc, valid-type]
+        def on_step_end(self, args: Any, state: Any, control: Any, **kwargs: Any) -> Any:
+            if deadline.should_stop():
+                control.should_training_stop = True
+            return control
+
+    return _DeadlineTrainerCallback()
+
+
+def _sft_max_steps(time_budget: int) -> int:
+    """Derive the optimizer-step cap from the wall-clock budget.
+
+    One step per ~10s of budget, clamped to ``[1, 100]`` (100 is the pretrained-adapter default
+    the from-scratch backends do not use). The :class:`DeadlineCallback` still enforces the exact
+    wall-clock stop; this only bounds the schedule so a tiny budget does not target 100 steps.
+    """
+    return max(1, min(100, time_budget // 10))
+
+
+def _mean_curated_score(records: list[dict[str, Any]]) -> float:
+    """Mean ``score`` over the curated records (0.0 when empty), for the metrics ``avg_score``."""
+    scores = [float(record.get("score", 0.0)) for record in records]
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def _trainable_params_m(trainer: Any) -> float:
+    """Trainable parameter count of the trainer's (LoRA-wrapped) model, in millions.
+
+    Best-effort: reads ``trainer.model.parameters()`` and sums the ``requires_grad`` ones. Any
+    failure (a fake trainer in tests, an API shift) yields ``0.0`` rather than breaking the run.
+    """
+    try:
+        total = sum(int(p.numel()) for p in trainer.model.parameters() if getattr(p, "requires_grad", False))
+    except Exception:
+        return 0.0
+    return total / 1e6
+
+
+def run_sft_training(
+    *,
+    scenario_name: str,  # noqa: ARG001 - seam-signature parity; SFT trains on the curated file, not a live scenario
+    data_path: Path,
+    output_dir: Path,
+    base_model: str,
+    time_budget: int,
+    memory_limit_mb: int,
+    deadline_seconds: float | None = None,
+) -> dict[str, float]:
+    """Fine-tune ``base_model`` over the curated jsonl with TRL's ``SFTTrainer`` (LoRA).
+
+    Cross-platform (Linux / CPU / NVIDIA); imports ``trl`` / ``transformers`` / ``peft`` /
+    ``torch`` / ``datasets`` lazily via :func:`_load_sft_runtime`, after a preflight that fails
+    fast if any is missing. Loads + curates the records (``elite_fraction=1.0``, ``dedupe=True``
+    to honor the curate crash-window mitigation, matching the mlxlm path), converts them to TRL
+    ``{"prompt", "completion"}`` pairs, and trains a LoRA adapter. When ``deadline_seconds`` is
+    set a real ``TrainerCallback`` wrapping :class:`DeadlineCallback` stops training at the next
+    step boundary once the wall-clock deadline passes. The adapter is saved to
+    ``output_dir/"adapters"`` -- the checkpoint path the ambient train seam reads.
+    """
+    from autocontext.training.autoresearch.data_selection import prepare_training_records
+    from autocontext.training.autoresearch.train import _all_records, _peak_memory_mb
+
+    _preflight_sft_deps()
+    (
+        sft_config_cls,
+        sft_trainer_cls,
+        lora_config_cls,
+        dataset_cls,
+        auto_model_cls,
+        auto_tokenizer_cls,
+        trainer_callback_cls,
+    ) = _load_sft_runtime()
+
+    curated = prepare_training_records(_all_records(data_path), elite_fraction=1.0, dedupe=True)
+    if not curated:
+        raise ValueError(f"no training records after curation in {data_path}")
+    pairs = sft_pairs_from_records(curated)
+    dataset = dataset_cls.from_list(pairs)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model = auto_model_cls.from_pretrained(base_model)
+    tokenizer = auto_tokenizer_cls.from_pretrained(base_model)
+
+    config = sft_config_cls(
+        **build_sft_config_kwargs(
+            output_dir=output_dir,
+            max_steps=_sft_max_steps(time_budget),
+            batch_size=1,
+            learning_rate=2e-4,
+        )
+    )
+    lora = lora_config_cls(r=8, lora_alpha=16, task_type="CAUSAL_LM")
+
+    callbacks: list[Any] = []
+    if deadline_seconds is not None:
+        callbacks.append(_make_deadline_callback(trainer_callback_cls, deadline_seconds))
+
+    trainer = sft_trainer_cls(
+        model=model,
+        args=config,
+        train_dataset=dataset,
+        peft_config=lora,
+        processing_class=tokenizer,
+        callbacks=callbacks,
+    )
+    started = time.perf_counter()
+    trainer.train()
+    elapsed = time.perf_counter() - started
+    # Save to output_dir/"adapters": the exact checkpoint path the ambient train seam
+    # (training_backend.run_training) reports for this run.
+    trainer.save_model(str(output_dir / "adapters"))
+
+    return {
+        "training_seconds": elapsed,
+        "num_records": float(len(pairs)),
+        "valid_rate": 1.0,
+        "avg_score": _mean_curated_score(curated),
+        "peak_memory_mb": min(_peak_memory_mb(), float(memory_limit_mb)),
+        "num_params_m": _trainable_params_m(trainer),
+    }

--- a/autocontext/src/autocontext/training/autoresearch/sft_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/sft_backend.py
@@ -213,6 +213,15 @@ def run_sft_training(
     dataset = dataset_cls.from_list(pairs)
 
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build the deadline callback BEFORE the model load so its wall clock starts at the top of the
+    # run. A slow model download/load is then charged against the budget: it does not extend the
+    # window but forecloses the training time left afterward, since the callback stops training at
+    # the next step boundary once the deadline has passed (even if the load ate most of the budget).
+    callbacks: list[Any] = []
+    if deadline_seconds is not None:
+        callbacks.append(_make_deadline_callback(trainer_callback_cls, deadline_seconds))
+
     model = auto_model_cls.from_pretrained(base_model)
     tokenizer = auto_tokenizer_cls.from_pretrained(base_model)
 
@@ -225,10 +234,6 @@ def run_sft_training(
         )
     )
     lora = lora_config_cls(r=8, lora_alpha=16, task_type="CAUSAL_LM")
-
-    callbacks: list[Any] = []
-    if deadline_seconds is not None:
-        callbacks.append(_make_deadline_callback(trainer_callback_cls, deadline_seconds))
 
     trainer = sft_trainer_cls(
         model=model,

--- a/autocontext/src/autocontext/training/autoresearch/sft_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/sft_backend.py
@@ -1,0 +1,78 @@
+"""Linux TRL SFT fine-tuning backend for autoresearch (pure helpers).
+
+The heavy ``run`` function -- which imports TRL/transformers/torch and drives a real
+``SFTTrainer`` -- lives in a later task. This module holds only the pure, CI-testable
+pieces: converting autoresearch records into TRL ``{"prompt", "completion"}`` SFT pairs,
+building the ``SFTConfig`` kwargs as a plain dict (no ``trl`` import), and the wall-clock
+deadline logic that a real ``transformers.TrainerCallback`` will wrap in task 3.
+
+The record-to-pair mapping is delegated to the mlx-lm backend's
+``records_to_completions`` so both backends train on the identical prompt/completion
+contract (per-record prompt fallback, verbatim text vs JSON-serialized strategy,
+reason-then-construct completions).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from autocontext.training.autoresearch.mlxlm_backend import records_to_completions
+
+
+def sft_pairs_from_records(records: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Convert autoresearch records into TRL SFT ``{"prompt", "completion"}`` pairs.
+
+    A thin adapter over the mlx-lm backend's ``records_to_completions``: each record
+    supplies its own ``prompt`` (dataset-style agent tasks) and the mapping serializes a
+    dict strategy to JSON, keeps a text strategy verbatim, and prepends any teacher
+    ``reasoning`` to the completion. Records without their own prompt fall back to the
+    empty task prompt (SFT pairs come from curated per-record data, not a shared prompt).
+    """
+    return records_to_completions(records, task_prompt="")
+
+
+def build_sft_config_kwargs(
+    *,
+    output_dir: Path,
+    max_steps: int,
+    batch_size: int,
+    learning_rate: float,
+    deadline_seconds: float,
+) -> dict[str, Any]:
+    """Build the plain-dict kwargs for a TRL ``SFTConfig`` (no ``trl`` import).
+
+    ``deadline_seconds`` is recorded so the caller can construct the matching
+    ``DeadlineCallback``; it is not an ``SFTConfig`` field and the caller pops it before
+    passing the remaining kwargs to ``SFTConfig(**kwargs)``.
+    """
+    return {
+        "output_dir": str(output_dir),
+        "max_steps": max_steps,
+        "per_device_train_batch_size": batch_size,
+        "learning_rate": learning_rate,
+        "deadline_seconds": deadline_seconds,
+    }
+
+
+class DeadlineCallback:
+    """Pure wall-clock stop logic for the TRL trainer (no ``transformers`` import).
+
+    Task 3 wraps this in a real ``TrainerCallback`` whose ``on_step_end`` sets
+    ``control.should_training_stop`` from :meth:`should_stop`. ``should_stop_at`` exposes
+    the same comparison against an explicit elapsed time so tests drive it deterministically.
+    """
+
+    def __init__(self, deadline_seconds: float, clock: Callable[[], float]) -> None:
+        self._deadline_seconds = deadline_seconds
+        self._clock = clock
+        self._start = clock()
+
+    def should_stop_at(self, elapsed_seconds: float) -> bool:
+        """True once ``elapsed_seconds`` has reached the deadline."""
+        return elapsed_seconds >= self._deadline_seconds
+
+    def should_stop(self) -> bool:
+        """True once the clock has advanced past the deadline since construction."""
+        return self.should_stop_at(self._clock() - self._start)

--- a/autocontext/src/autocontext/training/autoresearch/sft_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/sft_backend.py
@@ -39,20 +39,19 @@ def build_sft_config_kwargs(
     max_steps: int,
     batch_size: int,
     learning_rate: float,
-    deadline_seconds: float,
 ) -> dict[str, Any]:
     """Build the plain-dict kwargs for a TRL ``SFTConfig`` (no ``trl`` import).
 
-    ``deadline_seconds`` is recorded so the caller can construct the matching
-    ``DeadlineCallback``; it is not an ``SFTConfig`` field and the caller pops it before
-    passing the remaining kwargs to ``SFTConfig(**kwargs)``.
+    Every key is a real ``SFTConfig`` field, so the returned dict is directly
+    ``SFTConfig(**kwargs)``-safe. The wall-clock deadline is not an ``SFTConfig`` field:
+    the caller already holds ``deadline_seconds`` and passes it straight to
+    :class:`DeadlineCallback`, so it is never threaded through these kwargs.
     """
     return {
         "output_dir": str(output_dir),
         "max_steps": max_steps,
         "per_device_train_batch_size": batch_size,
         "learning_rate": learning_rate,
-        "deadline_seconds": deadline_seconds,
     }
 
 

--- a/autocontext/src/autocontext/training/autoresearch/sft_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/sft_backend.py
@@ -28,16 +28,18 @@ from autocontext.training.autoresearch.mlxlm_backend import records_to_completio
 _SFT_RUNTIME_DEPS = ("trl", "transformers", "peft", "torch", "datasets")
 
 
-def sft_pairs_from_records(records: list[dict[str, Any]]) -> list[dict[str, str]]:
+def sft_pairs_from_records(records: list[dict[str, Any]], task_prompt: str = "") -> list[dict[str, str]]:
     """Convert autoresearch records into TRL SFT ``{"prompt", "completion"}`` pairs.
 
-    A thin adapter over the mlx-lm backend's ``records_to_completions``: each record
-    supplies its own ``prompt`` (dataset-style agent tasks) and the mapping serializes a
-    dict strategy to JSON, keeps a text strategy verbatim, and prepends any teacher
-    ``reasoning`` to the completion. Records without their own prompt fall back to the
-    empty task prompt (SFT pairs come from curated per-record data, not a shared prompt).
+    A thin adapter over the mlx-lm backend's ``records_to_completions``: the mapping
+    serializes a dict strategy to JSON, keeps a text strategy verbatim, and prepends any
+    teacher ``reasoning`` to the completion. A record that carries its own ``prompt``
+    (dataset-style agent tasks) uses it; otherwise the completion trains on ``task_prompt``,
+    the reconstructed scenario task instruction. Ambient curate records persist no per-record
+    ``prompt``, so passing the scenario task prompt keeps the SFT from training completions
+    with no instruction at all (an empty ``task_prompt`` reproduces that bug).
     """
-    return records_to_completions(records, task_prompt="")
+    return records_to_completions(records, task_prompt=task_prompt)
 
 
 def build_sft_config_kwargs(
@@ -173,7 +175,7 @@ def _trainable_params_m(trainer: Any) -> float:
 
 def run_sft_training(
     *,
-    scenario_name: str,  # noqa: ARG001 - seam-signature parity; SFT trains on the curated file, not a live scenario
+    scenario_name: str,
     data_path: Path,
     output_dir: Path,
     base_model: str,
@@ -192,10 +194,18 @@ def run_sft_training(
     step boundary once the wall-clock deadline passes. The adapter is saved to
     ``output_dir/"adapters"`` -- the checkpoint path the ambient train seam reads.
     """
+    from autocontext.scenarios import SCENARIO_REGISTRY
     from autocontext.training.autoresearch.data_selection import prepare_training_records
+    from autocontext.training.autoresearch.mlxlm_backend import scenario_task_prompt_and_state
     from autocontext.training.autoresearch.train import _all_records, _peak_memory_mb
 
     _preflight_sft_deps()
+    if scenario_name not in SCENARIO_REGISTRY:
+        raise ValueError(f"unknown scenario: {scenario_name}")
+    # Reconstruct the scenario task instruction the SAME way the mlxlm backend does: ambient
+    # curate records persist no per-record prompt, so without this every completion would train
+    # with an empty instruction. sft_pairs_from_records still lets a record's own prompt win.
+    task_prompt, _eval_state = scenario_task_prompt_and_state(SCENARIO_REGISTRY[scenario_name]())
     (
         sft_config_cls,
         sft_trainer_cls,
@@ -209,7 +219,7 @@ def run_sft_training(
     curated = prepare_training_records(_all_records(data_path), elite_fraction=1.0, dedupe=True)
     if not curated:
         raise ValueError(f"no training records after curation in {data_path}")
-    pairs = sft_pairs_from_records(curated)
+    pairs = sft_pairs_from_records(curated, task_prompt)
     dataset = dataset_cls.from_list(pairs)
 
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/autocontext/src/autocontext/training/backends.py
+++ b/autocontext/src/autocontext/training/backends.py
@@ -251,10 +251,18 @@ class SFTBackend(TrainingBackend):
         return "sft"
 
     def is_available(self) -> bool:
+        # Availability must equal runnability: the run path's _preflight_sft_deps requires ALL of
+        # _SFT_RUNTIME_DEPS (trl + transformers + peft + torch + datasets). Checking only trl+torch
+        # here would report available on a box missing transformers/peft/datasets, so select_backend
+        # would pick sft and the run would preflight-error (a train failure that trips the breaker)
+        # instead of cleanly falling through to train_no_backend. Import the tuple (sft_backend's
+        # module top pulls in no heavy deps) to keep the two dep lists in sync.
         try:
             import importlib.util
 
-            return importlib.util.find_spec("trl") is not None and importlib.util.find_spec("torch") is not None
+            from autocontext.training.autoresearch.sft_backend import _SFT_RUNTIME_DEPS
+
+            return all(importlib.util.find_spec(name) is not None for name in _SFT_RUNTIME_DEPS)
         except Exception:
             logger.debug("training.backends: caught Exception", exc_info=True)
             return False

--- a/autocontext/src/autocontext/training/backends.py
+++ b/autocontext/src/autocontext/training/backends.py
@@ -237,6 +237,35 @@ class TRLBackend(TrainingBackend):
         return ["checkpoint"]  # PEFT/LoRA adapter or saved HF model
 
 
+class SFTBackend(TrainingBackend):
+    """Cross-platform TRL SFT backend: LoRA fine-tuning over a curated dataset via HuggingFace TRL.
+
+    The Linux/CUDA counterpart to the mlxlm backend: both train a LoRA-SFT adapter over the
+    curated per-target dataset file, but this one runs wherever ``trl`` + ``torch`` are installed
+    (Linux / NVIDIA / CPU) rather than being Apple-Silicon-locked. Unlike :class:`TRLBackend`
+    (on-policy GKD/GRPO, which cannot consume a curated file), this is the dataset-SFT path.
+    """
+
+    @property
+    def name(self) -> str:
+        return "sft"
+
+    def is_available(self) -> bool:
+        try:
+            import importlib.util
+
+            return importlib.util.find_spec("trl") is not None and importlib.util.find_spec("torch") is not None
+        except Exception:
+            logger.debug("training.backends: caught Exception", exc_info=True)
+            return False
+
+    def default_checkpoint_dir(self, scenario: str) -> Path:
+        return Path("models") / scenario / "sft"
+
+    def supported_runtime_types(self) -> list[str]:
+        return ["checkpoint"]  # PEFT/LoRA adapter saved under output_dir/adapters
+
+
 class BackendRegistry:
     """Registry of training backends by name."""
 
@@ -265,4 +294,5 @@ def default_backend_registry() -> BackendRegistry:
     registry.register(GRPOBackend())
     registry.register(OnPolicyDistillBackend())
     registry.register(TRLBackend())
+    registry.register(SFTBackend())
     return registry

--- a/autocontext/tests/test_ambient_charter.py
+++ b/autocontext/tests/test_ambient_charter.py
@@ -168,3 +168,41 @@ def test_duplicate_source_names_rejected() -> None:
                 CharterSource(name="main", kind="otel"),
             ]
         )
+
+
+def _target(name: str) -> CharterTarget:
+    return CharterTarget(
+        name=name,
+        kind="role",
+        selector="competitor@grid_ctf",
+        base_model="Qwen/Qwen2.5-3B-Instruct",
+        min_dataset_records=1,
+        eval_suite="s",
+    )
+
+
+def test_target_name_colliding_with_scenario_rejected() -> None:
+    # "grid_ctf" is a real registered scenario; ambient candidates are slotted by
+    # target name, so this would share the activation slot with non-ambient records
+    with pytest.raises(ValidationError, match="collides with a registered scenario name"):
+        _minimal_charter(targets=[_target("grid_ctf")])
+
+
+def test_target_name_collision_message_names_scenario() -> None:
+    with pytest.raises(ValidationError, match="'othello'"):
+        _minimal_charter(targets=[_target("othello")])
+
+
+def test_normal_target_name_accepted_alongside_scenario_guard() -> None:
+    charter = _minimal_charter(targets=[_target("competitor-local")])
+    assert charter.targets[0].name == "competitor-local"
+
+
+def test_scenario_collision_check_skipped_when_registry_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # a minimal environment where the scenario registry cannot be imported must
+    # not hard-fail charter construction; the guard is skipped, not enforced
+    import sys
+
+    monkeypatch.setitem(sys.modules, "autocontext.scenarios", None)
+    charter = _minimal_charter(targets=[_target("grid_ctf")])
+    assert charter.targets[0].name == "grid_ctf"

--- a/autocontext/tests/test_ambient_train_stage.py
+++ b/autocontext/tests/test_ambient_train_stage.py
@@ -180,6 +180,49 @@ def test_envelope_over_budget_blocks_even_when_train_budget_alone_fits(tmp_path:
     assert any(e["event"] == "train_budget_exhausted" for e in events)
 
 
+def test_sft_backend_reserves_true_ceiling_not_envelope(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    _patch_backend(monkeypatch, available="sft", gpu_hours=0.5)
+    stage = _stage(tmp_path)
+    # the sft backend enforces a real in-run wall-clock deadline, so its reservation is the TRUE
+    # ceiling = time_budget 1800s = 0.5h (no assess overhead). window budget is 10.0; seed 9.4 used:
+    # 9.4 + 0.5(ceiling) = 9.9 < 10.0 so the job is ALLOWED. the conservative envelope (0.5 + 0.5
+    # assess = 1.0h) would have blocked it (9.4 + 1.0 = 10.4 > 10.0); proving it is not applied.
+    stage.usage_ledger.record("competitor-local", 9.4, _NOW)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()], gpu_hours=10.0)))
+
+    assert result.processed == 1
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_candidate_published" for e in events)
+    assert not any(e["event"] == "train_budget_exhausted" for e in events)
+
+
+def test_mlxlm_backend_keeps_conservative_envelope(tmp_path: Path, monkeypatch: Any) -> None:
+    _seed_dataset(tmp_path, "competitor-local", 6)
+    trained = {"ran": False}
+    monkeypatch.setattr(train_mod, "select_backend", lambda method: "mlxlm")
+
+    def fake_run(backend_name: str, request: Any) -> TrainOutcome:
+        trained["ran"] = True  # the envelope must block before we get here
+        return TrainOutcome(request.output_dir / "adapters", backend_name, {"num_records": 5.0, "training_seconds": 3600.0}, 1.0)
+
+    monkeypatch.setattr(train_mod, "run_training", fake_run)
+    stage = _stage(tmp_path)
+    # mlxlm is NOT deadline-capable: its assessment runs outside any in-run deadline, so the
+    # conservative envelope (0.5 + 0.5 assess = 1.0h) still applies. the true ceiling alone (0.5h)
+    # would fit (9.4 + 0.5 = 9.9), but the envelope blocks it (9.4 + 1.0 = 10.4 > 10.0).
+    stage.usage_ledger.record("competitor-local", 9.4, _NOW)
+
+    result = stage.run_once(_ctx(tmp_path, _charter([_target()], gpu_hours=10.0)))
+
+    assert result.processed == 0
+    assert not trained["ran"]
+    assert stage.registry.list_all() == []
+    events = _events(tmp_path)
+    assert any(e["event"] == "train_budget_exhausted" for e in events)
+
+
 def test_budget_pool_is_charter_wide(tmp_path: Path, monkeypatch: Any) -> None:
     _seed_dataset(tmp_path, "competitor-local", 6)
     trained = {"ran": False}

--- a/autocontext/tests/test_ambient_training_backend.py
+++ b/autocontext/tests/test_ambient_training_backend.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import autocontext.ambient.training_backend as tb
-from autocontext.ambient.training_backend import TrainRequest, run_training, select_backend
+from autocontext.ambient.training_backend import BackendEntry, TrainRequest, run_training, select_backend
 
 
 def _request(tmp_path: Path) -> TrainRequest:
@@ -44,7 +44,10 @@ def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_pat
         captured.update(kwargs)
         return {"avg_score": 0.8, "valid_rate": 1.0, "training_seconds": 3600.0, "num_records": 12.0}
 
-    monkeypatch.setattr(tb, "_BACKEND_FNS", {"mlxlm": fake_run})
+    # monkeypatch a whole registry entry: the fn is swapped for capture, the real
+    # mlxlm adapter maps the TrainRequest to that backend's exact kwargs.
+    real_adapt = tb._BACKEND["mlxlm"].adapt
+    monkeypatch.setitem(tb._BACKEND, "mlxlm", BackendEntry(fn=fake_run, adapt=real_adapt))
     request = _request(tmp_path)
 
     outcome = run_training("mlxlm", request)
@@ -59,6 +62,22 @@ def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_pat
     assert captured["time_budget"] == request.time_budget_seconds
     assert captured["memory_limit_mb"] == request.memory_limit_mb
     assert captured["dedupe"] is True  # train-time dedupe honors the curate crash-window mitigation
+
+
+def test_mlxlm_adapter_maps_request_to_exact_kwargs(tmp_path: Path) -> None:
+    # the adapter is the seam guarding a second backend from foreign kwargs: it must
+    # produce exactly the mlxlm kwarg set, no more, no less.
+    request = _request(tmp_path)
+    kwargs = tb._BACKEND["mlxlm"].adapt(request)
+    assert kwargs == {
+        "scenario_name": "grid_ctf",
+        "data_path": request.data_path,
+        "output_dir": request.output_dir,
+        "time_budget": request.time_budget_seconds,
+        "memory_limit_mb": request.memory_limit_mb,
+        "base_model": "tiny",
+        "dedupe": True,
+    }
 
 
 def test_run_training_unknown_backend_raises(tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_training_backend.py
+++ b/autocontext/tests/test_ambient_training_backend.py
@@ -74,9 +74,32 @@ def test_sft_adapter_maps_request_including_whole_run_deadline(tmp_path: Path) -
 
 def test_sft_is_deadline_capable_and_mlxlm_is_not() -> None:
     # only the sft backend enforces a real in-run wall-clock deadline, so only it is marked
-    # deadline-capable; the train stage reads this set to pick the budget reservation.
-    assert "sft" in tb._DEADLINE_CAPABLE
-    assert "mlxlm" not in tb._DEADLINE_CAPABLE
+    # deadline-capable; the train stage reads this predicate to pick the budget reservation.
+    assert tb.is_deadline_capable("sft") is True
+    assert tb.is_deadline_capable("mlxlm") is False
+
+
+def test_every_deadline_capable_backend_adapter_emits_deadline(tmp_path: Path) -> None:
+    # the coupling invariant: a backend marked deadline-capable gets the exact-ceiling reservation,
+    # which is only safe if its adapter actually passes a deadline to the backend fn. enforce that
+    # every deadline-capable backend's adapter emits "deadline_seconds" so a future backend cannot be
+    # marked capable (and reserved the tight ceiling) without a deadline that would let it overrun.
+    request = _request(tmp_path)
+    capable = [name for name in tb._BACKEND if tb.is_deadline_capable(name)]
+    assert capable, "expected at least one deadline-capable backend"
+    for name in capable:
+        kwargs = tb._BACKEND[name].adapt(request)
+        assert "deadline_seconds" in kwargs, f"deadline-capable backend {name!r} must emit deadline_seconds"
+
+
+def test_non_deadline_capable_backend_adapter_omits_deadline(tmp_path: Path) -> None:
+    # the inverse: a backend WITHOUT an in-run deadline (mlxlm) must not emit deadline_seconds; it is
+    # reserved the conservative assess envelope precisely because it cannot stop itself at the ceiling.
+    request = _request(tmp_path)
+    for name in tb._BACKEND:
+        if not tb.is_deadline_capable(name):
+            kwargs = tb._BACKEND[name].adapt(request)
+            assert "deadline_seconds" not in kwargs, f"non-deadline-capable backend {name!r} must not emit deadline_seconds"
 
 
 def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_path: Path) -> None:

--- a/autocontext/tests/test_ambient_training_backend.py
+++ b/autocontext/tests/test_ambient_training_backend.py
@@ -37,6 +37,48 @@ def test_select_backend_unknown_method_is_none(monkeypatch: Any) -> None:
     assert select_backend("bogus") is None
 
 
+def test_select_backend_prefers_mlxlm_over_sft(monkeypatch: Any) -> None:
+    # both installed (a mac with trl too): mlxlm wins because it is first in the preference tuple.
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": True, "sft": True})
+    assert select_backend("sft-distill") == "mlxlm"
+
+
+def test_select_backend_falls_back_to_sft_on_linux(monkeypatch: Any) -> None:
+    # the linux/cuda path: no mlx runtime but trl+torch present, so sft is selected.
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": False, "sft": True})
+    assert select_backend("sft-distill") == "sft"
+
+
+def test_select_backend_none_when_neither_available(monkeypatch: Any) -> None:
+    monkeypatch.setattr(tb, "_availability", lambda: {"mlxlm": False, "sft": False})
+    assert select_backend("sft-distill") is None
+
+
+def test_sft_adapter_maps_request_including_whole_run_deadline(tmp_path: Path) -> None:
+    # the sft adapter carries every run_sft_training kwarg plus the whole-run deadline: the
+    # deadline is the wall-clock ceiling = time_budget_seconds, in seconds and as a float.
+    request = _request(tmp_path)
+    kwargs = tb._BACKEND["sft"].adapt(request)
+    assert kwargs == {
+        "scenario_name": "grid_ctf",
+        "data_path": request.data_path,
+        "output_dir": request.output_dir,
+        "base_model": "tiny",
+        "time_budget": request.time_budget_seconds,
+        "memory_limit_mb": request.memory_limit_mb,
+        "deadline_seconds": 600.0,
+    }
+    assert kwargs["deadline_seconds"] == float(request.time_budget_seconds)
+    assert isinstance(kwargs["deadline_seconds"], float)
+
+
+def test_sft_is_deadline_capable_and_mlxlm_is_not() -> None:
+    # only the sft backend enforces a real in-run wall-clock deadline, so only it is marked
+    # deadline-capable; the train stage reads this set to pick the budget reservation.
+    assert "sft" in tb._DEADLINE_CAPABLE
+    assert "mlxlm" not in tb._DEADLINE_CAPABLE
+
+
 def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_path: Path) -> None:
     captured: dict[str, Any] = {}
 

--- a/autocontext/tests/test_ambient_training_backend.py
+++ b/autocontext/tests/test_ambient_training_backend.py
@@ -102,6 +102,16 @@ def test_non_deadline_capable_backend_adapter_omits_deadline(tmp_path: Path) -> 
             assert "deadline_seconds" not in kwargs, f"non-deadline-capable backend {name!r} must not emit deadline_seconds"
 
 
+def test_select_backend_none_when_sft_deps_incomplete(monkeypatch: Any) -> None:
+    # end-to-end through the real _availability (not mocked): a box with trl+torch but datasets
+    # (and mlx_lm) missing must NOT select sft, because is_available now requires all five sft deps.
+    # Otherwise select_backend would pick sft and the run would preflight-error (a breaker-tripping
+    # train failure) instead of cleanly returning None -> train_no_backend.
+    present = {"trl", "torch", "transformers", "peft"}  # datasets + mlx_lm absent
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: object() if name in present else None)
+    assert select_backend("sft-distill") is None
+
+
 def test_run_training_dispatches_and_derives_gpu_hours(monkeypatch: Any, tmp_path: Path) -> None:
     captured: dict[str, Any] = {}
 

--- a/autocontext/tests/test_sft_backend.py
+++ b/autocontext/tests/test_sft_backend.py
@@ -1,13 +1,21 @@
-"""Tests for the Linux TRL SFT backend pure helpers (CI-safe, no TRL/torch/transformers).
+"""Tests for the Linux TRL SFT backend (CI-safe, no TRL/torch/transformers).
 
-Task 3 adds the heavy run function and the real TrainerCallback wrapper; these three
-helpers -- record->pair conversion, config-kwargs shape, and the wall-clock deadline
-logic -- are pure and unit-testable without any of those dependencies.
+The pure helpers -- record->pair conversion, config-kwargs shape, and the wall-clock
+deadline logic -- are unit-testable without any heavy dependency. The heavy ``run``
+path is exercised by patching the one lazy-import seam (``_load_sft_runtime``) with fakes,
+so the whole runner runs on a machine without ``trl``; a second, env-gated test does a
+real tiny CPU fine-tune and is skipped in CI.
 """
 
 from __future__ import annotations
 
+import importlib.util
+import json
+import os
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from autocontext.training.autoresearch import mlxlm_backend as mb
 from autocontext.training.autoresearch import sft_backend as sb
@@ -77,3 +85,199 @@ def test_deadline_callback_should_stop_uses_clock() -> None:
     cb = sb.DeadlineCallback(deadline_seconds=20.0, clock=clock)  # consumes 100.0 as start
     assert cb.should_stop() is False  # 105.0 - 100.0 = 5.0 < 20.0
     assert cb.should_stop() is True  # 130.0 - 100.0 = 30.0 >= 20.0
+
+
+# ---------------------------------------------------------------------------
+# Mock-the-run: exercise the whole runner with fakes (no real trl/torch/datasets)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTrainerCallback:
+    """Stand-in for ``transformers.TrainerCallback`` -- a real class so the deadline wrapper
+    can subclass it; the deadline callback attached to the trainer is an instance of this."""
+
+
+def _fake_runtime(captured: dict[str, Any]) -> tuple[Any, ...]:
+    """Build the 7-tuple ``_load_sft_runtime`` returns, with fakes that record their inputs."""
+
+    class _FakeSFTConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["config_kwargs"] = kwargs
+
+    class _FakeLoraConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["lora_kwargs"] = kwargs
+
+    class _FakeDataset:
+        @classmethod
+        def from_list(cls, pairs: list[dict[str, str]]) -> _FakeDataset:
+            captured["dataset_pairs"] = pairs
+            return cls()
+
+    class _FakeModel:
+        @classmethod
+        def from_pretrained(cls, base_model: str) -> _FakeModel:
+            captured["model_base"] = base_model
+            return cls()
+
+    class _FakeTokenizer:
+        @classmethod
+        def from_pretrained(cls, base_model: str) -> _FakeTokenizer:
+            captured["tokenizer_base"] = base_model
+            return cls()
+
+    class _FakeSFTTrainer:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["trainer_kwargs"] = kwargs
+            self.model = None  # no torch params -> _trainable_params_m falls back to 0.0
+
+        def train(self) -> None:
+            captured["trained"] = True
+
+        def save_model(self, path: str) -> None:
+            captured["save_path"] = path
+
+    return (
+        _FakeSFTConfig,
+        _FakeSFTTrainer,
+        _FakeLoraConfig,
+        _FakeDataset,
+        _FakeModel,
+        _FakeTokenizer,
+        _FakeTrainerCallback,
+    )
+
+
+def _write_records(path: Path) -> list[dict[str, Any]]:
+    """Write a 2-record jsonl (shared run_id so both survive the train/val split) and return them."""
+    records = [
+        {"run_id": "r0", "scenario": "grid_ctf", "prompt": "What is 2+2?", "strategy": "Answer: 4", "score": 1.0},
+        {"run_id": "r0", "scenario": "grid_ctf", "prompt": "What is 3+5?", "strategy": "Answer: 8", "score": 0.5},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return records
+
+
+def test_run_sft_training_wires_dataset_config_and_deadline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The runner (with the heavy imports faked) must: invoke preflight, build the dataset from
+    sft_pairs_from_records, build the SFTConfig from build_sft_config_kwargs, attach the deadline
+    TrainerCallback when a deadline is set, save to output_dir/'adapters', and return the metrics."""
+    from autocontext.training.autoresearch.data_selection import prepare_training_records
+    from autocontext.training.autoresearch.train import _all_records
+
+    data_path = tmp_path / "records.jsonl"
+    _write_records(data_path)
+    output_dir = tmp_path / "out"
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(sb, "_preflight_sft_deps", lambda: captured.__setitem__("preflight", True))
+    monkeypatch.setattr(sb, "_load_sft_runtime", lambda: _fake_runtime(captured))
+
+    metrics = sb.run_sft_training(
+        scenario_name="grid_ctf",
+        data_path=data_path,
+        output_dir=output_dir,
+        base_model="fake/tiny-model",
+        time_budget=600,
+        memory_limit_mb=4096,
+        deadline_seconds=30.0,
+    )
+
+    # Preflight ran before any heavy import.
+    assert captured["preflight"] is True
+
+    # The dataset was built from sft_pairs_from_records over the curated records.
+    curated = prepare_training_records(_all_records(data_path), elite_fraction=1.0, dedupe=True)
+    assert captured["dataset_pairs"] == sb.sft_pairs_from_records(curated)
+    assert all(set(p) == {"prompt", "completion"} for p in captured["dataset_pairs"])
+
+    # The SFTConfig kwargs came from build_sft_config_kwargs (its exact field set + values).
+    expected_cfg = sb.build_sft_config_kwargs(
+        output_dir=output_dir, max_steps=sb._sft_max_steps(600), batch_size=1, learning_rate=2e-4
+    )
+    assert captured["config_kwargs"] == expected_cfg
+    assert captured["config_kwargs"]["output_dir"] == str(output_dir)
+
+    # Model + tokenizer loaded from the requested base; LoRA config is the SFT default.
+    assert captured["model_base"] == "fake/tiny-model" and captured["tokenizer_base"] == "fake/tiny-model"
+    assert captured["lora_kwargs"] == {"r": 8, "lora_alpha": 16, "task_type": "CAUSAL_LM"}
+
+    # A deadline attaches exactly one real TrainerCallback wrapping DeadlineCallback.
+    callbacks = captured["trainer_kwargs"]["callbacks"]
+    assert len(callbacks) == 1 and isinstance(callbacks[0], _FakeTrainerCallback)
+    assert captured["trainer_kwargs"]["processing_class"] is not None
+
+    # Trained, then saved to the seam's checkpoint path (output_dir/'adapters').
+    assert captured["trained"] is True
+    assert captured["save_path"] == str(output_dir / "adapters")
+
+    # Metrics carry the seam-required keys.
+    for key in ("training_seconds", "num_records", "valid_rate", "avg_score", "peak_memory_mb"):
+        assert key in metrics
+    assert metrics["num_records"] == 2.0
+    assert metrics["valid_rate"] == 1.0
+    assert metrics["avg_score"] == pytest.approx(0.75)  # mean of curated scores 1.0 and 0.5
+
+
+def test_run_sft_training_attaches_no_callback_without_deadline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With no deadline, the trainer gets an empty callbacks list (nothing to stop it early)."""
+    data_path = tmp_path / "records.jsonl"
+    _write_records(data_path)
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(sb, "_preflight_sft_deps", lambda: None)
+    monkeypatch.setattr(sb, "_load_sft_runtime", lambda: _fake_runtime(captured))
+
+    sb.run_sft_training(
+        scenario_name="grid_ctf",
+        data_path=data_path,
+        output_dir=tmp_path / "out",
+        base_model="fake/tiny-model",
+        time_budget=5,
+        memory_limit_mb=4096,
+        deadline_seconds=None,
+    )
+    assert captured["trainer_kwargs"]["callbacks"] == []
+
+
+def test_run_sft_training_raises_when_no_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An empty jsonl yields no curated records; the runner raises rather than train on nothing."""
+    data_path = tmp_path / "empty.jsonl"
+    data_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(sb, "_preflight_sft_deps", lambda: None)
+    monkeypatch.setattr(sb, "_load_sft_runtime", lambda: _fake_runtime({}))
+    with pytest.raises(ValueError):
+        sb.run_sft_training(
+            scenario_name="grid_ctf",
+            data_path=data_path,
+            output_dir=tmp_path / "out",
+            base_model="fake/tiny-model",
+            time_budget=5,
+            memory_limit_mb=4096,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Env-gated real fine-tune (downloads a base model + trains; skipped in CI)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("trl") is None or not os.environ.get("AUTOCONTEXT_SFT_E2E"),
+    reason="downloads a base model + trains; set AUTOCONTEXT_SFT_E2E=1 with trl installed to run",
+)
+def test_run_sft_training_e2e_writes_adapter(tmp_path: Path) -> None:  # pragma: no cover - env-gated
+    data_path = tmp_path / "records.jsonl"
+    _write_records(data_path)
+    output_dir = tmp_path / "out"
+
+    metrics = sb.run_sft_training(
+        scenario_name="grid_ctf",
+        data_path=data_path,
+        output_dir=output_dir,
+        base_model="hf-internal-testing/tiny-random-LlamaForCausalLM",
+        time_budget=120,
+        memory_limit_mb=8192,
+    )
+    adapters = output_dir / "adapters"
+    assert adapters.is_dir() and any(adapters.iterdir())
+    assert metrics["num_records"] == 2.0

--- a/autocontext/tests/test_sft_backend.py
+++ b/autocontext/tests/test_sft_backend.py
@@ -50,14 +50,15 @@ def test_build_sft_config_kwargs_shape() -> None:
         max_steps=50,
         batch_size=4,
         learning_rate=1e-4,
-        deadline_seconds=120.0,
     )
     assert kwargs["output_dir"] == "/tmp/out"
     assert isinstance(kwargs["output_dir"], str)
     assert kwargs["max_steps"] == 50
     assert kwargs["per_device_train_batch_size"] == 4
     assert kwargs["learning_rate"] == 1e-4
-    assert kwargs["deadline_seconds"] == 120.0
+    # The dict is splatted as SFTConfig(**kwargs); it must carry only SFTConfig fields.
+    assert set(kwargs) == {"output_dir", "max_steps", "per_device_train_batch_size", "learning_rate"}
+    assert "deadline_seconds" not in kwargs
 
 
 def test_deadline_callback_should_stop_at_boundary() -> None:

--- a/autocontext/tests/test_sft_backend.py
+++ b/autocontext/tests/test_sft_backend.py
@@ -13,6 +13,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -85,6 +86,25 @@ def test_deadline_callback_should_stop_uses_clock() -> None:
     cb = sb.DeadlineCallback(deadline_seconds=20.0, clock=clock)  # consumes 100.0 as start
     assert cb.should_stop() is False  # 105.0 - 100.0 = 5.0 < 20.0
     assert cb.should_stop() is True  # 130.0 - 100.0 = 30.0 >= 20.0
+
+
+def test_deadline_trainer_callback_stops_training_past_deadline() -> None:
+    """The real TrainerCallback wrapper flips control.should_training_stop once the deadline passes.
+
+    This is the load-bearing enforcement line: a deadline in the past (a non-positive budget, so the
+    real perf_counter clock is already at/after it) must set should_training_stop on the next step."""
+    callback = sb._make_deadline_callback(_FakeTrainerCallback, deadline_seconds=-1.0)
+    control = SimpleNamespace(should_training_stop=False)
+    callback.on_step_end(args=None, state=None, control=control)
+    assert control.should_training_stop is True
+
+
+def test_deadline_trainer_callback_keeps_training_before_deadline() -> None:
+    """A deadline far in the future leaves should_training_stop untouched: training continues."""
+    callback = sb._make_deadline_callback(_FakeTrainerCallback, deadline_seconds=1e9)
+    control = SimpleNamespace(should_training_stop=False)
+    callback.on_step_end(args=None, state=None, control=control)
+    assert control.should_training_stop is False
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_sft_backend.py
+++ b/autocontext/tests/test_sft_backend.py
@@ -1,0 +1,78 @@
+"""Tests for the Linux TRL SFT backend pure helpers (CI-safe, no TRL/torch/transformers).
+
+Task 3 adds the heavy run function and the real TrainerCallback wrapper; these three
+helpers -- record->pair conversion, config-kwargs shape, and the wall-clock deadline
+logic -- are pure and unit-testable without any of those dependencies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.training.autoresearch import mlxlm_backend as mb
+from autocontext.training.autoresearch import sft_backend as sb
+
+
+def test_sft_pairs_match_build_completion_record() -> None:
+    """Each pair must equal build_completion_record's output for the same record, proving the
+    adapter reuses the mlxlm mapping rather than reimplementing it."""
+    records = [
+        {"run_id": "r0", "scenario": "grid_ctf", "prompt": "What is 2+2?", "strategy": "Answer: 4", "score": 1.0},
+        {"run_id": "r1", "scenario": "grid_ctf", "prompt": "What is 3+5?", "strategy": "Answer: 8", "score": 0.5},
+    ]
+    pairs = sb.sft_pairs_from_records(records)
+    assert pairs == [
+        mb.build_completion_record(task_prompt="What is 2+2?", strategy_json="Answer: 4"),
+        mb.build_completion_record(task_prompt="What is 3+5?", strategy_json="Answer: 8"),
+    ]
+    assert all(set(p) == {"prompt", "completion"} for p in pairs)
+
+
+def test_sft_pairs_serialize_dict_strategy_like_mlxlm() -> None:
+    """A game-scenario record carries a JSON-object strategy; the completion must be the JSON
+    serialization the mlxlm mapping produces, not a repr."""
+    records = [{"scenario": "grid_ctf", "prompt": "T", "strategy": {"a": 1}, "score": 1.0}]
+    pairs = sb.sft_pairs_from_records(records)
+    assert pairs == [mb.build_completion_record(task_prompt="T", strategy_json='{"a": 1}')]
+
+
+def test_sft_pairs_carry_reasoning_prefix() -> None:
+    """Reason-then-construct records prepend the teacher rationale to the completion; the adapter
+    must thread the reasoning field through the mlxlm mapping."""
+    records = [{"scenario": "grid_ctf", "prompt": "T", "strategy": "Answer: 4", "reasoning": "2+2=4", "score": 1.0}]
+    pairs = sb.sft_pairs_from_records(records)
+    assert pairs == [mb.build_completion_record(task_prompt="T", strategy_json="Answer: 4", reasoning="2+2=4")]
+
+
+def test_build_sft_config_kwargs_shape() -> None:
+    kwargs = sb.build_sft_config_kwargs(
+        output_dir=Path("/tmp/out"),
+        max_steps=50,
+        batch_size=4,
+        learning_rate=1e-4,
+        deadline_seconds=120.0,
+    )
+    assert kwargs["output_dir"] == "/tmp/out"
+    assert isinstance(kwargs["output_dir"], str)
+    assert kwargs["max_steps"] == 50
+    assert kwargs["per_device_train_batch_size"] == 4
+    assert kwargs["learning_rate"] == 1e-4
+    assert kwargs["deadline_seconds"] == 120.0
+
+
+def test_deadline_callback_should_stop_at_boundary() -> None:
+    cb = sb.DeadlineCallback(deadline_seconds=10.0, clock=lambda: 0.0)
+    assert cb.should_stop_at(9.999) is False
+    assert cb.should_stop_at(10.0) is True  # at the deadline stops
+    assert cb.should_stop_at(10.001) is True
+
+
+def test_deadline_callback_should_stop_uses_clock() -> None:
+    ticks = iter([100.0, 105.0, 130.0])  # start, before deadline, after deadline
+
+    def clock() -> float:
+        return next(ticks)
+
+    cb = sb.DeadlineCallback(deadline_seconds=20.0, clock=clock)  # consumes 100.0 as start
+    assert cb.should_stop() is False  # 105.0 - 100.0 = 5.0 < 20.0
+    assert cb.should_stop() is True  # 130.0 - 100.0 = 30.0 >= 20.0

--- a/autocontext/tests/test_sft_backend.py
+++ b/autocontext/tests/test_sft_backend.py
@@ -37,6 +37,23 @@ def test_sft_pairs_match_build_completion_record() -> None:
     assert all(set(p) == {"prompt", "completion"} for p in pairs)
 
 
+def test_sft_pairs_use_task_prompt_when_record_has_none() -> None:
+    """Ambient curate records carry no per-record ``prompt``; the pair must train on the passed
+    scenario ``task_prompt``, not the empty string (the bug: empty task prompt => no instruction)."""
+    records = [{"run_id": "r0", "scenario": "grid_ctf", "strategy": "Answer: 4", "score": 1.0}]
+    pairs = sb.sft_pairs_from_records(records, "Play grid capture-the-flag.")
+    assert pairs == [mb.build_completion_record(task_prompt="Play grid capture-the-flag.", strategy_json="Answer: 4")]
+    assert pairs[0]["prompt"] == "Play grid capture-the-flag."
+
+
+def test_sft_pairs_record_prompt_wins_over_task_prompt() -> None:
+    """A record that carries its own ``prompt`` (dataset-style agent task) keeps the per-record
+    precedence from records_to_completions: the record prompt wins over the shared task_prompt."""
+    records = [{"scenario": "grid_ctf", "prompt": "What is 2+2?", "strategy": "Answer: 4", "score": 1.0}]
+    pairs = sb.sft_pairs_from_records(records, "Play grid capture-the-flag.")
+    assert pairs[0]["prompt"] == "What is 2+2?"
+
+
 def test_sft_pairs_serialize_dict_strategy_like_mlxlm() -> None:
     """A game-scenario record carries a JSON-object strategy; the completion must be the JSON
     serialization the mlxlm mapping produces, not a repr."""
@@ -237,6 +254,60 @@ def test_run_sft_training_wires_dataset_config_and_deadline(monkeypatch: pytest.
     assert metrics["num_records"] == 2.0
     assert metrics["valid_rate"] == 1.0
     assert metrics["avg_score"] == pytest.approx(0.75)  # mean of curated scores 1.0 and 0.5
+
+
+def test_run_sft_training_reconstructs_scenario_task_prompt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Ambient curate records carry no per-record ``prompt``; the runner must reconstruct the
+    scenario task instruction from ``scenario_name`` and thread it into every dataset pair, so the
+    SFT never trains completions with an empty instruction."""
+    from autocontext.scenarios import SCENARIO_REGISTRY
+    from autocontext.training.autoresearch.data_selection import prepare_training_records
+    from autocontext.training.autoresearch.mlxlm_backend import scenario_task_prompt_and_state
+    from autocontext.training.autoresearch.train import _all_records
+
+    # Records WITHOUT their own prompt (the ambient curate shape): run_id/scenario/strategy/score.
+    records = [
+        {"run_id": "r0", "scenario": "grid_ctf", "strategy": "Answer: 4", "score": 1.0},
+        {"run_id": "r0", "scenario": "grid_ctf", "strategy": "Answer: 8", "score": 0.5},
+    ]
+    data_path = tmp_path / "records.jsonl"
+    data_path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(sb, "_preflight_sft_deps", lambda: None)
+    monkeypatch.setattr(sb, "_load_sft_runtime", lambda: _fake_runtime(captured))
+
+    sb.run_sft_training(
+        scenario_name="grid_ctf",
+        data_path=data_path,
+        output_dir=tmp_path / "out",
+        base_model="fake/tiny-model",
+        time_budget=5,
+        memory_limit_mb=4096,
+    )
+
+    expected_prompt, _ = scenario_task_prompt_and_state(SCENARIO_REGISTRY["grid_ctf"]())
+    assert expected_prompt, "grid_ctf must reconstruct a non-empty task prompt"
+    curated = prepare_training_records(_all_records(data_path), elite_fraction=1.0, dedupe=True)
+    assert captured["dataset_pairs"] == sb.sft_pairs_from_records(curated, expected_prompt)
+    # Every pair carries the reconstructed instruction, not "" (the bug this fix closes).
+    assert all(p["prompt"] == expected_prompt for p in captured["dataset_pairs"])
+
+
+def test_run_sft_training_raises_on_unknown_scenario(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An unknown scenario name cannot reconstruct a task prompt; the runner raises clearly."""
+    data_path = tmp_path / "records.jsonl"
+    _write_records(data_path)
+    monkeypatch.setattr(sb, "_preflight_sft_deps", lambda: None)
+    monkeypatch.setattr(sb, "_load_sft_runtime", lambda: _fake_runtime({}))
+    with pytest.raises(ValueError, match="unknown scenario"):
+        sb.run_sft_training(
+            scenario_name="does-not-exist",
+            data_path=data_path,
+            output_dir=tmp_path / "out",
+            base_model="fake/tiny-model",
+            time_budget=5,
+            memory_limit_mb=4096,
+        )
 
 
 def test_run_sft_training_attaches_no_callback_without_deadline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/autocontext/tests/test_training_backend.py
+++ b/autocontext/tests/test_training_backend.py
@@ -93,6 +93,29 @@ class TestTrainingBackend:
         assert meta["name"] == "mlx"
         assert "runtime_types" in meta
 
+    def test_sft_available_only_when_all_five_deps_present(self, monkeypatch) -> None:
+        # availability must equal runnability: the run path preflights ALL of _SFT_RUNTIME_DEPS, so
+        # is_available must too. trl+torch present but any of transformers/peft/datasets missing =>
+        # not available, so select_backend won't pick sft into a run that would then preflight-error.
+        from autocontext.training.autoresearch.sft_backend import _SFT_RUNTIME_DEPS
+        from autocontext.training.backends import SFTBackend
+
+        present = set(_SFT_RUNTIME_DEPS)
+        monkeypatch.setattr("importlib.util.find_spec", lambda name: object() if name in present else None)
+        assert SFTBackend().is_available() is True
+
+        for missing in ("transformers", "peft", "datasets"):
+            present = set(_SFT_RUNTIME_DEPS) - {missing}
+            assert SFTBackend().is_available() is False, f"missing {missing} must be unavailable"
+
+    def test_sft_unavailable_when_only_trl_and_torch_present(self, monkeypatch) -> None:
+        # the exact preflight-mismatch box: trl+torch installed, the other three absent.
+        present = {"trl", "torch"}
+        monkeypatch.setattr("importlib.util.find_spec", lambda name: object() if name in present else None)
+        from autocontext.training.backends import SFTBackend
+
+        assert SFTBackend().is_available() is False
+
 
 # ===========================================================================
 # BackendRegistry
@@ -201,7 +224,8 @@ class TestEndToEndActivationFlow:
         ctx = ScenarioRoutingContext(scenario="grid_ctf", backend="mlx")
 
         decision = resolve_provider_for_context(
-            ctx, registry,
+            ctx,
+            registry,
             fallback_provider="anthropic",
             fallback_model="claude-sonnet-4-20250514",
         )
@@ -227,19 +251,25 @@ class TestEndToEndActivationFlow:
         # Publish grid_ctf model
         grid_record = publish_training_output(
             TrainingCompletionOutput(
-                run_id="train-grid", checkpoint_path="/models/grid",
-                backend="mlx", scenario="grid_ctf",
+                run_id="train-grid",
+                checkpoint_path="/models/grid",
+                backend="mlx",
+                scenario="grid_ctf",
             ),
-            registry, auto_activate=True,
+            registry,
+            auto_activate=True,
         )
 
         # Publish othello model
         othello_record = publish_training_output(
             TrainingCompletionOutput(
-                run_id="train-othello", checkpoint_path="/models/othello",
-                backend="mlx", scenario="othello",
+                run_id="train-othello",
+                checkpoint_path="/models/othello",
+                backend="mlx",
+                scenario="othello",
             ),
-            registry, auto_activate=True,
+            registry,
+            auto_activate=True,
         )
 
         # Resolve for each scenario


### PR DESCRIPTION
Plan 5b of the ambient trainer roadmap (spec: docs/ambient-trainer-design.md), the training-backend wave. Builds on plans 1-5a. Makes ambient training actually run on the target Linux GPU box (plans 4/5a's only sft-over-dataset backend, mlxlm, is macOS-only), enforces the GPU-hours budget with a real whole-run deadline, and guards the charter target-name namespace.

## What this adds

**Linux TRL SFTTrainer backend.** run_sft_training fine-tunes a pretrained model with a LoRA adapter over the curated jsonl, reusing the existing records_to_completions to build SFT prompt/completion pairs and curating with dedupe=True. All heavy imports (trl, transformers, peft, torch, datasets) are lazy behind a single _load_sft_runtime seam, so the module imports on a machine without them; CI unit-tests the data conversion, config, deadline callback, and full run wiring with fakes, and a genuine tiny CPU run is env-gated behind AUTOCONTEXT_SFT_E2E. The adapter is saved to output_dir/adapters, matching the seam's checkpoint path.

**Per-backend kwarg adapter.** The training seam now dispatches each backend through its own adapter (a BackendEntry of fn + adapt), so a backend with a different signature cannot be handed foreign kwargs. mlxlm's adapter is byte-identical to the prior fixed kwarg set.

**Seam registration and a real whole-run deadline.** sft-distill resolves to mlxlm where the mlx runtime is present and the new sft backend where only trl and torch are (the Linux/CUDA path). The sft backend is deadline-capable: run_sft_training attaches a TrainerCallback that stops training when a wall-clock deadline passes, so the train stage reserves the exact time-budget ceiling for it (no conservative envelope), while mlxlm keeps its documented envelope because its in-process assessment runs outside any in-run deadline. The deadline clock starts before model load so a slow load forecloses subsequent training time.

**Charter name-collision guard (AC-884).** A charter validator rejects a target named exactly like a registered scenario, since plan 5a slots ambient candidates by target name and such a name would share a registry activation slot with non-ambient records. The scenario registry is imported lazily and the check is skipped when unavailable.

## Scope and honesty notes

- The deadline bounds training compute (what the recorded gpu_hours measures); model download/load is outside it and uncharged, so recorded usage stays within the reservation but a first run pulling a large base model can occupy the box past the window. Documented in train.py.
- Real TRL training correctness is not CI-verifiable (no GPU, trl not installed); the env-gated test covers it, and CI proves import safety, wiring, and budget arithmetic.

## Deferred to the eval/serve-on-real-hardware wave (its own plan, GPU/integration-bound)

Wiring real candidate generation into the evaluate stage (and adding the generation flag to the eval fingerprint), the per-role live-serving router integration so the generation loop resolves per-target ambient models, and AC-883 (re-evaluate incumbents under the current anchor). The plan-5a placeholder-promotion gate keeps promotion safe until then.

## Verification

Roughly 25 new ambient/sft tests (271 passed, 1 env-gated skip in the ambient-or-sft scope) covering the per-backend adapter, SFT conversion and deadline callback, the run wiring under fakes, backend selection and availability, the true-ceiling vs envelope budget asymmetry (proven by the same job passing for sft and blocked for mlxlm), the deadline-capable sync invariant, and the AC-884 guard. A final whole-branch review dynamically proved import safety by blocking the heavy modules and importing the whole chain, and returned READY. ruff and mypy strict clean; uv.lock untouched; CI runs no real fine-tune.