### PR TITLE
feat(knowledge): curate 'activate' restores stale and dead-end lessons

### DIFF
--- a/autocontext/src/autocontext/knowledge/lifecycle.py
+++ b/autocontext/src/autocontext/knowledge/lifecycle.py
@@ -202,10 +202,22 @@ def curate_lesson(
     del lesson_store, current_generation
     if action == "delete":
         found, _text = _remove_lesson(artifacts, scenario, lesson_id)
-        return "deleted" if found else None
+        if found:
+            return "deleted"
+        removed, _entry = _remove_dead_end(artifacts, scenario, lesson_id)
+        return "deleted" if removed else None
     if action == "stale":
         found, _text = _set_lesson_stale(artifacts, scenario, lesson_id, stale=True)
         return "stale" if found else None
+    if action == "activate":
+        found, _text = _set_lesson_stale(artifacts, scenario, lesson_id, stale=False)
+        if found:
+            return "active"
+        removed, entry = _remove_dead_end(artifacts, scenario, lesson_id)
+        if not removed or entry is None:
+            return None
+        _append_playbook_lesson(artifacts, scenario, entry)
+        return "active"
     if action == "deadEnd":
         found, text = _remove_lesson(artifacts, scenario, lesson_id)
         if not found or text is None:
@@ -219,6 +231,43 @@ def _remove_lesson(artifacts: ArtifactStore, scenario: str, lesson_id: str) -> t
     found_playbook, text = _rewrite_playbook_lessons(artifacts, scenario, lesson_id, mode="remove")
     found_skill, skill_text = _rewrite_skill_lessons(artifacts, scenario, lesson_id, mode="remove")
     return found_playbook or found_skill, text or skill_text
+
+
+def _remove_dead_end(
+    artifacts: ArtifactStore, scenario: str, lesson_id: str
+) -> tuple[bool, str | None]:
+    """Remove one dead-end block by its derived id; returns its text when found."""
+    md = artifacts.read_dead_ends(scenario)
+    kept: list[str] = []
+    removed: str | None = None
+    for block in md.split("### Dead End"):
+        text = block.strip()
+        if not text:
+            continue
+        did = "deadend_" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+        if removed is None and did == lesson_id:
+            removed = text
+            continue
+        kept.append(text)
+    if removed is None:
+        return False, None
+    rendered = "".join(f"### Dead End\n\n{text}\n\n" for text in kept)
+    artifacts.replace_dead_ends(scenario, rendered)
+    return True, removed
+
+
+def _append_playbook_lesson(artifacts: ArtifactStore, scenario: str, text: str) -> None:
+    """Append a lesson bullet to the playbook's lessons block (creating one if absent)."""
+    content = artifacts.read_playbook(scenario)
+    bullet = f"- {text}"
+    block = _playbook_block(content)
+    if block is None:
+        suffix = f"\n{LESSONS_START}\n{bullet}\n{LESSONS_END}\n"
+        artifacts.write_playbook(scenario, content + suffix)
+        return
+    block_start, end, body = block
+    new_body = body.rstrip("\n") + f"\n{bullet}\n"
+    artifacts.write_playbook(scenario, content[:block_start] + new_body + content[end:])
 
 
 def _set_lesson_stale(

--- a/autocontext/src/autocontext/server/knowledge_api.py
+++ b/autocontext/src/autocontext/server/knowledge_api.py
@@ -136,7 +136,7 @@ def solve_status(job_id: str) -> dict[str, Any]:
 
 
 class CurateRequest(BaseModel):
-    action: str = Field(pattern="^(stale|deadEnd|delete)$")
+    action: str = Field(pattern="^(stale|deadEnd|delete|activate)$")
 
 
 def _validate_scenario(scenario_name: str) -> str:
@@ -224,7 +224,7 @@ def reject_lesson_route(scenario_name: str, lesson_id: str) -> dict[str, Any]:
 
 @router.post("/{scenario_name}/lessons/{lesson_id}/curate")
 def curate_lesson_route(scenario_name: str, lesson_id: str, body: CurateRequest) -> dict[str, Any]:
-    """Manually mark an active lesson stale, move it to dead-end, or delete it."""
+    """Curate a lesson: mark stale, move to dead-end, delete, or restore to active."""
     from autocontext.knowledge.lifecycle import curate_lesson
 
     scenario_name = _validate_scenario(scenario_name)

--- a/autocontext/tests/test_lesson_lifecycle.py
+++ b/autocontext/tests/test_lesson_lifecycle.py
@@ -131,3 +131,66 @@ def test_curate_missing_or_unknown_action_returns_none(tmp_path: Path) -> None:
 
     assert curate_lesson(artifacts=artifacts, scenario="scn", lesson_id="missing", action="delete", current_generation=1) is None
     assert curate_lesson(artifacts=artifacts, scenario="scn", lesson_id="missing", action="bad", current_generation=1) is None
+
+
+def test_curate_activate_restores_a_stale_lesson(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("bring me back"))
+    [lesson] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=1)["active"]
+    curate_lesson(artifacts=artifacts, scenario="scn", lesson_id=lesson["id"], action="stale", current_generation=2)
+
+    assert (
+        curate_lesson(
+            artifacts=artifacts,
+            scenario="scn",
+            lesson_id=lesson["id"],
+            action="activate",
+            current_generation=3,
+        )
+        == "active"
+    )
+    view = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=3)
+    assert [v["text"] for v in view["active"]] == ["bring me back"]
+    assert view["stale"] == []
+
+
+def test_curate_activate_restores_a_dead_end_to_the_lessons_block(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("doomed", "survivor"))
+    [doomed, _] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=1)["active"]
+    curate_lesson(artifacts=artifacts, scenario="scn", lesson_id=doomed["id"], action="deadEnd", current_generation=2)
+    [dead] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=2)["deadEnd"]
+
+    assert (
+        curate_lesson(
+            artifacts=artifacts,
+            scenario="scn",
+            lesson_id=dead["id"],
+            action="activate",
+            current_generation=3,
+        )
+        == "active"
+    )
+    view = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=3)
+    assert view["deadEnd"] == []
+    assert sorted(v["text"] for v in view["active"]) == ["doomed", "survivor"]
+
+
+def test_curate_delete_removes_a_dead_end(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("doomed"))
+    [doomed] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=1)["active"]
+    curate_lesson(artifacts=artifacts, scenario="scn", lesson_id=doomed["id"], action="deadEnd", current_generation=2)
+    [dead] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=2)["deadEnd"]
+
+    assert (
+        curate_lesson(
+            artifacts=artifacts,
+            scenario="scn",
+            lesson_id=dead["id"],
+            action="delete",
+            current_generation=3,
+        )
+        == "deleted"
+    )
+    assert build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=3)["deadEnd"] == []


### PR DESCRIPTION
## Summary

Companion to autowork ERP-36 (knowledge workspace overhaul). The curate surface was one-way: stale lessons could only be deleted, and dead-end entries had no actions at all.

- `POST /api/knowledge/{scenario}/lessons/{id}/curate` now accepts `activate`: un-stales a lesson via the existing rewrite machinery, or removes a dead-end block (matched by its derived `deadend_` id) and appends the lesson back to the playbook's lessons block
- `delete` now also removes dead-end blocks

## Testing

- 3 new TDD tests (stale→activate, deadEnd→activate round-trip, deadEnd delete), observed red first; full lifecycle + protocol suites pass; ruff clean