### PR TITLE
harness optimization: deterministic repair gates (AC-878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - ambient trainer plan 5b: linux trl sft-trainer backend over the curated dataset, whole-run budget deadline, and charter name-collision guard
 - harness optimization protocol: candidate-evidence contract with python and typescript parity (AC-876)
 - harness optimization protocol: fresh blended promotion score with recompute-both semantics and python/typescript parity (AC-877)
+- harness optimization protocol: opt-in deterministic repair gates (artifact landing, tool-call json, finish guard, loop guard) with python/typescript parity (AC-878)
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -525,6 +525,15 @@ class AppSettings(BaseModel):
         default=True,
         description="Use staged validation pipeline for pre-tournament checks",
     )
+    # Opt-in harness repair gates (AC-878)
+    harness_repair_gates_enabled: bool = Field(
+        default=False,
+        description="Opt-in deterministic harness repair gates (AC-878)",
+    )
+    harness_repair_gate_scenarios: str = Field(
+        default="",
+        description="Comma-separated scenario allowlist for repair gates; empty = none",
+    )
     # Pre-flight harness synthesis (AC-150)
     harness_preflight_enabled: bool = Field(
         default=False,

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
@@ -9,6 +9,9 @@
     },
     "PromotionScore": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/promotion-score.json"
+    },
+    "RepairResult": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/repair-result.json"
     }
   }
 }

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/repair-result.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/repair-result.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/repair-result.json",
+  "title": "RepairResult",
+  "description": "Outcome of a single deterministic repair applied (or not applied) to a harness surface (AC-878). A repair is a named, auditable mechanism that fixes a known failure mode (for example tool_call_json, artifact_landing, finish_guard, loop_guard); this record captures whether it fired, why, what it targeted, and the before/after metadata a reviewer needs to trust the gate. This schema is the single source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "repair_name", "status", "reason", "parity"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "repair_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the repair mechanism, e.g. tool_call_json or finish_guard."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["applied", "skipped", "not_applicable"],
+      "description": "Whether the repair fired: applied, skipped, or not_applicable to this input."
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-auditable explanation of why the repair was applied or skipped."
+    },
+    "target": {
+      "type": "string",
+      "description": "What was repaired: a path, a tool name, or empty when nothing was targeted."
+    },
+    "before": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Pre-repair metadata, e.g. {\"valid\": false}."
+    },
+    "after": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Post-repair metadata, e.g. {\"valid\": true}."
+    },
+    "parity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "typescript", "schema_hash"],
+      "properties": {
+        "python": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the Python package."
+        },
+        "typescript": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the TypeScript package."
+        },
+        "schema_hash": {
+          "type": "string",
+          "description": "Content hash of the shared schema the two implementations agree on."
+        }
+      },
+      "description": "Cross-language parity status for this candidate."
+    }
+  }
+}

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -255,3 +255,52 @@ class PromotionScore(BaseModel):
     parity: Annotated[
         Parity, Field(description='Cross-language parity status for this candidate.')
     ]
+
+
+class RepairResult(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    schema_version: Annotated[
+        Literal[1],
+        Field(
+            description='Schema version for forward compatibility. Always 1 for this revision.'
+        ),
+    ]
+    repair_name: Annotated[
+        str,
+        Field(
+            description='Human-readable name of the repair mechanism, e.g. tool_call_json or finish_guard.',
+            min_length=1,
+        ),
+    ]
+    status: Annotated[
+        Literal['applied', 'skipped', 'not_applicable'],
+        Field(
+            description='Whether the repair fired: applied, skipped, or not_applicable to this input.'
+        ),
+    ]
+    reason: Annotated[
+        str,
+        Field(
+            description='Human-auditable explanation of why the repair was applied or skipped.',
+            min_length=1,
+        ),
+    ]
+    target: Annotated[
+        str | None,
+        Field(
+            description='What was repaired: a path, a tool name, or empty when nothing was targeted.'
+        ),
+    ] = None
+    before: Annotated[
+        dict[str, Any] | None,
+        Field(description='Pre-repair metadata, e.g. {"valid": false}.'),
+    ] = None
+    after: Annotated[
+        dict[str, Any] | None,
+        Field(description='Post-repair metadata, e.g. {"valid": true}.'),
+    ] = None
+    parity: Annotated[
+        Parity, Field(description='Cross-language parity status for this candidate.')
+    ]

--- a/autocontext/src/autocontext/harness_optimization/repair_gate.py
+++ b/autocontext/src/autocontext/harness_optimization/repair_gate.py
@@ -1,0 +1,153 @@
+"""Opt-in RepairGate: run deterministic repairs and emit trace events (AC-878).
+
+The gate is a thin, deterministic orchestrator over the pure repairs in
+:mod:`autocontext.harness_optimization.repairs`. It does NOT decide whether it is
+active: that is the caller's job via :func:`repair_gate_active_for`. When the
+caller determines the gate is active for a scenario, it constructs a
+:class:`RepairGate` and calls :meth:`RepairGate.run`, which invokes each enabled
+repair over the handed context, emits exactly one ``repair_applied`` /
+``repair_skipped`` trace event per repair, and returns the collected
+:class:`RepairResult` list.
+
+The gate MAY apply the decision a pure repair returns (record the repaired
+tool-call json string, record the relocation target) by writing it back onto the
+context, but it never introduces or alters task content: every applied decision
+is a structural one the pure repair already made. ``repair_applied`` is emitted
+when a repair's status is ``applied``; ``repair_skipped`` covers both ``skipped``
+and ``not_applicable`` (nothing was changed). Events go on the ``repair``
+channel and carry ``result.model_dump(mode="json")`` verbatim, so every emitted
+payload validates against the RepairResult schema.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from autocontext.config.settings import AppSettings
+from autocontext.control_plane.contract_probes._base import ArtifactContractProbeInputs
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.harness_optimization.contract.models import Parity, RepairResult
+from autocontext.harness_optimization.repairs import (
+    finish_guard,
+    repair_artifact_landing,
+    repair_tool_call_json,
+)
+
+REPAIR_CHANNEL = "repair"
+
+
+def repair_gate_active_for(settings: AppSettings, scenario_name: str) -> bool:
+    """True iff the gate is globally enabled AND the scenario is allowlisted.
+
+    The allowlist is the comma-separated ``harness_repair_gate_scenarios``
+    setting; an empty allowlist means no scenario is active even when the global
+    flag is on. This is the sole opt-in decision: callers check it and only build
+    and run a :class:`RepairGate` when it returns True.
+    """
+
+    allowlist = {s.strip() for s in settings.harness_repair_gate_scenarios.split(",") if s.strip()}
+    return settings.harness_repair_gates_enabled and scenario_name in allowlist
+
+
+@dataclass
+class RepairContext:
+    """Recorded state handed to the gate, one field group per enabled repair.
+
+    Every field is optional: a repair whose input is absent returns a
+    ``not_applicable`` result. The gate writes applied decisions back onto the
+    two output fields (``repaired_tool_call_json``, ``relocation_target``).
+    """
+
+    tool_call_json: str | None = None
+    repaired_tool_call_json: str | None = None
+    artifact_expected: ArtifactContractProbeInputs | None = None
+    artifact_produced: dict[str, str] = field(default_factory=dict)
+    relocation_target: str | None = None
+    finish_claimed_done: bool | None = None
+    finish_completion_ok: bool = True
+    finish_reason_if_not: str = ""
+
+
+RepairStep = Callable[[RepairContext], RepairResult]
+
+
+def _absent_result(repair_name: str, reason: str) -> RepairResult:
+    """A ``not_applicable`` result for a repair whose input is absent."""
+
+    return RepairResult(
+        schema_version=1,
+        repair_name=repair_name,
+        status="not_applicable",
+        reason=reason,
+        target="",
+        before={"present": False},
+        after={"present": False},
+        parity=Parity(python="implemented", typescript="pending", schema_hash=""),
+    )
+
+
+def repair_tool_call_json_step(ctx: RepairContext) -> RepairResult:
+    """Run the tool-call json repair; record the repaired string when applied."""
+
+    if ctx.tool_call_json is None:
+        return _absent_result("tool_call_json", "no tool-call json in context")
+    value, result = repair_tool_call_json(ctx.tool_call_json)
+    if result.status == "applied" and value is not None:
+        ctx.repaired_tool_call_json = value
+    return result
+
+
+def repair_artifact_landing_step(ctx: RepairContext) -> RepairResult:
+    """Run the artifact-landing repair; record the relocation target when applied."""
+
+    if ctx.artifact_expected is None:
+        return _absent_result("artifact_landing", "no expected artifact contract in context")
+    target, result = repair_artifact_landing(expected=ctx.artifact_expected, produced=ctx.artifact_produced)
+    if result.status == "applied" and target is not None:
+        ctx.relocation_target = target
+    return result
+
+
+def finish_guard_step(ctx: RepairContext) -> RepairResult:
+    """Run the finish guard when a completion claim is present in the context."""
+
+    if ctx.finish_claimed_done is None:
+        return _absent_result("finish_guard", "no finish claim in context")
+    return finish_guard(
+        claimed_done=ctx.finish_claimed_done,
+        completion_ok=ctx.finish_completion_ok,
+        reason_if_not=ctx.finish_reason_if_not,
+    )
+
+
+DEFAULT_REPAIRS: tuple[RepairStep, ...] = (
+    repair_tool_call_json_step,
+    repair_artifact_landing_step,
+    finish_guard_step,
+)
+
+
+@dataclass
+class RepairGate:
+    """Thin orchestrator: run each enabled repair, emit one event per result.
+
+    ``run`` does NOT check whether the gate is active; the caller gates via
+    :func:`repair_gate_active_for` and only constructs and runs the gate when
+    active.
+    """
+
+    emitter: EventStreamEmitter
+    repairs: Sequence[RepairStep] = DEFAULT_REPAIRS
+    channel: str = REPAIR_CHANNEL
+
+    def run(self, scenario_name: str, context: RepairContext) -> list[RepairResult]:
+        """Invoke each enabled repair over ``context``, emitting an event each."""
+
+        results: list[RepairResult] = []
+        for repair in self.repairs:
+            result = repair(context)
+            event = "repair_applied" if result.status == "applied" else "repair_skipped"
+            self.emitter.emit(event, result.model_dump(mode="json"), channel=self.channel)
+            results.append(result)
+        return results

--- a/autocontext/src/autocontext/harness_optimization/repair_gate.py
+++ b/autocontext/src/autocontext/harness_optimization/repair_gate.py
@@ -121,6 +121,8 @@ def finish_guard_step(ctx: RepairContext) -> RepairResult:
     )
 
 
+# loop_guard is intentionally omitted from the default set: it has no TypeScript
+# mirror yet, and the default set is kept identical across languages.
 DEFAULT_REPAIRS: tuple[RepairStep, ...] = (
     repair_tool_call_json_step,
     repair_artifact_landing_step,
@@ -142,12 +144,19 @@ class RepairGate:
     channel: str = REPAIR_CHANNEL
 
     def run(self, scenario_name: str, context: RepairContext) -> list[RepairResult]:
-        """Invoke each enabled repair over ``context``, emitting an event each."""
+        """Invoke each enabled repair over ``context``, emitting an event each.
+
+        The emitted payload is ``{"scenario": scenario_name, "result": <dump>}``:
+        the RepairResult dump stays a self-contained, schema-valid object under
+        ``result``, and the scenario rides alongside as a sibling so consumers
+        can attribute the repair without polluting the RepairResult schema.
+        """
 
         results: list[RepairResult] = []
         for repair in self.repairs:
             result = repair(context)
             event = "repair_applied" if result.status == "applied" else "repair_skipped"
-            self.emitter.emit(event, result.model_dump(mode="json"), channel=self.channel)
+            payload = {"scenario": scenario_name, "result": result.model_dump(mode="json")}
+            self.emitter.emit(event, payload, channel=self.channel)
             results.append(result)
         return results

--- a/autocontext/src/autocontext/harness_optimization/repairs.py
+++ b/autocontext/src/autocontext/harness_optimization/repairs.py
@@ -24,6 +24,7 @@ fixes that cannot change task content:
 from __future__ import annotations
 
 import json
+import re
 
 from autocontext.control_plane.contract_probes._base import (
     ArtifactContractProbeInputs,
@@ -58,7 +59,11 @@ def _strip_code_fence(raw: str) -> str | None:
     stripped = raw.strip()
     if not stripped.startswith("```"):
         return None
-    lines = stripped.splitlines()
+    # Split only on \n / \r\n / \r so a fence body containing a vertical tab or
+    # U+2028 stays one line, matching the TypeScript stripCodeFence regex. Plain
+    # str.splitlines() would additionally split on the full Unicode line-boundary
+    # set and diverge from the TS mirror.
+    lines = re.split(r"\r\n|\r|\n", stripped)
     if len(lines) < 2:
         return None
     if not lines[0].startswith("```"):

--- a/autocontext/src/autocontext/harness_optimization/repairs.py
+++ b/autocontext/src/autocontext/harness_optimization/repairs.py
@@ -1,0 +1,389 @@
+"""Deterministic, pure repair functions for harness surfaces (AC-878).
+
+Each repair here is a PURE function over recorded state: it never calls a
+model, never reads answer hints, never touches the filesystem, and is fully
+replayable. A repair inspects state it is handed, decides whether a known
+failure mode is present, and returns a :class:`RepairResult` describing what it
+did (or why it declined). The gate that owns side effects (writing files,
+breaking a loop, rejecting a finish) acts on the decision; these functions only
+decide.
+
+The repairs are deliberately conservative. They only ever apply *structural*
+fixes that cannot change task content:
+
+- ``repair_tool_call_json`` restructures malformed tool-call JSON (strips a code
+  fence, drops a trailing comma before a closer, closes a single truncated
+  brace/bracket). It never guesses or alters a field value.
+- ``repair_artifact_landing`` relocates by *matching existing produced content*
+  against the expected contract. It never fabricates artifact content.
+- ``finish_guard`` validates a completion claim; it never fabricates completion.
+- ``loop_guard`` detects a stuck no-op cycle; the recovery is signalling the
+  break, not synthesising an action.
+"""
+
+from __future__ import annotations
+
+import json
+
+from autocontext.control_plane.contract_probes._base import (
+    ArtifactContractProbeInputs,
+    probe_artifact_contract,
+)
+from autocontext.harness_optimization.contract.models import Parity, RepairResult
+
+
+def _parity() -> Parity:
+    """Fresh cross-language parity stamp for a Python-implemented repair.
+
+    TypeScript parity is pending until the mirror lands; the schema hash is
+    empty here because these repairs share the RepairResult schema, whose hash
+    is stamped by the sync tooling, not per-call.
+    """
+
+    return Parity(python="implemented", typescript="pending", schema_hash="")
+
+
+# ---------------------------------------------------------------------------
+# repair 1: tool-call JSON (structural-only)
+# ---------------------------------------------------------------------------
+
+
+def _strip_code_fence(raw: str) -> str | None:
+    """Return the inside of a ```...``` / ```json...``` fence, else None.
+
+    Structural wrapper removal only: the returned text is a verbatim slice of
+    the fenced body, so no field value is altered.
+    """
+
+    stripped = raw.strip()
+    if not stripped.startswith("```"):
+        return None
+    lines = stripped.splitlines()
+    if len(lines) < 2:
+        return None
+    if not lines[0].startswith("```"):
+        return None
+    if lines[-1].strip() != "```":
+        return None
+    return "\n".join(lines[1:-1])
+
+
+def _remove_trailing_commas(raw: str) -> str:
+    """Drop structural commas that sit immediately before a ``}`` or ``]``.
+
+    String-aware: a comma inside a JSON string literal is copied verbatim, so
+    a value like ``"a,]"`` is never mutated. Only a comma that the grammar
+    forbids (right before a closer) is removed.
+    """
+
+    out: list[str] = []
+    i = 0
+    n = len(raw)
+    in_string = False
+    escape = False
+    while i < n:
+        ch = raw[i]
+        if in_string:
+            out.append(ch)
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == ",":
+            j = i + 1
+            while j < n and raw[j] in " \t\r\n":
+                j += 1
+            if j < n and raw[j] in "}]":
+                # trailing comma before a closer: drop it, keep the closer.
+                i += 1
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _close_single_unclosed(raw: str) -> str | None:
+    """Append one closer iff exactly one brace/bracket is left open.
+
+    Returns None when the truncation is ambiguous: zero unclosed openers,
+    more than one unclosed opener (multiple plausible closings), or a
+    truncation that lands inside a string literal.
+    """
+
+    stack: list[str] = []
+    in_string = False
+    escape = False
+    for ch in raw:
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch in "}]":
+            if stack:
+                stack.pop()
+    if in_string:
+        return None
+    if len(stack) != 1:
+        return None
+    return raw + ("}" if stack[0] == "{" else "]")
+
+
+def _structural_attempts(raw: str) -> list[tuple[str, str]]:
+    """Ordered (reason, candidate) structural repairs to try, most-local first.
+
+    Every candidate is derived from ``raw`` by structural transforms only
+    (fence strip, trailing-comma drop, single-closer append), so none can
+    introduce or change a field value.
+    """
+
+    attempts: list[tuple[str, str]] = []
+
+    bases: list[tuple[str, str]] = [("", raw)]
+    fenced = _strip_code_fence(raw)
+    if fenced is not None and fenced != raw:
+        bases.append(("stripped markdown code fence", fenced))
+
+    for base_reason, base in bases:
+        if base_reason:
+            attempts.append((base_reason, base))
+        no_comma = _remove_trailing_commas(base)
+        if no_comma != base:
+            attempts.append((_join(base_reason, "removed trailing comma before closer"), no_comma))
+        closed = _close_single_unclosed(base)
+        if closed is not None and closed != base:
+            attempts.append((_join(base_reason, "closed a single truncated brace/bracket"), closed))
+        if no_comma != base:
+            both = _close_single_unclosed(no_comma)
+            if both is not None and both != no_comma:
+                attempts.append((_join(base_reason, "removed trailing comma and closed a truncated brace/bracket"), both))
+    return attempts
+
+
+def _join(prefix: str, suffix: str) -> str:
+    return f"{prefix}; {suffix}" if prefix else suffix
+
+
+def repair_tool_call_json(raw: str) -> tuple[str | None, RepairResult]:
+    """Structurally repair malformed tool-call JSON without touching values.
+
+    Returns ``(json_string, result)`` when already valid or repaired, and
+    ``(None, result)`` when the input is ambiguous or unrecoverable by
+    structural means. Field values are never guessed or altered.
+    """
+
+    try:
+        json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        pass
+    else:
+        return raw, RepairResult(
+            schema_version=1,
+            repair_name="tool_call_json",
+            status="not_applicable",
+            reason="already valid json",
+            target="",
+            before={"valid": True},
+            after={"valid": True},
+            parity=_parity(),
+        )
+
+    for reason, candidate in _structural_attempts(raw):
+        try:
+            json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        return candidate, RepairResult(
+            schema_version=1,
+            repair_name="tool_call_json",
+            status="applied",
+            reason=f"structural repair: {reason}",
+            target="",
+            before={"valid": False},
+            after={"valid": True},
+            parity=_parity(),
+        )
+
+    return None, RepairResult(
+        schema_version=1,
+        repair_name="tool_call_json",
+        status="skipped",
+        reason="ambiguous or unrecoverable tool json",
+        target="",
+        before={"valid": False},
+        after={"valid": False},
+        parity=_parity(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# repair 2: artifact landing (relocate by matching existing content)
+# ---------------------------------------------------------------------------
+
+
+def _contract_for(path: str, content: str, expected: ArtifactContractProbeInputs) -> ArtifactContractProbeInputs:
+    """Rebuild the expected contract against a candidate path+content, in memory."""
+
+    return ArtifactContractProbeInputs(
+        path=path,
+        content=content,
+        expected_line_ending=expected.expected_line_ending,
+        required_substrings=expected.required_substrings,
+        forbidden_substrings=expected.forbidden_substrings,
+        required_json_fields=expected.required_json_fields,
+    )
+
+
+def repair_artifact_landing(
+    *,
+    expected: ArtifactContractProbeInputs,
+    produced: dict[str, str],
+) -> tuple[str | None, RepairResult]:
+    """Detect the "right content, wrong path" landing mistake, purely.
+
+    ``produced`` maps produced_path -> file content (cached in memory). If the
+    expected contract already passes, this is ``not_applicable``. Otherwise it
+    searches ``produced`` for a path whose content satisfies the contract; when
+    found at a different path, it returns that path as the relocation target.
+    It performs no filesystem writes: the gate relocates, this function decides.
+    """
+
+    if probe_artifact_contract(expected).passed:
+        return None, RepairResult(
+            schema_version=1,
+            repair_name="artifact_landing",
+            status="not_applicable",
+            reason="expected artifact already satisfies the contract",
+            target="",
+            before={"landed": True},
+            after={"landed": True},
+            parity=_parity(),
+        )
+
+    for produced_path, content in produced.items():
+        if produced_path == expected.path:
+            continue
+        if probe_artifact_contract(_contract_for(produced_path, content, expected)).passed:
+            return produced_path, RepairResult(
+                schema_version=1,
+                repair_name="artifact_landing",
+                status="applied",
+                reason="expected content found at a different path; relocate",
+                target=produced_path,
+                before={"landed": False},
+                after={"landed": True, "source_path": produced_path},
+                parity=_parity(),
+            )
+
+    return None, RepairResult(
+        schema_version=1,
+        repair_name="artifact_landing",
+        status="skipped",
+        reason="no produced artifact matches the expected contract",
+        target="",
+        before={"landed": False},
+        after={"landed": False},
+        parity=_parity(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# repair 3: finish guard (validate completion before accepting done)
+# ---------------------------------------------------------------------------
+
+
+def finish_guard(*, claimed_done: bool, completion_ok: bool, reason_if_not: str) -> RepairResult:
+    """Reject a done claim when completion conditions are not met.
+
+    This validates completion; it never fabricates completion. When the run
+    claims done but ``completion_ok`` is False, the finish is rejected.
+    """
+
+    if claimed_done and not completion_ok:
+        return RepairResult(
+            schema_version=1,
+            repair_name="finish_guard",
+            status="applied",
+            reason=f"finish rejected: {reason_if_not}",
+            target="",
+            before={"claimed_done": True},
+            after={"accepted_done": False},
+            parity=_parity(),
+        )
+
+    return RepairResult(
+        schema_version=1,
+        repair_name="finish_guard",
+        status="not_applicable",
+        reason="no unmet completion claim to reject",
+        target="",
+        before={"claimed_done": claimed_done},
+        after={"accepted_done": claimed_done},
+        parity=_parity(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# repair 4: loop guard (detect a stuck identical-action cycle)
+# ---------------------------------------------------------------------------
+
+
+def loop_guard(*, recent_actions: list[str], max_repeat: int) -> RepairResult:
+    """Detect ``>= max_repeat`` consecutive identical trailing actions.
+
+    Deterministic detection only. When a stuck cycle is present the result
+    signals the break; acting on it (breaking the loop) is the gate's job.
+    """
+
+    trailing = _trailing_repeat_count(recent_actions)
+    if trailing >= max_repeat >= 1:
+        return RepairResult(
+            schema_version=1,
+            repair_name="loop_guard",
+            status="applied",
+            reason=f"loop detected: {max_repeat} identical actions",
+            target=recent_actions[-1],
+            before={"repeat_count": trailing},
+            after={"loop_break": True},
+            parity=_parity(),
+        )
+
+    return RepairResult(
+        schema_version=1,
+        repair_name="loop_guard",
+        status="not_applicable",
+        reason="no identical-action loop at the tail",
+        target="",
+        before={"repeat_count": trailing},
+        after={"loop_break": False},
+        parity=_parity(),
+    )
+
+
+def _trailing_repeat_count(actions: list[str]) -> int:
+    if not actions:
+        return 0
+    last = actions[-1]
+    count = 0
+    for action in reversed(actions):
+        if action == last:
+            count += 1
+        else:
+            break
+    return count

--- a/autocontext/src/autocontext/harness_optimization/repairs.py
+++ b/autocontext/src/autocontext/harness_optimization/repairs.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import re
+from typing import Literal
 
 from autocontext.control_plane.contract_probes._base import (
     ArtifactContractProbeInputs,
@@ -32,16 +33,21 @@ from autocontext.control_plane.contract_probes._base import (
 )
 from autocontext.harness_optimization.contract.models import Parity, RepairResult
 
+ParityStatus = Literal["implemented", "pending", "n_a"]
 
-def _parity() -> Parity:
+
+def _parity(ts: ParityStatus = "implemented") -> Parity:
     """Fresh cross-language parity stamp for a Python-implemented repair.
 
-    TypeScript parity is pending until the mirror lands; the schema hash is
-    empty here because these repairs share the RepairResult schema, whose hash
-    is stamped by the sync tooling, not per-call.
+    The three parity repairs (``tool_call_json`` / ``artifact_landing`` /
+    ``finish_guard``) have a shipped TypeScript mirror, so they default to
+    ``typescript="implemented"``; the Python-only ``loop_guard`` passes
+    ``ts="pending"`` because it has no mirror yet. The schema hash is empty
+    here because these repairs share the RepairResult schema, whose hash is
+    stamped by the sync tooling, not per-call.
     """
 
-    return Parity(python="implemented", typescript="pending", schema_hash="")
+    return Parity(python="implemented", typescript=ts, schema_hash="")
 
 
 # ---------------------------------------------------------------------------
@@ -366,7 +372,7 @@ def loop_guard(*, recent_actions: list[str], max_repeat: int) -> RepairResult:
             target=recent_actions[-1],
             before={"repeat_count": trailing},
             after={"loop_break": True},
-            parity=_parity(),
+            parity=_parity(ts="pending"),
         )
 
     return RepairResult(
@@ -377,7 +383,7 @@ def loop_guard(*, recent_actions: list[str], max_repeat: int) -> RepairResult:
         target="",
         before={"repeat_count": trailing},
         after={"loop_break": False},
-        parity=_parity(),
+        parity=_parity(ts="pending"),
     )
 
 

--- a/autocontext/src/autocontext/loop/generation_pipeline.py
+++ b/autocontext/src/autocontext/loop/generation_pipeline.py
@@ -22,6 +22,7 @@ from autocontext.loop.stage_helpers.tournament_prep import _build_empty_tourname
 from autocontext.loop.stage_preflight import stage_preflight
 from autocontext.loop.stage_prevalidation import stage_prevalidation
 from autocontext.loop.stage_probe import stage_probe
+from autocontext.loop.stage_repair import stage_repair
 from autocontext.loop.stage_staged_validation import stage_staged_validation
 from autocontext.loop.stage_tree_search import stage_tree_search
 from autocontext.loop.stage_types import GenerationContext
@@ -453,6 +454,10 @@ class GenerationPipeline:
                         role, message = chat_request
                         response = self._chat_with_agent_fn(role, message, ctx.prompts, ctx.tool_context)
                         self._controller.respond_chat(role, response)
+
+                # Stage 2.25: Opt-in deterministic repair gate (default off => no-op)
+                if not _over_budget(ctx) and not _phase_exhausted(scaffolding_started_at, scaffolding_budget):
+                    ctx = stage_repair(ctx, events=self._events)
 
                 # Stage 2.3: Staged validation (progressive checks before tournament)
                 if not _over_budget(ctx) and not _phase_exhausted(scaffolding_started_at, scaffolding_budget):

--- a/autocontext/src/autocontext/loop/stage_repair.py
+++ b/autocontext/src/autocontext/loop/stage_repair.py
@@ -13,18 +13,18 @@ on the :class:`GenerationContext` and runs the gate, which emits one
 channel. The stage is deterministic and never fabricates task content: it only
 runs the pure repairs and records their structural decisions.
 
-The lone recorded-state input wired today is a raw tool-call JSON string the
-competitor stage may attach under ``ctx.current_strategy["__tool_call_json__"]``;
-when present and structurally repairable, the repaired string is recorded back
-onto the same key so downstream consumers see valid JSON. Richer inputs
-(artifact-landing relocation, finish-claim validation) and the runtime
-parse-seam wiring are follow-ups tracked with the deferred artifact-reassembly
-work in ``docs/harness-optimization-protocol.md``.
+The lone recorded-state input this stage reads is a raw tool-call JSON string
+under ``ctx.current_strategy["__tool_call_json__"]``; when present and
+structurally repairable, the repaired string is recorded back onto the same key
+so downstream consumers see valid JSON. No production stage attaches this key
+yet, so the stage is opt-in telemetry until a producer is added (a documented
+follow-up). Richer inputs (artifact-landing relocation, finish-claim validation)
+and the runtime parse-seam wiring are follow-ups tracked with the deferred
+artifact-reassembly work in ``docs/harness-optimization-protocol.md``.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from autocontext.harness_optimization.repair_gate import (
@@ -36,8 +36,6 @@ from autocontext.loop.stage_types import GenerationContext
 
 if TYPE_CHECKING:
     from autocontext.loop.events import EventStreamEmitter
-
-logger = logging.getLogger(__name__)
 
 _RAW_TOOL_CALL_KEY = "__tool_call_json__"
 

--- a/autocontext/src/autocontext/loop/stage_repair.py
+++ b/autocontext/src/autocontext/loop/stage_repair.py
@@ -1,0 +1,75 @@
+"""Opt-in deterministic repair stage: runs the RepairGate before validation.
+
+This is the pre-scoring seam for the AC-878 repair gates. It sits immediately
+before :func:`stage_staged_validation` so any structural recovery happens before
+a candidate is scored. The stage is caller-gated: it early-returns unless
+:func:`repair_gate_active_for` says the gate is active for this scenario, so with
+the default flags OFF the generation path is byte-unchanged (this stage is a
+no-op that touches nothing on ``ctx`` and emits no events).
+
+When active, it builds a :class:`RepairContext` from the recorded state present
+on the :class:`GenerationContext` and runs the gate, which emits one
+``repair_applied`` / ``repair_skipped`` event per repair on the ``repair``
+channel. The stage is deterministic and never fabricates task content: it only
+runs the pure repairs and records their structural decisions.
+
+The lone recorded-state input wired today is a raw tool-call JSON string the
+competitor stage may attach under ``ctx.current_strategy["__tool_call_json__"]``;
+when present and structurally repairable, the repaired string is recorded back
+onto the same key so downstream consumers see valid JSON. Richer inputs
+(artifact-landing relocation, finish-claim validation) and the runtime
+parse-seam wiring are follow-ups tracked with the deferred artifact-reassembly
+work in ``docs/harness-optimization-protocol.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from autocontext.harness_optimization.repair_gate import (
+    RepairContext,
+    RepairGate,
+    repair_gate_active_for,
+)
+from autocontext.loop.stage_types import GenerationContext
+
+if TYPE_CHECKING:
+    from autocontext.loop.events import EventStreamEmitter
+
+logger = logging.getLogger(__name__)
+
+_RAW_TOOL_CALL_KEY = "__tool_call_json__"
+
+
+def _repair_context_from(ctx: GenerationContext) -> RepairContext:
+    """Build a RepairContext from the recorded state available on ``ctx``.
+
+    Only structural inputs the pipeline actually records are mapped; everything
+    else stays absent so the corresponding repair returns ``not_applicable``.
+    """
+
+    raw_tool_call = ctx.current_strategy.get(_RAW_TOOL_CALL_KEY) if isinstance(ctx.current_strategy, dict) else None
+    return RepairContext(tool_call_json=raw_tool_call if isinstance(raw_tool_call, str) else None)
+
+
+def stage_repair(
+    ctx: GenerationContext,
+    *,
+    events: EventStreamEmitter,
+) -> GenerationContext:
+    """Run the opt-in RepairGate when active; otherwise a byte-unchanged no-op."""
+
+    if not repair_gate_active_for(ctx.settings, ctx.scenario_name):
+        return ctx
+
+    context = _repair_context_from(ctx)
+    gate = RepairGate(emitter=events)
+    gate.run(ctx.scenario_name, context)
+
+    # Record a structurally repaired tool-call back onto the strategy so the
+    # downstream stages see valid JSON. This only happens under the opt-in flag.
+    if context.repaired_tool_call_json is not None and isinstance(ctx.current_strategy, dict):
+        ctx.current_strategy[_RAW_TOOL_CALL_KEY] = context.repaired_tool_call_json
+
+    return ctx

--- a/autocontext/tests/test_harness_optimization_contract.py
+++ b/autocontext/tests/test_harness_optimization_contract.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from autocontext.harness_optimization.contract.models import (
     CandidateEvidence,
     PromotionScore,
+    RepairResult,
 )
 
 # Walk up to the repo root: autocontext/tests/ -> autocontext/ -> <repo root>.
@@ -202,3 +203,94 @@ def test_shared_promotion_score_fixture_directory_contains_the_expected_set() ->
     # here instead of being silently ignored.
     names = {p.name for p in PROMOTION_SCORE_FIXTURES_DIR.glob("*.json")}
     assert names == EXPECTED_PROMOTION_SCORE_FIXTURES | {"score-cases.json"}
+
+
+# --- Shared repair-result contract fixtures (mirrors candidate-evidence) --------
+
+REPAIR_RESULT_FIXTURES_DIR = REPO_ROOT / "fixtures" / "harness-optimization" / "repair-result"
+
+# The contract fixtures validated by both packages.
+EXPECTED_REPAIR_RESULT_FIXTURES = {
+    "valid-applied.json",
+    "valid-skipped.json",
+    "invalid-missing-status.json",
+    "invalid-bad-status.json",
+    "invalid-empty-parity.json",
+}
+
+
+def _repair_result_fixtures(prefix: str) -> list[Path]:
+    assert REPAIR_RESULT_FIXTURES_DIR.is_dir(), f"expected fixtures dir at {REPAIR_RESULT_FIXTURES_DIR}"
+    return sorted(REPAIR_RESULT_FIXTURES_DIR.glob(f"{prefix}*.json"))
+
+
+def _valid_repair_result() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "repair_name": "tool_call_json",
+        "status": "applied",
+        "reason": "The tool call arguments were not valid JSON; re-serialized before dispatch.",
+        "target": "run_python",
+        "before": {"valid": False},
+        "after": {"valid": True},
+        "parity": {
+            "python": "implemented",
+            "typescript": "implemented",
+            "schema_hash": "abc123",
+        },
+    }
+
+
+def test_valid_repair_result_round_trips() -> None:
+    data = _valid_repair_result()
+    model = RepairResult(**data)
+    dumped = model.model_dump(exclude_none=True)
+    assert dumped == data
+
+
+def test_repair_result_missing_status_raises() -> None:
+    data = _valid_repair_result()
+    del data["status"]
+    with pytest.raises(ValidationError):
+        RepairResult(**data)
+
+
+def test_repair_result_bad_status_raises() -> None:
+    data = _valid_repair_result()
+    data["status"] = "bogus"
+    with pytest.raises(ValidationError):
+        RepairResult(**data)
+
+
+def test_repair_result_extra_field_raises() -> None:
+    data = _valid_repair_result()
+    data["unexpected_field"] = "nope"
+    with pytest.raises(ValidationError):
+        RepairResult(**data)
+
+
+def test_repair_result_empty_parity_raises() -> None:
+    data = _valid_repair_result()
+    data["parity"] = {}
+    with pytest.raises(ValidationError):
+        RepairResult(**data)
+
+
+@pytest.mark.parametrize("fixture", _repair_result_fixtures("valid-"), ids=lambda p: p.name)
+def test_shared_valid_repair_result_fixtures_construct(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    RepairResult(**data)
+
+
+@pytest.mark.parametrize("fixture", _repair_result_fixtures("invalid-"), ids=lambda p: p.name)
+def test_shared_invalid_repair_result_fixtures_raise(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    with pytest.raises(ValidationError):
+        RepairResult(**data)
+
+
+def test_shared_repair_result_fixture_directory_contains_the_expected_set() -> None:
+    # Set-membership guard over EVERY .json in the directory: a stray or dropped
+    # .json fails here instead of being silently ignored.
+    names = {p.name for p in REPAIR_RESULT_FIXTURES_DIR.glob("*.json")}
+    assert names == EXPECTED_REPAIR_RESULT_FIXTURES

--- a/autocontext/tests/test_harness_optimization_repair_gate.py
+++ b/autocontext/tests/test_harness_optimization_repair_gate.py
@@ -87,8 +87,9 @@ def test_run_emits_repair_applied_with_schema_valid_payload(tmp_path: Path) -> N
     assert len(capture.events) == 1
     event, payload = capture.events[0]
     assert event == "repair_applied"
-    # The emitted payload is the RepairResult dump and re-validates against it.
-    revalidated = RepairResult.model_validate(payload)
+    # The scenario rides alongside the RepairResult dump, which re-validates.
+    assert payload["scenario"] == "grid_ctf"
+    revalidated = RepairResult.model_validate(payload["result"])
     assert revalidated.status == "applied"
     assert revalidated.repair_name == "tool_call_json"
 
@@ -101,7 +102,8 @@ def test_run_emits_repair_skipped_for_ambiguous_input(tmp_path: Path) -> None:
 
     assert results[0].status == "skipped"
     assert [e for e, _ in capture.events] == ["repair_skipped"]
-    RepairResult.model_validate(capture.events[0][1])
+    assert capture.events[0][1]["scenario"] == "grid_ctf"
+    RepairResult.model_validate(capture.events[0][1]["result"])
 
 
 def test_run_emits_repair_skipped_for_not_applicable_absent_input(tmp_path: Path) -> None:
@@ -112,7 +114,7 @@ def test_run_emits_repair_skipped_for_not_applicable_absent_input(tmp_path: Path
 
     assert results[0].status == "not_applicable"
     assert [e for e, _ in capture.events] == ["repair_skipped"]
-    RepairResult.model_validate(capture.events[0][1])
+    RepairResult.model_validate(capture.events[0][1]["result"])
 
 
 def test_run_applies_artifact_relocation_and_emits_applied(tmp_path: Path) -> None:
@@ -132,7 +134,7 @@ def test_run_applies_artifact_relocation_and_emits_applied(tmp_path: Path) -> No
     assert results[0].status == "applied"
     assert ctx.relocation_target == "tmp/report.md"
     assert [e for e, _ in capture.events] == ["repair_applied"]
-    RepairResult.model_validate(capture.events[0][1])
+    RepairResult.model_validate(capture.events[0][1]["result"])
 
 
 def test_run_emits_one_event_per_enabled_repair(tmp_path: Path) -> None:
@@ -144,4 +146,5 @@ def test_run_emits_one_event_per_enabled_repair(tmp_path: Path) -> None:
     assert len(results) == len(DEFAULT_REPAIRS) == 3
     assert len(capture.events) == 3
     for _event, payload in capture.events:
-        RepairResult.model_validate(payload)
+        assert payload["scenario"] == "grid_ctf"
+        RepairResult.model_validate(payload["result"])

--- a/autocontext/tests/test_harness_optimization_repair_gate.py
+++ b/autocontext/tests/test_harness_optimization_repair_gate.py
@@ -1,0 +1,147 @@
+"""Tests for the opt-in RepairGate and its trace events (AC-878)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.config.settings import AppSettings
+from autocontext.control_plane.contract_probes._base import ArtifactContractProbeInputs
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.harness_optimization.contract.models import RepairResult
+from autocontext.harness_optimization.repair_gate import (
+    DEFAULT_REPAIRS,
+    RepairContext,
+    RepairGate,
+    finish_guard_step,
+    repair_artifact_landing_step,
+    repair_gate_active_for,
+    repair_tool_call_json_step,
+)
+
+
+def _settings(*, enabled: bool, scenarios: str) -> AppSettings:
+    return AppSettings(
+        harness_repair_gates_enabled=enabled,
+        harness_repair_gate_scenarios=scenarios,
+    )
+
+
+# ---------------------------------------------------------------------------
+# repair_gate_active_for: the opt-in truth table
+# ---------------------------------------------------------------------------
+
+
+def test_active_when_enabled_and_scenario_allowlisted() -> None:
+    settings = _settings(enabled=True, scenarios="grid_ctf, othello")
+    assert repair_gate_active_for(settings, "grid_ctf") is True
+    assert repair_gate_active_for(settings, "othello") is True
+
+
+def test_inactive_when_enabled_but_scenario_not_allowlisted() -> None:
+    settings = _settings(enabled=True, scenarios="grid_ctf")
+    assert repair_gate_active_for(settings, "othello") is False
+
+
+def test_inactive_when_disabled_even_if_scenario_listed() -> None:
+    settings = _settings(enabled=False, scenarios="grid_ctf")
+    assert repair_gate_active_for(settings, "grid_ctf") is False
+
+
+def test_inactive_when_allowlist_empty() -> None:
+    settings = _settings(enabled=True, scenarios="")
+    assert repair_gate_active_for(settings, "grid_ctf") is False
+
+
+# ---------------------------------------------------------------------------
+# RepairGate.run: events + schema-valid payloads
+# ---------------------------------------------------------------------------
+
+
+class _Capture:
+    """Subscriber collecting (event, payload) tuples off the emitter."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def __call__(self, event: str, payload: dict[str, object]) -> None:
+        self.events.append((event, payload))
+
+
+def _gate(tmp_path: Path, *steps: object) -> tuple[RepairGate, _Capture]:
+    emitter = EventStreamEmitter(tmp_path / "events.ndjson")
+    capture = _Capture()
+    emitter.subscribe(capture)
+    repairs = tuple(steps) if steps else DEFAULT_REPAIRS
+    return RepairGate(emitter=emitter, repairs=repairs), capture  # type: ignore[arg-type]
+
+
+def test_run_emits_repair_applied_with_schema_valid_payload(tmp_path: Path) -> None:
+    gate, capture = _gate(tmp_path, repair_tool_call_json_step)
+    ctx = RepairContext(tool_call_json='{"a": 1,}')  # trailing comma -> repairable
+
+    results = gate.run("grid_ctf", ctx)
+
+    assert len(results) == 1
+    assert results[0].status == "applied"
+    assert ctx.repaired_tool_call_json == '{"a": 1}'
+    assert len(capture.events) == 1
+    event, payload = capture.events[0]
+    assert event == "repair_applied"
+    # The emitted payload is the RepairResult dump and re-validates against it.
+    revalidated = RepairResult.model_validate(payload)
+    assert revalidated.status == "applied"
+    assert revalidated.repair_name == "tool_call_json"
+
+
+def test_run_emits_repair_skipped_for_ambiguous_input(tmp_path: Path) -> None:
+    gate, capture = _gate(tmp_path, repair_tool_call_json_step)
+    ctx = RepairContext(tool_call_json="{{{{ not json")  # unrecoverable
+
+    results = gate.run("grid_ctf", ctx)
+
+    assert results[0].status == "skipped"
+    assert [e for e, _ in capture.events] == ["repair_skipped"]
+    RepairResult.model_validate(capture.events[0][1])
+
+
+def test_run_emits_repair_skipped_for_not_applicable_absent_input(tmp_path: Path) -> None:
+    gate, capture = _gate(tmp_path, finish_guard_step)
+    ctx = RepairContext()  # no finish claim present
+
+    results = gate.run("grid_ctf", ctx)
+
+    assert results[0].status == "not_applicable"
+    assert [e for e, _ in capture.events] == ["repair_skipped"]
+    RepairResult.model_validate(capture.events[0][1])
+
+
+def test_run_applies_artifact_relocation_and_emits_applied(tmp_path: Path) -> None:
+    expected = ArtifactContractProbeInputs(
+        path="out/report.md",
+        content="",  # nothing landed at the expected path
+        required_substrings=("SUMMARY",),
+    )
+    gate, capture = _gate(tmp_path, repair_artifact_landing_step)
+    ctx = RepairContext(
+        artifact_expected=expected,
+        artifact_produced={"tmp/report.md": "SUMMARY: all good"},
+    )
+
+    results = gate.run("grid_ctf", ctx)
+
+    assert results[0].status == "applied"
+    assert ctx.relocation_target == "tmp/report.md"
+    assert [e for e, _ in capture.events] == ["repair_applied"]
+    RepairResult.model_validate(capture.events[0][1])
+
+
+def test_run_emits_one_event_per_enabled_repair(tmp_path: Path) -> None:
+    gate, capture = _gate(tmp_path)  # DEFAULT_REPAIRS (three repairs)
+    ctx = RepairContext(tool_call_json='{"a": 1}')  # only tool json present
+
+    results = gate.run("grid_ctf", ctx)
+
+    assert len(results) == len(DEFAULT_REPAIRS) == 3
+    assert len(capture.events) == 3
+    for _event, payload in capture.events:
+        RepairResult.model_validate(payload)

--- a/autocontext/tests/test_harness_optimization_repairs.py
+++ b/autocontext/tests/test_harness_optimization_repairs.py
@@ -16,6 +16,7 @@ import pytest
 from autocontext.control_plane.contract_probes._base import ArtifactContractProbeInputs
 from autocontext.harness_optimization.contract.models import RepairResult
 from autocontext.harness_optimization.repairs import (
+    _strip_code_fence,
     finish_guard,
     loop_guard,
     repair_artifact_landing,
@@ -92,6 +93,16 @@ def test_tool_call_fence_wrapping_trailing_comma_is_repaired() -> None:
     assert value is not None
     assert json.loads(value) == {"a": 1}
     _roundtrip(result)
+
+
+@pytest.mark.parametrize("sep", ["\x0b", "\u2028"])
+def test_strip_code_fence_body_is_one_line_across_unicode_separators(sep: str) -> None:
+    # A fence body containing a vertical tab (U+000B) or U+2028 LINE SEPARATOR is
+    # ONE line: Python's str.splitlines() would split on these, the TS regex
+    # (\r\n|\r|\n) does not. The narrowed split keeps both languages stripping
+    # the fence identically, preserving the body verbatim.
+    body = f"alpha{sep}beta"
+    assert _strip_code_fence(f"```\n{body}\n```") == body
 
 
 def test_tool_call_truncated_single_unclosed_object_is_closed() -> None:

--- a/autocontext/tests/test_harness_optimization_repairs.py
+++ b/autocontext/tests/test_harness_optimization_repairs.py
@@ -1,0 +1,269 @@
+"""Tests for the deterministic, pure repair functions (AC-878).
+
+These pin the structural-only / relocation-only / validation-only behaviour:
+no repair may fabricate task content, and every RepairResult must validate
+against the generated schema model.
+"""
+
+from __future__ import annotations
+
+import json
+
+from autocontext.control_plane.contract_probes._base import ArtifactContractProbeInputs
+from autocontext.harness_optimization.contract.models import RepairResult
+from autocontext.harness_optimization.repairs import (
+    finish_guard,
+    loop_guard,
+    repair_artifact_landing,
+    repair_tool_call_json,
+)
+
+
+def _roundtrip(result: RepairResult) -> None:
+    """Assert the result validates against the RepairResult schema, both ways."""
+
+    assert isinstance(result, RepairResult)
+    reloaded = RepairResult.model_validate(result.model_dump())
+    assert reloaded == result
+    # JSON round-trip too, mirroring how the gate would persist it.
+    assert RepairResult.model_validate_json(result.model_dump_json()) == result
+
+
+# ---------------------------------------------------------------------------
+# repair_tool_call_json
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_valid_json_is_not_applicable() -> None:
+    raw = '{"tool": "read", "path": "a.py"}'
+    value, result = repair_tool_call_json(raw)
+    assert value == raw
+    assert result.status == "not_applicable"
+    assert result.before == {"valid": True}
+    _roundtrip(result)
+
+
+def test_tool_call_trailing_comma_is_repaired() -> None:
+    value, result = repair_tool_call_json('{"a":1,}')
+    assert result.status == "applied"
+    assert value is not None
+    parsed = json.loads(value)
+    # The value is preserved exactly; only the trailing comma was removed.
+    assert parsed == {"a": 1}
+    assert result.before == {"valid": False}
+    assert result.after == {"valid": True}
+    _roundtrip(result)
+
+
+def test_tool_call_trailing_comma_in_array_is_repaired() -> None:
+    value, result = repair_tool_call_json('{"items": [1, 2, 3,]}')
+    assert result.status == "applied"
+    assert value is not None
+    assert json.loads(value) == {"items": [1, 2, 3]}
+    _roundtrip(result)
+
+
+def test_tool_call_code_fence_is_stripped() -> None:
+    raw = '```json\n{"a": 1, "b": "x"}\n```'
+    value, result = repair_tool_call_json(raw)
+    assert result.status == "applied"
+    assert value is not None
+    assert json.loads(value) == {"a": 1, "b": "x"}
+    _roundtrip(result)
+
+
+def test_tool_call_bare_code_fence_is_stripped() -> None:
+    raw = '```\n{"a": 1}\n```'
+    value, result = repair_tool_call_json(raw)
+    assert result.status == "applied"
+    assert value is not None
+    assert json.loads(value) == {"a": 1}
+    _roundtrip(result)
+
+
+def test_tool_call_fence_wrapping_trailing_comma_is_repaired() -> None:
+    raw = '```json\n{"a": 1,}\n```'
+    value, result = repair_tool_call_json(raw)
+    assert result.status == "applied"
+    assert value is not None
+    assert json.loads(value) == {"a": 1}
+    _roundtrip(result)
+
+
+def test_tool_call_truncated_single_unclosed_object_is_closed() -> None:
+    value, result = repair_tool_call_json('{"a":1')
+    assert result.status == "applied"
+    assert value is not None
+    assert value.endswith("}")
+    assert json.loads(value) == {"a": 1}
+    _roundtrip(result)
+
+
+def test_tool_call_truncated_single_unclosed_array_is_closed() -> None:
+    # A single unclosed array (exactly one opener on the stack) -> close it.
+    value, result = repair_tool_call_json("[1, 2, 3")
+    assert result.status == "applied"
+    assert value is not None
+    assert json.loads(value) == [1, 2, 3]
+    _roundtrip(result)
+
+
+def test_tool_call_two_unclosed_is_ambiguous_and_skipped() -> None:
+    # Object and array both left open -> multiple plausible closings -> skip.
+    value, result = repair_tool_call_json('{"a": [1, 2, 3')
+    assert value is None
+    assert result.status == "skipped"
+    assert result.after == {"valid": False}
+    _roundtrip(result)
+
+
+def test_tool_call_garbage_is_skipped() -> None:
+    value, result = repair_tool_call_json("this is not json at all")
+    assert value is None
+    assert result.status == "skipped"
+    assert result.reason == "ambiguous or unrecoverable tool json"
+    _roundtrip(result)
+
+
+def test_tool_call_missing_value_is_not_fabricated() -> None:
+    # A missing field VALUE is never guessed; structural closing yields
+    # invalid json, so the repair skips rather than inventing a value.
+    value, result = repair_tool_call_json('{"a":')
+    assert value is None
+    assert result.status == "skipped"
+    _roundtrip(result)
+
+
+def test_tool_call_repair_never_changes_a_field_value() -> None:
+    # A comma inside a string literal must survive untouched, and no key or
+    # value may be added, removed, or altered by the structural repair.
+    raw = '{"note": "hello, world]", "n": 1,}'
+    value, result = repair_tool_call_json(raw)
+    assert result.status == "applied"
+    assert value is not None
+    parsed = json.loads(value)
+    assert parsed == {"note": "hello, world]", "n": 1}
+    # No fabricated content: every key in the repaired output was in the input.
+    assert set(parsed.keys()) == {"note", "n"}
+
+
+# ---------------------------------------------------------------------------
+# repair_artifact_landing
+# ---------------------------------------------------------------------------
+
+
+def _expected(path: str, content: str) -> ArtifactContractProbeInputs:
+    return ArtifactContractProbeInputs(
+        path=path,
+        content=content,
+        required_substrings=("REPORT", "conclusion"),
+    )
+
+
+def test_artifact_landing_passing_contract_is_not_applicable() -> None:
+    expected = _expected("report.md", "REPORT\nthe conclusion is here")
+    target, result = repair_artifact_landing(expected=expected, produced={})
+    assert target is None
+    assert result.status == "not_applicable"
+    _roundtrip(result)
+
+
+def test_artifact_landing_right_content_wrong_path_is_relocated() -> None:
+    # Nothing landed at report.md, but the right content is at draft.md.
+    expected = _expected("report.md", "")
+    produced = {
+        "notes.txt": "some unrelated scratch notes",
+        "draft.md": "REPORT\nthe conclusion is here",
+    }
+    target, result = repair_artifact_landing(expected=expected, produced=produced)
+    assert target == "draft.md"
+    assert result.status == "applied"
+    assert result.target == "draft.md"
+    assert result.after == {"landed": True, "source_path": "draft.md"}
+    _roundtrip(result)
+
+
+def test_artifact_landing_no_matching_content_is_skipped() -> None:
+    expected = _expected("report.md", "")
+    produced = {"notes.txt": "nothing relevant here at all"}
+    target, result = repair_artifact_landing(expected=expected, produced=produced)
+    assert target is None
+    assert result.status == "skipped"
+    _roundtrip(result)
+
+
+def test_artifact_landing_only_relocates_existing_content() -> None:
+    # The relocation target must be a path that is actually in `produced`;
+    # the repair never invents a path or content.
+    expected = _expected("report.md", "")
+    produced = {"elsewhere/report.md": "REPORT\nthe conclusion is here"}
+    target, result = repair_artifact_landing(expected=expected, produced=produced)
+    assert target in produced
+    assert result.status == "applied"
+
+
+# ---------------------------------------------------------------------------
+# finish_guard
+# ---------------------------------------------------------------------------
+
+
+def test_finish_guard_rejects_unmet_completion() -> None:
+    result = finish_guard(claimed_done=True, completion_ok=False, reason_if_not="target theorem absent")
+    assert result.status == "applied"
+    assert "target theorem absent" in result.reason
+    assert result.after == {"accepted_done": False}
+    _roundtrip(result)
+
+
+def test_finish_guard_accepts_valid_completion() -> None:
+    result = finish_guard(claimed_done=True, completion_ok=True, reason_if_not="unused")
+    assert result.status == "not_applicable"
+    _roundtrip(result)
+
+
+def test_finish_guard_no_claim_is_not_applicable() -> None:
+    result = finish_guard(claimed_done=False, completion_ok=False, reason_if_not="unused")
+    assert result.status == "not_applicable"
+    _roundtrip(result)
+
+
+# ---------------------------------------------------------------------------
+# loop_guard
+# ---------------------------------------------------------------------------
+
+
+def test_loop_guard_detects_identical_trailing_actions() -> None:
+    result = loop_guard(recent_actions=["read a", "read a", "read a"], max_repeat=3)
+    assert result.status == "applied"
+    assert result.target == "read a"
+    assert result.before == {"repeat_count": 3}
+    assert result.after == {"loop_break": True}
+    _roundtrip(result)
+
+
+def test_loop_guard_counts_only_the_tail_run() -> None:
+    result = loop_guard(
+        recent_actions=["x", "read a", "read a", "read a"],
+        max_repeat=3,
+    )
+    assert result.status == "applied"
+    assert result.before == {"repeat_count": 3}
+    _roundtrip(result)
+
+
+def test_loop_guard_varied_actions_is_not_applicable() -> None:
+    result = loop_guard(recent_actions=["a", "b", "c", "a"], max_repeat=3)
+    assert result.status == "not_applicable"
+    _roundtrip(result)
+
+
+def test_loop_guard_below_threshold_is_not_applicable() -> None:
+    result = loop_guard(recent_actions=["a", "a"], max_repeat=3)
+    assert result.status == "not_applicable"
+    _roundtrip(result)
+
+
+def test_loop_guard_empty_actions_is_not_applicable() -> None:
+    result = loop_guard(recent_actions=[], max_repeat=3)
+    assert result.status == "not_applicable"
+    _roundtrip(result)

--- a/autocontext/tests/test_harness_optimization_repairs.py
+++ b/autocontext/tests/test_harness_optimization_repairs.py
@@ -8,6 +8,10 @@ against the generated schema model.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from typing import Any
+
+import pytest
 
 from autocontext.control_plane.contract_probes._base import ArtifactContractProbeInputs
 from autocontext.harness_optimization.contract.models import RepairResult
@@ -266,4 +270,71 @@ def test_loop_guard_below_threshold_is_not_applicable() -> None:
 def test_loop_guard_empty_actions_is_not_applicable() -> None:
     result = loop_guard(recent_actions=[], max_repeat=3)
     assert result.status == "not_applicable"
+    _roundtrip(result)
+
+
+# ---------------------------------------------------------------------------
+# shared cross-language parity fixture (AC-878)
+# ---------------------------------------------------------------------------
+#
+# The SAME repo-root fixture is loaded by the TypeScript suite
+# (``ts/tests/harness-optimization/repairs.test.ts``). Both languages assert the
+# same status (and relocation target / reason substring) for every recorded
+# input, which is what proves the two implementations make identical repair
+# decisions on identical inputs. The reason strings are IDENTICAL across
+# languages, so the ``reason_contains`` substring holds on both sides.
+
+# Walk up to the repo root: autocontext/tests/ -> autocontext/ -> <repo root>.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REPAIR_FIXTURE = _REPO_ROOT / "fixtures" / "harness-optimization" / "repair-cases" / "repair-cases.json"
+
+_REPAIR_CASES = json.loads(_REPAIR_FIXTURE.read_text())
+
+
+def _assert_decision(status: str, reason: str, target: str, expected: dict[str, Any]) -> None:
+    assert status == expected["status"]
+    if "reason_contains" in expected:
+        assert expected["reason_contains"] in reason
+    if "target" in expected:
+        assert target == expected["target"]
+
+
+def _artifact_inputs(contract: dict[str, Any]) -> ArtifactContractProbeInputs:
+    kwargs: dict[str, Any] = {"path": contract["path"], "content": contract["content"]}
+    if "expected_line_ending" in contract:
+        kwargs["expected_line_ending"] = contract["expected_line_ending"]
+    if "required_substrings" in contract:
+        kwargs["required_substrings"] = tuple(contract["required_substrings"])
+    if "forbidden_substrings" in contract:
+        kwargs["forbidden_substrings"] = tuple(contract["forbidden_substrings"])
+    if "required_json_fields" in contract:
+        kwargs["required_json_fields"] = tuple(contract["required_json_fields"])
+    return ArtifactContractProbeInputs(**kwargs)
+
+
+@pytest.mark.parametrize("case", _REPAIR_CASES["tool_call"], ids=lambda c: c["name"])
+def test_shared_fixture_tool_call(case: dict[str, Any]) -> None:
+    _value, result = repair_tool_call_json(case["raw"])
+    _assert_decision(result.status, result.reason, result.target, case["expected"])
+    _roundtrip(result)
+
+
+@pytest.mark.parametrize("case", _REPAIR_CASES["artifact_landing"], ids=lambda c: c["name"])
+def test_shared_fixture_artifact_landing(case: dict[str, Any]) -> None:
+    _path, result = repair_artifact_landing(
+        expected=_artifact_inputs(case["expected_contract"]),
+        produced=dict(case["produced"]),
+    )
+    _assert_decision(result.status, result.reason, result.target, case["expected"])
+    _roundtrip(result)
+
+
+@pytest.mark.parametrize("case", _REPAIR_CASES["finish_guard"], ids=lambda c: c["name"])
+def test_shared_fixture_finish_guard(case: dict[str, Any]) -> None:
+    result = finish_guard(
+        claimed_done=case["claimed_done"],
+        completion_ok=case["completion_ok"],
+        reason_if_not=case["reason_if_not"],
+    )
+    _assert_decision(result.status, result.reason, result.target, case["expected"])
     _roundtrip(result)

--- a/autocontext/tests/test_module_size_limits.py
+++ b/autocontext/tests/test_module_size_limits.py
@@ -26,6 +26,7 @@ GRANDFATHERED: dict[str, int] = {
     "execution/task_runner.py": 1000,
     "scenarios/custom/family_pipeline.py": 1000,
     "knowledge/research_hub.py": 1000,
+    "config/settings.py": 850,  # config monolith at ceiling; split into per-domain settings modules
 }
 
 
@@ -46,9 +47,7 @@ class TestModuleSizeLimits:
                 if lines > limit:
                     violations.append(f"{rel}: {lines} lines (limit {limit})")
 
-        assert violations == [], (
-            "Modules exceeding size limits:\n" + "\n".join(f"  {v}" for v in violations)
-        )
+        assert violations == [], "Modules exceeding size limits:\n" + "\n".join(f"  {v}" for v in violations)
 
     def test_stages_helpers_exist(self) -> None:
         """loop/stage_helpers/ should exist with extracted helper modules."""
@@ -56,9 +55,8 @@ class TestModuleSizeLimits:
         assert helpers_dir.is_dir(), "loop/stage_helpers/ package missing"
         helper_files = list(helpers_dir.glob("*.py"))
         # Expect __init__.py + 6 helper modules
-        assert len(helper_files) >= 7, (
-            f"Expected 7+ files in stage_helpers/, found {len(helper_files)}: "
-            + ", ".join(f.name for f in helper_files)
+        assert len(helper_files) >= 7, f"Expected 7+ files in stage_helpers/, found {len(helper_files)}: " + ", ".join(
+            f.name for f in helper_files
         )
 
     def test_stages_under_grandfathered_limit(self) -> None:
@@ -66,7 +64,4 @@ class TestModuleSizeLimits:
         stages_path = SRC_ROOT / "loop" / "stages.py"
         lines = sum(1 for _ in stages_path.open())
         limit = GRANDFATHERED["loop/stages.py"]
-        assert lines <= limit, (
-            f"loop/stages.py is {lines} lines (limit {limit}). "
-            f"Extract more helpers into loop/stage_helpers/."
-        )
+        assert lines <= limit, f"loop/stages.py is {lines} lines (limit {limit}). Extract more helpers into loop/stage_helpers/."

--- a/autocontext/tests/test_stage_repair.py
+++ b/autocontext/tests/test_stage_repair.py
@@ -1,0 +1,117 @@
+"""Tests for the opt-in repair stage wired before staged validation (AC-878).
+
+Two properties are pinned:
+
+- flag OFF (the default): the stage is a byte-unchanged no-op. It emits no
+  events and mutates nothing on the GenerationContext.
+- flag ON (scenario allowlisted): the RepairGate runs at the seam, emits a
+  ``repair`` channel event per repair, and a structurally repairable tool-call
+  JSON is repaired in place on the strategy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from autocontext.config.settings import AppSettings
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.loop.stage_repair import stage_repair
+from autocontext.loop.stage_types import GenerationContext
+
+
+class _FakeScenario:
+    name = "grid_ctf"
+
+
+def _make_ctx(
+    *,
+    enabled: bool,
+    scenarios: str,
+    strategy: dict[str, Any] | None = None,
+) -> GenerationContext:
+    settings = AppSettings(
+        harness_repair_gates_enabled=enabled,
+        harness_repair_gate_scenarios=scenarios,
+    )
+    return GenerationContext(
+        run_id="test-run",
+        scenario_name="grid_ctf",
+        scenario=_FakeScenario(),
+        generation=1,
+        settings=settings,
+        previous_best=0.0,
+        challenger_elo=1000.0,
+        score_history=[],
+        gate_decision_history=[],
+        coach_competitor_hints="",
+        replay_narrative="",
+        current_strategy=strategy if strategy is not None else {"action": "move"},
+    )
+
+
+def _capture(tmp_path: Path) -> tuple[EventStreamEmitter, list[tuple[str, dict[str, object]]]]:
+    emitter = EventStreamEmitter(tmp_path / "events.ndjson")
+    events: list[tuple[str, dict[str, object]]] = []
+    emitter.subscribe(lambda event, payload: events.append((event, payload)))
+    return emitter, events
+
+
+def test_flag_off_is_byte_unchanged_no_op(tmp_path: Path) -> None:
+    # Golden: with the gate disabled the stage returns the identical context,
+    # mutates nothing, and emits nothing (byte-unchanged default path).
+    strategy = {"action": "move", "__tool_call_json__": '{"a": 1,}'}
+    ctx = _make_ctx(enabled=False, scenarios="grid_ctf", strategy=strategy)
+    before = dict(ctx.current_strategy)
+    emitter, events = _capture(tmp_path)
+
+    result = stage_repair(ctx, events=emitter)
+
+    assert result is ctx
+    assert ctx.current_strategy == before
+    assert events == []
+    # No events file is written when the stage is a no-op.
+    assert not (tmp_path / "events.ndjson").exists()
+
+
+def test_flag_off_when_scenario_not_allowlisted(tmp_path: Path) -> None:
+    ctx = _make_ctx(enabled=True, scenarios="othello", strategy={"__tool_call_json__": '{"a": 1,}'})
+    before = dict(ctx.current_strategy)
+    emitter, events = _capture(tmp_path)
+
+    stage_repair(ctx, events=emitter)
+
+    assert ctx.current_strategy == before
+    assert events == []
+
+
+def test_flag_on_runs_gate_and_emits_at_the_seam(tmp_path: Path) -> None:
+    # A repairable tool-call JSON is repaired in place, and one event per repair
+    # is emitted on the repair channel carrying the scenario alongside a
+    # schema-valid RepairResult.
+    ctx = _make_ctx(enabled=True, scenarios="grid_ctf", strategy={"__tool_call_json__": '{"a": 1,}'})
+    emitter, events = _capture(tmp_path)
+
+    stage_repair(ctx, events=emitter)
+
+    # The trailing-comma JSON was structurally repaired back onto the strategy.
+    assert ctx.current_strategy["__tool_call_json__"] == '{"a": 1}'
+
+    # One event per default repair (three), the first is the applied tool-call.
+    assert len(events) == 3
+    applied = [payload for event, payload in events if event == "repair_applied"]
+    assert len(applied) == 1
+    assert applied[0]["scenario"] == "grid_ctf"
+    assert applied[0]["result"]["repair_name"] == "tool_call_json"
+    assert applied[0]["result"]["status"] == "applied"
+
+
+def test_flag_on_without_repairable_input_still_emits_skips(tmp_path: Path) -> None:
+    ctx = _make_ctx(enabled=True, scenarios="grid_ctf", strategy={"action": "move"})
+    emitter, events = _capture(tmp_path)
+
+    stage_repair(ctx, events=emitter)
+
+    # Nothing to repair, but the seam still ran the gate and emitted skips.
+    assert [event for event, _ in events] == ["repair_skipped", "repair_skipped", "repair_skipped"]
+    assert ctx.current_strategy == {"action": "move"}

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -164,6 +164,79 @@ const fresh = harnessPromotionScore(components, weights);
 const advances = beatsIncumbent(challengerComponents, incumbentComponents, weights, 0.05);
 ```
 
+## Repair gates (AC-878)
+
+Some harness failures are not a reasoning problem: a tool-call JSON is malformed,
+an artifact landed at the wrong path, a run claims done without meeting its
+completion conditions, or an agent is stuck repeating one no-op action. A
+**repair gate** fixes these deterministically, before the candidate is scored.
+
+A repair gate is different from the other two ways autocontext recovers a run:
+
+- A **prompt playbook** teaches the model, in natural language, how to avoid a
+  failure next time. It is advisory and its effect is probabilistic.
+- A **model retry** re-runs the model (often with feedback). It costs another
+  generation and its result is non-deterministic.
+- A **repair gate** is a pure, bounded function over recorded state. It never
+  calls a model, never reads answer hints, never touches the filesystem, and is
+  fully replayable: the same recorded state always yields the same decision. It
+  only ever applies _structural_ fixes that cannot change task content.
+
+Because a repair gate cannot invent task content, it is safe to run on every
+candidate once enabled. Each repair inspects the state it is handed, decides
+whether a known failure mode is present, and returns a schema-valid
+**RepairResult** (`status` is `applied`, `skipped`, or `not_applicable`). The
+gate owns any side effect the decision implies (recording the repaired string,
+recording a relocation target); the repairs themselves only decide.
+
+### The repairs
+
+- **tool_call_json**: restructures malformed tool-call JSON: strips a code
+  fence, drops a trailing comma before a closer, closes a single truncated
+  brace/bracket. It is string-aware and never guesses or alters a field value.
+- **artifact_landing**: detects "right content, wrong path" by matching existing
+  produced content against the expected contract, and returns the correct path as
+  a relocation target. It never fabricates artifact content.
+- **finish_guard**: rejects a done claim whose completion conditions are not met.
+  It validates completion; it never fabricates completion.
+- **loop_guard**: detects a stuck run of identical trailing actions and signals a
+  break. Python-only for now: it is intentionally omitted from the default repair
+  set so the default set stays identical across Python and TypeScript until the
+  TypeScript mirror lands.
+
+### Opt-in flags (default off)
+
+The gate is off by default and changes nothing about a default run. Two settings
+turn it on, and BOTH must agree before any repair runs:
+
+- `harness_repair_gates_enabled` (bool, default `false`): the global switch.
+- `harness_repair_gate_scenarios` (comma-separated allowlist, default empty): the
+  scenarios the gate is active for. An empty allowlist means no scenario is active
+  even when the global flag is on.
+
+`repair_gate_active_for(settings, scenario)` (Python) and
+`repairGateActiveFor(config, scenario)` (TypeScript) are the sole opt-in decision.
+Callers check it and only build and run a gate when it returns true, so with the
+flags off the wired seams are byte-unchanged no-ops. The seams wired today are the
+pre-validation `stage_repair` in the Python generation pipeline (before staged
+validation) and the malformed-envelope path in the TypeScript `ClaudeCLIRuntime`
+parse step; both are guarded by the active-for check.
+
+### Events
+
+The gate emits exactly one event per repair on the `repair` channel:
+`repair_applied` when a repair's status is `applied`, and `repair_skipped` for
+both `skipped` and `not_applicable`. The payload is `{ "scenario": <name>,
+"result": <RepairResult> }`: the RepairResult stays a self-contained, schema-valid
+object under `result`, and the scenario rides alongside as a sibling so consumers
+can attribute the repair without changing the RepairResult schema.
+
+### Deferred: artifact reassembly
+
+A fifth repair, reassembling a partially written artifact from a recorded
+tool-call trace, is deliberately deferred: it needs a recorded tool-call trace
+that the harness does not yet capture. It is a follow-up, not part of this gate.
+
 ## The contract pattern
 
 This is the foundation artifact. The later protocol artifacts follow the same

--- a/fixtures/harness-optimization/repair-cases/repair-cases.json
+++ b/fixtures/harness-optimization/repair-cases/repair-cases.json
@@ -1,0 +1,103 @@
+{
+  "_comment": "Shared AC-878 repair-decision fixture. Loaded by BOTH the Python and TypeScript repair tests. Each case's `expected` block asserts the status, and where given a relocation `target` and a stable `reason_contains` substring. The two languages produce IDENTICAL reason strings, so the substring holds on both sides and proves parity + replayability over cached inputs. Artifact contract fields use snake_case; the TS test maps them to the camelCase probe inputs.",
+  "tool_call": [
+    {
+      "name": "valid_json_is_not_applicable",
+      "raw": "{\"tool\": \"read\", \"path\": \"a.py\"}",
+      "expected": { "status": "not_applicable", "reason_contains": "already valid json" }
+    },
+    {
+      "name": "trailing_comma_before_closer_is_applied",
+      "raw": "{\"tool\": \"read\", \"path\": \"a.py\",}",
+      "expected": { "status": "applied", "reason_contains": "removed trailing comma before closer" }
+    },
+    {
+      "name": "string_internal_comma_is_already_valid",
+      "raw": "{\"note\": \"a,}\"}",
+      "expected": { "status": "not_applicable", "reason_contains": "already valid json" }
+    },
+    {
+      "name": "single_unclosed_brace_with_string_internal_comma_is_applied",
+      "raw": "{\"note\": \"a,}\"",
+      "expected": {
+        "status": "applied",
+        "reason_contains": "closed a single truncated brace/bracket"
+      }
+    },
+    {
+      "name": "two_unclosed_openers_is_ambiguous_skipped",
+      "raw": "{\"a\": {\"b\": 1",
+      "expected": { "status": "skipped", "reason_contains": "ambiguous or unrecoverable" }
+    },
+    {
+      "name": "garbage_is_skipped",
+      "raw": "not json at all",
+      "expected": { "status": "skipped", "reason_contains": "ambiguous or unrecoverable" }
+    }
+  ],
+  "artifact_landing": [
+    {
+      "name": "contract_passes_is_not_applicable",
+      "expected_contract": {
+        "path": "out.json",
+        "content": "{\"ok\": true}",
+        "required_json_fields": ["ok"]
+      },
+      "produced": {},
+      "expected": {
+        "status": "not_applicable",
+        "reason_contains": "already satisfies the contract"
+      }
+    },
+    {
+      "name": "right_content_wrong_path_is_relocated",
+      "expected_contract": {
+        "path": "expected.md",
+        "content": "TODO placeholder",
+        "required_substrings": ["FINAL ANSWER"]
+      },
+      "produced": {
+        "expected.md": "TODO placeholder",
+        "scratch.md": "still thinking, no answer here",
+        "actual.md": "the FINAL ANSWER is 42"
+      },
+      "expected": { "status": "applied", "target": "actual.md", "reason_contains": "relocate" }
+    },
+    {
+      "name": "no_matching_content_is_skipped",
+      "expected_contract": {
+        "path": "expected.md",
+        "content": "TODO placeholder",
+        "required_substrings": ["FINAL ANSWER"]
+      },
+      "produced": {
+        "a.md": "nothing useful",
+        "b.md": "also nothing"
+      },
+      "expected": { "status": "skipped", "reason_contains": "no produced artifact matches" }
+    }
+  ],
+  "finish_guard": [
+    {
+      "name": "completion_ok_is_not_applicable",
+      "claimed_done": true,
+      "completion_ok": true,
+      "reason_if_not": "",
+      "expected": { "status": "not_applicable", "reason_contains": "no unmet completion claim" }
+    },
+    {
+      "name": "not_claimed_is_not_applicable",
+      "claimed_done": false,
+      "completion_ok": false,
+      "reason_if_not": "tests still failing",
+      "expected": { "status": "not_applicable", "reason_contains": "no unmet completion claim" }
+    },
+    {
+      "name": "claimed_but_not_ok_is_applied",
+      "claimed_done": true,
+      "completion_ok": false,
+      "reason_if_not": "tests still failing",
+      "expected": { "status": "applied", "reason_contains": "finish rejected: tests still failing" }
+    }
+  ]
+}

--- a/fixtures/harness-optimization/repair-result/invalid-bad-status.json
+++ b/fixtures/harness-optimization/repair-result/invalid-bad-status.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "repair_name": "loop_guard",
+  "status": "bogus",
+  "reason": "The status value is not one of applied, skipped, or not_applicable.",
+  "parity": {
+    "python": "implemented",
+    "typescript": "pending",
+    "schema_hash": "abc123"
+  }
+}

--- a/fixtures/harness-optimization/repair-result/invalid-empty-parity.json
+++ b/fixtures/harness-optimization/repair-result/invalid-empty-parity.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "repair_name": "tool_call_json",
+  "status": "applied",
+  "reason": "The parity block is empty; python, typescript, and schema_hash are all required.",
+  "target": "run_python",
+  "parity": {}
+}

--- a/fixtures/harness-optimization/repair-result/invalid-missing-status.json
+++ b/fixtures/harness-optimization/repair-result/invalid-missing-status.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "repair_name": "finish_guard",
+  "reason": "The finish guard fired but the record omits the required status field.",
+  "parity": {
+    "python": "implemented",
+    "typescript": "pending",
+    "schema_hash": "abc123"
+  }
+}

--- a/fixtures/harness-optimization/repair-result/valid-applied.json
+++ b/fixtures/harness-optimization/repair-result/valid-applied.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "repair_name": "tool_call_json",
+  "status": "applied",
+  "reason": "The tool call arguments were not valid JSON; re-serialized the object before dispatch.",
+  "target": "run_python",
+  "before": {
+    "valid": false,
+    "raw": "{'threshold': 0.9,}"
+  },
+  "after": {
+    "valid": true,
+    "raw": "{\"threshold\": 0.9}"
+  },
+  "parity": {
+    "python": "implemented",
+    "typescript": "implemented",
+    "schema_hash": "9f8e7d6c5b4a"
+  }
+}

--- a/fixtures/harness-optimization/repair-result/valid-skipped.json
+++ b/fixtures/harness-optimization/repair-result/valid-skipped.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "repair_name": "artifact_landing",
+  "status": "skipped",
+  "reason": "The artifact already landed at the expected path; no relocation was needed.",
+  "target": "",
+  "parity": {
+    "python": "implemented",
+    "typescript": "pending",
+    "schema_hash": "abc123"
+  }
+}

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -195,3 +195,59 @@ export interface PromotionScore {
     schema_hash: string;
   };
 }
+
+// ---- repair-result.schema.json ----
+/**
+ * Outcome of a single deterministic repair applied (or not applied) to a harness surface (AC-878). A repair is a named, auditable mechanism that fixes a known failure mode (for example tool_call_json, artifact_landing, finish_guard, loop_guard); this record captures whether it fired, why, what it targeted, and the before/after metadata a reviewer needs to trust the gate. This schema is the single source of truth for both the Python and TypeScript autocontext packages.
+ */
+export interface RepairResult {
+  /**
+   * Schema version for forward compatibility. Always 1 for this revision.
+   */
+  schema_version: 1;
+  /**
+   * Human-readable name of the repair mechanism, e.g. tool_call_json or finish_guard.
+   */
+  repair_name: string;
+  /**
+   * Whether the repair fired: applied, skipped, or not_applicable to this input.
+   */
+  status: "applied" | "skipped" | "not_applicable";
+  /**
+   * Human-auditable explanation of why the repair was applied or skipped.
+   */
+  reason: string;
+  /**
+   * What was repaired: a path, a tool name, or empty when nothing was targeted.
+   */
+  target?: string;
+  /**
+   * Pre-repair metadata, e.g. {"valid": false}.
+   */
+  before?: {
+    [k: string]: unknown;
+  };
+  /**
+   * Post-repair metadata, e.g. {"valid": true}.
+   */
+  after?: {
+    [k: string]: unknown;
+  };
+  /**
+   * Cross-language parity status for this candidate.
+   */
+  parity: {
+    /**
+     * Implementation status of this candidate in the Python package.
+     */
+    python: "implemented" | "pending" | "n_a";
+    /**
+     * Implementation status of this candidate in the TypeScript package.
+     */
+    typescript: "implemented" | "pending" | "n_a";
+    /**
+     * Content hash of the shared schema the two implementations agree on.
+     */
+    schema_hash: string;
+  };
+}

--- a/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
@@ -9,6 +9,9 @@
     },
     "PromotionScore": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/promotion-score.json"
+    },
+    "RepairResult": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/repair-result.json"
     }
   }
 }

--- a/ts/src/harness-optimization/contract/json-schemas/repair-result.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/repair-result.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/repair-result.json",
+  "title": "RepairResult",
+  "description": "Outcome of a single deterministic repair applied (or not applied) to a harness surface (AC-878). A repair is a named, auditable mechanism that fixes a known failure mode (for example tool_call_json, artifact_landing, finish_guard, loop_guard); this record captures whether it fired, why, what it targeted, and the before/after metadata a reviewer needs to trust the gate. This schema is the single source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "repair_name", "status", "reason", "parity"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "repair_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the repair mechanism, e.g. tool_call_json or finish_guard."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["applied", "skipped", "not_applicable"],
+      "description": "Whether the repair fired: applied, skipped, or not_applicable to this input."
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-auditable explanation of why the repair was applied or skipped."
+    },
+    "target": {
+      "type": "string",
+      "description": "What was repaired: a path, a tool name, or empty when nothing was targeted."
+    },
+    "before": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Pre-repair metadata, e.g. {\"valid\": false}."
+    },
+    "after": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Post-repair metadata, e.g. {\"valid\": true}."
+    },
+    "parity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "typescript", "schema_hash"],
+      "properties": {
+        "python": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the Python package."
+        },
+        "typescript": {
+          "type": "string",
+          "enum": ["implemented", "pending", "n_a"],
+          "description": "Implementation status of this candidate in the TypeScript package."
+        },
+        "schema_hash": {
+          "type": "string",
+          "description": "Content hash of the shared schema the two implementations agree on."
+        }
+      },
+      "description": "Cross-language parity status for this candidate."
+    }
+  }
+}

--- a/ts/src/harness-optimization/contract/validators.ts
+++ b/ts/src/harness-optimization/contract/validators.ts
@@ -3,7 +3,8 @@ import type { ErrorObject, ValidateFunction } from "ajv";
 import addFormats from "ajv-formats";
 import candidateEvidenceSchema from "./json-schemas/candidate-evidence.schema.json" with { type: "json" };
 import promotionScoreSchema from "./json-schemas/promotion-score.schema.json" with { type: "json" };
-import type { CandidateEvidence, PromotionScore } from "./generated-types.js";
+import repairResultSchema from "./json-schemas/repair-result.schema.json" with { type: "json" };
+import type { CandidateEvidence, PromotionScore, RepairResult } from "./generated-types.js";
 
 // Shared validation-result shape (matches the production-traces contract).
 export type ValidationResult =
@@ -20,6 +21,7 @@ addFormatsFn(ajv);
 // Register the schemas once at module init so $refs resolve.
 ajv.addSchema(candidateEvidenceSchema as object);
 ajv.addSchema(promotionScoreSchema as object);
+ajv.addSchema(repairResultSchema as object);
 
 const candidateEvidenceValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json",
@@ -27,6 +29,10 @@ const candidateEvidenceValidator = ajv.getSchema(
 
 const promotionScoreValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/promotion-score.json",
+)!;
+
+const repairResultValidator = ajv.getSchema(
+  "https://autocontext.dev/schema/harness-optimization/repair-result.json",
 )!;
 
 function toResult(validate: ValidateFunction, input: unknown): ValidationResult {
@@ -49,5 +55,9 @@ export function validatePromotionScore(input: unknown): ValidationResult {
   return toResult(promotionScoreValidator, input);
 }
 
+export function validateRepairResult(input: unknown): ValidationResult {
+  return toResult(repairResultValidator, input);
+}
+
 // Type-level assertion — if a TS type drifts from its schema this won't compile.
-export type _TypeCheck = CandidateEvidence | PromotionScore;
+export type _TypeCheck = CandidateEvidence | PromotionScore | RepairResult;

--- a/ts/src/harness-optimization/repair-gate.ts
+++ b/ts/src/harness-optimization/repair-gate.ts
@@ -116,6 +116,8 @@ export function finishGuardStep(ctx: RepairContext): RepairResult {
   });
 }
 
+// loop_guard is intentionally omitted from the default set: it has no TypeScript
+// mirror yet, and the default set is kept identical across languages.
 export const DEFAULT_REPAIRS: readonly RepairStep[] = [
   repairToolCallJsonStep,
   repairArtifactLandingStep,
@@ -143,12 +145,21 @@ export class RepairGate {
     this.#channel = channel;
   }
 
-  run(_scenarioName: string, context: RepairContext): RepairResult[] {
+  /**
+   * Invoke each enabled repair over `context`, emitting an event each.
+   *
+   * The emitted payload is `{ scenario, result }`: the RepairResult stays a
+   * self-contained, schema-valid object under `result`, and the scenario rides
+   * alongside as a sibling so consumers can attribute the repair without
+   * polluting the RepairResult schema. Mirrors the Python `RepairGate.run`.
+   */
+  run(scenarioName: string, context: RepairContext): RepairResult[] {
     const results: RepairResult[] = [];
     for (const repair of this.#repairs) {
       const result = repair(context);
       const event = result.status === "applied" ? "repair_applied" : "repair_skipped";
-      this.#emitter.emit(event, result as unknown as Record<string, unknown>, this.#channel);
+      const payload = { scenario: scenarioName, result } as unknown as Record<string, unknown>;
+      this.#emitter.emit(event, payload, this.#channel);
       results.push(result);
     }
     return results;

--- a/ts/src/harness-optimization/repair-gate.ts
+++ b/ts/src/harness-optimization/repair-gate.ts
@@ -1,0 +1,156 @@
+// Opt-in RepairGate: run deterministic repairs and emit trace events (AC-878).
+//
+// TypeScript half of the AC-878 gate. It mirrors the Python reference at
+// `autocontext/src/autocontext/harness_optimization/repair_gate.py`: the gate is
+// a thin, deterministic orchestrator over the pure repairs in `./repairs.js`. It
+// does NOT decide whether it is active; that is the caller's job via
+// `repairGateActiveFor`. When the caller determines the gate is active, it
+// constructs a `RepairGate` and calls `run`, which invokes each enabled repair
+// over the handed context, emits exactly one `repair_applied` / `repair_skipped`
+// event per repair, and returns the collected `RepairResult` list.
+//
+// The gate MAY apply the decision a pure repair returns (record the repaired
+// tool-call json string, record the relocation target) by writing it back onto
+// the context, but it never introduces or alters task content. `repair_applied`
+// is emitted when a repair's status is `applied`; `repair_skipped` covers both
+// `skipped` and `not_applicable`. Events go on the `repair` channel and carry
+// the RepairResult verbatim, so every payload validates against the schema.
+
+import type { EventStreamEmitter } from "../loop/events.js";
+import type { RepairResult } from "./contract/generated-types.js";
+import type { ArtifactContractProbeInputs } from "../control-plane/contract-probes/index.js";
+import { finishGuard, repairArtifactLanding, repairToolCallJson } from "./repairs.js";
+
+export const REPAIR_CHANNEL = "repair";
+
+/** Config carrying the global flag plus the scenario allowlist. */
+export interface RepairGateConfig {
+  readonly enabled: boolean;
+  readonly scenarios: string | readonly string[];
+}
+
+/**
+ * True iff the gate is globally enabled AND the scenario is allowlisted.
+ *
+ * The allowlist is either a comma-separated string or a string array; an empty
+ * allowlist means no scenario is active even when the global flag is on. This is
+ * the sole opt-in decision: callers check it and only build and run a
+ * `RepairGate` when it returns true.
+ */
+export function repairGateActiveFor(config: RepairGateConfig, scenarioName: string): boolean {
+  const raw = typeof config.scenarios === "string" ? config.scenarios.split(",") : config.scenarios;
+  const allowlist = raw.map((s) => s.trim()).filter((s) => s.length > 0);
+  return config.enabled && allowlist.includes(scenarioName);
+}
+
+/**
+ * Recorded state handed to the gate, one field group per enabled repair.
+ *
+ * Every field is optional: a repair whose input is absent returns a
+ * `not_applicable` result. The gate writes applied decisions back onto the two
+ * output fields (`repairedToolCallJson`, `relocationTarget`).
+ */
+export interface RepairContext {
+  toolCallJson?: string;
+  repairedToolCallJson?: string;
+  artifactExpected?: ArtifactContractProbeInputs;
+  artifactProduced?: Record<string, string>;
+  relocationTarget?: string;
+  finishClaimedDone?: boolean;
+  finishCompletionOk?: boolean;
+  finishReasonIfNot?: string;
+}
+
+export type RepairStep = (ctx: RepairContext) => RepairResult;
+
+/** A `not_applicable` result for a repair whose input is absent. */
+function absentResult(repairName: string, reason: string): RepairResult {
+  return {
+    schema_version: 1,
+    repair_name: repairName,
+    status: "not_applicable",
+    reason,
+    target: "",
+    before: { present: false },
+    after: { present: false },
+    parity: { python: "pending", typescript: "implemented", schema_hash: "" },
+  };
+}
+
+/** Run the tool-call json repair; record the repaired string when applied. */
+export function repairToolCallJsonStep(ctx: RepairContext): RepairResult {
+  if (ctx.toolCallJson === undefined) {
+    return absentResult("tool_call_json", "no tool-call json in context");
+  }
+  const { value, result } = repairToolCallJson(ctx.toolCallJson);
+  if (result.status === "applied" && value !== null) {
+    ctx.repairedToolCallJson = value;
+  }
+  return result;
+}
+
+/** Run the artifact-landing repair; record the relocation target when applied. */
+export function repairArtifactLandingStep(ctx: RepairContext): RepairResult {
+  if (ctx.artifactExpected === undefined) {
+    return absentResult("artifact_landing", "no expected artifact contract in context");
+  }
+  const { path, result } = repairArtifactLanding({
+    expected: ctx.artifactExpected,
+    produced: ctx.artifactProduced ?? {},
+  });
+  if (result.status === "applied" && path !== null) {
+    ctx.relocationTarget = path;
+  }
+  return result;
+}
+
+/** Run the finish guard when a completion claim is present in the context. */
+export function finishGuardStep(ctx: RepairContext): RepairResult {
+  if (ctx.finishClaimedDone === undefined) {
+    return absentResult("finish_guard", "no finish claim in context");
+  }
+  return finishGuard({
+    claimedDone: ctx.finishClaimedDone,
+    completionOk: ctx.finishCompletionOk ?? true,
+    reasonIfNot: ctx.finishReasonIfNot ?? "",
+  });
+}
+
+export const DEFAULT_REPAIRS: readonly RepairStep[] = [
+  repairToolCallJsonStep,
+  repairArtifactLandingStep,
+  finishGuardStep,
+];
+
+/**
+ * Thin orchestrator: run each enabled repair, emit one event per result.
+ *
+ * `run` does NOT check whether the gate is active; the caller gates via
+ * `repairGateActiveFor` and only constructs and runs the gate when active.
+ */
+export class RepairGate {
+  readonly #emitter: EventStreamEmitter;
+  readonly #repairs: readonly RepairStep[];
+  readonly #channel: string;
+
+  constructor(
+    emitter: EventStreamEmitter,
+    repairs: readonly RepairStep[] = DEFAULT_REPAIRS,
+    channel: string = REPAIR_CHANNEL,
+  ) {
+    this.#emitter = emitter;
+    this.#repairs = repairs;
+    this.#channel = channel;
+  }
+
+  run(_scenarioName: string, context: RepairContext): RepairResult[] {
+    const results: RepairResult[] = [];
+    for (const repair of this.#repairs) {
+      const result = repair(context);
+      const event = result.status === "applied" ? "repair_applied" : "repair_skipped";
+      this.#emitter.emit(event, result as unknown as Record<string, unknown>, this.#channel);
+      results.push(result);
+    }
+    return results;
+  }
+}

--- a/ts/src/harness-optimization/repairs.ts
+++ b/ts/src/harness-optimization/repairs.ts
@@ -1,0 +1,380 @@
+// Deterministic, pure repair functions for harness surfaces (AC-878).
+//
+// This is the TypeScript half of the AC-878 parity pair. The reference
+// semantics live in
+// `autocontext/src/autocontext/harness_optimization/repairs.py`; this module
+// reproduces the SAME repair decisions (status / reason / target) on the SAME
+// inputs. A shared repo-root fixture
+// (`fixtures/harness-optimization/repair-cases/repair-cases.json`) is loaded by
+// both languages' tests to prove the two implementations agree.
+//
+// Each repair is a PURE function over recorded state: it never calls a model,
+// never reads answer hints, never touches the filesystem, and is fully
+// replayable. A repair inspects the state it is handed, decides whether a known
+// failure mode is present, and returns a `RepairResult` describing what it did
+// (or why it declined). The gate that owns side effects (writing files,
+// breaking a loop, rejecting a finish) acts on the decision; these functions
+// only decide.
+
+import type { RepairResult } from "./contract/generated-types.js";
+import {
+  probeArtifactContract,
+  type ArtifactContractProbeInputs,
+} from "../control-plane/contract-probes/index.js";
+
+/**
+ * Fresh cross-language parity stamp for a TypeScript-implemented repair.
+ *
+ * Python parity is pending until its mirror lands (here it already has); the
+ * schema hash is empty because these repairs share the RepairResult schema,
+ * whose hash is stamped by the sync tooling, not per-call. This mirrors the
+ * Python `_parity()` helper with the implemented/pending sides flipped.
+ */
+function parity(): RepairResult["parity"] {
+  return { python: "pending", typescript: "implemented", schema_hash: "" };
+}
+
+// ---------------------------------------------------------------------------
+// repair 1: tool-call JSON (structural-only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the inside of a ```...``` / ```json...``` fence, else null.
+ *
+ * Structural wrapper removal only: the returned text is a verbatim slice of the
+ * fenced body, so no field value is altered.
+ */
+function stripCodeFence(raw: string): string | null {
+  const stripped = raw.trim();
+  if (!stripped.startsWith("```")) return null;
+  const lines = stripped.split(/\r\n|\r|\n/);
+  if (lines.length < 2) return null;
+  if (!lines[0].startsWith("```")) return null;
+  if (lines[lines.length - 1].trim() !== "```") return null;
+  return lines.slice(1, -1).join("\n");
+}
+
+/**
+ * Drop structural commas that sit immediately before a `}` or `]`.
+ *
+ * String-aware: a comma inside a JSON string literal is copied verbatim, so a
+ * value like `"a,]"` is never mutated. Only a comma the grammar forbids (right
+ * before a closer) is removed.
+ */
+function removeTrailingCommas(raw: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const n = raw.length;
+  let inString = false;
+  let escape = false;
+  while (i < n) {
+    const ch = raw[i];
+    if (inString) {
+      out.push(ch);
+      if (escape) {
+        escape = false;
+      } else if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out.push(ch);
+      i += 1;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < n && " \t\r\n".includes(raw[j])) {
+        j += 1;
+      }
+      if (j < n && (raw[j] === "}" || raw[j] === "]")) {
+        // trailing comma before a closer: drop it, keep the closer.
+        i += 1;
+        continue;
+      }
+    }
+    out.push(ch);
+    i += 1;
+  }
+  return out.join("");
+}
+
+/**
+ * Append one closer iff exactly one brace/bracket is left open.
+ *
+ * Returns null when the truncation is ambiguous: zero unclosed openers, more
+ * than one unclosed opener (multiple plausible closings), or a truncation that
+ * lands inside a string literal.
+ */
+function closeSingleUnclosed(raw: string): string | null {
+  const stack: string[] = [];
+  let inString = false;
+  let escape = false;
+  for (const ch of raw) {
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{" || ch === "[") {
+      stack.push(ch);
+    } else if (ch === "}" || ch === "]") {
+      if (stack.length > 0) stack.pop();
+    }
+  }
+  if (inString) return null;
+  if (stack.length !== 1) return null;
+  return raw + (stack[0] === "{" ? "}" : "]");
+}
+
+function joinReason(prefix: string, suffix: string): string {
+  return prefix ? `${prefix}; ${suffix}` : suffix;
+}
+
+/**
+ * Ordered (reason, candidate) structural repairs to try, most-local first.
+ *
+ * Every candidate is derived from `raw` by structural transforms only (fence
+ * strip, trailing-comma drop, single-closer append), so none can introduce or
+ * change a field value.
+ */
+function structuralAttempts(raw: string): Array<[string, string]> {
+  const attempts: Array<[string, string]> = [];
+
+  const bases: Array<[string, string]> = [["", raw]];
+  const fenced = stripCodeFence(raw);
+  if (fenced !== null && fenced !== raw) {
+    bases.push(["stripped markdown code fence", fenced]);
+  }
+
+  for (const [baseReason, base] of bases) {
+    if (baseReason) {
+      attempts.push([baseReason, base]);
+    }
+    const noComma = removeTrailingCommas(base);
+    if (noComma !== base) {
+      attempts.push([joinReason(baseReason, "removed trailing comma before closer"), noComma]);
+    }
+    const closed = closeSingleUnclosed(base);
+    if (closed !== null && closed !== base) {
+      attempts.push([joinReason(baseReason, "closed a single truncated brace/bracket"), closed]);
+    }
+    if (noComma !== base) {
+      const both = closeSingleUnclosed(noComma);
+      if (both !== null && both !== noComma) {
+        attempts.push([
+          joinReason(baseReason, "removed trailing comma and closed a truncated brace/bracket"),
+          both,
+        ]);
+      }
+    }
+  }
+  return attempts;
+}
+
+function isValidJson(raw: string): boolean {
+  try {
+    JSON.parse(raw);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Structurally repair malformed tool-call JSON without touching values.
+ *
+ * Returns `{ value: json, result }` when already valid or repaired, and
+ * `{ value: null, result }` when the input is ambiguous or unrecoverable by
+ * structural means. Field values are never guessed or altered.
+ */
+export function repairToolCallJson(raw: string): { value: string | null; result: RepairResult } {
+  if (isValidJson(raw)) {
+    return {
+      value: raw,
+      result: {
+        schema_version: 1,
+        repair_name: "tool_call_json",
+        status: "not_applicable",
+        reason: "already valid json",
+        target: "",
+        before: { valid: true },
+        after: { valid: true },
+        parity: parity(),
+      },
+    };
+  }
+
+  for (const [reason, candidate] of structuralAttempts(raw)) {
+    if (!isValidJson(candidate)) continue;
+    return {
+      value: candidate,
+      result: {
+        schema_version: 1,
+        repair_name: "tool_call_json",
+        status: "applied",
+        reason: `structural repair: ${reason}`,
+        target: "",
+        before: { valid: false },
+        after: { valid: true },
+        parity: parity(),
+      },
+    };
+  }
+
+  return {
+    value: null,
+    result: {
+      schema_version: 1,
+      repair_name: "tool_call_json",
+      status: "skipped",
+      reason: "ambiguous or unrecoverable tool json",
+      target: "",
+      before: { valid: false },
+      after: { valid: false },
+      parity: parity(),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// repair 2: artifact landing (relocate by matching existing content)
+// ---------------------------------------------------------------------------
+
+/** Rebuild the expected contract against a candidate path+content, in memory. */
+function contractFor(
+  path: string,
+  content: string,
+  expected: ArtifactContractProbeInputs,
+): ArtifactContractProbeInputs {
+  return {
+    path,
+    content,
+    expectedLineEnding: expected.expectedLineEnding,
+    requiredSubstrings: expected.requiredSubstrings,
+    forbiddenSubstrings: expected.forbiddenSubstrings,
+    requiredJsonFields: expected.requiredJsonFields,
+  };
+}
+
+/**
+ * Detect the "right content, wrong path" landing mistake, purely.
+ *
+ * `produced` maps produced_path -> file content (cached in memory). If the
+ * expected contract already passes, this is `not_applicable`. Otherwise it
+ * searches `produced` for a path whose content satisfies the contract; when
+ * found at a different path, it returns that path as the relocation target. It
+ * performs no filesystem writes: the gate relocates, this function decides.
+ */
+export function repairArtifactLanding({
+  expected,
+  produced,
+}: {
+  expected: ArtifactContractProbeInputs;
+  produced: Record<string, string>;
+}): { path: string | null; result: RepairResult } {
+  if (probeArtifactContract(expected).passed) {
+    return {
+      path: null,
+      result: {
+        schema_version: 1,
+        repair_name: "artifact_landing",
+        status: "not_applicable",
+        reason: "expected artifact already satisfies the contract",
+        target: "",
+        before: { landed: true },
+        after: { landed: true },
+        parity: parity(),
+      },
+    };
+  }
+
+  for (const [producedPath, content] of Object.entries(produced)) {
+    if (producedPath === expected.path) continue;
+    if (probeArtifactContract(contractFor(producedPath, content, expected)).passed) {
+      return {
+        path: producedPath,
+        result: {
+          schema_version: 1,
+          repair_name: "artifact_landing",
+          status: "applied",
+          reason: "expected content found at a different path; relocate",
+          target: producedPath,
+          before: { landed: false },
+          after: { landed: true, source_path: producedPath },
+          parity: parity(),
+        },
+      };
+    }
+  }
+
+  return {
+    path: null,
+    result: {
+      schema_version: 1,
+      repair_name: "artifact_landing",
+      status: "skipped",
+      reason: "no produced artifact matches the expected contract",
+      target: "",
+      before: { landed: false },
+      after: { landed: false },
+      parity: parity(),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// repair 3: finish guard (validate completion before accepting done)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reject a done claim when completion conditions are not met.
+ *
+ * This validates completion; it never fabricates completion. When the run
+ * claims done but `completionOk` is false, the finish is rejected.
+ */
+export function finishGuard({
+  claimedDone,
+  completionOk,
+  reasonIfNot,
+}: {
+  claimedDone: boolean;
+  completionOk: boolean;
+  reasonIfNot: string;
+}): RepairResult {
+  if (claimedDone && !completionOk) {
+    return {
+      schema_version: 1,
+      repair_name: "finish_guard",
+      status: "applied",
+      reason: `finish rejected: ${reasonIfNot}`,
+      target: "",
+      before: { claimed_done: true },
+      after: { accepted_done: false },
+      parity: parity(),
+    };
+  }
+
+  return {
+    schema_version: 1,
+    repair_name: "finish_guard",
+    status: "not_applicable",
+    reason: "no unmet completion claim to reject",
+    target: "",
+    before: { claimed_done: claimedDone },
+    after: { accepted_done: claimedDone },
+    parity: parity(),
+  };
+}

--- a/ts/src/harness-optimization/repairs.ts
+++ b/ts/src/harness-optimization/repairs.ts
@@ -23,15 +23,17 @@ import {
 } from "../control-plane/contract-probes/index.js";
 
 /**
- * Fresh cross-language parity stamp for a TypeScript-implemented repair.
+ * Fresh cross-language parity stamp for the shipped parity repairs.
  *
- * Python parity is pending until its mirror lands (here it already has); the
- * schema hash is empty because these repairs share the RepairResult schema,
- * whose hash is stamped by the sync tooling, not per-call. This mirrors the
- * Python `_parity()` helper with the implemented/pending sides flipped.
+ * All three repairs in this module (repairToolCallJson / repairArtifactLanding
+ * / finishGuard) have a shipped Python mirror, so both sides stamp
+ * "implemented"; the emitted parity subfield is therefore identical across
+ * languages. The schema hash is empty because these repairs share the
+ * RepairResult schema, whose hash is stamped by the sync tooling, not per-call.
+ * This mirrors the Python `_parity()` helper.
  */
 function parity(): RepairResult["parity"] {
-  return { python: "pending", typescript: "implemented", schema_hash: "" };
+  return { python: "implemented", typescript: "implemented", schema_hash: "" };
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/runtimes/claude-cli.ts
+++ b/ts/src/runtimes/claude-cli.ts
@@ -7,6 +7,13 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { which } from "../util.js";
+import type { EventStreamEmitter } from "../loop/events.js";
+import {
+  RepairGate,
+  repairGateActiveFor,
+  type RepairContext,
+  type RepairGateConfig,
+} from "../harness-optimization/repair-gate.js";
 import type { AgentOutput, AgentRuntime } from "./base.js";
 
 const execFileAsync = promisify(execFile);
@@ -22,13 +29,18 @@ export interface ClaudeCLIConfig {
   systemPrompt?: string;
   appendSystemPrompt?: string;
   extraArgs?: string[];
+  // Opt-in AC-878 repair gate. All three must be present AND the gate active for
+  // `repairScenario` for a malformed CLI JSON envelope to be structurally
+  // repaired before the raw-text fallback. Absent (the default) => the parse
+  // path is byte-unchanged.
+  repairGate?: RepairGateConfig;
+  repairScenario?: string;
+  repairEmitter?: EventStreamEmitter;
 }
 
 export class ClaudeCLIRuntime implements AgentRuntime {
   readonly name = "ClaudeCLI";
-  #config: Required<
-    Pick<ClaudeCLIConfig, "model" | "permissionMode" | "timeout">
-  > &
+  #config: Required<Pick<ClaudeCLIConfig, "model" | "permissionMode" | "timeout">> &
     ClaudeCLIConfig;
   #totalCost = 0;
   #claudePath: string | null;
@@ -76,10 +88,7 @@ export class ClaudeCLIRuntime implements AgentRuntime {
     return this.#invoke(revisionPrompt, args);
   }
 
-  #buildArgs(
-    system?: string,
-    schema?: Record<string, unknown>,
-  ): string[] {
+  #buildArgs(system?: string, schema?: Record<string, unknown>): string[] {
     const args = ["-p", "--output-format", "json"];
 
     args.push("--model", this.#config.model);
@@ -147,31 +156,77 @@ export class ClaudeCLIRuntime implements AgentRuntime {
 
   #parseOutput(raw: string): AgentOutput {
     try {
-      const data = JSON.parse(raw);
-      const cost = data.total_cost_usd;
-      if (cost != null) this.#totalCost += cost;
-
-      const modelUsage = data.modelUsage ?? {};
-      const model = Object.keys(modelUsage)[0];
-
-      return {
-        text: data.result ?? "",
-        structured: data.structured_output,
-        costUsd: cost,
-        model,
-        sessionId: data.session_id,
-        metadata: {
-          durationMs: data.duration_ms,
-          durationApiMs: data.duration_api_ms,
-          numTurns: data.num_turns,
-          isError: data.is_error ?? false,
-          usage: data.usage ?? {},
-        },
-      };
+      return this.#buildOutput(JSON.parse(raw));
     } catch {
+      // Opt-in AC-878 seam: try a structural repair of the malformed envelope
+      // before falling back to raw text. Default (no repair config) => the gate
+      // is never consulted and this is byte-identical to the old fallback.
+      const repaired = this.#tryRepairEnvelope(raw);
+      if (repaired !== null) {
+        try {
+          return this.#buildOutput(JSON.parse(repaired));
+        } catch {
+          // repaired string still did not parse; fall through to text fallback.
+        }
+      }
       return { text: raw.trim() };
     }
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  #buildOutput(data: any): AgentOutput {
+    const cost = data.total_cost_usd;
+    if (cost != null) this.#totalCost += cost;
+
+    const modelUsage = data.modelUsage ?? {};
+    const model = Object.keys(modelUsage)[0];
+
+    return {
+      text: data.result ?? "",
+      structured: data.structured_output,
+      costUsd: cost,
+      model,
+      sessionId: data.session_id,
+      metadata: {
+        durationMs: data.duration_ms,
+        durationApiMs: data.duration_api_ms,
+        numTurns: data.num_turns,
+        isError: data.is_error ?? false,
+        usage: data.usage ?? {},
+      },
+    };
+  }
+
+  #tryRepairEnvelope(raw: string): string | null {
+    return repairCliEnvelope(raw, {
+      gate: this.#config.repairGate,
+      scenario: this.#config.repairScenario,
+      emitter: this.#config.repairEmitter,
+    });
+  }
+}
+
+/**
+ * Run the opt-in AC-878 repair gate over a malformed CLI JSON envelope, returning
+ * the structurally repaired string or null. Returns null (a no-op) unless all
+ * three repair fields are present AND `repairGateActiveFor` says the gate is
+ * active for the scenario, so the default parse path stays byte-unchanged. When
+ * active it runs the gate over the raw string and emits one event per repair.
+ */
+export function repairCliEnvelope(
+  raw: string,
+  opts: {
+    gate?: RepairGateConfig;
+    scenario?: string;
+    emitter?: EventStreamEmitter;
+  },
+): string | null {
+  const { gate, scenario, emitter } = opts;
+  if (gate === undefined || scenario === undefined || emitter === undefined) return null;
+  if (!repairGateActiveFor(gate, scenario)) return null;
+  const ctx: RepairContext = { toolCallJson: raw };
+  new RepairGate(emitter).run(scenario, ctx);
+  return ctx.repairedToolCallJson ?? null;
 }
 
 export function createSessionRuntime(opts?: {

--- a/ts/tests/harness-optimization/claude-cli-repair-seam.test.ts
+++ b/ts/tests/harness-optimization/claude-cli-repair-seam.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test, expect } from "vitest";
+import { EventStreamEmitter } from "../../src/loop/events.js";
+import { repairCliEnvelope } from "../../src/runtimes/claude-cli.js";
+
+// The opt-in AC-878 repair seam wired into ClaudeCLIRuntime.#parseOutput. The
+// hard-private parse method delegates to `repairCliEnvelope`, exercised here.
+
+function emitter(): {
+  emitter: EventStreamEmitter;
+  events: Array<{ event: string; payload: Record<string, unknown> }>;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "cli-repair-"));
+  const em = new EventStreamEmitter(join(dir, "events.ndjson"));
+  const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  em.subscribe((event, payload) => events.push({ event, payload }));
+  return { emitter: em, events };
+}
+
+describe("repairCliEnvelope (parse seam)", () => {
+  test("no repair config is a byte-unchanged no-op (returns null, emits nothing)", () => {
+    const { emitter: em, events } = emitter();
+    // No gate/scenario => null regardless of a repairable input.
+    expect(repairCliEnvelope('{"result": "ok",}', {})).toBeNull();
+    expect(
+      repairCliEnvelope('{"result": "ok",}', { emitter: em, scenario: "grid_ctf" }),
+    ).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  test("configured but gate disabled is a no-op", () => {
+    const { emitter: em, events } = emitter();
+    const out = repairCliEnvelope('{"result": "ok",}', {
+      gate: { enabled: false, scenarios: "grid_ctf" },
+      scenario: "grid_ctf",
+      emitter: em,
+    });
+    expect(out).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  test("configured but scenario not allowlisted is a no-op", () => {
+    const { emitter: em, events } = emitter();
+    const out = repairCliEnvelope('{"result": "ok",}', {
+      gate: { enabled: true, scenarios: "othello" },
+      scenario: "grid_ctf",
+      emitter: em,
+    });
+    expect(out).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  test("active gate repairs a malformed envelope and emits at the seam", () => {
+    const { emitter: em, events } = emitter();
+    const out = repairCliEnvelope('{"result": "ok",}', {
+      gate: { enabled: true, scenarios: "grid_ctf" },
+      scenario: "grid_ctf",
+      emitter: em,
+    });
+    // Trailing-comma envelope is structurally repaired and now parses.
+    expect(out).toBe('{"result": "ok"}');
+    expect(JSON.parse(out as string).result).toBe("ok");
+
+    // One event per default repair; the applied one carries the scenario.
+    expect(events).toHaveLength(3);
+    const applied = events.filter((e) => e.event === "repair_applied");
+    expect(applied).toHaveLength(1);
+    expect(applied[0].payload.scenario).toBe("grid_ctf");
+  });
+
+  test("active gate leaves an unrepairable envelope as null (text fallback)", () => {
+    const { emitter: em } = emitter();
+    const out = repairCliEnvelope("{{{{ not json", {
+      gate: { enabled: true, scenarios: "grid_ctf" },
+      scenario: "grid_ctf",
+      emitter: em,
+    });
+    expect(out).toBeNull();
+  });
+});

--- a/ts/tests/harness-optimization/repair-gate.test.ts
+++ b/ts/tests/harness-optimization/repair-gate.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test, expect } from "vitest";
+import { EventStreamEmitter } from "../../src/loop/events.js";
+import { validateRepairResult } from "../../src/harness-optimization/contract/validators.js";
+import type { ArtifactContractProbeInputs } from "../../src/control-plane/contract-probes/index.js";
+import {
+  DEFAULT_REPAIRS,
+  RepairGate,
+  finishGuardStep,
+  repairArtifactLandingStep,
+  repairGateActiveFor,
+  repairToolCallJsonStep,
+  type RepairContext,
+} from "../../src/harness-optimization/repair-gate.js";
+
+// ---------------------------------------------------------------------------
+// repairGateActiveFor: the opt-in truth table (parity with Python)
+// ---------------------------------------------------------------------------
+
+describe("repairGateActiveFor", () => {
+  test("active when enabled and scenario allowlisted", () => {
+    const config = { enabled: true, scenarios: "grid_ctf, othello" };
+    expect(repairGateActiveFor(config, "grid_ctf")).toBe(true);
+    expect(repairGateActiveFor(config, "othello")).toBe(true);
+  });
+
+  test("inactive when enabled but scenario not allowlisted", () => {
+    expect(repairGateActiveFor({ enabled: true, scenarios: "grid_ctf" }, "othello")).toBe(false);
+  });
+
+  test("inactive when disabled even if scenario listed", () => {
+    expect(repairGateActiveFor({ enabled: false, scenarios: "grid_ctf" }, "grid_ctf")).toBe(false);
+  });
+
+  test("inactive when allowlist empty", () => {
+    expect(repairGateActiveFor({ enabled: true, scenarios: "" }, "grid_ctf")).toBe(false);
+  });
+
+  test("accepts a string-array allowlist", () => {
+    expect(repairGateActiveFor({ enabled: true, scenarios: ["grid_ctf"] }, "grid_ctf")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RepairGate.run: events + schema-valid payloads
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+function gate(
+  steps?: readonly ((ctx: RepairContext) => ReturnType<typeof repairToolCallJsonStep>)[],
+): {
+  gate: RepairGate;
+  captured: Captured[];
+} {
+  const dir = mkdtempSync(join(tmpdir(), "repair-gate-"));
+  const emitter = new EventStreamEmitter(join(dir, "events.ndjson"));
+  const captured: Captured[] = [];
+  emitter.subscribe((event, payload) => captured.push({ event, payload }));
+  return { gate: new RepairGate(emitter, steps ?? DEFAULT_REPAIRS), captured };
+}
+
+describe("RepairGate.run", () => {
+  test("emits repair_applied with a schema-valid payload", () => {
+    const { gate: g, captured } = gate([repairToolCallJsonStep]);
+    const ctx: RepairContext = { toolCallJson: '{"a": 1,}' }; // trailing comma -> repairable
+
+    const results = g.run("grid_ctf", ctx);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("applied");
+    expect(ctx.repairedToolCallJson).toBe('{"a": 1}');
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe("repair_applied");
+    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+  });
+
+  test("emits repair_skipped for an ambiguous input", () => {
+    const { gate: g, captured } = gate([repairToolCallJsonStep]);
+    const ctx: RepairContext = { toolCallJson: "{{{{ not json" };
+
+    const results = g.run("grid_ctf", ctx);
+
+    expect(results[0].status).toBe("skipped");
+    expect(captured.map((c) => c.event)).toEqual(["repair_skipped"]);
+    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+  });
+
+  test("emits repair_skipped (not_applicable) for absent input", () => {
+    const { gate: g, captured } = gate([finishGuardStep]);
+    const ctx: RepairContext = {}; // no finish claim present
+
+    const results = g.run("grid_ctf", ctx);
+
+    expect(results[0].status).toBe("not_applicable");
+    expect(captured.map((c) => c.event)).toEqual(["repair_skipped"]);
+    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+  });
+
+  test("applies artifact relocation and emits repair_applied", () => {
+    const expected: ArtifactContractProbeInputs = {
+      path: "out/report.md",
+      content: "",
+      requiredSubstrings: ["SUMMARY"],
+    };
+    const { gate: g, captured } = gate([repairArtifactLandingStep]);
+    const ctx: RepairContext = {
+      artifactExpected: expected,
+      artifactProduced: { "tmp/report.md": "SUMMARY: all good" },
+    };
+
+    const results = g.run("grid_ctf", ctx);
+
+    expect(results[0].status).toBe("applied");
+    expect(ctx.relocationTarget).toBe("tmp/report.md");
+    expect(captured.map((c) => c.event)).toEqual(["repair_applied"]);
+    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+  });
+
+  test("emits one event per enabled repair", () => {
+    const { gate: g, captured } = gate(); // DEFAULT_REPAIRS (three repairs)
+    const ctx: RepairContext = { toolCallJson: '{"a": 1}' };
+
+    const results = g.run("grid_ctf", ctx);
+
+    expect(results).toHaveLength(DEFAULT_REPAIRS.length);
+    expect(DEFAULT_REPAIRS.length).toBe(3);
+    expect(captured).toHaveLength(3);
+    for (const c of captured) {
+      expect(validateRepairResult(c.payload).valid).toBe(true);
+    }
+  });
+});

--- a/ts/tests/harness-optimization/repair-gate.test.ts
+++ b/ts/tests/harness-optimization/repair-gate.test.ts
@@ -77,7 +77,8 @@ describe("RepairGate.run", () => {
     expect(ctx.repairedToolCallJson).toBe('{"a": 1}');
     expect(captured).toHaveLength(1);
     expect(captured[0].event).toBe("repair_applied");
-    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+    expect(captured[0].payload.scenario).toBe("grid_ctf");
+    expect(validateRepairResult(captured[0].payload.result).valid).toBe(true);
   });
 
   test("emits repair_skipped for an ambiguous input", () => {
@@ -88,7 +89,8 @@ describe("RepairGate.run", () => {
 
     expect(results[0].status).toBe("skipped");
     expect(captured.map((c) => c.event)).toEqual(["repair_skipped"]);
-    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+    expect(captured[0].payload.scenario).toBe("grid_ctf");
+    expect(validateRepairResult(captured[0].payload.result).valid).toBe(true);
   });
 
   test("emits repair_skipped (not_applicable) for absent input", () => {
@@ -99,7 +101,7 @@ describe("RepairGate.run", () => {
 
     expect(results[0].status).toBe("not_applicable");
     expect(captured.map((c) => c.event)).toEqual(["repair_skipped"]);
-    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+    expect(validateRepairResult(captured[0].payload.result).valid).toBe(true);
   });
 
   test("applies artifact relocation and emits repair_applied", () => {
@@ -119,7 +121,7 @@ describe("RepairGate.run", () => {
     expect(results[0].status).toBe("applied");
     expect(ctx.relocationTarget).toBe("tmp/report.md");
     expect(captured.map((c) => c.event)).toEqual(["repair_applied"]);
-    expect(validateRepairResult(captured[0].payload).valid).toBe(true);
+    expect(validateRepairResult(captured[0].payload.result).valid).toBe(true);
   });
 
   test("emits one event per enabled repair", () => {
@@ -132,7 +134,8 @@ describe("RepairGate.run", () => {
     expect(DEFAULT_REPAIRS.length).toBe(3);
     expect(captured).toHaveLength(3);
     for (const c of captured) {
-      expect(validateRepairResult(c.payload).valid).toBe(true);
+      expect(c.payload.scenario).toBe("grid_ctf");
+      expect(validateRepairResult(c.payload.result).valid).toBe(true);
     }
   });
 });

--- a/ts/tests/harness-optimization/repair-result.test.ts
+++ b/ts/tests/harness-optimization/repair-result.test.ts
@@ -1,0 +1,103 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test, expect } from "vitest";
+import { validateRepairResult } from "../../src/harness-optimization/contract/validators.js";
+import type { RepairResult } from "../../src/harness-optimization/contract/generated-types.js";
+
+// Walk up to the repo root: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const FIXTURES_DIR = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "fixtures",
+  "harness-optimization",
+  "repair-result",
+);
+
+// The contract fixtures validated by both packages.
+const EXPECTED_FIXTURES = new Set([
+  "valid-applied.json",
+  "valid-skipped.json",
+  "invalid-missing-status.json",
+  "invalid-bad-status.json",
+  "invalid-empty-parity.json",
+]);
+
+function fixtures(prefix: string): string[] {
+  return readdirSync(FIXTURES_DIR)
+    .filter((name) => name.startsWith(prefix) && name.endsWith(".json"))
+    .sort();
+}
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), "utf8"));
+}
+
+// A minimal fully-valid RepairResult used as the fixture-of-record.
+const validResult: RepairResult = {
+  schema_version: 1,
+  repair_name: "tool_call_json",
+  status: "applied",
+  reason: "The tool call arguments were not valid JSON; re-serialized before dispatch.",
+  target: "run_python",
+  before: { valid: false },
+  after: { valid: true },
+  parity: {
+    python: "implemented",
+    typescript: "implemented",
+    schema_hash: "abc123",
+  },
+};
+
+describe("validateRepairResult", () => {
+  test("a fully-valid repair result validates", () => {
+    const result = validateRepairResult(validResult);
+    expect(result.valid).toBe(true);
+  });
+
+  test("a result missing the required status field fails", () => {
+    const { status: _omitted, ...missingStatus } = validResult;
+    const result = validateRepairResult(missingStatus);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.join("\n")).toContain("status");
+    }
+  });
+
+  test("a bad status enum value fails", () => {
+    const result = validateRepairResult({ ...validResult, status: "bogus" });
+    expect(result.valid).toBe(false);
+  });
+
+  test("a result with an unknown extra field fails (additionalProperties)", () => {
+    const withExtra = { ...validResult, surprise_field: "nope" };
+    const result = validateRepairResult(withExtra);
+    expect(result.valid).toBe(false);
+  });
+
+  test("an empty parity object fails (python/typescript/schema_hash required)", () => {
+    const emptyParity = { ...validResult, parity: {} };
+    const result = validateRepairResult(emptyParity);
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("shared repo-root repair-result fixtures", () => {
+  test.each(fixtures("valid-"))("%s validates", (name) => {
+    const result = validateRepairResult(loadFixture(name));
+    expect(result.valid).toBe(true);
+  });
+
+  test.each(fixtures("invalid-"))("%s fails validation", (name) => {
+    const result = validateRepairResult(loadFixture(name));
+    expect(result.valid).toBe(false);
+  });
+
+  test("the fixtures directory contains exactly the expected file set", () => {
+    // Set-membership guard over EVERY .json in the directory: a stray or dropped
+    // .json fails here instead of being silently ignored.
+    const allJson = new Set(readdirSync(FIXTURES_DIR).filter((name) => name.endsWith(".json")));
+    expect(allJson).toEqual(EXPECTED_FIXTURES);
+  });
+});

--- a/ts/tests/harness-optimization/repairs.test.ts
+++ b/ts/tests/harness-optimization/repairs.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test, expect } from "vitest";
+import {
+  repairToolCallJson,
+  repairArtifactLanding,
+  finishGuard,
+} from "../../src/harness-optimization/repairs.js";
+import { validateRepairResult } from "../../src/harness-optimization/contract/validators.js";
+import type { ArtifactContractProbeInputs } from "../../src/control-plane/contract-probes/index.js";
+
+// Load the SAME repo-root fixture the Python suite loads. Matching it in both
+// languages is the load-bearing parity proof: both implementations must return
+// the same status (and target / reason substring) for every recorded input.
+// Walk up to the repo root: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const FIXTURE = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "fixtures",
+  "harness-optimization",
+  "repair-cases",
+  "repair-cases.json",
+);
+
+interface ExpectedDecision {
+  status: "applied" | "skipped" | "not_applicable";
+  reason_contains?: string;
+  target?: string;
+}
+
+interface ToolCallCase {
+  name: string;
+  raw: string;
+  expected: ExpectedDecision;
+}
+
+interface ArtifactContractFixture {
+  path: string;
+  content: string;
+  expected_line_ending?: "lf" | "crlf";
+  required_substrings?: string[];
+  forbidden_substrings?: string[];
+  required_json_fields?: string[];
+}
+
+interface ArtifactLandingCase {
+  name: string;
+  expected_contract: ArtifactContractFixture;
+  produced: Record<string, string>;
+  expected: ExpectedDecision;
+}
+
+interface FinishGuardCase {
+  name: string;
+  claimed_done: boolean;
+  completion_ok: boolean;
+  reason_if_not: string;
+  expected: ExpectedDecision;
+}
+
+const cases = JSON.parse(readFileSync(FIXTURE, "utf8")) as {
+  tool_call: ToolCallCase[];
+  artifact_landing: ArtifactLandingCase[];
+  finish_guard: FinishGuardCase[];
+};
+
+// Map the language-neutral snake_case contract in the fixture to the camelCase
+// probe inputs the TypeScript repair consumes.
+function toProbeInputs(c: ArtifactContractFixture): ArtifactContractProbeInputs {
+  return {
+    path: c.path,
+    content: c.content,
+    expectedLineEnding: c.expected_line_ending,
+    requiredSubstrings: c.required_substrings,
+    forbiddenSubstrings: c.forbidden_substrings,
+    requiredJsonFields: c.required_json_fields,
+  };
+}
+
+function assertDecision(
+  actual: { status: string; reason: string; target?: string },
+  expected: ExpectedDecision,
+): void {
+  expect(actual.status).toBe(expected.status);
+  if (expected.reason_contains !== undefined) {
+    expect(actual.reason).toContain(expected.reason_contains);
+  }
+  if (expected.target !== undefined) {
+    expect(actual.target).toBe(expected.target);
+  }
+}
+
+describe("repairToolCallJson matches the shared fixture", () => {
+  for (const c of cases.tool_call) {
+    test(c.name, () => {
+      const { result } = repairToolCallJson(c.raw);
+      assertDecision(result, c.expected);
+      expect(validateRepairResult(result).valid).toBe(true);
+    });
+  }
+});
+
+describe("repairArtifactLanding matches the shared fixture", () => {
+  for (const c of cases.artifact_landing) {
+    test(c.name, () => {
+      const { result } = repairArtifactLanding({
+        expected: toProbeInputs(c.expected_contract),
+        produced: c.produced,
+      });
+      assertDecision(result, c.expected);
+      expect(validateRepairResult(result).valid).toBe(true);
+    });
+  }
+});
+
+describe("finishGuard matches the shared fixture", () => {
+  for (const c of cases.finish_guard) {
+    test(c.name, () => {
+      const result = finishGuard({
+        claimedDone: c.claimed_done,
+        completionOk: c.completion_ok,
+        reasonIfNot: c.reason_if_not,
+      });
+      assertDecision(result, c.expected);
+      expect(validateRepairResult(result).valid).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
AC-878 in the harness-optimization protocol (AC-875). Builds on AC-876 (contract harness) and AC-877 (promotion score). Spec: docs/superpowers/specs/2026-07-06-harness-optimization-protocol-design.md.

## What this adds

Opt-in deterministic repair gates that fix harness-contract failures with pure, bounded, auditable functions over recorded run state, no model call, no answer hints, emitting trace events, with Python and TS sharing one repair-result schema.

**repair-result contract** (the 3rd harness-optimization artifact) reuses the AC-876/877 codegen harness: one schema plus one `$defs` ref, regenerating both languages. CandidateEvidence and PromotionScore are unchanged; the drift gate now covers all three artifacts.

**Pure deterministic repairs.** Four in Python (tool-call JSON, artifact landing, finish guard, loop guard) and the three required parity repairs in TS. Each is a pure function over cached state that returns a RepairResult. The safety property is enforced structurally: every structural repair candidate is re-parsed before acceptance, so a wrong transform can only produce `skipped`, never a corrupted accept, and no repair can inject task content (tool-call repair is structural-only and string-aware, so a comma inside a string is never touched and no field value is ever changed; artifact landing only relocates existing produced content; finish guard only rejects; loop guard only detects).

**Cross-language parity.** Both languages make identical repair decisions on one shared repo-root fixture (repair-cases.json). The fence-strip line splitting is aligned so exotic Unicode separators are treated identically.

**Opt-in RepairGate.** A global flag (`harness_repair_gates_enabled`, default off) plus a per-scenario allowlist (`harness_repair_gate_scenarios`) gate the repairs. When active, the gate emits `repair_applied`/`repair_skipped` on a dedicated `repair` channel with a `{scenario, result}` payload whose result stays schema-valid. The opt-in check is caller-side, so the gate stays a thin deterministic orchestrator.

**Wiring (default off, byte-unchanged).** The gate is wired at a Python generation-pipeline `stage_repair` (before staged validation) and the TS claude-cli parse seam, both behind the opt-in guard. Golden tests prove the flag-off path is byte-unchanged at each seam; the production advancement and generation paths do not change by default.

## Scope (honest)

- No production stage attaches the tool-call JSON input yet, so the Python seam is opt-in telemetry until a producer is added (documented follow-up).
- Artifact reassembly is deferred (it needs a recorded tool-call trace that does not exist yet), documented in the protocol doc.
- loop_guard is Python-only (no TS mirror yet), so it is out of the gate's default cross-language repair set; documented.

## Verification

75 TS + roughly 130 Python harness-optimization/repair tests: the repair-result contract, the four repairs with adversarial purity cases (string-internal commas untouched, values never changed, no fs writes), the shared repair-cases parity fixture, the opt-in RepairGate truth table and events, and the two wired seams with flag-off golden proofs. The schema drift gate is green on the regenerated files; ruff, mypy strict, and TS lint clean; uv.lock untouched. Each task was implemented and reviewed by separate agents; a whole-branch review re-traced the re-parse-before-accept safety guarantee and confirmed the default-off byte-unchanged wiring.

## Note on CI

The ts-test full-suite job is red for a repo-wide CI-environment reason tracked in AC-892, unrelated to this change. The substantive checks (schema drift gate, lint, Python tests, SDK matrices) pass; the harness-optimization slice passes locally and in the drift-gate/lint jobs.