### PR TITLE
harness optimization: holdout leakage audit + integrity metadata (AC-879)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - harness optimization protocol: candidate-evidence contract with python and typescript parity (AC-876)
 - harness optimization protocol: fresh blended promotion score with recompute-both semantics and python/typescript parity (AC-877)
 - harness optimization protocol: opt-in deterministic repair gates (artifact landing, tool-call json, finish guard, loop guard) with python/typescript parity (AC-878)
+- harness optimization protocol: post-proposal holdout-leakage audit (clean/contaminated/unknown over forbidden-source, forbidden-split, and web-policy passes) and verified/exploratory fail-closed gate with python/typescript parity (AC-879)
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -534,6 +534,14 @@ class AppSettings(BaseModel):
         default="",
         description="Comma-separated scenario allowlist for repair gates; empty = none",
     )
+    harness_leakage_gate_enabled: bool = Field(
+        default=False,
+        description="Opt-in verified-mode leakage gate (AC-879)",
+    )
+    harness_leakage_gate_scenarios: str = Field(
+        default="",
+        description="Comma-separated scenario allowlist for the leakage gate; empty = none",
+    )
     # Pre-flight harness synthesis (AC-150)
     harness_preflight_enabled: bool = Field(
         default=False,

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
@@ -12,6 +12,9 @@
     },
     "RepairResult": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/repair-result.json"
+    },
+    "IntegrityMetadata": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json"
     }
   }
 }

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/integrity-metadata.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/integrity-metadata.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json",
+  "title": "IntegrityMetadata",
+  "description": "Declared integrity scope for a harness-optimization run (AC-879). It records which sources the proposer and evaluator were allowed to read, which are forbidden (holdout, test splits), the web-access policy, the benchmark split manifest in play, and the computed leakage status so a reviewer can prove a candidate was proposed without touching held-out evidence. Verified-mode enforcement (fail closed on contamination or unknown status) is applied by the leakage gate, not by this schema. This schema is the single source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "mode",
+    "allowed_sources",
+    "forbidden_sources",
+    "required_sources",
+    "web_policy",
+    "split_ids",
+    "adapter_capabilities",
+    "leakage_status",
+    "contamination_reasons"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the run this integrity record describes."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["verified", "exploratory"],
+      "description": "Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade."
+    },
+    "allowed_sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Source ids the proposer or evaluator may read."
+    },
+    "forbidden_sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Source ids that must never be read, for example holdout or test-split sources."
+    },
+    "required_sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Subset of sources whose status must be known-clean for a verified run to advance."
+    },
+    "web_policy": {
+      "type": "string",
+      "enum": ["blocked", "allowlist", "open"],
+      "description": "Web-access policy: blocked forbids all web reads, allowlist permits only listed hosts, open permits any."
+    },
+    "web_allowlist": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Hosts permitted when web_policy is allowlist. Optional; omitted or empty means no host is permitted."
+    },
+    "split_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Benchmark or test split manifest ids in play for this run."
+    },
+    "prompt_provenance": {
+      "type": "string",
+      "description": "Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it."
+    },
+    "adapter_capabilities": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "What the runtime or adapter can enforce, for example filesystem sandboxing or network blocking."
+    },
+    "leakage_status": {
+      "type": "string",
+      "enum": ["clean", "contaminated", "unknown"],
+      "description": "Computed leakage status: clean, contaminated, or unknown when it cannot be proven clean."
+    },
+    "contamination_reasons": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Human-readable reasons for a contaminated or unknown status. Empty when clean."
+    }
+  }
+}

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/integrity-metadata.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/integrity-metadata.schema.json
@@ -32,7 +32,7 @@
     "mode": {
       "type": "string",
       "enum": ["verified", "exploratory"],
-      "description": "Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade."
+      "description": "Run mode: verified fails closed on leakage, exploratory is marked non-promotion-grade."
     },
     "allowed_sources": {
       "type": "array",
@@ -55,7 +55,7 @@
       "description": "Web-access policy: blocked forbids all web reads, allowlist permits only listed hosts, open permits any."
     },
     "web_allowlist": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": { "type": "string" },
       "description": "Hosts permitted when web_policy is allowlist. Optional; omitted or empty means no host is permitted."
     },
@@ -65,8 +65,8 @@
       "description": "Benchmark or test split manifest ids in play for this run."
     },
     "prompt_provenance": {
-      "type": "string",
-      "description": "Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it."
+      "type": ["string", "null"],
+      "description": "Where proposer prompts came from. Verified mode requires it non-empty (gate-enforced, not schema)."
     },
     "adapter_capabilities": {
       "type": "array",

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -304,3 +304,83 @@ class RepairResult(BaseModel):
     parity: Annotated[
         Parity, Field(description='Cross-language parity status for this candidate.')
     ]
+
+
+class IntegrityMetadata(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    schema_version: Annotated[
+        Literal[1],
+        Field(
+            description='Schema version for forward compatibility. Always 1 for this revision.'
+        ),
+    ]
+    run_id: Annotated[
+        str,
+        Field(
+            description='Identifier of the run this integrity record describes.',
+            min_length=1,
+        ),
+    ]
+    mode: Annotated[
+        Literal['verified', 'exploratory'],
+        Field(
+            description='Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade.'
+        ),
+    ]
+    allowed_sources: Annotated[
+        list[str], Field(description='Source ids the proposer or evaluator may read.')
+    ]
+    forbidden_sources: Annotated[
+        list[str],
+        Field(
+            description='Source ids that must never be read, for example holdout or test-split sources.'
+        ),
+    ]
+    required_sources: Annotated[
+        list[str],
+        Field(
+            description='Subset of sources whose status must be known-clean for a verified run to advance.'
+        ),
+    ]
+    web_policy: Annotated[
+        Literal['blocked', 'allowlist', 'open'],
+        Field(
+            description='Web-access policy: blocked forbids all web reads, allowlist permits only listed hosts, open permits any.'
+        ),
+    ]
+    web_allowlist: Annotated[
+        list[str] | None,
+        Field(
+            description='Hosts permitted when web_policy is allowlist. Optional; omitted or empty means no host is permitted.'
+        ),
+    ] = None
+    split_ids: Annotated[
+        list[str],
+        Field(description='Benchmark or test split manifest ids in play for this run.'),
+    ]
+    prompt_provenance: Annotated[
+        str | None,
+        Field(
+            description='Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it.'
+        ),
+    ] = None
+    adapter_capabilities: Annotated[
+        list[str],
+        Field(
+            description='What the runtime or adapter can enforce, for example filesystem sandboxing or network blocking.'
+        ),
+    ]
+    leakage_status: Annotated[
+        Literal['clean', 'contaminated', 'unknown'],
+        Field(
+            description='Computed leakage status: clean, contaminated, or unknown when it cannot be proven clean.'
+        ),
+    ]
+    contamination_reasons: Annotated[
+        list[str],
+        Field(
+            description='Human-readable reasons for a contaminated or unknown status. Empty when clean.'
+        ),
+    ]

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -326,7 +326,7 @@ class IntegrityMetadata(BaseModel):
     mode: Annotated[
         Literal['verified', 'exploratory'],
         Field(
-            description='Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade.'
+            description='Run mode: verified fails closed on leakage, exploratory is marked non-promotion-grade.'
         ),
     ]
     allowed_sources: Annotated[
@@ -363,7 +363,7 @@ class IntegrityMetadata(BaseModel):
     prompt_provenance: Annotated[
         str | None,
         Field(
-            description='Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it.'
+            description='Where proposer prompts came from. Verified mode requires it non-empty (gate-enforced, not schema).'
         ),
     ] = None
     adapter_capabilities: Annotated[

--- a/autocontext/src/autocontext/harness_optimization/leakage.py
+++ b/autocontext/src/autocontext/harness_optimization/leakage.py
@@ -34,16 +34,14 @@ def _web_host(resource: str) -> str:
 
 def audit_leakage(metadata: IntegrityMetadata, access_records: Sequence[AccessRecord]) -> LeakageAudit:
     forbidden = set(metadata.forbidden_sources)
-    split_ids = set(metadata.split_ids)
     allowlist = set(metadata.web_allowlist or [])
     reasons: list[str] = []
 
+    # Pass 1: forbidden source read.
     for rec in access_records:
         if rec.source_id in forbidden:
             reasons.append(f"forbidden source read: {rec.source_id} ({rec.resource})")
-    for rec in access_records:
-        if rec.kind == "split" and rec.resource in split_ids and rec.source_id in forbidden:
-            reasons.append(f"forbidden split touched: {rec.resource}")
+    # Pass 2: web policy.
     for rec in access_records:
         if rec.kind == "web":
             host = _web_host(rec.resource)
@@ -63,3 +61,23 @@ def audit_leakage(metadata: IntegrityMetadata, access_records: Sequence[AccessRe
             reasons=tuple(f"required source unproven: {s}" for s in unknown),
         )
     return LeakageAudit(status="clean", reasons=())
+
+
+def render_leakage_report(metadata: IntegrityMetadata, audit: LeakageAudit) -> str:
+    """Render a short multi-line report of the metadata policy and the computed audit.
+
+    Lists mode, allowed_sources, forbidden_sources, required_sources, web_policy,
+    web_allowlist, the computed status, and each reason prefixed with ``- ``.
+    """
+    lines = [
+        "autocontext leakage audit",
+        f"mode: {metadata.mode}",
+        f"allowed_sources: {', '.join(metadata.allowed_sources)}",
+        f"forbidden_sources: {', '.join(metadata.forbidden_sources)}",
+        f"required_sources: {', '.join(metadata.required_sources)}",
+        f"web_policy: {metadata.web_policy}",
+        f"web_allowlist: {', '.join(metadata.web_allowlist or [])}",
+        f"status: {audit.status}",
+    ]
+    lines.extend(f"- {reason}" for reason in audit.reasons)
+    return "\n".join(lines)

--- a/autocontext/src/autocontext/harness_optimization/leakage.py
+++ b/autocontext/src/autocontext/harness_optimization/leakage.py
@@ -1,0 +1,65 @@
+"""Deterministic post-proposal leakage audit (AC-879).
+
+Pure functions over declared integrity metadata plus observed access records.
+No filesystem or network access: the caller supplies the access log. Maps a run
+to clean | contaminated | unknown so a verified gate can fail closed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from autocontext.harness_optimization.contract.models import IntegrityMetadata
+
+
+@dataclass(frozen=True, slots=True)
+class AccessRecord:
+    resource: str
+    source_id: str
+    kind: str  # "file" | "trace" | "web" | "split"
+
+
+@dataclass(frozen=True, slots=True)
+class LeakageAudit:
+    status: str  # "clean" | "contaminated" | "unknown"
+    reasons: tuple[str, ...]
+
+
+def _web_host(resource: str) -> str:
+    parsed = urlparse(resource if "://" in resource else f"//{resource}")
+    return parsed.hostname or resource
+
+
+def audit_leakage(metadata: IntegrityMetadata, access_records: Sequence[AccessRecord]) -> LeakageAudit:
+    forbidden = set(metadata.forbidden_sources)
+    split_ids = set(metadata.split_ids)
+    allowlist = set(metadata.web_allowlist or [])
+    reasons: list[str] = []
+
+    for rec in access_records:
+        if rec.source_id in forbidden:
+            reasons.append(f"forbidden source read: {rec.source_id} ({rec.resource})")
+    for rec in access_records:
+        if rec.kind == "split" and rec.resource in split_ids and rec.source_id in forbidden:
+            reasons.append(f"forbidden split touched: {rec.resource}")
+    for rec in access_records:
+        if rec.kind == "web":
+            host = _web_host(rec.resource)
+            if metadata.web_policy == "blocked":
+                reasons.append(f"web access under blocked policy: {host}")
+            elif metadata.web_policy == "allowlist" and host not in allowlist:
+                reasons.append(f"web host not in allowlist: {host}")
+
+    if reasons:
+        return LeakageAudit(status="contaminated", reasons=tuple(reasons))
+
+    covered = {rec.source_id for rec in access_records}
+    unknown = [s for s in metadata.required_sources if s not in covered and s not in metadata.allowed_sources]
+    if unknown:
+        return LeakageAudit(
+            status="unknown",
+            reasons=tuple(f"required source unproven: {s}" for s in unknown),
+        )
+    return LeakageAudit(status="clean", reasons=())

--- a/autocontext/src/autocontext/harness_optimization/leakage_gate.py
+++ b/autocontext/src/autocontext/harness_optimization/leakage_gate.py
@@ -10,8 +10,25 @@ invokes it.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from autocontext.harness_optimization.leakage import LeakageAudit
+
+if TYPE_CHECKING:
+    from autocontext.config.settings import AppSettings
+
+
+def leakage_gate_active_for(settings: AppSettings, scenario_name: str) -> bool:
+    """True iff the leakage gate is globally enabled AND the scenario is allowlisted.
+
+    The allowlist is the comma-separated ``harness_leakage_gate_scenarios``
+    setting; an empty allowlist means no scenario is active even when the global
+    flag is on. This is the sole opt-in decision: callers check it and only run
+    the leakage audit + gate when it returns True.
+    """
+
+    allowlist = {s.strip() for s in settings.harness_leakage_gate_scenarios.split(",") if s.strip()}
+    return settings.harness_leakage_gate_enabled and scenario_name in allowlist
 
 
 @dataclass(frozen=True, slots=True)

--- a/autocontext/src/autocontext/harness_optimization/leakage_gate.py
+++ b/autocontext/src/autocontext/harness_optimization/leakage_gate.py
@@ -1,0 +1,43 @@
+"""Verified/exploratory leakage gate (AC-879).
+
+Consumes a LeakageAudit and the run mode. Verified runs fail closed on
+contaminated or unknown status, or on missing prompt provenance. Exploratory
+runs always advance but are stamped non-promotion-grade. Caller-gated: this
+function never reads settings, so default runs are unaffected until a caller
+invokes it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.harness_optimization.leakage import LeakageAudit
+
+
+@dataclass(frozen=True, slots=True)
+class LeakageGateDecision:
+    advance: bool
+    non_promotion_grade: bool
+    rationale: str
+
+
+def evaluate_leakage_gate(audit: LeakageAudit, mode: str, prompt_provenance: str) -> LeakageGateDecision:
+    if mode == "exploratory":
+        return LeakageGateDecision(
+            advance=True,
+            non_promotion_grade=True,
+            rationale="exploratory override: advancing non-promotion-grade regardless of leakage",
+        )
+    # verified
+    blockers: list[str] = []
+    if audit.status != "clean":
+        blockers.append(f"leakage status {audit.status}: {'; '.join(audit.reasons)}")
+    if not prompt_provenance.strip():
+        blockers.append("missing prompt provenance")
+    if blockers:
+        return LeakageGateDecision(
+            advance=False,
+            non_promotion_grade=True,
+            rationale="verified run blocked: " + "; ".join(blockers),
+        )
+    return LeakageGateDecision(advance=True, non_promotion_grade=False, rationale="verified run clean")

--- a/autocontext/src/autocontext/loop/generation_pipeline.py
+++ b/autocontext/src/autocontext/loop/generation_pipeline.py
@@ -19,6 +19,7 @@ from autocontext.extensions import HookEvents
 from autocontext.knowledge.coherence import check_coherence
 from autocontext.loop.cost_control import CostBudget, CostPolicy, CostTracker, throttle_state
 from autocontext.loop.stage_helpers.tournament_prep import _build_empty_tournament
+from autocontext.loop.stage_leakage import stage_leakage
 from autocontext.loop.stage_preflight import stage_preflight
 from autocontext.loop.stage_prevalidation import stage_prevalidation
 from autocontext.loop.stage_probe import stage_probe
@@ -458,6 +459,10 @@ class GenerationPipeline:
                 # Stage 2.25: Opt-in deterministic repair gate (default off => no-op)
                 if not _over_budget(ctx) and not _phase_exhausted(scaffolding_started_at, scaffolding_budget):
                     ctx = stage_repair(ctx, events=self._events)
+
+                # Stage 2.26: Opt-in verified-mode leakage gate (default off => no-op)
+                if not _over_budget(ctx) and not _phase_exhausted(scaffolding_started_at, scaffolding_budget):
+                    ctx = stage_leakage(ctx, events=self._events)
 
                 # Stage 2.3: Staged validation (progressive checks before tournament)
                 if not _over_budget(ctx) and not _phase_exhausted(scaffolding_started_at, scaffolding_budget):

--- a/autocontext/src/autocontext/loop/stage_leakage.py
+++ b/autocontext/src/autocontext/loop/stage_leakage.py
@@ -1,0 +1,92 @@
+"""Opt-in leakage stage: runs the verified-mode leakage gate in the pipeline (AC-879).
+
+This is the pre-scoring seam for the AC-879 leakage gate, mirroring the AC-878
+repair-gate seam. It sits alongside :func:`stage_repair` and is caller-gated: it
+early-returns unless :func:`leakage_gate_active_for` says the gate is active for
+this scenario, so with the default flags OFF the generation path is
+byte-unchanged (this stage is a no-op that touches nothing on ``ctx``, reads
+nothing, and emits no events).
+
+When active, it looks for declared integrity metadata under
+``ctx.current_strategy["__integrity_metadata__"]`` and observed access records
+under ``ctx.current_strategy["__access_records__"]``. It builds an
+:class:`IntegrityMetadata`, runs :func:`audit_leakage`, evaluates the gate via
+:func:`evaluate_leakage_gate`, and records the decision onto
+``ctx.exploration_metadata["leakage_gate"]`` plus one telemetry event on the
+``leakage`` channel. When the gate fails closed it appends ``leakage_blocked``
+to ``ctx.gate_decision_history``.
+
+No production stage attaches the integrity-metadata key yet, so the stage is
+opt-in telemetry until a producer is added (a documented follow-up, consistent
+with the AC-878 deferred-producer pattern). Full advancement enforcement (acting
+on a blocked decision to halt promotion) is likewise a follow-up: this stage
+records the gate decision and telemetry, opt-in and default-off.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from autocontext.harness_optimization.contract.models import IntegrityMetadata
+from autocontext.harness_optimization.leakage import AccessRecord, audit_leakage
+from autocontext.harness_optimization.leakage_gate import evaluate_leakage_gate, leakage_gate_active_for
+from autocontext.loop.stage_types import GenerationContext
+
+if TYPE_CHECKING:
+    from autocontext.loop.events import EventStreamEmitter
+
+LEAKAGE_CHANNEL = "leakage"
+_INTEGRITY_METADATA_KEY = "__integrity_metadata__"
+_ACCESS_RECORDS_KEY = "__access_records__"
+
+
+def stage_leakage(
+    ctx: GenerationContext,
+    *,
+    events: EventStreamEmitter | None = None,
+) -> GenerationContext:
+    """Run the opt-in leakage gate when active; otherwise a byte-unchanged no-op."""
+
+    if not leakage_gate_active_for(ctx.settings, ctx.scenario_name):
+        return ctx
+
+    strategy = ctx.current_strategy if isinstance(ctx.current_strategy, dict) else {}
+    meta = strategy.get(_INTEGRITY_METADATA_KEY)
+    if not isinstance(meta, dict):
+        if events is not None:
+            events.emit(
+                "leakage_skipped",
+                {"scenario": ctx.scenario_name, "reason": "no integrity metadata"},
+                channel=LEAKAGE_CHANNEL,
+            )
+        return ctx
+
+    records = strategy.get(_ACCESS_RECORDS_KEY, [])
+    meta_model = IntegrityMetadata.model_validate(meta)
+    access_records = [AccessRecord(**r) for r in records]
+    audit = audit_leakage(meta_model, access_records)
+    decision = evaluate_leakage_gate(audit, meta_model.mode, meta_model.prompt_provenance or "")
+
+    if events is not None:
+        events.emit(
+            "leakage_clean" if decision.advance else "leakage_blocked",
+            {
+                "scenario": ctx.scenario_name,
+                "status": audit.status,
+                "advance": decision.advance,
+                "non_promotion_grade": decision.non_promotion_grade,
+                "rationale": decision.rationale,
+            },
+            channel=LEAKAGE_CHANNEL,
+        )
+
+    ctx.exploration_metadata["leakage_gate"] = {
+        "status": audit.status,
+        "advance": decision.advance,
+        "non_promotion_grade": decision.non_promotion_grade,
+        "rationale": decision.rationale,
+    }
+    if not decision.advance:
+        ctx.gate_decision_history.append("leakage_blocked")
+
+    return ctx

--- a/autocontext/tests/harness_optimization/test_integrity_metadata_contract.py
+++ b/autocontext/tests/harness_optimization/test_integrity_metadata_contract.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from autocontext.harness_optimization.contract.models import IntegrityMetadata
 
@@ -17,5 +18,5 @@ def test_valid_verified_clean_round_trips() -> None:
 
 def test_missing_mode_rejected() -> None:
     data = json.loads((FIX / "invalid-missing-mode.json").read_text())
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         IntegrityMetadata.model_validate(data)

--- a/autocontext/tests/harness_optimization/test_integrity_metadata_contract.py
+++ b/autocontext/tests/harness_optimization/test_integrity_metadata_contract.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from autocontext.harness_optimization.contract.models import IntegrityMetadata
+
+FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "integrity-metadata"
+
+
+def test_valid_verified_clean_round_trips() -> None:
+    data = json.loads((FIX / "valid-verified-clean.json").read_text())
+    model = IntegrityMetadata.model_validate(data)
+    assert model.mode == "verified"
+    assert model.leakage_status == "clean"
+
+
+def test_missing_mode_rejected() -> None:
+    data = json.loads((FIX / "invalid-missing-mode.json").read_text())
+    with pytest.raises(Exception):
+        IntegrityMetadata.model_validate(data)

--- a/autocontext/tests/harness_optimization/test_leakage_audit.py
+++ b/autocontext/tests/harness_optimization/test_leakage_audit.py
@@ -2,9 +2,13 @@ import json
 from pathlib import Path
 
 import pytest
-from autocontext.harness_optimization.leakage import AccessRecord, audit_leakage
 
 from autocontext.harness_optimization.contract.models import IntegrityMetadata
+from autocontext.harness_optimization.leakage import (
+    AccessRecord,
+    audit_leakage,
+    render_leakage_report,
+)
 
 FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "leakage-cases" / "leakage-cases.json"
 CASES = json.loads(FIX.read_text())["cases"]
@@ -19,13 +23,12 @@ def test_audit_matches_fixture(case: dict) -> None:
     assert len(audit.reasons) == case["expected_reason_count"]
 
 
-def test_forbidden_split_touch_is_contaminated() -> None:
-    meta = IntegrityMetadata.model_validate(CASES[0]["metadata"])
-    rec = AccessRecord(
-        resource=meta.split_ids[0] if meta.split_ids else "holdout-1",
-        source_id="split",
-        kind="split",
-    )
-    # only meaningful when the fixture's clean case declares a forbidden split; assert deterministic reason text
-    audit = audit_leakage(meta, [rec])
-    assert audit.status in {"clean", "contaminated", "unknown"}
+def test_render_report_shows_status_and_forbidden() -> None:
+    case = CASES[0]
+    meta = IntegrityMetadata.model_validate(case["metadata"])
+    audit = audit_leakage(meta, [AccessRecord(**r) for r in case["access_records"]])
+    report = render_leakage_report(meta, audit)
+    assert f"status: {audit.status}" in report
+    assert "forbidden_sources:" in report
+    assert "required_sources:" in report
+    assert "web_allowlist:" in report

--- a/autocontext/tests/harness_optimization/test_leakage_audit.py
+++ b/autocontext/tests/harness_optimization/test_leakage_audit.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+import pytest
+from autocontext.harness_optimization.leakage import AccessRecord, audit_leakage
+
+from autocontext.harness_optimization.contract.models import IntegrityMetadata
+
+FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "leakage-cases" / "leakage-cases.json"
+CASES = json.loads(FIX.read_text())["cases"]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
+def test_audit_matches_fixture(case: dict) -> None:
+    meta = IntegrityMetadata.model_validate(case["metadata"])
+    records = [AccessRecord(**r) for r in case["access_records"]]
+    audit = audit_leakage(meta, records)
+    assert audit.status == case["expected_status"]
+    assert len(audit.reasons) == case["expected_reason_count"]
+
+
+def test_forbidden_split_touch_is_contaminated() -> None:
+    meta = IntegrityMetadata.model_validate(CASES[0]["metadata"])
+    rec = AccessRecord(
+        resource=meta.split_ids[0] if meta.split_ids else "holdout-1",
+        source_id="split",
+        kind="split",
+    )
+    # only meaningful when the fixture's clean case declares a forbidden split; assert deterministic reason text
+    audit = audit_leakage(meta, [rec])
+    assert audit.status in {"clean", "contaminated", "unknown"}

--- a/autocontext/tests/harness_optimization/test_leakage_gate.py
+++ b/autocontext/tests/harness_optimization/test_leakage_gate.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from autocontext.harness_optimization.contract.models import IntegrityMetadata
+from autocontext.harness_optimization.leakage import AccessRecord, audit_leakage
+from autocontext.harness_optimization.leakage_gate import evaluate_leakage_gate
+
+FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "leakage-cases" / "leakage-cases.json"
+CASES = [c for c in json.loads(FIX.read_text())["cases"] if "gate" in c]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
+def test_gate_matches_fixture(case: dict) -> None:
+    meta = IntegrityMetadata.model_validate(case["metadata"])
+    audit = audit_leakage(meta, [AccessRecord(**r) for r in case["access_records"]])
+    decision = evaluate_leakage_gate(audit, meta.mode, meta.prompt_provenance or "")
+    assert decision.advance is case["gate"]["expected_advance"]
+    assert decision.non_promotion_grade is case["gate"]["expected_non_promotion_grade"]

--- a/autocontext/tests/harness_optimization/test_leakage_gate.py
+++ b/autocontext/tests/harness_optimization/test_leakage_gate.py
@@ -11,6 +11,9 @@ FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" 
 CASES = [c for c in json.loads(FIX.read_text())["cases"] if "gate" in c]
 
 
+BY_NAME = {c["name"]: c for c in json.loads(FIX.read_text())["cases"]}
+
+
 @pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
 def test_gate_matches_fixture(case: dict) -> None:
     meta = IntegrityMetadata.model_validate(case["metadata"])
@@ -18,3 +21,21 @@ def test_gate_matches_fixture(case: dict) -> None:
     decision = evaluate_leakage_gate(audit, meta.mode, meta.prompt_provenance or "")
     assert decision.advance is case["gate"]["expected_advance"]
     assert decision.non_promotion_grade is case["gate"]["expected_non_promotion_grade"]
+
+
+def test_blocked_verified_rationale_is_exact() -> None:
+    case = BY_NAME["holdout_file_touch"]
+    meta = IntegrityMetadata.model_validate(case["metadata"])
+    audit = audit_leakage(meta, [AccessRecord(**r) for r in case["access_records"]])
+    decision = evaluate_leakage_gate(audit, meta.mode, meta.prompt_provenance or "")
+    assert decision.rationale == (
+        "verified run blocked: leakage status contaminated: forbidden source read: holdout-split (data/holdout.jsonl)"
+    )
+
+
+def test_exploratory_override_rationale_is_exact() -> None:
+    case = BY_NAME["exploratory_override"]
+    meta = IntegrityMetadata.model_validate(case["metadata"])
+    audit = audit_leakage(meta, [AccessRecord(**r) for r in case["access_records"]])
+    decision = evaluate_leakage_gate(audit, meta.mode, meta.prompt_provenance or "")
+    assert decision.rationale == ("exploratory override: advancing non-promotion-grade regardless of leakage")

--- a/autocontext/tests/test_stage_leakage.py
+++ b/autocontext/tests/test_stage_leakage.py
@@ -1,0 +1,170 @@
+"""Tests for the opt-in leakage stage wired into the generation pipeline (AC-879).
+
+Mirrors the AC-878 repair-gate seam. Two properties are pinned:
+
+- flag OFF (the default): the stage is a byte-unchanged no-op. It returns the
+  identical context, mutates nothing, and reads nothing.
+- flag ON (scenario allowlisted): the stage reads declared integrity metadata
+  plus access records off the strategy, runs the leakage audit + gate, records
+  the decision onto ``ctx.exploration_metadata`` and telemetry, and appends
+  ``leakage_blocked`` to the gate decision history when the gate fails closed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from autocontext.config.settings import AppSettings
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.loop.stage_leakage import stage_leakage
+from autocontext.loop.stage_types import GenerationContext
+
+
+class _FakeScenario:
+    name = "grid_ctf"
+
+
+def _make_ctx(
+    *,
+    enabled: bool,
+    scenarios: str,
+    strategy: dict[str, Any] | None = None,
+) -> GenerationContext:
+    settings = AppSettings(
+        harness_leakage_gate_enabled=enabled,
+        harness_leakage_gate_scenarios=scenarios,
+    )
+    return GenerationContext(
+        run_id="test-run",
+        scenario_name="grid_ctf",
+        scenario=_FakeScenario(),
+        generation=1,
+        settings=settings,
+        previous_best=0.0,
+        challenger_elo=1000.0,
+        score_history=[],
+        gate_decision_history=[],
+        coach_competitor_hints="",
+        replay_narrative="",
+        current_strategy=strategy if strategy is not None else {"action": "move"},
+    )
+
+
+def _capture(tmp_path: Path) -> tuple[EventStreamEmitter, list[tuple[str, dict[str, object]]]]:
+    emitter = EventStreamEmitter(tmp_path / "events.ndjson")
+    events: list[tuple[str, dict[str, object]]] = []
+    emitter.subscribe(lambda event, payload: events.append((event, payload)))
+    return emitter, events
+
+
+def _integrity_meta(*, mode: str, forbidden: list[str], status: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "run_id": "test-run",
+        "mode": mode,
+        "allowed_sources": [],
+        "forbidden_sources": forbidden,
+        "required_sources": [],
+        "web_policy": "open",
+        "web_allowlist": None,
+        "split_ids": [],
+        "prompt_provenance": "repo",
+        "adapter_capabilities": [],
+        "leakage_status": status,
+        "contamination_reasons": [],
+    }
+
+
+def test_flag_off_is_byte_unchanged_no_op(tmp_path: Path) -> None:
+    # Golden: with the gate disabled the stage returns the identical context,
+    # mutates nothing, and emits nothing (byte-unchanged default path).
+    strategy = {
+        "action": "move",
+        "__integrity_metadata__": _integrity_meta(mode="verified", forbidden=["holdout"], status="contaminated"),
+        "__access_records__": [{"resource": "holdout.txt", "source_id": "holdout", "kind": "file"}],
+    }
+    ctx = _make_ctx(enabled=False, scenarios="grid_ctf", strategy=strategy)
+    before = dict(ctx.current_strategy)
+    emitter, events = _capture(tmp_path)
+
+    result = stage_leakage(ctx, events=emitter)
+
+    assert result is ctx
+    assert ctx.current_strategy == before
+    assert "leakage_gate" not in ctx.exploration_metadata
+    assert ctx.gate_decision_history == []
+    assert events == []
+    assert not (tmp_path / "events.ndjson").exists()
+
+
+def test_flag_off_when_scenario_not_allowlisted(tmp_path: Path) -> None:
+    ctx = _make_ctx(enabled=True, scenarios="othello", strategy={"action": "move"})
+    emitter, events = _capture(tmp_path)
+
+    result = stage_leakage(ctx, events=emitter)
+
+    assert result is ctx
+    assert "leakage_gate" not in ctx.exploration_metadata
+    assert events == []
+
+
+def test_active_without_integrity_metadata_emits_skip(tmp_path: Path) -> None:
+    ctx = _make_ctx(enabled=True, scenarios="grid_ctf", strategy={"action": "move"})
+    emitter, events = _capture(tmp_path)
+
+    result = stage_leakage(ctx, events=emitter)
+
+    assert result is ctx
+    assert "leakage_gate" not in ctx.exploration_metadata
+    assert [event for event, _ in events] == ["leakage_skipped"]
+    payload = events[0][1]
+    assert payload["scenario"] == "grid_ctf"
+    assert payload["reason"] == "no integrity metadata"
+
+
+def test_active_contaminated_blocks(tmp_path: Path) -> None:
+    strategy = {
+        "__integrity_metadata__": _integrity_meta(mode="verified", forbidden=["holdout"], status="contaminated"),
+        "__access_records__": [{"resource": "holdout.txt", "source_id": "holdout", "kind": "file"}],
+    }
+    ctx = _make_ctx(enabled=True, scenarios="grid_ctf", strategy=strategy)
+    emitter, events = _capture(tmp_path)
+
+    stage_leakage(ctx, events=emitter)
+
+    decision = ctx.exploration_metadata["leakage_gate"]
+    assert decision["advance"] is False
+    assert decision["status"] == "contaminated"
+    assert ctx.gate_decision_history == ["leakage_blocked"]
+    assert [event for event, _ in events] == ["leakage_blocked"]
+
+
+def test_active_clean_advances(tmp_path: Path) -> None:
+    strategy = {
+        "__integrity_metadata__": _integrity_meta(mode="verified", forbidden=[], status="clean"),
+        "__access_records__": [],
+    }
+    ctx = _make_ctx(enabled=True, scenarios="grid_ctf", strategy=strategy)
+    emitter, events = _capture(tmp_path)
+
+    stage_leakage(ctx, events=emitter)
+
+    decision = ctx.exploration_metadata["leakage_gate"]
+    assert decision["advance"] is True
+    assert decision["status"] == "clean"
+    assert ctx.gate_decision_history == []
+    assert [event for event, _ in events] == ["leakage_clean"]
+
+
+def test_active_without_events_emitter_is_safe(tmp_path: Path) -> None:
+    strategy = {
+        "__integrity_metadata__": _integrity_meta(mode="verified", forbidden=[], status="clean"),
+        "__access_records__": [],
+    }
+    ctx = _make_ctx(enabled=True, scenarios="grid_ctf", strategy=strategy)
+
+    result = stage_leakage(ctx)
+
+    assert result is ctx
+    assert ctx.exploration_metadata["leakage_gate"]["advance"] is True

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -268,25 +268,28 @@ sequence of observed `AccessRecord`s (each an `{resource, source_id, kind}`
 triple, where kind is `file`, `trace`, `web`, or `split`) and return a
 `LeakageAudit` of `status` plus `reasons`. Both are pure functions over the
 declared policy and the supplied access log: no filesystem or network access, so
-the same inputs always produce the same verdict. The audit runs three
-contamination passes and, only if all three are clean, one proven-clean check:
+the same inputs always produce the same verdict. The audit runs two
+contamination passes and, only if both are clean, one proven-clean check:
 
 - **Pass 1, forbidden source read**: any access record whose `source_id` is a
   forbidden source is a contamination.
-- **Pass 2, forbidden split touched**: any `split`-kind record whose `resource`
-  is a declared split id and whose `source_id` is forbidden is a contamination.
-- **Pass 3, web policy**: under a `blocked` policy any web read is a
+- **Pass 2, web policy**: under a `blocked` policy any web read is a
   contamination; under an `allowlist` policy a web read whose host is not in the
   allowlist is a contamination; an `open` policy permits any host.
 
+Holdout/forbidden detection is source-id-attribution-based: an access record must
+carry the forbidden `source_id` to be flagged, so `split_ids` and
+`adapter_capabilities` are declarative metadata, not audited.
+
 If any pass fires, the status is `contaminated` and every reason is listed. If
-all three passes are clean, the audit applies the **required-source proven-clean
+both passes are clean, the audit applies the **required-source proven-clean
 rule**: a required source is proven clean when it is a declared allowed source OR
 it appears in the access log. Any required source that is neither is unproven, so
 the status is `unknown` (the run cannot be shown clean, but no contamination was
 observed either). Only when every required source is proven clean is the status
-`clean`. `renderLeakageReport` (TypeScript) renders a short human-readable report
-of the policy plus the computed status and reasons.
+`clean`. `render_leakage_report` (Python) and `renderLeakageReport` (TypeScript)
+render a short human-readable report of the policy (including `required_sources`
+and `web_allowlist`) plus the computed status and reasons.
 
 ### Verified fail-closed and the exploratory override
 
@@ -312,10 +315,10 @@ it only means the result cannot be trusted as a clean measurement, so it must no
 enter the promotion set. Framing these as discarded rather than as failures keeps
 the leakage signal honest and separate from the quality signal.
 
-### The five worked cases
+### The worked cases
 
 A shared fixture
-(`fixtures/harness-optimization/leakage-cases/leakage-cases.json`) pins five
+(`fixtures/harness-optimization/leakage-cases/leakage-cases.json`) pins eight
 cases that both packages load to prove they compute identical statuses, reason
 counts, and gate decisions:
 
@@ -334,6 +337,16 @@ counts, and gate decisions:
 - **exploratory_override**: an exploratory run peeks at the forbidden
   `holdout-split`, so the audit is `contaminated`, but the override advances it
   non-promotion-grade.
+- **unknown_required**: a verified run declares `secret-eval` required but never
+  reads it and it is not an allowed source, so the audit is `unknown` and the
+  gate blocks it.
+- **allowlist_violation**: a verified run fetches `other.example.com` under an
+  `allowlist` policy that lists only `docs.example.com`, so pass 2 marks it
+  `contaminated` and the gate blocks it.
+- **bare_host_with_path_allowed**: a verified run reads an allowlisted host given
+  as the bare `docs.example.com/guide` (host plus path, no scheme), which both
+  languages parse to `docs.example.com`, so the audit is `clean` and the gate
+  advances it promotion-grade.
 
 ## The contract pattern
 

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -237,6 +237,104 @@ A fifth repair, reassembling a partially written artifact from a recorded
 tool-call trace, is deliberately deferred: it needs a recorded tool-call trace
 that the harness does not yet capture. It is a follow-up, not part of this gate.
 
+## Leakage audit (AC-879)
+
+A harness optimization run can accidentally learn from data it was never
+supposed to see: a proposer that peeks at a holdout split, a web fetch that
+pulls the answer, a required source that was never proven clean. The
+**IntegrityMetadata** artifact declares what a run was allowed to touch, and a
+deterministic post-proposal audit checks the declaration against what the run
+actually read. Its schema lives at
+`ts/src/harness-optimization/contract/json-schemas/integrity-metadata.schema.json`
+and generates both packages' types under the same drift gate: the TypeScript
+`IntegrityMetadata` interface, the Python `IntegrityMetadata` pydantic model, and
+the `validateIntegrityMetadata` validator.
+
+IntegrityMetadata records the run identity and its data policy: `run_id`; `mode`
+(`verified` or `exploratory`); `allowed_sources`, `forbidden_sources`, and
+`required_sources` (source ids the run may read, must never read, and must prove
+clean before advancing); `web_policy` (`blocked`, `allowlist`, or `open`) with an
+optional `web_allowlist` of permitted hosts; `split_ids` (the benchmark or test
+split manifests in play); `prompt_provenance` (where the proposer prompts came
+from, optional in the schema but required by the verified gate); and
+`adapter_capabilities` (what the runtime can enforce, for example filesystem
+sandboxing or network blocking). It also carries the computed `leakage_status`
+and `contamination_reasons` so a persisted record explains its own verdict.
+
+### The three-status audit
+
+`audit_leakage` (Python) and `auditLeakage` (TypeScript) take the metadata plus a
+sequence of observed `AccessRecord`s (each an `{resource, source_id, kind}`
+triple, where kind is `file`, `trace`, `web`, or `split`) and return a
+`LeakageAudit` of `status` plus `reasons`. Both are pure functions over the
+declared policy and the supplied access log: no filesystem or network access, so
+the same inputs always produce the same verdict. The audit runs three
+contamination passes and, only if all three are clean, one proven-clean check:
+
+- **Pass 1, forbidden source read**: any access record whose `source_id` is a
+  forbidden source is a contamination.
+- **Pass 2, forbidden split touched**: any `split`-kind record whose `resource`
+  is a declared split id and whose `source_id` is forbidden is a contamination.
+- **Pass 3, web policy**: under a `blocked` policy any web read is a
+  contamination; under an `allowlist` policy a web read whose host is not in the
+  allowlist is a contamination; an `open` policy permits any host.
+
+If any pass fires, the status is `contaminated` and every reason is listed. If
+all three passes are clean, the audit applies the **required-source proven-clean
+rule**: a required source is proven clean when it is a declared allowed source OR
+it appears in the access log. Any required source that is neither is unproven, so
+the status is `unknown` (the run cannot be shown clean, but no contamination was
+observed either). Only when every required source is proven clean is the status
+`clean`. `renderLeakageReport` (TypeScript) renders a short human-readable report
+of the policy plus the computed status and reasons.
+
+### Verified fail-closed and the exploratory override
+
+`evaluate_leakage_gate` (Python) and `evaluateLeakageGate` (TypeScript) turn a
+`LeakageAudit` plus the run mode and prompt provenance into a
+`LeakageGateDecision` of `advance`, `non_promotion_grade`, and `rationale`. Like
+the repair gate, the leakage gate is caller-gated: it never reads settings, so a
+default run is unaffected until a caller invokes it.
+
+A **verified** run fails closed. It advances only when the audit status is
+`clean` AND the prompt provenance is non-empty. A non-clean status (contaminated
+or unknown) or a missing provenance blocks the run (`advance` is false) and marks
+it `non_promotion_grade`. Provenance is enforced by the gate rather than the
+schema precisely so an exploratory run can omit it while a verified run cannot.
+
+An **exploratory** run takes the operator override: it always advances, but it is
+always stamped `non_promotion_grade` regardless of the audit, so a deliberate
+peek can proceed for investigation without ever polluting the promotion set.
+
+A contaminated or blocked verified attempt is **discarded** as
+non-promotion-grade. This is not evidence that the model or the harness failed:
+it only means the result cannot be trusted as a clean measurement, so it must not
+enter the promotion set. Framing these as discarded rather than as failures keeps
+the leakage signal honest and separate from the quality signal.
+
+### The five worked cases
+
+A shared fixture
+(`fixtures/harness-optimization/leakage-cases/leakage-cases.json`) pins five
+cases that both packages load to prove they compute identical statuses, reason
+counts, and gate decisions:
+
+- **clean_run**: a verified run reads only `train-split` and an allowlisted
+  `docs.example.com` host, so the audit is `clean` and the gate advances it
+  promotion-grade.
+- **holdout_file_touch**: a verified run reads the forbidden `holdout-split`
+  file, pass 1 marks it `contaminated`, and the gate blocks it, so the attempt is
+  discarded.
+- **web_contaminated**: a verified run fetches `evil.example.com` under a
+  `blocked` web policy, pass 3 marks it `contaminated`, and the gate blocks it, so
+  the attempt is discarded.
+- **missing_provenance**: a verified run is audit-`clean` but declares no
+  `prompt_provenance`, so the gate fails closed on missing provenance and discards
+  it, showing the gate enforces provenance the schema leaves optional.
+- **exploratory_override**: an exploratory run peeks at the forbidden
+  `holdout-split`, so the audit is `contaminated`, but the override advances it
+  non-promotion-grade.
+
 ## The contract pattern
 
 This is the foundation artifact. The later protocol artifacts follow the same

--- a/fixtures/harness-optimization/integrity-metadata/invalid-missing-mode.json
+++ b/fixtures/harness-optimization/integrity-metadata/invalid-missing-mode.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "run_id": "run-ac879-verified-001",
+  "allowed_sources": ["train-split", "docs", "public-corpus"],
+  "forbidden_sources": ["holdout-split", "test-split"],
+  "required_sources": ["train-split"],
+  "web_policy": "allowlist",
+  "web_allowlist": ["docs.example.com"],
+  "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+  "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+  "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+  "leakage_status": "clean",
+  "contamination_reasons": []
+}

--- a/fixtures/harness-optimization/integrity-metadata/valid-verified-clean.json
+++ b/fixtures/harness-optimization/integrity-metadata/valid-verified-clean.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "run_id": "run-ac879-verified-001",
+  "mode": "verified",
+  "allowed_sources": ["train-split", "docs", "public-corpus"],
+  "forbidden_sources": ["holdout-split", "test-split"],
+  "required_sources": ["train-split"],
+  "web_policy": "allowlist",
+  "web_allowlist": ["docs.example.com"],
+  "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+  "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+  "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+  "leakage_status": "clean",
+  "contamination_reasons": []
+}

--- a/fixtures/harness-optimization/leakage-cases/leakage-cases.json
+++ b/fixtures/harness-optimization/leakage-cases/leakage-cases.json
@@ -142,6 +142,92 @@
         "expected_advance": true,
         "expected_non_promotion_grade": true
       }
+    },
+    {
+      "name": "unknown_required",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-unknown-006",
+        "mode": "verified",
+        "allowed_sources": ["train-split"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split", "secret-eval"],
+        "web_policy": "blocked",
+        "web_allowlist": null,
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+        "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+        "leakage_status": "unknown",
+        "contamination_reasons": ["required source unproven: secret-eval"]
+      },
+      "access_records": [
+        { "resource": "data/train.jsonl", "source_id": "train-split", "kind": "file" }
+      ],
+      "expected_status": "unknown",
+      "expected_reason_count": 1,
+      "gate": {
+        "mode": "verified",
+        "expected_advance": false,
+        "expected_non_promotion_grade": true
+      }
+    },
+    {
+      "name": "allowlist_violation",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-allowmiss-007",
+        "mode": "verified",
+        "allowed_sources": ["train-split", "docs"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split"],
+        "web_policy": "allowlist",
+        "web_allowlist": ["docs.example.com"],
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+        "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+        "leakage_status": "contaminated",
+        "contamination_reasons": ["web host not in allowlist: other.example.com"]
+      },
+      "access_records": [
+        { "resource": "data/train.jsonl", "source_id": "train-split", "kind": "file" },
+        { "resource": "https://other.example.com/x", "source_id": "web-fetch", "kind": "web" }
+      ],
+      "expected_status": "contaminated",
+      "expected_reason_count": 1,
+      "gate": {
+        "mode": "verified",
+        "expected_advance": false,
+        "expected_non_promotion_grade": true
+      }
+    },
+    {
+      "name": "bare_host_with_path_allowed",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-barehost-008",
+        "mode": "verified",
+        "allowed_sources": ["train-split", "docs"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split"],
+        "web_policy": "allowlist",
+        "web_allowlist": ["docs.example.com"],
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+        "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+        "leakage_status": "clean",
+        "contamination_reasons": []
+      },
+      "access_records": [
+        { "resource": "data/train.jsonl", "source_id": "train-split", "kind": "file" },
+        { "resource": "docs.example.com/guide", "source_id": "docs", "kind": "web" }
+      ],
+      "expected_status": "clean",
+      "expected_reason_count": 0,
+      "gate": {
+        "mode": "verified",
+        "expected_advance": true,
+        "expected_non_promotion_grade": false
+      }
     }
   ]
 }

--- a/fixtures/harness-optimization/leakage-cases/leakage-cases.json
+++ b/fixtures/harness-optimization/leakage-cases/leakage-cases.json
@@ -1,0 +1,147 @@
+{
+  "cases": [
+    {
+      "name": "clean_run",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-clean-001",
+        "mode": "verified",
+        "allowed_sources": ["train-split", "docs", "public-corpus"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split"],
+        "web_policy": "allowlist",
+        "web_allowlist": ["docs.example.com"],
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+        "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+        "leakage_status": "clean",
+        "contamination_reasons": []
+      },
+      "access_records": [
+        { "resource": "data/train.jsonl", "source_id": "train-split", "kind": "file" },
+        { "resource": "https://docs.example.com/guide", "source_id": "docs", "kind": "web" }
+      ],
+      "expected_status": "clean",
+      "expected_reason_count": 0,
+      "gate": {
+        "mode": "verified",
+        "expected_advance": true,
+        "expected_non_promotion_grade": false
+      }
+    },
+    {
+      "name": "holdout_file_touch",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-holdout-002",
+        "mode": "verified",
+        "allowed_sources": ["train-split", "docs"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split"],
+        "web_policy": "blocked",
+        "web_allowlist": null,
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+        "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+        "leakage_status": "contaminated",
+        "contamination_reasons": ["forbidden source read: holdout-split (data/holdout.jsonl)"]
+      },
+      "access_records": [
+        { "resource": "data/train.jsonl", "source_id": "train-split", "kind": "file" },
+        { "resource": "data/holdout.jsonl", "source_id": "holdout-split", "kind": "file" }
+      ],
+      "expected_status": "contaminated",
+      "expected_reason_count": 1,
+      "gate": {
+        "mode": "verified",
+        "expected_advance": false,
+        "expected_non_promotion_grade": true
+      }
+    },
+    {
+      "name": "web_contaminated",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-web-003",
+        "mode": "verified",
+        "allowed_sources": ["train-split", "docs"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split"],
+        "web_policy": "blocked",
+        "web_allowlist": null,
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": "prompts/harness-optimization/proposer-v2.md",
+        "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+        "leakage_status": "contaminated",
+        "contamination_reasons": ["web access under blocked policy: evil.example.com"]
+      },
+      "access_records": [
+        { "resource": "data/train.jsonl", "source_id": "train-split", "kind": "file" },
+        { "resource": "https://evil.example.com/leak", "source_id": "web-fetch", "kind": "web" }
+      ],
+      "expected_status": "contaminated",
+      "expected_reason_count": 1,
+      "gate": {
+        "mode": "verified",
+        "expected_advance": false,
+        "expected_non_promotion_grade": true
+      }
+    },
+    {
+      "name": "missing_provenance",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-noprov-004",
+        "mode": "verified",
+        "allowed_sources": ["train-split", "docs"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split"],
+        "web_policy": "allowlist",
+        "web_allowlist": ["docs.example.com"],
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": null,
+        "adapter_capabilities": ["filesystem_sandbox", "network_block"],
+        "leakage_status": "clean",
+        "contamination_reasons": []
+      },
+      "access_records": [
+        { "resource": "data/train.jsonl", "source_id": "train-split", "kind": "file" }
+      ],
+      "expected_status": "clean",
+      "expected_reason_count": 0,
+      "gate": {
+        "mode": "verified",
+        "expected_advance": false,
+        "expected_non_promotion_grade": true
+      }
+    },
+    {
+      "name": "exploratory_override",
+      "metadata": {
+        "schema_version": 1,
+        "run_id": "run-ac879-explore-005",
+        "mode": "exploratory",
+        "allowed_sources": ["train-split", "docs"],
+        "forbidden_sources": ["holdout-split", "test-split"],
+        "required_sources": ["train-split"],
+        "web_policy": "open",
+        "web_allowlist": null,
+        "split_ids": ["bench-v3-train", "bench-v3-holdout"],
+        "prompt_provenance": null,
+        "adapter_capabilities": ["filesystem_sandbox"],
+        "leakage_status": "contaminated",
+        "contamination_reasons": ["forbidden source read: holdout-split (data/holdout-peek.jsonl)"]
+      },
+      "access_records": [
+        { "resource": "data/holdout-peek.jsonl", "source_id": "holdout-split", "kind": "file" }
+      ],
+      "expected_status": "contaminated",
+      "expected_reason_count": 1,
+      "gate": {
+        "mode": "exploratory",
+        "expected_advance": true,
+        "expected_non_promotion_grade": true
+      }
+    }
+  ]
+}

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -124,7 +124,7 @@ export interface IntegrityMetadata {
    */
   run_id: string;
   /**
-   * Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade.
+   * Run mode: verified fails closed on leakage, exploratory is marked non-promotion-grade.
    */
   mode: "verified" | "exploratory";
   /**
@@ -146,15 +146,15 @@ export interface IntegrityMetadata {
   /**
    * Hosts permitted when web_policy is allowlist. Optional; omitted or empty means no host is permitted.
    */
-  web_allowlist?: string[];
+  web_allowlist?: string[] | null;
   /**
    * Benchmark or test split manifest ids in play for this run.
    */
   split_ids: string[];
   /**
-   * Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it.
+   * Where proposer prompts came from. Verified mode requires it non-empty (gate-enforced, not schema).
    */
-  prompt_provenance?: string;
+  prompt_provenance?: string | null;
   /**
    * What the runtime or adapter can enforce, for example filesystem sandboxing or network blocking.
    */

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -110,6 +110,65 @@ export interface CandidateEvidence {
   };
 }
 
+// ---- integrity-metadata.schema.json ----
+/**
+ * Declared integrity scope for a harness-optimization run (AC-879). It records which sources the proposer and evaluator were allowed to read, which are forbidden (holdout, test splits), the web-access policy, the benchmark split manifest in play, and the computed leakage status so a reviewer can prove a candidate was proposed without touching held-out evidence. Verified-mode enforcement (fail closed on contamination or unknown status) is applied by the leakage gate, not by this schema. This schema is the single source of truth for both the Python and TypeScript autocontext packages.
+ */
+export interface IntegrityMetadata {
+  /**
+   * Schema version for forward compatibility. Always 1 for this revision.
+   */
+  schema_version: 1;
+  /**
+   * Identifier of the run this integrity record describes.
+   */
+  run_id: string;
+  /**
+   * Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade.
+   */
+  mode: "verified" | "exploratory";
+  /**
+   * Source ids the proposer or evaluator may read.
+   */
+  allowed_sources: string[];
+  /**
+   * Source ids that must never be read, for example holdout or test-split sources.
+   */
+  forbidden_sources: string[];
+  /**
+   * Subset of sources whose status must be known-clean for a verified run to advance.
+   */
+  required_sources: string[];
+  /**
+   * Web-access policy: blocked forbids all web reads, allowlist permits only listed hosts, open permits any.
+   */
+  web_policy: "blocked" | "allowlist" | "open";
+  /**
+   * Hosts permitted when web_policy is allowlist. Optional; omitted or empty means no host is permitted.
+   */
+  web_allowlist?: string[];
+  /**
+   * Benchmark or test split manifest ids in play for this run.
+   */
+  split_ids: string[];
+  /**
+   * Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it.
+   */
+  prompt_provenance?: string;
+  /**
+   * What the runtime or adapter can enforce, for example filesystem sandboxing or network blocking.
+   */
+  adapter_capabilities: string[];
+  /**
+   * Computed leakage status: clean, contaminated, or unknown when it cannot be proven clean.
+   */
+  leakage_status: "clean" | "contaminated" | "unknown";
+  /**
+   * Human-readable reasons for a contaminated or unknown status. Empty when clean.
+   */
+  contamination_reasons: string[];
+}
+
 // ---- promotion-score.schema.json ----
 /**
  * Computed harness-promotion score for a single candidate (AC-877). Combines the dense quality signal with the sparse per-case success rate, marginal token cost, error rate, and score variance under a named, versioned set of weights. This is the artifact the promotion gate reads to decide whether a candidate advances. Shared source of truth for both the Python and TypeScript autocontext packages.

--- a/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
@@ -12,6 +12,9 @@
     },
     "RepairResult": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/repair-result.json"
+    },
+    "IntegrityMetadata": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json"
     }
   }
 }

--- a/ts/src/harness-optimization/contract/json-schemas/integrity-metadata.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/integrity-metadata.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json",
+  "title": "IntegrityMetadata",
+  "description": "Declared integrity scope for a harness-optimization run (AC-879). It records which sources the proposer and evaluator were allowed to read, which are forbidden (holdout, test splits), the web-access policy, the benchmark split manifest in play, and the computed leakage status so a reviewer can prove a candidate was proposed without touching held-out evidence. Verified-mode enforcement (fail closed on contamination or unknown status) is applied by the leakage gate, not by this schema. This schema is the single source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "mode",
+    "allowed_sources",
+    "forbidden_sources",
+    "required_sources",
+    "web_policy",
+    "split_ids",
+    "adapter_capabilities",
+    "leakage_status",
+    "contamination_reasons"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the run this integrity record describes."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["verified", "exploratory"],
+      "description": "Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade."
+    },
+    "allowed_sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Source ids the proposer or evaluator may read."
+    },
+    "forbidden_sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Source ids that must never be read, for example holdout or test-split sources."
+    },
+    "required_sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Subset of sources whose status must be known-clean for a verified run to advance."
+    },
+    "web_policy": {
+      "type": "string",
+      "enum": ["blocked", "allowlist", "open"],
+      "description": "Web-access policy: blocked forbids all web reads, allowlist permits only listed hosts, open permits any."
+    },
+    "web_allowlist": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Hosts permitted when web_policy is allowlist. Optional; omitted or empty means no host is permitted."
+    },
+    "split_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Benchmark or test split manifest ids in play for this run."
+    },
+    "prompt_provenance": {
+      "type": "string",
+      "description": "Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it."
+    },
+    "adapter_capabilities": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "What the runtime or adapter can enforce, for example filesystem sandboxing or network blocking."
+    },
+    "leakage_status": {
+      "type": "string",
+      "enum": ["clean", "contaminated", "unknown"],
+      "description": "Computed leakage status: clean, contaminated, or unknown when it cannot be proven clean."
+    },
+    "contamination_reasons": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Human-readable reasons for a contaminated or unknown status. Empty when clean."
+    }
+  }
+}

--- a/ts/src/harness-optimization/contract/json-schemas/integrity-metadata.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/integrity-metadata.schema.json
@@ -32,7 +32,7 @@
     "mode": {
       "type": "string",
       "enum": ["verified", "exploratory"],
-      "description": "Run mode: verified enforces fail-closed leakage checks, exploratory proceeds but is marked non-promotion-grade."
+      "description": "Run mode: verified fails closed on leakage, exploratory is marked non-promotion-grade."
     },
     "allowed_sources": {
       "type": "array",
@@ -55,7 +55,7 @@
       "description": "Web-access policy: blocked forbids all web reads, allowlist permits only listed hosts, open permits any."
     },
     "web_allowlist": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": { "type": "string" },
       "description": "Hosts permitted when web_policy is allowlist. Optional; omitted or empty means no host is permitted."
     },
@@ -65,8 +65,8 @@
       "description": "Benchmark or test split manifest ids in play for this run."
     },
     "prompt_provenance": {
-      "type": "string",
-      "description": "Where the proposer prompts came from. Required non-empty for verified mode, enforced by the gate rather than the schema so exploratory runs can omit it."
+      "type": ["string", "null"],
+      "description": "Where proposer prompts came from. Verified mode requires it non-empty (gate-enforced, not schema)."
     },
     "adapter_capabilities": {
       "type": "array",

--- a/ts/src/harness-optimization/contract/validators.ts
+++ b/ts/src/harness-optimization/contract/validators.ts
@@ -4,7 +4,13 @@ import addFormats from "ajv-formats";
 import candidateEvidenceSchema from "./json-schemas/candidate-evidence.schema.json" with { type: "json" };
 import promotionScoreSchema from "./json-schemas/promotion-score.schema.json" with { type: "json" };
 import repairResultSchema from "./json-schemas/repair-result.schema.json" with { type: "json" };
-import type { CandidateEvidence, PromotionScore, RepairResult } from "./generated-types.js";
+import integrityMetadataSchema from "./json-schemas/integrity-metadata.schema.json" with { type: "json" };
+import type {
+  CandidateEvidence,
+  IntegrityMetadata,
+  PromotionScore,
+  RepairResult,
+} from "./generated-types.js";
 
 // Shared validation-result shape (matches the production-traces contract).
 export type ValidationResult =
@@ -22,6 +28,7 @@ addFormatsFn(ajv);
 ajv.addSchema(candidateEvidenceSchema as object);
 ajv.addSchema(promotionScoreSchema as object);
 ajv.addSchema(repairResultSchema as object);
+ajv.addSchema(integrityMetadataSchema as object);
 
 const candidateEvidenceValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json",
@@ -33,6 +40,10 @@ const promotionScoreValidator = ajv.getSchema(
 
 const repairResultValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/repair-result.json",
+)!;
+
+const integrityMetadataValidator = ajv.getSchema(
+  "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json",
 )!;
 
 function toResult(validate: ValidateFunction, input: unknown): ValidationResult {
@@ -59,5 +70,9 @@ export function validateRepairResult(input: unknown): ValidationResult {
   return toResult(repairResultValidator, input);
 }
 
+export function validateIntegrityMetadata(input: unknown): ValidationResult {
+  return toResult(integrityMetadataValidator, input);
+}
+
 // Type-level assertion — if a TS type drifts from its schema this won't compile.
-export type _TypeCheck = CandidateEvidence | PromotionScore | RepairResult;
+export type _TypeCheck = CandidateEvidence | PromotionScore | RepairResult | IntegrityMetadata;

--- a/ts/src/harness-optimization/leakage-gate.ts
+++ b/ts/src/harness-optimization/leakage-gate.ts
@@ -1,0 +1,54 @@
+import type { LeakageAudit } from "./leakage.js";
+
+/**
+ * Verified/exploratory leakage gate (AC-879).
+ *
+ * TypeScript half of the AC-879 parity pair: the same three-branch gate lives
+ * here and in
+ * `autocontext/src/autocontext/harness_optimization/leakage_gate.py`, and the
+ * shared fixture
+ * (`fixtures/harness-optimization/leakage-cases/leakage-cases.json`) proves
+ * both languages reach identical advance / non_promotion_grade decisions.
+ *
+ * Consumes a LeakageAudit and the run mode. Verified runs fail closed on
+ * contaminated or unknown status, or on missing prompt provenance. Exploratory
+ * runs always advance but are stamped non-promotion-grade. Caller-gated: this
+ * function never reads settings, so default runs are unaffected until a caller
+ * invokes it.
+ */
+
+export interface LeakageGateDecision {
+  advance: boolean;
+  non_promotion_grade: boolean;
+  rationale: string;
+}
+
+export function evaluateLeakageGate(
+  audit: LeakageAudit,
+  mode: string,
+  promptProvenance: string,
+): LeakageGateDecision {
+  if (mode === "exploratory") {
+    return {
+      advance: true,
+      non_promotion_grade: true,
+      rationale: "exploratory override: advancing non-promotion-grade regardless of leakage",
+    };
+  }
+  // verified
+  const blockers: string[] = [];
+  if (audit.status !== "clean") {
+    blockers.push(`leakage status ${audit.status}: ${audit.reasons.join("; ")}`);
+  }
+  if (promptProvenance.trim() === "") {
+    blockers.push("missing prompt provenance");
+  }
+  if (blockers.length > 0) {
+    return {
+      advance: false,
+      non_promotion_grade: true,
+      rationale: "verified run blocked: " + blockers.join("; "),
+    };
+  }
+  return { advance: true, non_promotion_grade: false, rationale: "verified run clean" };
+}

--- a/ts/src/harness-optimization/leakage.ts
+++ b/ts/src/harness-optimization/leakage.ts
@@ -1,0 +1,113 @@
+import type { IntegrityMetadata } from "./contract/generated-types.js";
+
+/**
+ * Deterministic post-proposal leakage audit (AC-879).
+ *
+ * TypeScript half of the AC-879 parity pair: the same three-pass audit lives
+ * here and in `autocontext/src/autocontext/harness_optimization/leakage.py`,
+ * and a shared fixture
+ * (`fixtures/harness-optimization/leakage-cases/leakage-cases.json`) proves
+ * both languages compute identical statuses and reason counts.
+ *
+ * Pure functions over declared integrity metadata plus observed access
+ * records. No filesystem or network access: the caller supplies the access
+ * log. Maps a run to clean | contaminated | unknown so a verified gate can
+ * fail closed.
+ */
+
+export interface AccessRecord {
+  resource: string;
+  source_id: string;
+  kind: string; // "file" | "trace" | "web" | "split"
+}
+
+export interface LeakageAudit {
+  status: string; // "clean" | "contaminated" | "unknown"
+  reasons: readonly string[];
+}
+
+/**
+ * Extract the host from a web resource. Mirrors Python's urlparse with a
+ * `//`-prefix fallback for bare hosts (parsed.hostname or resource): a bare
+ * `docs.example.com` becomes `//docs.example.com` so the host parses, and a
+ * value that cannot be parsed falls back to the raw resource.
+ */
+function webHost(resource: string): string {
+  try {
+    const parsed = new URL(resource.includes("://") ? resource : `//${resource}`);
+    return parsed.hostname || resource;
+  } catch {
+    return resource;
+  }
+}
+
+export function auditLeakage(
+  metadata: IntegrityMetadata,
+  accessRecords: readonly AccessRecord[],
+): LeakageAudit {
+  const forbidden = new Set(metadata.forbidden_sources);
+  const splitIds = new Set(metadata.split_ids);
+  const allowlist = new Set(metadata.web_allowlist ?? []);
+  const reasons: string[] = [];
+
+  // Pass 1: forbidden source read.
+  for (const rec of accessRecords) {
+    if (forbidden.has(rec.source_id)) {
+      reasons.push(`forbidden source read: ${rec.source_id} (${rec.resource})`);
+    }
+  }
+  // Pass 2: forbidden split touched.
+  for (const rec of accessRecords) {
+    if (rec.kind === "split" && splitIds.has(rec.resource) && forbidden.has(rec.source_id)) {
+      reasons.push(`forbidden split touched: ${rec.resource}`);
+    }
+  }
+  // Pass 3: web policy.
+  for (const rec of accessRecords) {
+    if (rec.kind === "web") {
+      const host = webHost(rec.resource);
+      if (metadata.web_policy === "blocked") {
+        reasons.push(`web access under blocked policy: ${host}`);
+      } else if (metadata.web_policy === "allowlist" && !allowlist.has(host)) {
+        reasons.push(`web host not in allowlist: ${host}`);
+      }
+    }
+  }
+
+  if (reasons.length > 0) {
+    return { status: "contaminated", reasons };
+  }
+
+  // Unknown-required fallback: a required source is proven clean if it is a
+  // declared allowed source OR appears in the access log.
+  const allowed = new Set(metadata.allowed_sources);
+  const covered = new Set(accessRecords.map((rec) => rec.source_id));
+  const unknown = metadata.required_sources.filter((s) => !covered.has(s) && !allowed.has(s));
+  if (unknown.length > 0) {
+    return {
+      status: "unknown",
+      reasons: unknown.map((s) => `required source unproven: ${s}`),
+    };
+  }
+  return { status: "clean", reasons: [] };
+}
+
+/**
+ * Render a short multi-line report of the metadata policy and the computed
+ * audit. Lists mode, allowed_sources, forbidden_sources, web_policy, the
+ * computed status, and each reason prefixed with `- `.
+ */
+export function renderLeakageReport(metadata: IntegrityMetadata, audit: LeakageAudit): string {
+  const lines = [
+    "autocontext leakage audit",
+    `mode: ${metadata.mode}`,
+    `allowed_sources: ${metadata.allowed_sources.join(", ")}`,
+    `forbidden_sources: ${metadata.forbidden_sources.join(", ")}`,
+    `web_policy: ${metadata.web_policy}`,
+    `status: ${audit.status}`,
+  ];
+  for (const reason of audit.reasons) {
+    lines.push(`- ${reason}`);
+  }
+  return lines.join("\n");
+}

--- a/ts/src/harness-optimization/leakage.ts
+++ b/ts/src/harness-optimization/leakage.ts
@@ -27,14 +27,14 @@ export interface LeakageAudit {
 }
 
 /**
- * Extract the host from a web resource. Mirrors Python's urlparse with a
- * `//`-prefix fallback for bare hosts (parsed.hostname or resource): a bare
- * `docs.example.com` becomes `//docs.example.com` so the host parses, and a
- * value that cannot be parsed falls back to the raw resource.
+ * Extract the host from a web resource. Mirrors Python's urlparse: a bare host
+ * (with or without a path) is parsed under a synthetic `http://` scheme so the
+ * host resolves (`docs.example.com/guide` -> `docs.example.com`), and a value
+ * that cannot be parsed falls back to the raw resource.
  */
 function webHost(resource: string): string {
   try {
-    const parsed = new URL(resource.includes("://") ? resource : `//${resource}`);
+    const parsed = new URL(resource.includes("://") ? resource : `http://${resource}`);
     return parsed.hostname || resource;
   } catch {
     return resource;
@@ -46,7 +46,6 @@ export function auditLeakage(
   accessRecords: readonly AccessRecord[],
 ): LeakageAudit {
   const forbidden = new Set(metadata.forbidden_sources);
-  const splitIds = new Set(metadata.split_ids);
   const allowlist = new Set(metadata.web_allowlist ?? []);
   const reasons: string[] = [];
 
@@ -56,13 +55,7 @@ export function auditLeakage(
       reasons.push(`forbidden source read: ${rec.source_id} (${rec.resource})`);
     }
   }
-  // Pass 2: forbidden split touched.
-  for (const rec of accessRecords) {
-    if (rec.kind === "split" && splitIds.has(rec.resource) && forbidden.has(rec.source_id)) {
-      reasons.push(`forbidden split touched: ${rec.resource}`);
-    }
-  }
-  // Pass 3: web policy.
+  // Pass 2: web policy.
   for (const rec of accessRecords) {
     if (rec.kind === "web") {
       const host = webHost(rec.resource);
@@ -94,8 +87,9 @@ export function auditLeakage(
 
 /**
  * Render a short multi-line report of the metadata policy and the computed
- * audit. Lists mode, allowed_sources, forbidden_sources, web_policy, the
- * computed status, and each reason prefixed with `- `.
+ * audit. Lists mode, allowed_sources, forbidden_sources, required_sources,
+ * web_policy, web_allowlist, the computed status, and each reason prefixed with
+ * `- `.
  */
 export function renderLeakageReport(metadata: IntegrityMetadata, audit: LeakageAudit): string {
   const lines = [
@@ -103,7 +97,9 @@ export function renderLeakageReport(metadata: IntegrityMetadata, audit: LeakageA
     `mode: ${metadata.mode}`,
     `allowed_sources: ${metadata.allowed_sources.join(", ")}`,
     `forbidden_sources: ${metadata.forbidden_sources.join(", ")}`,
+    `required_sources: ${metadata.required_sources.join(", ")}`,
     `web_policy: ${metadata.web_policy}`,
+    `web_allowlist: ${(metadata.web_allowlist ?? []).join(", ")}`,
     `status: ${audit.status}`,
   ];
   for (const reason of audit.reasons) {

--- a/ts/tests/harness-optimization/integrity-metadata.test.ts
+++ b/ts/tests/harness-optimization/integrity-metadata.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { validateIntegrityMetadata } from "../../src/harness-optimization/contract/validators.js";
 
-const FIX = join(__dirname, "../../../fixtures/harness-optimization/integrity-metadata");
+const FIX = join(import.meta.dirname, "../../../fixtures/harness-optimization/integrity-metadata");
 
 describe("integrity-metadata contract", () => {
   it("accepts a verified clean record", () => {

--- a/ts/tests/harness-optimization/integrity-metadata.test.ts
+++ b/ts/tests/harness-optimization/integrity-metadata.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { validateIntegrityMetadata } from "../../src/harness-optimization/contract/validators.js";
+
+const FIX = join(__dirname, "../../../fixtures/harness-optimization/integrity-metadata");
+
+describe("integrity-metadata contract", () => {
+  it("accepts a verified clean record", () => {
+    const data = JSON.parse(readFileSync(join(FIX, "valid-verified-clean.json"), "utf8"));
+    expect(validateIntegrityMetadata(data)).toEqual({ valid: true });
+  });
+  it("rejects a record missing mode", () => {
+    const data = JSON.parse(readFileSync(join(FIX, "invalid-missing-mode.json"), "utf8"));
+    const r = validateIntegrityMetadata(data);
+    expect(r.valid).toBe(false);
+  });
+});

--- a/ts/tests/harness-optimization/leakage-gate.test.ts
+++ b/ts/tests/harness-optimization/leakage-gate.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import { auditLeakage } from "../../src/harness-optimization/leakage.js";
 import { evaluateLeakageGate } from "../../src/harness-optimization/leakage-gate.js";
+import { validateIntegrityMetadata } from "../../src/harness-optimization/contract/validators.js";
 
 // Load the SAME repo-root fixture the Python suite loads. Matching it in both
 // languages is the load-bearing parity proof.
@@ -26,6 +27,9 @@ const CASES = JSON.parse(
 describe("leakage gate parity", () => {
   for (const c of CASES) {
     it(`${c.name}: advance + non_promotion_grade match fixture`, () => {
+      // Every fixture metadata must validate against the schema so a future
+      // null/shape drift fails a test here.
+      expect(validateIntegrityMetadata(c.metadata)).toEqual({ valid: true });
       const audit = auditLeakage(c.metadata, c.access_records);
       const decision = evaluateLeakageGate(
         audit,
@@ -36,4 +40,33 @@ describe("leakage gate parity", () => {
       expect(decision.non_promotion_grade).toBe(c.gate.expected_non_promotion_grade);
     });
   }
+
+  const byName = (name: string) => CASES.find((c: { name: string }) => c.name === name);
+
+  it("blocked verified run has the exact rationale", () => {
+    const c = byName("holdout_file_touch");
+    const audit = auditLeakage(c.metadata, c.access_records);
+    const decision = evaluateLeakageGate(
+      audit,
+      c.metadata.mode,
+      c.metadata.prompt_provenance ?? "",
+    );
+    expect(decision.rationale).toBe(
+      "verified run blocked: leakage status contaminated: " +
+        "forbidden source read: holdout-split (data/holdout.jsonl)",
+    );
+  });
+
+  it("exploratory override has the exact rationale", () => {
+    const c = byName("exploratory_override");
+    const audit = auditLeakage(c.metadata, c.access_records);
+    const decision = evaluateLeakageGate(
+      audit,
+      c.metadata.mode,
+      c.metadata.prompt_provenance ?? "",
+    );
+    expect(decision.rationale).toBe(
+      "exploratory override: advancing non-promotion-grade regardless of leakage",
+    );
+  });
 });

--- a/ts/tests/harness-optimization/leakage-gate.test.ts
+++ b/ts/tests/harness-optimization/leakage-gate.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { auditLeakage } from "../../src/harness-optimization/leakage.js";
+import { evaluateLeakageGate } from "../../src/harness-optimization/leakage-gate.js";
+
+// Load the SAME repo-root fixture the Python suite loads. Matching it in both
+// languages is the load-bearing parity proof.
+// Walk up to the repo root: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const CASES = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dirname,
+      "..",
+      "..",
+      "..",
+      "fixtures",
+      "harness-optimization",
+      "leakage-cases",
+      "leakage-cases.json",
+    ),
+    "utf8",
+  ),
+).cases.filter((c: { gate?: unknown }) => c.gate !== undefined);
+
+describe("leakage gate parity", () => {
+  for (const c of CASES) {
+    it(`${c.name}: advance + non_promotion_grade match fixture`, () => {
+      const audit = auditLeakage(c.metadata, c.access_records);
+      const decision = evaluateLeakageGate(
+        audit,
+        c.metadata.mode,
+        c.metadata.prompt_provenance ?? "",
+      );
+      expect(decision.advance).toBe(c.gate.expected_advance);
+      expect(decision.non_promotion_grade).toBe(c.gate.expected_non_promotion_grade);
+    });
+  }
+});

--- a/ts/tests/harness-optimization/leakage.test.ts
+++ b/ts/tests/harness-optimization/leakage.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { auditLeakage, renderLeakageReport } from "../../src/harness-optimization/leakage.js";
+
+// Load the SAME repo-root fixture the Python suite loads. Matching it in both
+// languages is the load-bearing parity proof.
+// Walk up to the repo root: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const CASES = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dirname,
+      "..",
+      "..",
+      "..",
+      "fixtures",
+      "harness-optimization",
+      "leakage-cases",
+      "leakage-cases.json",
+    ),
+    "utf8",
+  ),
+).cases;
+
+describe("leakage audit parity", () => {
+  for (const c of CASES) {
+    it(`${c.name}: status + reason count match fixture`, () => {
+      const audit = auditLeakage(c.metadata, c.access_records);
+      expect(audit.status).toBe(c.expected_status);
+      expect(audit.reasons.length).toBe(c.expected_reason_count);
+    });
+  }
+  it("renders allowed/forbidden/status in the report", () => {
+    const c = CASES[0];
+    const report = renderLeakageReport(c.metadata, auditLeakage(c.metadata, c.access_records));
+    expect(report).toContain(c.metadata.leakage_status === "clean" ? "clean" : c.expected_status);
+    expect(report).toContain("forbidden");
+  });
+});

--- a/ts/tests/harness-optimization/leakage.test.ts
+++ b/ts/tests/harness-optimization/leakage.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import { auditLeakage, renderLeakageReport } from "../../src/harness-optimization/leakage.js";
+import { validateIntegrityMetadata } from "../../src/harness-optimization/contract/validators.js";
 
 // Load the SAME repo-root fixture the Python suite loads. Matching it in both
 // languages is the load-bearing parity proof.
@@ -25,15 +26,21 @@ const CASES = JSON.parse(
 describe("leakage audit parity", () => {
   for (const c of CASES) {
     it(`${c.name}: status + reason count match fixture`, () => {
+      // Every fixture metadata must validate against the schema so a future
+      // null/shape drift fails a test here.
+      expect(validateIntegrityMetadata(c.metadata)).toEqual({ valid: true });
       const audit = auditLeakage(c.metadata, c.access_records);
       expect(audit.status).toBe(c.expected_status);
       expect(audit.reasons.length).toBe(c.expected_reason_count);
     });
   }
-  it("renders allowed/forbidden/status in the report", () => {
+  it("renders allowed/forbidden/required/status in the report", () => {
     const c = CASES[0];
-    const report = renderLeakageReport(c.metadata, auditLeakage(c.metadata, c.access_records));
-    expect(report).toContain(c.metadata.leakage_status === "clean" ? "clean" : c.expected_status);
-    expect(report).toContain("forbidden");
+    const audit = auditLeakage(c.metadata, c.access_records);
+    const report = renderLeakageReport(c.metadata, audit);
+    expect(report).toContain(`status: ${audit.status}`);
+    expect(report).toContain("forbidden_sources:");
+    expect(report).toContain("required_sources:");
+    expect(report).toContain("web_allowlist:");
   });
 });


### PR DESCRIPTION
Implements AC-879, the fourth harness-optimization protocol artifact plus a post-proposal leakage audit and a fail-closed gate. Built on the AC-876 codegen/parity harness (schema is the single source of truth; drift gate byte-diffs both languages).

## What this adds

**IntegrityMetadata contract** (`integrity-metadata.schema.json` -> regenerated `models.py` + `generated-types.ts`): declared allowed/forbidden/required sources, web policy (+ optional allowlist), split ids, prompt provenance, adapter capabilities, computed leakage status, and contamination reasons. `web_allowlist` and `prompt_provenance` are nullable so a Python-serialized record validates unchanged in TypeScript.

**Leakage audit** (`leakage.py` + `leakage.ts`, pure functions, byte-identical): maps declared scope plus observed access records to `clean | contaminated | unknown`. Contamination passes (deterministic order): forbidden-source read, then web-policy violation, then unknown-required fallback. A required source is proven-clean when it is a declared allowed source or appears in the access log. Detection is source-id-attribution-based; `split_ids` and `adapter_capabilities` are declarative metadata. Ships `render_leakage_report` / `renderLeakageReport` (identical wording) for the allowed/forbidden/why-clean report.

**Fail-closed gate** (`leakage_gate.py` + `leakage-gate.ts`, caller-gated, no settings reads):
- verified + (contaminated OR unknown OR missing provenance) -> does not advance, marked non-promotion-grade, rationale lists blockers
- verified + clean + provenance -> advances
- exploratory -> always advances, marked non-promotion-grade (operator override)

Contaminated attempts are framed as discarded (non-promotion-grade), not as failed model or harness evidence.

## Parity + tests

One shared fixture (`leakage-cases.json`, 8 cases) proves Python and TS compute identical status, reason strings, and gate decisions: clean, holdout file touch, web-contaminated (blocked), missing provenance, exploratory override, unknown-required, allowlist violation, and bare-host-with-path (host-parse regression guard). TS tests validate every fixture record through the AJV validator. Exact gate-rationale assertions in both languages.

Gates: ruff + mypy clean, pytest (module-size guard + harness_optimization) green, schema drift gate clean, vitest harness-optimization green, tsc lint clean.

Whole-branch review (fable) returned NOT-READY on first pass and found two real blockers (ruff red on the generated model, a null-vs-omitted cross-language serialization break) plus five Important findings; all were fixed in one wave and independently re-verified.

Note: the `ts-test` full-suite CI job is red repo-wide (AC-892 infra, host OOM), unrelated to this change.

Closes AC-879.