### PR TITLE
harness optimization: fresh blended promotion score (AC-877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - ambient trainer plan 5a: evaluate, promote, and serving-resolution stages closing the ambient loop
 - ambient trainer plan 5b: linux trl sft-trainer backend over the curated dataset, whole-run budget deadline, and charter name-collision guard
 - harness optimization protocol: candidate-evidence contract with python and typescript parity (AC-876)
+- harness optimization protocol: fresh blended promotion score with recompute-both semantics and python/typescript parity (AC-877)
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/harness/pipeline/advancement.py
+++ b/autocontext/src/autocontext/harness/pipeline/advancement.py
@@ -14,9 +14,13 @@ Key types:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+from autocontext.harness_optimization.contract.models import Components, Weights
+from autocontext.harness_optimization.scoring import beats_incumbent, harness_promotion_score
 
 # Thresholds
 _ERROR_RATE_THRESHOLD = 0.2
@@ -77,12 +81,120 @@ class AdvancementRationale(BaseModel):
         return cls.model_validate(data)
 
 
+@dataclass(slots=True)
+class HarnessPromotionInputs:
+    """Opt-in inputs for the recompute-both harness promotion gate (AC-877).
+
+    Carries only RAW component metrics (never a stored score) for the
+    challenger and the optional incumbent, plus the weights and their
+    version tag. The gate recomputes BOTH scores from these components
+    under the SAME current weights, so a stale stored score can never
+    enter the comparison.
+
+    Stale-weight safety: if the incumbent's components were recorded under
+    an older weight version, they are STILL re-scored under the current
+    ``weights`` here (because the score is derived from raw components, not
+    read from storage). There is no code path where a stored score computed
+    under an old weight version is compared against a fresh challenger score.
+    """
+
+    challenger_components: Components
+    weights: Weights
+    weight_version: str
+    min_margin: float = 0.0
+    incumbent_components: Components | None = None
+
+
+def _evaluate_harness_promotion(inputs: HarnessPromotionInputs) -> AdvancementRationale:
+    """Recompute-both, weight-versioned promotion gate (AC-877).
+
+    Recomputes the challenger score (and the incumbent score when present)
+    from raw components under ``inputs.weights`` and advances only when the
+    challenger beats the incumbent by more than ``inputs.min_margin``. A
+    challenger with no incumbent is promotable.
+    """
+    challenger = inputs.challenger_components
+    weights = inputs.weights
+    weight_version = inputs.weight_version
+    challenger_score = harness_promotion_score(challenger, weights)
+
+    components: dict[str, float] = {
+        "challenger_score": challenger_score,
+        "dense_quality_score": challenger.dense_quality_score,
+        "sparse_success_rate": challenger.sparse_success_rate,
+        "tokens_per_million": challenger.tokens_per_million,
+        "error_rate": challenger.error_rate,
+        "score_variance": challenger.score_variance,
+    }
+    metadata: dict[str, Any] = {
+        "harness_promotion": True,
+        "weight_version": weight_version,
+        "min_margin": inputs.min_margin,
+        "challenger_components": challenger.model_dump(),
+        "weights": weights.model_dump(),
+    }
+
+    if inputs.incumbent_components is None:
+        components["promotion_margin"] = challenger_score
+        metadata["incumbent_components"] = None
+        return AdvancementRationale(
+            decision="advance",
+            reason=(f"No incumbent — challenger promotable at score {challenger_score:.4f} (weights {weight_version})"),
+            component_scores=components,
+            binding_checks=["harness_promotion_score"],
+            proxy_signals=[],
+            risk_flags=[],
+            metadata=metadata,
+        )
+
+    incumbent = inputs.incumbent_components
+    incumbent_score = harness_promotion_score(incumbent, weights)
+    margin = challenger_score - incumbent_score
+    # Decision comes from the shared never-stale primitive, which recomputes
+    # both scores under the same weights — identical to the margin above.
+    advances = beats_incumbent(challenger, incumbent, weights, inputs.min_margin)
+
+    components["incumbent_score"] = incumbent_score
+    components["promotion_margin"] = margin
+    metadata["incumbent_components"] = incumbent.model_dump()
+
+    if advances:
+        return AdvancementRationale(
+            decision="advance",
+            reason=(
+                f"Challenger promotion score {challenger_score:.4f} beats incumbent "
+                f"{incumbent_score:.4f} by {margin:.4f} (> margin {inputs.min_margin}, "
+                f"weights {weight_version})"
+            ),
+            component_scores=components,
+            binding_checks=["harness_promotion_score"],
+            proxy_signals=[],
+            risk_flags=[],
+            metadata=metadata,
+        )
+
+    return AdvancementRationale(
+        decision="rollback",
+        reason=(
+            f"Challenger promotion score {challenger_score:.4f} does not beat incumbent "
+            f"{incumbent_score:.4f} by enough (margin {margin:.4f} <= {inputs.min_margin}, "
+            f"weights {weight_version})"
+        ),
+        component_scores=components,
+        binding_checks=["harness_promotion_score"],
+        proxy_signals=[],
+        risk_flags=["promotion_margin_below_threshold"],
+        metadata=metadata,
+    )
+
+
 def evaluate_advancement(
     metrics: AdvancementMetrics,
     *,
     min_delta: float = 0.005,
     max_retries: int = 3,
     retry_count: int = 0,
+    harness_promotion: HarnessPromotionInputs | None = None,
 ) -> AdvancementRationale:
     """Evaluate whether a generation should advance, retry, or rollback.
 
@@ -92,7 +204,15 @@ def evaluate_advancement(
     3. Confidence / sample agreement (risk flag)
     4. Resolved truth score (binding when present, overrides proxy)
     5. Score variance (risk flag)
+
+    Opt-in harness-promotion path (AC-877): when ``harness_promotion`` is
+    provided, the decision is driven by the recompute-both, weight-versioned
+    promotion gate instead. When it is ``None`` (the default), this function
+    behaves exactly as before and ``metrics`` alone drives the decision.
     """
+    if harness_promotion is not None:
+        return _evaluate_harness_promotion(harness_promotion)
+
     risk_flags: list[str] = []
     binding_checks: list[str] = ["score_delta"]
     proxy_signals: list[str] = []

--- a/autocontext/src/autocontext/harness/pipeline/advancement.py
+++ b/autocontext/src/autocontext/harness/pipeline/advancement.py
@@ -139,7 +139,7 @@ def _evaluate_harness_promotion(inputs: HarnessPromotionInputs) -> AdvancementRa
         metadata["incumbent_components"] = None
         return AdvancementRationale(
             decision="advance",
-            reason=(f"No incumbent — challenger promotable at score {challenger_score:.4f} (weights {weight_version})"),
+            reason=(f"No incumbent: challenger promotable at score {challenger_score:.4f} (weights {weight_version})"),
             component_scores=components,
             binding_checks=["harness_promotion_score"],
             proxy_signals=[],
@@ -151,7 +151,7 @@ def _evaluate_harness_promotion(inputs: HarnessPromotionInputs) -> AdvancementRa
     incumbent_score = harness_promotion_score(incumbent, weights)
     margin = challenger_score - incumbent_score
     # Decision comes from the shared never-stale primitive, which recomputes
-    # both scores under the same weights — identical to the margin above.
+    # both scores under the same weights, identical to the margin above.
     advances = beats_incumbent(challenger, incumbent, weights, inputs.min_margin)
 
     components["incumbent_score"] = incumbent_score

--- a/autocontext/src/autocontext/harness_optimization/contract/__init__.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/__init__.py
@@ -5,8 +5,12 @@ The models module is auto-generated from the canonical TS schemas via
 `models.py` by hand — CI enforces drift-free regeneration.
 """
 
-from autocontext.harness_optimization.contract.models import CandidateEvidence
+from autocontext.harness_optimization.contract.models import (
+    CandidateEvidence,
+    PromotionScore,
+)
 
 __all__ = [
     "CandidateEvidence",
+    "PromotionScore",
 ]

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/_aggregate.json",
+  "title": "HarnessOptimizationContracts",
+  "description": "Codegen-only aggregate root; $refs each artifact so one models.py is emitted. Not a runtime schema.",
+  "$defs": {
+    "CandidateEvidence": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json"
+    },
+    "PromotionScore": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/promotion-score.json"
+    }
+  }
+}

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/promotion-score.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/promotion-score.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/promotion-score.json",
+  "title": "PromotionScore",
+  "description": "Computed harness-promotion score for a single candidate (AC-877). Combines the dense quality signal with the sparse per-case success rate, marginal token cost, error rate, and score variance under a named, versioned set of weights. This is the artifact the promotion gate reads to decide whether a candidate advances. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "weight_version",
+    "components",
+    "weights",
+    "score",
+    "parity"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "candidate_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique identifier of the candidate this score belongs to."
+    },
+    "weight_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Version tag of the weight set used to compute this score."
+    },
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dense_quality_score",
+        "sparse_success_rate",
+        "tokens_per_million",
+        "error_rate",
+        "score_variance"
+      ],
+      "properties": {
+        "dense_quality_score": {
+          "type": "number",
+          "description": "Dense quality signal, typically a judge or rubric score."
+        },
+        "sparse_success_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Fraction of target cases the candidate resolved, in [0, 1]."
+        },
+        "tokens_per_million": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Marginal token cost expressed per million tokens."
+        },
+        "error_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Fraction of runs that errored, in [0, 1]."
+        },
+        "score_variance": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Variance of the score across samples."
+        }
+      },
+      "description": "The measured components that feed the weighted promotion score."
+    },
+    "weights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sparse_success_weight", "token_cost_weight", "error_weight", "variance_weight"],
+      "properties": {
+        "sparse_success_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the sparse success rate."
+        },
+        "token_cost_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the marginal token cost."
+        },
+        "error_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the error rate."
+        },
+        "variance_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the score variance."
+        }
+      },
+      "description": "The named weights applied to each component."
+    },
+    "score": {
+      "type": "number",
+      "description": "The computed harness promotion score."
+    },
+    "parity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "typescript", "schema_hash"],
+      "properties": {
+        "python": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the Python package."
+        },
+        "typescript": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the TypeScript package."
+        },
+        "schema_hash": {
+          "type": "string",
+          "description": "Content hash of the shared schema the two implementations agree on."
+        }
+      },
+      "description": "Cross-language parity status for this candidate."
+    }
+  }
+}

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -4,9 +4,19 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+
+
+class HarnessOptimizationContracts(RootModel[Any]):
+    root: Annotated[
+        Any,
+        Field(
+            description='Codegen-only aggregate root; $refs each artifact so one models.py is emitted. Not a runtime schema.',
+            title='HarnessOptimizationContracts',
+        ),
+    ]
 
 
 class CostExpectation(BaseModel):
@@ -156,6 +166,92 @@ class CandidateEvidence(BaseModel):
             description='What data the proposer was allowed to inspect, for leakage auditing.'
         ),
     ] = None
+    parity: Annotated[
+        Parity, Field(description='Cross-language parity status for this candidate.')
+    ]
+
+
+class Components(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    dense_quality_score: Annotated[
+        float,
+        Field(description='Dense quality signal, typically a judge or rubric score.'),
+    ]
+    sparse_success_rate: Annotated[
+        float,
+        Field(
+            description='Fraction of target cases the candidate resolved, in [0, 1].',
+            ge=0.0,
+            le=1.0,
+        ),
+    ]
+    tokens_per_million: Annotated[
+        float,
+        Field(description='Marginal token cost expressed per million tokens.', ge=0.0),
+    ]
+    error_rate: Annotated[
+        float,
+        Field(description='Fraction of runs that errored, in [0, 1].', ge=0.0, le=1.0),
+    ]
+    score_variance: Annotated[
+        float, Field(description='Variance of the score across samples.', ge=0.0)
+    ]
+
+
+class Weights(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    sparse_success_weight: Annotated[
+        float, Field(description='Weight applied to the sparse success rate.', ge=0.0)
+    ]
+    token_cost_weight: Annotated[
+        float, Field(description='Weight applied to the marginal token cost.', ge=0.0)
+    ]
+    error_weight: Annotated[
+        float, Field(description='Weight applied to the error rate.', ge=0.0)
+    ]
+    variance_weight: Annotated[
+        float, Field(description='Weight applied to the score variance.', ge=0.0)
+    ]
+
+
+class PromotionScore(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    schema_version: Annotated[
+        Literal[1],
+        Field(
+            description='Schema version for forward compatibility. Always 1 for this revision.'
+        ),
+    ]
+    candidate_id: Annotated[
+        str,
+        Field(
+            description='Stable unique identifier of the candidate this score belongs to.',
+            min_length=1,
+        ),
+    ]
+    weight_version: Annotated[
+        str,
+        Field(
+            description='Version tag of the weight set used to compute this score.',
+            min_length=1,
+        ),
+    ]
+    components: Annotated[
+        Components,
+        Field(
+            description='The measured components that feed the weighted promotion score.'
+        ),
+    ]
+    weights: Annotated[
+        Weights, Field(description='The named weights applied to each component.')
+    ]
+    score: Annotated[float, Field(description='The computed harness promotion score.')]
     parity: Annotated[
         Parity, Field(description='Cross-language parity status for this candidate.')
     ]

--- a/autocontext/src/autocontext/harness_optimization/scoring.py
+++ b/autocontext/src/autocontext/harness_optimization/scoring.py
@@ -1,0 +1,77 @@
+"""Pure harness promotion scorer (AC-877).
+
+This module is the parity heart of AC-877: the same weighted formula is
+implemented here and in ``ts/src/harness-optimization/scoring.ts``, and a shared
+numeric fixture (``fixtures/harness-optimization/promotion-score/score-cases.json``)
+proves both languages compute identical scores.
+
+The formula is::
+
+    harness_promotion_score = dense_quality_score
+                            + sparse_success_weight * sparse_success_rate
+                            - token_cost_weight     * tokens_per_million
+                            - error_weight          * error_rate
+                            - variance_weight       * score_variance
+
+Signature choice: the scorer accepts the generated ``Components`` and ``Weights``
+pydantic models (reading ``.dense_quality_score`` etc.) so it is trivially
+testable from the raw numbers. ``components_from_dict`` / ``weights_from_dict``
+are provided to build those models from plain dicts (fixtures, JSON payloads).
+
+``beats_incumbent`` is the never-stale primitive: it always recomputes BOTH
+scores under the SAME weights and never reads a stored score.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.harness_optimization.contract.models import Components, Weights
+
+__all__ = [
+    "beats_incumbent",
+    "components_from_dict",
+    "harness_promotion_score",
+    "weights_from_dict",
+]
+
+
+def components_from_dict(data: dict[str, Any]) -> Components:
+    """Build a validated ``Components`` model from a plain dict."""
+    return Components(**data)
+
+
+def weights_from_dict(data: dict[str, Any]) -> Weights:
+    """Build a validated ``Weights`` model from a plain dict."""
+    return Weights(**data)
+
+
+def harness_promotion_score(components: Components, weights: Weights) -> float:
+    """Compute the weighted harness promotion score for one candidate.
+
+    Reward is the dense quality score plus the weighted sparse success rate;
+    the weighted token cost, error rate, and score variance are penalties.
+    """
+    return (
+        components.dense_quality_score
+        + weights.sparse_success_weight * components.sparse_success_rate
+        - weights.token_cost_weight * components.tokens_per_million
+        - weights.error_weight * components.error_rate
+        - weights.variance_weight * components.score_variance
+    )
+
+
+def beats_incumbent(
+    challenger_components: Components,
+    incumbent_components: Components,
+    weights: Weights,
+    min_margin: float,
+) -> bool:
+    """Return whether the challenger beats the incumbent by more than ``min_margin``.
+
+    Both scores are recomputed here from their components under the SAME
+    weights, so the comparison can never read a stale stored score.
+    """
+    challenger_score = harness_promotion_score(challenger_components, weights)
+    incumbent_score = harness_promotion_score(incumbent_components, weights)
+    return (challenger_score - incumbent_score) > min_margin

--- a/autocontext/tests/test_advancement_contract.py
+++ b/autocontext/tests/test_advancement_contract.py
@@ -38,8 +38,11 @@ class TestAdvancementMetrics:
         from autocontext.harness.pipeline.advancement import AdvancementMetrics
 
         m = AdvancementMetrics(
-            best_score=0.72, mean_score=0.68, previous_best=0.70,
-            score_variance=0.02, sample_count=3,
+            best_score=0.72,
+            mean_score=0.68,
+            previous_best=0.70,
+            score_variance=0.02,
+            sample_count=3,
         )
         assert abs(m.delta - 0.02) < 0.001
 
@@ -47,9 +50,13 @@ class TestAdvancementMetrics:
         from autocontext.harness.pipeline.advancement import AdvancementMetrics
 
         m = AdvancementMetrics(
-            best_score=0.9, mean_score=0.85, previous_best=0.8,
-            score_variance=0.005, sample_count=5,
-            confidence=0.95, resolved_truth_score=0.88,
+            best_score=0.9,
+            mean_score=0.85,
+            previous_best=0.8,
+            score_variance=0.005,
+            sample_count=5,
+            confidence=0.95,
+            resolved_truth_score=0.88,
             previous_resolved_truth_score=0.84,
         )
         d = m.to_dict()
@@ -115,9 +122,13 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.85, mean_score=0.80, previous_best=0.70,
-            score_variance=0.005, sample_count=5,
-            confidence=0.9, error_rate=0.0,
+            best_score=0.85,
+            mean_score=0.80,
+            previous_best=0.70,
+            score_variance=0.005,
+            sample_count=5,
+            confidence=0.9,
+            error_rate=0.0,
         )
         rationale = evaluate_advancement(metrics, min_delta=0.005)
         assert rationale.decision == "advance"
@@ -129,8 +140,11 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.60, mean_score=0.55, previous_best=0.70,
-            score_variance=0.01, sample_count=5,
+            best_score=0.60,
+            mean_score=0.55,
+            previous_best=0.70,
+            score_variance=0.01,
+            sample_count=5,
         )
         rationale = evaluate_advancement(metrics, min_delta=0.005)
         assert rationale.decision == "rollback"
@@ -142,8 +156,11 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.705, mean_score=0.69, previous_best=0.70,
-            score_variance=0.02, sample_count=3,
+            best_score=0.705,
+            mean_score=0.69,
+            previous_best=0.70,
+            score_variance=0.02,
+            sample_count=3,
         )
         rationale = evaluate_advancement(metrics, min_delta=0.01)
         assert rationale.decision in ("retry", "rollback")
@@ -155,8 +172,11 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.85, mean_score=0.80, previous_best=0.70,
-            score_variance=0.005, sample_count=5,
+            best_score=0.85,
+            mean_score=0.80,
+            previous_best=0.70,
+            score_variance=0.005,
+            sample_count=5,
             error_rate=0.4,  # 40% errors
         )
         rationale = evaluate_advancement(metrics, min_delta=0.005)
@@ -170,8 +190,11 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.85, mean_score=0.80, previous_best=0.70,
-            score_variance=0.05, sample_count=2,
+            best_score=0.85,
+            mean_score=0.80,
+            previous_best=0.70,
+            score_variance=0.05,
+            sample_count=2,
             confidence=0.3,
         )
         rationale = evaluate_advancement(metrics, min_delta=0.005)
@@ -185,8 +208,11 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.90, mean_score=0.85, previous_best=0.70,
-            score_variance=0.005, sample_count=5,
+            best_score=0.90,
+            mean_score=0.85,
+            previous_best=0.70,
+            score_variance=0.005,
+            sample_count=5,
             search_proxy_score=0.90,
             resolved_truth_score=0.55,  # truth says much worse
             previous_resolved_truth_score=0.70,
@@ -202,8 +228,11 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.90, mean_score=0.85, previous_best=0.70,
-            score_variance=0.005, sample_count=5,
+            best_score=0.90,
+            mean_score=0.85,
+            previous_best=0.70,
+            score_variance=0.005,
+            sample_count=5,
             search_proxy_score=0.90,
             resolved_truth_score=0.55,
         )
@@ -218,9 +247,72 @@ class TestEvaluateAdvancement:
         )
 
         metrics = AdvancementMetrics(
-            best_score=0.85, mean_score=0.80, previous_best=0.70,
-            score_variance=0.005, sample_count=5,
+            best_score=0.85,
+            mean_score=0.80,
+            previous_best=0.70,
+            score_variance=0.005,
+            sample_count=5,
         )
         rationale = evaluate_advancement(metrics, min_delta=0.005)
         assert len(rationale.component_scores) > 0
         assert "score_delta" in rationale.component_scores
+
+
+# ===========================================================================
+# AC-877: the opt-in harness-promotion path must leave the default
+# (protocol-disabled) behavior byte-unchanged.
+# ===========================================================================
+
+
+class TestHarnessPromotionDisabledPathUnchanged:
+    def test_disabled_path_matches_pre_change_golden(self) -> None:
+        """With harness_promotion unset the rationale is exactly as before."""
+        from autocontext.harness.pipeline.advancement import (
+            AdvancementMetrics,
+            evaluate_advancement,
+        )
+
+        metrics = AdvancementMetrics(
+            best_score=0.85,
+            mean_score=0.80,
+            previous_best=0.70,
+            score_variance=0.005,
+            sample_count=5,
+            confidence=0.9,
+            error_rate=0.0,
+        )
+        rationale = evaluate_advancement(metrics, min_delta=0.005)
+
+        assert rationale.to_dict() == {
+            "decision": "advance",
+            "reason": "Score improved by 0.1500 (>= 0.005)",
+            "component_scores": {
+                "score_delta": 0.15,
+                "error_rate": 0.0,
+                "confidence": 0.9,
+                "sample_agreement": 1.0,
+                "score_variance": 0.005,
+            },
+            "binding_checks": ["score_delta"],
+            "proxy_signals": [],
+            "risk_flags": [],
+            "metadata": {},
+        }
+
+    def test_explicit_none_equals_default(self) -> None:
+        """Passing harness_promotion=None is identical to omitting it."""
+        from autocontext.harness.pipeline.advancement import (
+            AdvancementMetrics,
+            evaluate_advancement,
+        )
+
+        metrics = AdvancementMetrics(
+            best_score=0.60,
+            mean_score=0.55,
+            previous_best=0.70,
+            score_variance=0.01,
+            sample_count=5,
+        )
+        default = evaluate_advancement(metrics, min_delta=0.005)
+        explicit = evaluate_advancement(metrics, min_delta=0.005, harness_promotion=None)
+        assert default.to_dict() == explicit.to_dict()

--- a/autocontext/tests/test_harness_optimization_contract.py
+++ b/autocontext/tests/test_harness_optimization_contract.py
@@ -15,7 +15,10 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from autocontext.harness_optimization.contract.models import CandidateEvidence
+from autocontext.harness_optimization.contract.models import (
+    CandidateEvidence,
+    PromotionScore,
+)
 
 # Walk up to the repo root: autocontext/tests/ -> autocontext/ -> <repo root>.
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -101,3 +104,58 @@ def test_shared_fixture_directory_contains_the_expected_set() -> None:
     # Set-membership guard: a dropped or renamed fixture fails here.
     names = {p.name for p in FIXTURES_DIR.glob("*.json")}
     assert names == EXPECTED_FIXTURES
+
+
+def _valid_promotion_score() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "candidate_id": "cand-001",
+        "weight_version": "w-2026-07",
+        "components": {
+            "dense_quality_score": 0.82,
+            "sparse_success_rate": 0.6,
+            "tokens_per_million": 1200.0,
+            "error_rate": 0.05,
+            "score_variance": 0.01,
+        },
+        "weights": {
+            "sparse_success_weight": 1.0,
+            "token_cost_weight": 0.2,
+            "error_weight": 0.5,
+            "variance_weight": 0.1,
+        },
+        "score": 0.71,
+        "parity": {
+            "python": "implemented",
+            "typescript": "pending",
+            "schema_hash": "abc123",
+        },
+    }
+
+
+def test_valid_promotion_score_round_trips() -> None:
+    data = _valid_promotion_score()
+    model = PromotionScore(**data)
+    dumped = model.model_dump(exclude_none=True)
+    assert dumped == data
+
+
+def test_promotion_score_missing_required_component_raises() -> None:
+    data = _valid_promotion_score()
+    del data["components"]["error_rate"]
+    with pytest.raises(ValidationError):
+        PromotionScore(**data)
+
+
+def test_promotion_score_extra_field_raises() -> None:
+    data = _valid_promotion_score()
+    data["unexpected_field"] = "nope"
+    with pytest.raises(ValidationError):
+        PromotionScore(**data)
+
+
+def test_promotion_score_empty_parity_raises() -> None:
+    data = _valid_promotion_score()
+    data["parity"] = {}
+    with pytest.raises(ValidationError):
+        PromotionScore(**data)

--- a/autocontext/tests/test_harness_optimization_contract.py
+++ b/autocontext/tests/test_harness_optimization_contract.py
@@ -159,3 +159,46 @@ def test_promotion_score_empty_parity_raises() -> None:
     data["parity"] = {}
     with pytest.raises(ValidationError):
         PromotionScore(**data)
+
+
+# --- Shared promotion-score contract fixtures (mirrors candidate-evidence) -----
+
+PROMOTION_SCORE_FIXTURES_DIR = REPO_ROOT / "fixtures" / "harness-optimization" / "promotion-score"
+
+# The contract fixtures validated by both packages. score-cases.json also lives in
+# this directory (it is the SCORER numeric fixture, loaded by the scoring tests) and
+# is deliberately excluded here: it matches neither the valid- nor invalid- prefix.
+EXPECTED_PROMOTION_SCORE_FIXTURES = {
+    "valid-full.json",
+    "valid-minimal.json",
+    "invalid-missing-component.json",
+    "invalid-empty-parity.json",
+    "invalid-extra-field.json",
+}
+
+
+def _promotion_score_fixtures(prefix: str) -> list[Path]:
+    assert PROMOTION_SCORE_FIXTURES_DIR.is_dir(), f"expected fixtures dir at {PROMOTION_SCORE_FIXTURES_DIR}"
+    return sorted(PROMOTION_SCORE_FIXTURES_DIR.glob(f"{prefix}*.json"))
+
+
+@pytest.mark.parametrize("fixture", _promotion_score_fixtures("valid-"), ids=lambda p: p.name)
+def test_shared_valid_promotion_score_fixtures_construct(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    PromotionScore(**data)
+
+
+@pytest.mark.parametrize("fixture", _promotion_score_fixtures("invalid-"), ids=lambda p: p.name)
+def test_shared_invalid_promotion_score_fixtures_raise(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    with pytest.raises(ValidationError):
+        PromotionScore(**data)
+
+
+def test_shared_promotion_score_fixture_directory_contains_the_expected_set() -> None:
+    # Set-membership guard over the valid-/invalid- contract fixtures only, so a
+    # dropped or renamed contract fixture fails here while score-cases.json (the
+    # scorer numeric fixture) is left untouched.
+    names = {p.name for p in _promotion_score_fixtures("valid-")}
+    names |= {p.name for p in _promotion_score_fixtures("invalid-")}
+    assert names == EXPECTED_PROMOTION_SCORE_FIXTURES

--- a/autocontext/tests/test_harness_optimization_contract.py
+++ b/autocontext/tests/test_harness_optimization_contract.py
@@ -196,9 +196,9 @@ def test_shared_invalid_promotion_score_fixtures_raise(fixture: Path) -> None:
 
 
 def test_shared_promotion_score_fixture_directory_contains_the_expected_set() -> None:
-    # Set-membership guard over the valid-/invalid- contract fixtures only, so a
-    # dropped or renamed contract fixture fails here while score-cases.json (the
-    # scorer numeric fixture) is left untouched.
-    names = {p.name for p in _promotion_score_fixtures("valid-")}
-    names |= {p.name for p in _promotion_score_fixtures("invalid-")}
-    assert names == EXPECTED_PROMOTION_SCORE_FIXTURES
+    # Set-membership guard over EVERY .json in the directory: the five valid-/invalid-
+    # contract fixtures plus score-cases.json (the scorer numeric fixture). Globbing all
+    # files (not just the valid-/invalid- prefixes) means a stray or dropped .json fails
+    # here instead of being silently ignored.
+    names = {p.name for p in PROMOTION_SCORE_FIXTURES_DIR.glob("*.json")}
+    assert names == EXPECTED_PROMOTION_SCORE_FIXTURES | {"score-cases.json"}

--- a/autocontext/tests/test_harness_optimization_gate.py
+++ b/autocontext/tests/test_harness_optimization_gate.py
@@ -1,0 +1,268 @@
+"""Tests for the recompute-both weight-versioned promotion gate (AC-877).
+
+Exercises the opt-in ``harness_promotion`` path of ``evaluate_advancement``:
+challenger vs incumbent scores are always recomputed from raw components under
+the SAME current weights, so a stale stored score can never enter the gate.
+"""
+
+from __future__ import annotations
+
+from autocontext.harness.pipeline.advancement import (
+    AdvancementMetrics,
+    HarnessPromotionInputs,
+    evaluate_advancement,
+)
+from autocontext.harness_optimization.contract.models import Components, Weights
+from autocontext.harness_optimization.scoring import harness_promotion_score
+
+# The harness-promotion path never reads ``metrics``; a fixed placeholder makes
+# that explicit across every case below.
+_UNUSED_METRICS = AdvancementMetrics(
+    best_score=0.0,
+    mean_score=0.0,
+    previous_best=0.0,
+    score_variance=0.0,
+    sample_count=1,
+)
+
+# Standard weight set used by most cases. Cost, error, and variance are
+# genuine penalties so the gate is not driven by dense quality alone.
+_WEIGHTS = Weights(
+    sparse_success_weight=1.0,
+    token_cost_weight=0.1,
+    error_weight=1.0,
+    variance_weight=1.0,
+)
+
+
+def _components(
+    *,
+    dense: float,
+    sparse: float = 0.0,
+    tpm: float = 0.0,
+    err: float = 0.0,
+    var: float = 0.0,
+) -> Components:
+    return Components(
+        dense_quality_score=dense,
+        sparse_success_rate=sparse,
+        tokens_per_million=tpm,
+        error_rate=err,
+        score_variance=var,
+    )
+
+
+def test_positive_advance_beats_incumbent_by_margin() -> None:
+    challenger = _components(dense=0.9, sparse=0.8, tpm=1.0)
+    incumbent = _components(dense=0.7, sparse=0.5, tpm=1.0)
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=challenger,
+            incumbent_components=incumbent,
+            weights=_WEIGHTS,
+            weight_version="v1",
+            min_margin=0.05,
+        ),
+    )
+    assert rationale.decision == "advance"
+    assert rationale.component_scores["promotion_margin"] > 0.05
+
+
+def test_no_advance_when_within_margin() -> None:
+    challenger = _components(dense=0.72, sparse=0.5, tpm=1.0)
+    incumbent = _components(dense=0.70, sparse=0.5, tpm=1.0)
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=challenger,
+            incumbent_components=incumbent,
+            weights=_WEIGHTS,
+            weight_version="v1",
+            min_margin=0.05,
+        ),
+    )
+    assert rationale.decision == "rollback"
+    assert 0.0 < rationale.component_scores["promotion_margin"] <= 0.05
+
+
+def test_no_advance_when_challenger_worse() -> None:
+    challenger = _components(dense=0.6, sparse=0.4)
+    incumbent = _components(dense=0.9, sparse=0.6)
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=challenger,
+            incumbent_components=incumbent,
+            weights=_WEIGHTS,
+            weight_version="v1",
+            min_margin=0.05,
+        ),
+    )
+    assert rationale.decision == "rollback"
+    assert rationale.component_scores["promotion_margin"] < 0.0
+
+
+def test_cost_regression_flips_would_advance_to_no_advance() -> None:
+    # On dense quality alone the challenger (1.5) beats the incumbent (1.0),
+    # but a high tokens_per_million re-scores it below the incumbent.
+    challenger = _components(dense=1.5, tpm=20.0)
+    incumbent = _components(dense=1.0, tpm=1.0)
+
+    # Sanity: challenger wins on dense quality alone.
+    assert challenger.dense_quality_score > incumbent.dense_quality_score
+
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=challenger,
+            incumbent_components=incumbent,
+            weights=_WEIGHTS,
+            weight_version="v1",
+            min_margin=0.05,
+        ),
+    )
+    assert rationale.decision == "rollback"
+    # Cost penalty is what sinks it: challenger score is now below incumbent.
+    assert rationale.component_scores["challenger_score"] < rationale.component_scores["incumbent_score"]
+
+
+def test_high_variance_flips_would_advance_to_no_advance() -> None:
+    weights = Weights(
+        sparse_success_weight=1.0,
+        token_cost_weight=0.1,
+        error_weight=1.0,
+        variance_weight=5.0,
+    )
+    # Same challenger that beats the incumbent on dense quality.
+    incumbent = _components(dense=1.0)
+
+    low_variance = _components(dense=1.2, var=0.0)
+    high_variance = _components(dense=1.2, var=0.2)
+
+    # Control: with no variance the challenger advances.
+    control = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=low_variance,
+            incumbent_components=incumbent,
+            weights=weights,
+            weight_version="v1",
+            min_margin=0.05,
+        ),
+    )
+    assert control.decision == "advance"
+
+    # High variance re-scores the identical dense quality below the margin.
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=high_variance,
+            incumbent_components=incumbent,
+            weights=weights,
+            weight_version="v1",
+            min_margin=0.05,
+        ),
+    )
+    assert rationale.decision == "rollback"
+
+
+def test_no_incumbent_is_promotable() -> None:
+    challenger = _components(dense=0.5, sparse=0.3, tpm=2.0)
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=challenger,
+            incumbent_components=None,
+            weights=_WEIGHTS,
+            weight_version="v1",
+            min_margin=0.05,
+        ),
+    )
+    assert rationale.decision == "advance"
+    assert "incumbent_score" not in rationale.component_scores
+    assert rationale.metadata["incumbent_components"] is None
+
+
+def test_stale_weight_incumbent_is_rescored_under_current_weights() -> None:
+    """Never-stale proof.
+
+    The incumbent's components were recorded under an OLD weight set that
+    ignored token cost (token_cost_weight=0). Under the CURRENT weights the
+    incumbent's high token cost is penalized. Because the gate recomputes
+    both scores from raw components, the challenger correctly advances — even
+    though a naive comparison against the incumbent's stale stored score would
+    (wrongly) reject it.
+    """
+    old_weights = Weights(
+        sparse_success_weight=1.0,
+        token_cost_weight=0.0,  # old regime ignored token cost
+        error_weight=1.0,
+        variance_weight=1.0,
+    )
+    current_weights = Weights(
+        sparse_success_weight=1.0,
+        token_cost_weight=0.1,  # current regime penalizes token cost
+        error_weight=1.0,
+        variance_weight=1.0,
+    )
+
+    # Incumbent looked great under the old weights (high token cost was free).
+    incumbent = _components(dense=0.9, tpm=5.0)
+    challenger = _components(dense=0.6, tpm=0.0)
+
+    stale_incumbent_score = harness_promotion_score(incumbent, old_weights)
+    fresh_challenger_score = harness_promotion_score(challenger, current_weights)
+    current_incumbent_score = harness_promotion_score(incumbent, current_weights)
+
+    # A NAIVE stale comparison (fresh challenger vs stored old-weight score)
+    # would reject the challenger...
+    assert fresh_challenger_score - stale_incumbent_score < 0.05
+    # ...but the correct recompute-both comparison accepts it.
+    assert fresh_challenger_score - current_incumbent_score > 0.05
+
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=challenger,
+            incumbent_components=incumbent,
+            weights=current_weights,
+            weight_version="v2",
+            min_margin=0.05,
+        ),
+    )
+    # The gate advances (recompute-both), never using the stale stored score.
+    assert rationale.decision == "advance"
+    assert rationale.component_scores["incumbent_score"] == current_incumbent_score
+    assert rationale.metadata["weight_version"] == "v2"
+
+
+def test_rationale_records_scores_weight_version_components_and_margin() -> None:
+    challenger = _components(dense=0.9, sparse=0.8, tpm=1.0, err=0.05, var=0.01)
+    incumbent = _components(dense=0.7, sparse=0.5, tpm=1.0)
+    rationale = evaluate_advancement(
+        _UNUSED_METRICS,
+        harness_promotion=HarnessPromotionInputs(
+            challenger_components=challenger,
+            incumbent_components=incumbent,
+            weights=_WEIGHTS,
+            weight_version="v7",
+            min_margin=0.05,
+        ),
+    )
+    scores = rationale.component_scores
+    assert "challenger_score" in scores
+    assert "incumbent_score" in scores
+    assert "promotion_margin" in scores
+    # Score components are surfaced for the audit trail.
+    assert scores["dense_quality_score"] == 0.9
+    assert scores["sparse_success_rate"] == 0.8
+    assert scores["tokens_per_million"] == 1.0
+    assert scores["error_rate"] == 0.05
+    assert scores["score_variance"] == 0.01
+    # Weight version and raw component breakdown live in metadata.
+    assert rationale.metadata["weight_version"] == "v7"
+    assert rationale.metadata["challenger_components"]["dense_quality_score"] == 0.9
+    assert rationale.metadata["incumbent_components"]["dense_quality_score"] == 0.7
+    # Margin equals the recomputed challenger minus incumbent score.
+    assert scores["promotion_margin"] == scores["challenger_score"] - scores["incumbent_score"]

--- a/autocontext/tests/test_harness_optimization_scoring.py
+++ b/autocontext/tests/test_harness_optimization_scoring.py
@@ -1,0 +1,46 @@
+"""Parity tests for the harness promotion scorer (AC-877).
+
+Loads the shared repo-root fixture and asserts the Python scorer matches every
+hand-computed ground-truth value. The TypeScript suite
+(``ts/tests/harness-optimization/scoring.test.ts``) loads the SAME fixture, which
+is what proves the two implementations compute identical scores.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autocontext.harness_optimization.scoring import (
+    beats_incumbent,
+    components_from_dict,
+    harness_promotion_score,
+    weights_from_dict,
+)
+
+# Walk up to the repo root: autocontext/tests/ -> autocontext/ -> <repo root>.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = REPO_ROOT / "fixtures" / "harness-optimization" / "promotion-score" / "score-cases.json"
+
+_CASES = json.loads(FIXTURE.read_text())
+SCORE_CASES = _CASES["score_cases"]
+BEATS_CASES = _CASES["beats_cases"]
+
+TOL = 1e-9
+
+
+@pytest.mark.parametrize("case", SCORE_CASES, ids=[c["name"] for c in SCORE_CASES])
+def test_harness_promotion_score_matches_fixture(case: dict) -> None:
+    components = components_from_dict(case["components"])
+    weights = weights_from_dict(case["weights"])
+    assert harness_promotion_score(components, weights) == pytest.approx(case["expected_score"], abs=TOL)
+
+
+@pytest.mark.parametrize("case", BEATS_CASES, ids=[c["name"] for c in BEATS_CASES])
+def test_beats_incumbent_matches_fixture(case: dict) -> None:
+    challenger = components_from_dict(case["challenger"])
+    incumbent = components_from_dict(case["incumbent"])
+    weights = weights_from_dict(case["weights"])
+    assert beats_incumbent(challenger, incumbent, weights, case["min_margin"]) == case["expected_beats"]

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -85,6 +85,81 @@ console.log(evidence.candidate_id, evidence.mechanism_type);
 writeCandidateEvidence(evidence, "out/candidate.json"); // 2-space indent + trailing newline
 ```
 
+## Promotion score (AC-877)
+
+Once candidates have been evaluated, the promotion gate needs a single comparable
+number per candidate. The **PromotionScore** artifact carries that number together
+with the raw components it was computed from, the named weight set (and its
+version), and the same cross-language parity block as CandidateEvidence. Its schema
+lives at `ts/src/harness-optimization/contract/json-schemas/promotion-score.schema.json`
+and generates both packages' types under the same drift gate.
+
+The score is a fresh blend of five components under four named weights:
+
+```
+score = dense_quality_score
+      + sparse_success_weight * sparse_success_rate
+      - token_cost_weight     * tokens_per_million
+      - error_weight          * error_rate
+      - variance_weight       * score_variance
+```
+
+Dense quality is the reward, the weighted sparse success rate adds to it, and the
+weighted token cost, error rate, and score variance are penalties. The scorer is a
+pure function of components and weights, so the same inputs always produce the same
+number. A shared numeric fixture
+(`fixtures/harness-optimization/promotion-score/score-cases.json`) pins the exact
+expected scores and beat decisions, and both packages load it to prove they compute
+identical results.
+
+### The never-stale rule
+
+A candidate beats an incumbent only when its score exceeds the incumbent's by more
+than a margin, and the comparison always recomputes BOTH scores from raw components
+under the SAME weight version. Never compare a fresh challenger score against a
+stored incumbent score: a stored score may have been computed under an older weight
+version, and mixing weight versions makes the comparison meaningless. `beats_incumbent`
+(Python) and `beatsIncumbent` (TypeScript) enforce this by taking components (not
+scores) and rescoring both sides in place. The threshold is strict: a challenger
+whose recomputed margin exactly equals the minimum margin does not beat the incumbent.
+
+### Tuning the weights
+
+The weights are the policy knob, and they carry a version tag precisely so a
+retune is an explicit, recorded event rather than a silent drift. When the dev set
+is small, sparse per-case success is noisy: a couple of extra solved cases can swing
+`sparse_success_rate` sharply, so a large `sparse_success_weight` lets sparse success
+dominate a blend that should still be anchored by the dense quality signal. Keep the
+sparse weight modest relative to the dense signal on small dev sets, and only raise
+it once the case count is large enough for the success rate to be stable. Bump the
+`weight_version` whenever any weight changes so that no incumbent recorded under the
+old weights is ever compared under the new ones.
+
+### Reading and validating the artifact
+
+Both packages validate a PromotionScore against the shared schema and expose the
+pure scorer. Python:
+
+```python
+from autocontext.harness_optimization.contract.models import PromotionScore
+from autocontext.harness_optimization.scoring import beats_incumbent, harness_promotion_score
+
+score = PromotionScore(**data)  # raises ValidationError on an invalid record
+fresh = harness_promotion_score(score.components, score.weights)
+advances = beats_incumbent(challenger.components, incumbent.components, weights, min_margin=0.05)
+```
+
+TypeScript:
+
+```ts
+import { validatePromotionScore } from "autoctx/harness-optimization/contract/validators";
+import { beatsIncumbent, harnessPromotionScore } from "autoctx/harness-optimization/scoring";
+
+const result = validatePromotionScore(data); // { valid: false, errors } on an invalid record
+const fresh = harnessPromotionScore(components, weights);
+const advances = beatsIncumbent(challengerComponents, incumbentComponents, weights, 0.05);
+```
+
 ## The contract pattern
 
 This is the foundation artifact. The later protocol artifacts follow the same

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -135,6 +135,10 @@ it once the case count is large enough for the success rate to be stable. Bump t
 `weight_version` whenever any weight changes so that no incumbent recorded under the
 old weights is ever compared under the new ones.
 
+The python advancement gate's harness-promotion path is opt-in (`harness_promotion`
+defaults to `None`) and is not yet wired into the live tournament loop; that
+live-loop wiring lands with a later issue.
+
 ### Reading and validating the artifact
 
 Both packages validate a PromotionScore against the shared schema and expose the

--- a/fixtures/harness-optimization/promotion-score/invalid-empty-parity.json
+++ b/fixtures/harness-optimization/promotion-score/invalid-empty-parity.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "candidate_id": "cand-full-002",
+  "weight_version": "w-2026-07",
+  "components": {
+    "dense_quality_score": 0.82,
+    "sparse_success_rate": 0.6,
+    "tokens_per_million": 0.5,
+    "error_rate": 0.05,
+    "score_variance": 0.01
+  },
+  "weights": {
+    "sparse_success_weight": 1.0,
+    "token_cost_weight": 0.2,
+    "error_weight": 0.5,
+    "variance_weight": 0.1
+  },
+  "score": 1.294,
+  "parity": {}
+}

--- a/fixtures/harness-optimization/promotion-score/invalid-extra-field.json
+++ b/fixtures/harness-optimization/promotion-score/invalid-extra-field.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "candidate_id": "cand-full-002",
+  "weight_version": "w-2026-07",
+  "components": {
+    "dense_quality_score": 0.82,
+    "sparse_success_rate": 0.6,
+    "tokens_per_million": 0.5,
+    "error_rate": 0.05,
+    "score_variance": 0.01
+  },
+  "weights": {
+    "sparse_success_weight": 1.0,
+    "token_cost_weight": 0.2,
+    "error_weight": 0.5,
+    "variance_weight": 0.1
+  },
+  "score": 1.294,
+  "parity": {
+    "python": "implemented",
+    "typescript": "implemented",
+    "schema_hash": "9f8e7d6c5b4a"
+  },
+  "surprise": true
+}

--- a/fixtures/harness-optimization/promotion-score/invalid-missing-component.json
+++ b/fixtures/harness-optimization/promotion-score/invalid-missing-component.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "candidate_id": "cand-full-002",
+  "weight_version": "w-2026-07",
+  "components": {
+    "dense_quality_score": 0.82,
+    "sparse_success_rate": 0.6,
+    "tokens_per_million": 0.5,
+    "error_rate": 0.05
+  },
+  "weights": {
+    "sparse_success_weight": 1.0,
+    "token_cost_weight": 0.2,
+    "error_weight": 0.5,
+    "variance_weight": 0.1
+  },
+  "score": 1.294,
+  "parity": {
+    "python": "implemented",
+    "typescript": "implemented",
+    "schema_hash": "9f8e7d6c5b4a"
+  }
+}

--- a/fixtures/harness-optimization/promotion-score/score-cases.json
+++ b/fixtures/harness-optimization/promotion-score/score-cases.json
@@ -187,6 +187,31 @@
       },
       "min_margin": 0.05,
       "expected_beats": true
+    },
+    {
+      "name": "boundary tie: recomputed diff exactly equals min_margin does not beat (strict greater-than, not >=)",
+      "challenger": {
+        "dense_quality_score": 0.75,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.25,
+        "error_rate": 0.0,
+        "score_variance": 0.0
+      },
+      "incumbent": {
+        "dense_quality_score": 0.5,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.25,
+        "error_rate": 0.0,
+        "score_variance": 0.0
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 1.0,
+        "error_weight": 1.0,
+        "variance_weight": 1.0
+      },
+      "min_margin": 0.25,
+      "expected_beats": false
     }
   ]
 }

--- a/fixtures/harness-optimization/promotion-score/score-cases.json
+++ b/fixtures/harness-optimization/promotion-score/score-cases.json
@@ -1,0 +1,192 @@
+{
+  "_comment": "Ground-truth numeric fixture for the AC-877 harness promotion scorer. Loaded by BOTH the Python and TypeScript test suites to prove the two implementations compute identical scores. expected_score / expected_beats are computed by hand from the formula: dense_quality_score + sparse_success_weight*sparse_success_rate - token_cost_weight*tokens_per_million - error_weight*error_rate - variance_weight*score_variance.",
+  "score_cases": [
+    {
+      "name": "plain positive case",
+      "components": {
+        "dense_quality_score": 0.8,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.1,
+        "error_rate": 0.02,
+        "score_variance": 0.01
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 0.5,
+        "error_weight": 2.0,
+        "variance_weight": 1.0
+      },
+      "expected_score": 1.2
+    },
+    {
+      "name": "cost regression pulls score negative",
+      "components": {
+        "dense_quality_score": 0.9,
+        "sparse_success_rate": 0.4,
+        "tokens_per_million": 5.0,
+        "error_rate": 0.0,
+        "score_variance": 0.0
+      },
+      "weights": {
+        "sparse_success_weight": 0.5,
+        "token_cost_weight": 1.0,
+        "error_weight": 1.0,
+        "variance_weight": 1.0
+      },
+      "expected_score": -3.9
+    },
+    {
+      "name": "high variance pulls score down",
+      "components": {
+        "dense_quality_score": 1.0,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.2,
+        "error_rate": 0.05,
+        "score_variance": 2.0
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 1.0,
+        "error_weight": 1.0,
+        "variance_weight": 3.0
+      },
+      "expected_score": -4.75
+    },
+    {
+      "name": "high error rate penalizes score",
+      "components": {
+        "dense_quality_score": 0.7,
+        "sparse_success_rate": 0.8,
+        "tokens_per_million": 0.1,
+        "error_rate": 0.9,
+        "score_variance": 0.02
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 1.0,
+        "error_weight": 5.0,
+        "variance_weight": 1.0
+      },
+      "expected_score": -3.12
+    },
+    {
+      "name": "zero weights: score equals dense quality score",
+      "components": {
+        "dense_quality_score": 0.65,
+        "sparse_success_rate": 0.9,
+        "tokens_per_million": 3.0,
+        "error_rate": 0.5,
+        "score_variance": 1.0
+      },
+      "weights": {
+        "sparse_success_weight": 0.0,
+        "token_cost_weight": 0.0,
+        "error_weight": 0.0,
+        "variance_weight": 0.0
+      },
+      "expected_score": 0.65
+    }
+  ],
+  "beats_cases": [
+    {
+      "name": "challenger clearly beats by more than the margin",
+      "challenger": {
+        "dense_quality_score": 1.0,
+        "sparse_success_rate": 0.6,
+        "tokens_per_million": 0.1,
+        "error_rate": 0.01,
+        "score_variance": 0.01
+      },
+      "incumbent": {
+        "dense_quality_score": 0.8,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.2,
+        "error_rate": 0.05,
+        "score_variance": 0.02
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 0.5,
+        "error_weight": 2.0,
+        "variance_weight": 1.0
+      },
+      "min_margin": 0.1,
+      "expected_beats": true
+    },
+    {
+      "name": "challenger ahead but within the margin: no beat",
+      "challenger": {
+        "dense_quality_score": 1.05,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.1,
+        "error_rate": 0.02,
+        "score_variance": 0.01
+      },
+      "incumbent": {
+        "dense_quality_score": 1.0,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.1,
+        "error_rate": 0.02,
+        "score_variance": 0.01
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 1.0,
+        "error_weight": 1.0,
+        "variance_weight": 1.0
+      },
+      "min_margin": 0.1,
+      "expected_beats": false
+    },
+    {
+      "name": "challenger worse than incumbent: no beat",
+      "challenger": {
+        "dense_quality_score": 0.5,
+        "sparse_success_rate": 0.4,
+        "tokens_per_million": 0.5,
+        "error_rate": 0.1,
+        "score_variance": 0.1
+      },
+      "incumbent": {
+        "dense_quality_score": 0.9,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.1,
+        "error_rate": 0.02,
+        "score_variance": 0.01
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 1.0,
+        "error_weight": 1.0,
+        "variance_weight": 1.0
+      },
+      "min_margin": 0.0,
+      "expected_beats": false
+    },
+    {
+      "name": "recompute-both: incumbent has higher dense quality but its heavy token cost, rescored under these shared weights, lets the challenger win",
+      "challenger": {
+        "dense_quality_score": 0.9,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 0.1,
+        "error_rate": 0.02,
+        "score_variance": 0.01
+      },
+      "incumbent": {
+        "dense_quality_score": 1.5,
+        "sparse_success_rate": 0.5,
+        "tokens_per_million": 1.0,
+        "error_rate": 0.02,
+        "score_variance": 0.01
+      },
+      "weights": {
+        "sparse_success_weight": 1.0,
+        "token_cost_weight": 1.0,
+        "error_weight": 1.0,
+        "variance_weight": 1.0
+      },
+      "min_margin": 0.05,
+      "expected_beats": true
+    }
+  ]
+}

--- a/fixtures/harness-optimization/promotion-score/valid-full.json
+++ b/fixtures/harness-optimization/promotion-score/valid-full.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "candidate_id": "cand-full-002",
+  "weight_version": "w-2026-07",
+  "components": {
+    "dense_quality_score": 0.82,
+    "sparse_success_rate": 0.6,
+    "tokens_per_million": 0.5,
+    "error_rate": 0.05,
+    "score_variance": 0.01
+  },
+  "weights": {
+    "sparse_success_weight": 1.0,
+    "token_cost_weight": 0.2,
+    "error_weight": 0.5,
+    "variance_weight": 0.1
+  },
+  "score": 1.294,
+  "parity": {
+    "python": "implemented",
+    "typescript": "implemented",
+    "schema_hash": "9f8e7d6c5b4a"
+  }
+}

--- a/fixtures/harness-optimization/promotion-score/valid-minimal.json
+++ b/fixtures/harness-optimization/promotion-score/valid-minimal.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "candidate_id": "c",
+  "weight_version": "w",
+  "components": {
+    "dense_quality_score": 0.0,
+    "sparse_success_rate": 0.0,
+    "tokens_per_million": 0.0,
+    "error_rate": 0.0,
+    "score_variance": 0.0
+  },
+  "weights": {
+    "sparse_success_weight": 0.0,
+    "token_cost_weight": 0.0,
+    "error_weight": 0.0,
+    "variance_weight": 0.0
+  },
+  "score": 0.0,
+  "parity": {
+    "python": "pending",
+    "typescript": "pending",
+    "schema_hash": "0"
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -113,6 +113,14 @@
       "import": "./dist/harness-optimization/evidence.js",
       "types": "./dist/harness-optimization/evidence.d.ts"
     },
+    "./harness-optimization/scoring": {
+      "import": "./dist/harness-optimization/scoring.js",
+      "types": "./dist/harness-optimization/scoring.d.ts"
+    },
+    "./harness-optimization/contract/validators": {
+      "import": "./dist/harness-optimization/contract/validators.js",
+      "types": "./dist/harness-optimization/contract/validators.d.ts"
+    },
     "./detectors/openai-python": {
       "types": "./dist/control-plane/instrument/detectors/openai-python/index.d.ts",
       "import": "./dist/control-plane/instrument/detectors/openai-python/index.js",

--- a/ts/scripts/sync-python-harness-optimization-schemas.mjs
+++ b/ts/scripts/sync-python-harness-optimization-schemas.mjs
@@ -5,14 +5,15 @@
  *
  * Pipeline:
  *   1. Mirror schemas: ts/.../json-schemas/ → autocontext/.../json_schemas/
- *   2. Bundle $refs in the aggregate `candidate-evidence.schema.json` using a
- *      custom local URL resolver (maps `https://autocontext.dev/schema/
+ *   2. Bundle $refs in the codegen-only aggregate `_aggregate.schema.json` using
+ *      a custom local URL resolver (maps `https://autocontext.dev/schema/
  *      harness-optimization/*.json` to the local canonical files).
  *   3. Feed the bundled aggregate to `datamodel-codegen` to regenerate
  *      `autocontext/.../contract/models.py`.
  *   4. Rewrite the generator's default banner to our AUTO-GENERATED banner.
  *
- * The Pydantic side only needs `CandidateEvidence` (the top-level aggregate).
+ * The aggregate root $refs every public artifact so the Pydantic side emits each
+ * as its own top-level model (CandidateEvidence, PromotionScore, ...).
  *
  * Usage:
  *   node scripts/sync-python-harness-optimization-schemas.mjs          # regenerate
@@ -47,7 +48,10 @@ const DST_SCHEMAS_DIR = join(PY_ROOT, "src/autocontext/harness_optimization/cont
 const MODELS_PY_PATH = join(PY_ROOT, "src/autocontext/harness_optimization/contract/models.py");
 
 const URL_PREFIX = "https://autocontext.dev/schema/harness-optimization/";
-const AGGREGATE_FOR_PYDANTIC = "candidate-evidence.schema.json";
+// Codegen-only aggregate root that $refs every public artifact so datamodel-codegen
+// emits each as its own top-level model into one models.py (CandidateEvidence,
+// PromotionScore, ...). See json-schemas/_aggregate.schema.json.
+const AGGREGATE_FOR_PYDANTIC = "_aggregate.schema.json";
 
 const args = process.argv.slice(2);
 const checkOnly = args.includes("--check");
@@ -124,7 +128,7 @@ const bundled = await $RefParser.bundle(aggregateEntry, {
 // -- Step 3: invoke datamodel-codegen on the bundled schema -------------------
 
 const tmpDir = mkdtempSync(join(tmpdir(), "autoctx-pydantic-gen-"));
-const bundledPath = join(tmpDir, "candidate-evidence.bundled.json");
+const bundledPath = join(tmpDir, "aggregate.bundled.json");
 const generatedPath = join(tmpDir, "models.py");
 writeFileSync(bundledPath, JSON.stringify(bundled, null, 2));
 

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -3,6 +3,14 @@
 // Regenerate with: node scripts/generate-harness-optimization-types.mjs
 // CI gate: node scripts/generate-harness-optimization-types.mjs --check
 
+// ---- _aggregate.schema.json ----
+/**
+ * Codegen-only aggregate root; $refs each artifact so one models.py is emitted. Not a runtime schema.
+ */
+export interface HarnessOptimizationContracts {
+  [k: string]: unknown;
+}
+
 // ---- candidate-evidence.schema.json ----
 /**
  * Canonical evidence record for a single harness-optimization candidate (AC-876). A candidate is a proposed mechanism change to some target surface, carrying the hypothesis, the concrete changes, the fix and regression cases it is expected to move, its cost expectation, and its cross-language parity status. This schema is the single source of truth for both the Python and TypeScript autocontext packages.
@@ -83,6 +91,92 @@ export interface CandidateEvidence {
    * What data the proposer was allowed to inspect, for leakage auditing.
    */
   leakage_scope?: string[];
+  /**
+   * Cross-language parity status for this candidate.
+   */
+  parity: {
+    /**
+     * Implementation status of this candidate in the Python package.
+     */
+    python: "implemented" | "pending" | "n_a";
+    /**
+     * Implementation status of this candidate in the TypeScript package.
+     */
+    typescript: "implemented" | "pending" | "n_a";
+    /**
+     * Content hash of the shared schema the two implementations agree on.
+     */
+    schema_hash: string;
+  };
+}
+
+// ---- promotion-score.schema.json ----
+/**
+ * Computed harness-promotion score for a single candidate (AC-877). Combines the dense quality signal with the sparse per-case success rate, marginal token cost, error rate, and score variance under a named, versioned set of weights. This is the artifact the promotion gate reads to decide whether a candidate advances. Shared source of truth for both the Python and TypeScript autocontext packages.
+ */
+export interface PromotionScore {
+  /**
+   * Schema version for forward compatibility. Always 1 for this revision.
+   */
+  schema_version: 1;
+  /**
+   * Stable unique identifier of the candidate this score belongs to.
+   */
+  candidate_id: string;
+  /**
+   * Version tag of the weight set used to compute this score.
+   */
+  weight_version: string;
+  /**
+   * The measured components that feed the weighted promotion score.
+   */
+  components: {
+    /**
+     * Dense quality signal, typically a judge or rubric score.
+     */
+    dense_quality_score: number;
+    /**
+     * Fraction of target cases the candidate resolved, in [0, 1].
+     */
+    sparse_success_rate: number;
+    /**
+     * Marginal token cost expressed per million tokens.
+     */
+    tokens_per_million: number;
+    /**
+     * Fraction of runs that errored, in [0, 1].
+     */
+    error_rate: number;
+    /**
+     * Variance of the score across samples.
+     */
+    score_variance: number;
+  };
+  /**
+   * The named weights applied to each component.
+   */
+  weights: {
+    /**
+     * Weight applied to the sparse success rate.
+     */
+    sparse_success_weight: number;
+    /**
+     * Weight applied to the marginal token cost.
+     */
+    token_cost_weight: number;
+    /**
+     * Weight applied to the error rate.
+     */
+    error_weight: number;
+    /**
+     * Weight applied to the score variance.
+     */
+    variance_weight: number;
+  };
+  /**
+   * The computed harness promotion score.
+   */
+  score: number;
   /**
    * Cross-language parity status for this candidate.
    */

--- a/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/_aggregate.json",
+  "title": "HarnessOptimizationContracts",
+  "description": "Codegen-only aggregate root; $refs each artifact so one models.py is emitted. Not a runtime schema.",
+  "$defs": {
+    "CandidateEvidence": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json"
+    },
+    "PromotionScore": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/promotion-score.json"
+    }
+  }
+}

--- a/ts/src/harness-optimization/contract/json-schemas/promotion-score.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/promotion-score.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/promotion-score.json",
+  "title": "PromotionScore",
+  "description": "Computed harness-promotion score for a single candidate (AC-877). Combines the dense quality signal with the sparse per-case success rate, marginal token cost, error rate, and score variance under a named, versioned set of weights. This is the artifact the promotion gate reads to decide whether a candidate advances. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "weight_version",
+    "components",
+    "weights",
+    "score",
+    "parity"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "candidate_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique identifier of the candidate this score belongs to."
+    },
+    "weight_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Version tag of the weight set used to compute this score."
+    },
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dense_quality_score",
+        "sparse_success_rate",
+        "tokens_per_million",
+        "error_rate",
+        "score_variance"
+      ],
+      "properties": {
+        "dense_quality_score": {
+          "type": "number",
+          "description": "Dense quality signal, typically a judge or rubric score."
+        },
+        "sparse_success_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Fraction of target cases the candidate resolved, in [0, 1]."
+        },
+        "tokens_per_million": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Marginal token cost expressed per million tokens."
+        },
+        "error_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Fraction of runs that errored, in [0, 1]."
+        },
+        "score_variance": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Variance of the score across samples."
+        }
+      },
+      "description": "The measured components that feed the weighted promotion score."
+    },
+    "weights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sparse_success_weight", "token_cost_weight", "error_weight", "variance_weight"],
+      "properties": {
+        "sparse_success_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the sparse success rate."
+        },
+        "token_cost_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the marginal token cost."
+        },
+        "error_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the error rate."
+        },
+        "variance_weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Weight applied to the score variance."
+        }
+      },
+      "description": "The named weights applied to each component."
+    },
+    "score": {
+      "type": "number",
+      "description": "The computed harness promotion score."
+    },
+    "parity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "typescript", "schema_hash"],
+      "properties": {
+        "python": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the Python package."
+        },
+        "typescript": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the TypeScript package."
+        },
+        "schema_hash": {
+          "type": "string",
+          "description": "Content hash of the shared schema the two implementations agree on."
+        }
+      },
+      "description": "Cross-language parity status for this candidate."
+    }
+  }
+}

--- a/ts/src/harness-optimization/contract/validators.ts
+++ b/ts/src/harness-optimization/contract/validators.ts
@@ -2,7 +2,8 @@ import Ajv2020 from "ajv/dist/2020.js";
 import type { ErrorObject, ValidateFunction } from "ajv";
 import addFormats from "ajv-formats";
 import candidateEvidenceSchema from "./json-schemas/candidate-evidence.schema.json" with { type: "json" };
-import type { CandidateEvidence } from "./generated-types.js";
+import promotionScoreSchema from "./json-schemas/promotion-score.schema.json" with { type: "json" };
+import type { CandidateEvidence, PromotionScore } from "./generated-types.js";
 
 // Shared validation-result shape (matches the production-traces contract).
 export type ValidationResult =
@@ -16,11 +17,16 @@ const addFormatsFn =
 const ajv = new AjvCtor({ strict: true, allErrors: true });
 addFormatsFn(ajv);
 
-// Register the schema once at module init so $refs resolve.
+// Register the schemas once at module init so $refs resolve.
 ajv.addSchema(candidateEvidenceSchema as object);
+ajv.addSchema(promotionScoreSchema as object);
 
 const candidateEvidenceValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json",
+)!;
+
+const promotionScoreValidator = ajv.getSchema(
+  "https://autocontext.dev/schema/harness-optimization/promotion-score.json",
 )!;
 
 function toResult(validate: ValidateFunction, input: unknown): ValidationResult {
@@ -39,5 +45,9 @@ export function validateCandidateEvidence(input: unknown): ValidationResult {
   return toResult(candidateEvidenceValidator, input);
 }
 
-// Type-level assertion — if the TS type drifts from the schema this won't compile.
-export type _TypeCheck = CandidateEvidence;
+export function validatePromotionScore(input: unknown): ValidationResult {
+  return toResult(promotionScoreValidator, input);
+}
+
+// Type-level assertion — if a TS type drifts from its schema this won't compile.
+export type _TypeCheck = CandidateEvidence | PromotionScore;

--- a/ts/src/harness-optimization/scoring.ts
+++ b/ts/src/harness-optimization/scoring.ts
@@ -1,0 +1,56 @@
+import type { PromotionScore } from "./contract/generated-types.js";
+
+/**
+ * Pure harness promotion scorer (AC-877).
+ *
+ * This is the TypeScript half of the AC-877 parity pair: the same weighted
+ * formula lives here and in `autocontext/src/autocontext/harness_optimization/scoring.py`,
+ * and a shared numeric fixture
+ * (`fixtures/harness-optimization/promotion-score/score-cases.json`) proves both
+ * languages compute identical scores.
+ *
+ * The formula is:
+ *
+ *   harness_promotion_score = dense_quality_score
+ *                           + sparse_success_weight * sparse_success_rate
+ *                           - token_cost_weight     * tokens_per_million
+ *                           - error_weight          * error_rate
+ *                           - variance_weight       * score_variance
+ */
+
+// Reuse the generated contract types so the scorer stays in lockstep with the schema.
+export type Components = PromotionScore["components"];
+export type Weights = PromotionScore["weights"];
+
+/**
+ * Compute the weighted harness promotion score for one candidate.
+ *
+ * Reward is the dense quality score plus the weighted sparse success rate; the
+ * weighted token cost, error rate, and score variance are penalties.
+ */
+export function harnessPromotionScore(components: Components, weights: Weights): number {
+  return (
+    components.dense_quality_score +
+    weights.sparse_success_weight * components.sparse_success_rate -
+    weights.token_cost_weight * components.tokens_per_million -
+    weights.error_weight * components.error_rate -
+    weights.variance_weight * components.score_variance
+  );
+}
+
+/**
+ * Return whether the challenger beats the incumbent by more than `minMargin`.
+ *
+ * Both scores are recomputed here from their components under the SAME weights,
+ * so the comparison can never read a stale stored score.
+ */
+export function beatsIncumbent(
+  challengerComponents: Components,
+  incumbentComponents: Components,
+  weights: Weights,
+  minMargin: number,
+): boolean {
+  const challengerScore = harnessPromotionScore(challengerComponents, weights);
+  const incumbentScore = harnessPromotionScore(incumbentComponents, weights);
+  return challengerScore - incumbentScore > minMargin;
+}

--- a/ts/tests/harness-optimization/promotion-score.test.ts
+++ b/ts/tests/harness-optimization/promotion-score.test.ts
@@ -1,6 +1,40 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, test, expect } from "vitest";
 import { validatePromotionScore } from "../../src/harness-optimization/contract/validators.js";
 import type { PromotionScore } from "../../src/harness-optimization/contract/generated-types.js";
+
+// Walk up to the repo root: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const FIXTURES_DIR = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "fixtures",
+  "harness-optimization",
+  "promotion-score",
+);
+
+// The contract fixtures validated by both packages. score-cases.json also lives in
+// this directory (the SCORER numeric fixture) and is deliberately excluded here: it
+// matches neither the valid- nor invalid- prefix.
+const EXPECTED_FIXTURES = new Set([
+  "valid-full.json",
+  "valid-minimal.json",
+  "invalid-missing-component.json",
+  "invalid-empty-parity.json",
+  "invalid-extra-field.json",
+]);
+
+function fixtures(prefix: string): string[] {
+  return readdirSync(FIXTURES_DIR)
+    .filter((name) => name.startsWith(prefix) && name.endsWith(".json"))
+    .sort();
+}
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), "utf8"));
+}
 
 // A minimal fully-valid PromotionScore used as the fixture-of-record.
 const validScore: PromotionScore = {
@@ -71,5 +105,25 @@ describe("validatePromotionScore", () => {
     };
     const result = validatePromotionScore(outOfRange);
     expect(result.valid).toBe(false);
+  });
+});
+
+describe("shared repo-root promotion-score fixtures", () => {
+  test.each(fixtures("valid-"))("%s validates", (name) => {
+    const result = validatePromotionScore(loadFixture(name));
+    expect(result.valid).toBe(true);
+  });
+
+  test.each(fixtures("invalid-"))("%s fails validation", (name) => {
+    const result = validatePromotionScore(loadFixture(name));
+    expect(result.valid).toBe(false);
+  });
+
+  test("the fixtures directory contains exactly the expected contract set", () => {
+    // Set-membership guard over the valid-/invalid- contract fixtures only, so a
+    // dropped or renamed contract fixture fails here while score-cases.json (the
+    // scorer numeric fixture) is left untouched.
+    const names = new Set([...fixtures("valid-"), ...fixtures("invalid-")]);
+    expect(names).toEqual(EXPECTED_FIXTURES);
   });
 });

--- a/ts/tests/harness-optimization/promotion-score.test.ts
+++ b/ts/tests/harness-optimization/promotion-score.test.ts
@@ -119,11 +119,12 @@ describe("shared repo-root promotion-score fixtures", () => {
     expect(result.valid).toBe(false);
   });
 
-  test("the fixtures directory contains exactly the expected contract set", () => {
-    // Set-membership guard over the valid-/invalid- contract fixtures only, so a
-    // dropped or renamed contract fixture fails here while score-cases.json (the
-    // scorer numeric fixture) is left untouched.
-    const names = new Set([...fixtures("valid-"), ...fixtures("invalid-")]);
-    expect(names).toEqual(EXPECTED_FIXTURES);
+  test("the fixtures directory contains exactly the expected file set", () => {
+    // Set-membership guard over EVERY .json in the directory: the five valid-/invalid-
+    // contract fixtures plus score-cases.json (the scorer numeric fixture). Globbing all
+    // files (not just the valid-/invalid- prefixes) means a stray or dropped .json fails
+    // here instead of being silently ignored.
+    const allJson = new Set(readdirSync(FIXTURES_DIR).filter((name) => name.endsWith(".json")));
+    expect(allJson).toEqual(new Set([...EXPECTED_FIXTURES, "score-cases.json"]));
   });
 });

--- a/ts/tests/harness-optimization/promotion-score.test.ts
+++ b/ts/tests/harness-optimization/promotion-score.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "vitest";
+import { validatePromotionScore } from "../../src/harness-optimization/contract/validators.js";
+import type { PromotionScore } from "../../src/harness-optimization/contract/generated-types.js";
+
+// A minimal fully-valid PromotionScore used as the fixture-of-record.
+const validScore: PromotionScore = {
+  schema_version: 1,
+  candidate_id: "cand-001",
+  weight_version: "w-2026-07",
+  components: {
+    dense_quality_score: 0.82,
+    sparse_success_rate: 0.6,
+    tokens_per_million: 1200,
+    error_rate: 0.05,
+    score_variance: 0.01,
+  },
+  weights: {
+    sparse_success_weight: 1,
+    token_cost_weight: 0.2,
+    error_weight: 0.5,
+    variance_weight: 0.1,
+  },
+  score: 0.71,
+  parity: {
+    python: "implemented",
+    typescript: "pending",
+    schema_hash: "abc123",
+  },
+};
+
+describe("validatePromotionScore", () => {
+  test("a fully-valid promotion score validates", () => {
+    const result = validatePromotionScore(validScore);
+    expect(result.valid).toBe(true);
+  });
+
+  test("a score missing a required component (error_rate) fails", () => {
+    const { error_rate: _omitted, ...missingComponent } = validScore.components;
+    const result = validatePromotionScore({ ...validScore, components: missingComponent });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.join("\n")).toContain("error_rate");
+    }
+  });
+
+  test("a score with an unknown extra field fails (additionalProperties)", () => {
+    const withExtra = { ...validScore, surprise_field: "nope" };
+    const result = validatePromotionScore(withExtra);
+    expect(result.valid).toBe(false);
+  });
+
+  test("an empty parity object fails (python/typescript/schema_hash required)", () => {
+    const emptyParity = { ...validScore, parity: {} };
+    const result = validatePromotionScore(emptyParity);
+    expect(result.valid).toBe(false);
+  });
+
+  test("a bad parity enum value fails", () => {
+    const badEnum = {
+      ...validScore,
+      parity: { ...validScore.parity, python: "maybe" },
+    };
+    const result = validatePromotionScore(badEnum);
+    expect(result.valid).toBe(false);
+  });
+
+  test("a sparse_success_rate above 1 fails (maximum 1)", () => {
+    const outOfRange = {
+      ...validScore,
+      components: { ...validScore.components, sparse_success_rate: 1.5 },
+    };
+    const result = validatePromotionScore(outOfRange);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/ts/tests/harness-optimization/scoring.test.ts
+++ b/ts/tests/harness-optimization/scoring.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test, expect } from "vitest";
+import {
+  harnessPromotionScore,
+  beatsIncumbent,
+  type Components,
+  type Weights,
+} from "../../src/harness-optimization/scoring.js";
+
+// Load the SAME repo-root fixture the Python suite loads. Matching it in both
+// languages is the load-bearing parity proof.
+// Walk up to the repo root: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const FIXTURE = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "fixtures",
+  "harness-optimization",
+  "promotion-score",
+  "score-cases.json",
+);
+
+interface ScoreCase {
+  name: string;
+  components: Components;
+  weights: Weights;
+  expected_score: number;
+}
+
+interface BeatsCase {
+  name: string;
+  challenger: Components;
+  incumbent: Components;
+  weights: Weights;
+  min_margin: number;
+  expected_beats: boolean;
+}
+
+const cases = JSON.parse(readFileSync(FIXTURE, "utf8")) as {
+  score_cases: ScoreCase[];
+  beats_cases: BeatsCase[];
+};
+
+const TOL = 1e-9;
+
+describe("harnessPromotionScore matches the shared fixture", () => {
+  for (const c of cases.score_cases) {
+    test(c.name, () => {
+      expect(harnessPromotionScore(c.components, c.weights)).toBeCloseTo(c.expected_score, 9);
+      // toBeCloseTo(x, 9) is a decimal-places check; assert the absolute tolerance explicitly too.
+      expect(
+        Math.abs(harnessPromotionScore(c.components, c.weights) - c.expected_score),
+      ).toBeLessThan(TOL);
+    });
+  }
+});
+
+describe("beatsIncumbent matches the shared fixture", () => {
+  for (const c of cases.beats_cases) {
+    test(c.name, () => {
+      expect(beatsIncumbent(c.challenger, c.incumbent, c.weights, c.min_margin)).toBe(
+        c.expected_beats,
+      );
+    });
+  }
+});


### PR DESCRIPTION
AC-877 in the harness-optimization protocol (AC-875). Builds on the AC-876 foundation. Spec: docs/superpowers/specs/2026-07-06-harness-optimization-protocol-design.md.

## What this adds

A promotion score for harness-optimization candidates that recomputes BOTH incumbent and challenger from raw stored metrics under the current weight version, promoting only when the challenger clears a calibrated margin, never comparing a fresh challenger score to a stored incumbent score.

**promotion-score contract + codegen generalization.** A new promotion-score JSON Schema artifact joins candidate-evidence under one generated models.py, via an _aggregate root schema that references both artifacts. CandidateEvidence's generated output is byte-unchanged (verified), and the drift gate now covers both artifacts. The generalization scales: each later artifact (AC-878 onward) adds one schema plus one $defs reference.

**Pure scorer with real cross-language parity.** harness_promotion_score = dense + sparse_w*sparse - token_w*tokens_per_million - error_w*error_rate - variance_w*score_variance, implemented identically in Python and TypeScript and proven against one shared numeric fixture (fixtures/harness-optimization/promotion-score/score-cases.json). The fixture's expected values are hand-computed ground truth, so parity is anchored to correctness, not just agreement. beats_incumbent recomputes both scores under the same weights and gates on strict > min_margin; a boundary-tie case pins the strict comparison.

**Recompute-both, weight-versioned advancement gate (opt-in).** evaluate_advancement gains an optional harness_promotion path. When it is None (the default), the existing gate behavior is byte-unchanged (a golden test pins the exact pre-change rationale). When provided, the gate recomputes both challenger and incumbent scores from raw components under the current weights and records the components, both scores, the weight version, and the final margin in the rationale. A stale-weight test proves an incumbent recorded under old weights is re-scored under the current ones, so a naive stored-score comparison would decide differently.

## Scope (honest)

The gate path is opt-in and NOT yet wired into the live tournament loop (documented in docs/harness-optimization-protocol.md); the production caller does not pass the new input, so no default run changes. Live-loop wiring lands with a later issue, consistent with the protocol's deferred-integration approach.

## Verification

37 TS + 54 Python harness-optimization tests: contract round-trips and fixtures for both artifacts, the shared-fixture scorer parity (within 1e-9, hand-verified ground truth, boundary-tie), and the gate (positive advance, rollback, cost-regression and high-variance flips, no-incumbent, stale-weight never-stale proof, and the disabled-path golden). The schema drift gate is green on the regenerated files (proven to fail on a hand-edit); ruff, mypy strict, and TS lint clean; uv.lock untouched. Each task was implemented and reviewed by separate agents; a whole-branch review traced the never-stale invariant end to end and re-verified the drift gate and every fixture value.

## Note on CI

The ts-test full-suite job is red for a repo-wide CI-environment reason tracked in AC-892, unrelated to this change (the AC-876 foundation diagnosed it: an effectively-main suite fails on the runner). This PR's substantive checks (schema drift gate, lint, Python tests, SDK matrices) pass; the harness-optimization slice passes locally and in the drift-gate/lint jobs.