### PR TITLE
harness optimization: frontier + orphan mechanism archive (AC-880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - harness optimization protocol: fresh blended promotion score with recompute-both semantics and python/typescript parity (AC-877)
 - harness optimization protocol: opt-in deterministic repair gates (artifact landing, tool-call json, finish guard, loop guard) with python/typescript parity (AC-878)
 - harness optimization protocol: post-proposal holdout-leakage audit (clean/contaminated/unknown over forbidden-source, forbidden-split, and web-policy passes) and verified/exploratory fail-closed gate with python/typescript parity (AC-879)
+- harness optimization protocol: in-memory mechanism archive of promoted (frontier) and gated-out (orphan) mechanisms with candidate-evidence and parent-frontier lineage, reuse-ranked orphan rescue/prune, and a bounded ranked proposer digest with python/typescript parity (AC-880)
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
@@ -15,6 +15,12 @@
     },
     "IntegrityMetadata": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json"
+    },
+    "FrontierMechanism": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/frontier-mechanism.json"
+    },
+    "OrphanMechanism": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json"
     }
   }
 }

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/frontier-mechanism.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/frontier-mechanism.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/frontier-mechanism.json",
+  "title": "FrontierMechanism",
+  "description": "A promoted mechanism on the harness-optimization frontier (AC-880). It records a candidate that passed the promotion gate, its lineage parent, the surfaces it affects, the regression risks it carries, and how many generations of support it has. This is the archived record of what advanced. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "mechanism_id",
+    "candidate_evidence_id",
+    "mechanism_name",
+    "mechanism_type",
+    "target_surface",
+    "gate_decision",
+    "affected_surfaces",
+    "regression_risks",
+    "support_count",
+    "promoted_at_generation"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "mechanism_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique identifier for this frontier mechanism."
+    },
+    "candidate_evidence_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the candidate evidence record this mechanism was promoted from."
+    },
+    "parent_frontier_id": {
+      "type": "string",
+      "description": "Identifier of the frontier this mechanism descends from. Empty for a root frontier."
+    },
+    "mechanism_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the promoted mechanism."
+    },
+    "mechanism_type": {
+      "type": "string",
+      "enum": [
+        "deterministic_code",
+        "prompt_playbook",
+        "tool_wrapper",
+        "context_policy",
+        "judge_policy",
+        "mixed"
+      ],
+      "description": "Category of mechanism being changed."
+    },
+    "target_surface": {
+      "type": "string",
+      "enum": [
+        "prompt",
+        "tool",
+        "harness_validator",
+        "runtime_adapter",
+        "artifact_landing",
+        "evaluator",
+        "routing",
+        "docs"
+      ],
+      "description": "The surface of the harness this mechanism targets."
+    },
+    "gate_decision": {
+      "type": "string",
+      "description": "The advancement decision that promoted this mechanism."
+    },
+    "affected_surfaces": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Surfaces this mechanism touches beyond its primary target."
+    },
+    "regression_risks": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Known regression risks this mechanism carries forward."
+    },
+    "support_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of runs or generations that support this mechanism."
+    },
+    "promoted_at_generation": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Generation index at which this mechanism was promoted."
+    }
+  }
+}

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/orphan-mechanism.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/orphan-mechanism.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json",
+  "title": "OrphanMechanism",
+  "description": "A rejected or rolled-back mechanism in the harness-optimization archive (AC-880). It records a candidate that failed the promotion gate, the failure family it belongs to, why it was rejected, how many times it was retried, and whether a later combination rescued it. This is the archived record of what did not advance. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "mechanism_id",
+    "candidate_evidence_id",
+    "mechanism_name",
+    "mechanism_type",
+    "target_surface",
+    "gate_decision",
+    "failure_family",
+    "rejection_reason",
+    "retry_count"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "mechanism_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique identifier for this orphan mechanism."
+    },
+    "candidate_evidence_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the candidate evidence record this mechanism came from."
+    },
+    "parent_frontier_id": {
+      "type": "string",
+      "description": "Identifier of the frontier this mechanism descends from. Empty for a root candidate."
+    },
+    "mechanism_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the orphaned mechanism."
+    },
+    "mechanism_type": {
+      "type": "string",
+      "enum": [
+        "deterministic_code",
+        "prompt_playbook",
+        "tool_wrapper",
+        "context_policy",
+        "judge_policy",
+        "mixed"
+      ],
+      "description": "Category of mechanism being changed."
+    },
+    "target_surface": {
+      "type": "string",
+      "enum": [
+        "prompt",
+        "tool",
+        "harness_validator",
+        "runtime_adapter",
+        "artifact_landing",
+        "evaluator",
+        "routing",
+        "docs"
+      ],
+      "description": "The surface of the harness this mechanism targets."
+    },
+    "gate_decision": {
+      "type": "string",
+      "description": "The gate outcome for this mechanism, such as retry, rollback, or reject."
+    },
+    "failure_family": {
+      "type": "string",
+      "description": "The family of failure this mechanism belongs to, for clustering orphans."
+    },
+    "rejection_reason": {
+      "type": "string",
+      "description": "Human-readable reason this mechanism was not promoted."
+    },
+    "retry_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of times this mechanism was retried before being orphaned."
+    },
+    "support_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of runs or generations that support this mechanism."
+    },
+    "rescued_into_frontier_id": {
+      "type": "string",
+      "description": "Frontier id a later combination rescued this into. Empty while still orphaned."
+    }
+  }
+}

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -384,3 +384,186 @@ class IntegrityMetadata(BaseModel):
             description='Human-readable reasons for a contaminated or unknown status. Empty when clean.'
         ),
     ]
+
+
+class FrontierMechanism(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    schema_version: Annotated[
+        Literal[1],
+        Field(
+            description='Schema version for forward compatibility. Always 1 for this revision.'
+        ),
+    ]
+    mechanism_id: Annotated[
+        str,
+        Field(
+            description='Stable unique identifier for this frontier mechanism.',
+            min_length=1,
+        ),
+    ]
+    candidate_evidence_id: Annotated[
+        str,
+        Field(
+            description='Identifier of the candidate evidence record this mechanism was promoted from.',
+            min_length=1,
+        ),
+    ]
+    parent_frontier_id: Annotated[
+        str | None,
+        Field(
+            description='Identifier of the frontier this mechanism descends from. Empty for a root frontier.'
+        ),
+    ] = None
+    mechanism_name: Annotated[
+        str,
+        Field(
+            description='Human-readable name of the promoted mechanism.', min_length=1
+        ),
+    ]
+    mechanism_type: Annotated[
+        Literal[
+            'deterministic_code',
+            'prompt_playbook',
+            'tool_wrapper',
+            'context_policy',
+            'judge_policy',
+            'mixed',
+        ],
+        Field(description='Category of mechanism being changed.'),
+    ]
+    target_surface: Annotated[
+        Literal[
+            'prompt',
+            'tool',
+            'harness_validator',
+            'runtime_adapter',
+            'artifact_landing',
+            'evaluator',
+            'routing',
+            'docs',
+        ],
+        Field(description='The surface of the harness this mechanism targets.'),
+    ]
+    gate_decision: Annotated[
+        str, Field(description='The advancement decision that promoted this mechanism.')
+    ]
+    affected_surfaces: Annotated[
+        list[str],
+        Field(description='Surfaces this mechanism touches beyond its primary target.'),
+    ]
+    regression_risks: Annotated[
+        list[str],
+        Field(description='Known regression risks this mechanism carries forward.'),
+    ]
+    support_count: Annotated[
+        int,
+        Field(
+            description='Number of runs or generations that support this mechanism.',
+            ge=0,
+        ),
+    ]
+    promoted_at_generation: Annotated[
+        int,
+        Field(
+            description='Generation index at which this mechanism was promoted.', ge=0
+        ),
+    ]
+
+
+class OrphanMechanism(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    schema_version: Annotated[
+        Literal[1],
+        Field(
+            description='Schema version for forward compatibility. Always 1 for this revision.'
+        ),
+    ]
+    mechanism_id: Annotated[
+        str,
+        Field(
+            description='Stable unique identifier for this orphan mechanism.',
+            min_length=1,
+        ),
+    ]
+    candidate_evidence_id: Annotated[
+        str,
+        Field(
+            description='Identifier of the candidate evidence record this mechanism came from.',
+            min_length=1,
+        ),
+    ]
+    parent_frontier_id: Annotated[
+        str | None,
+        Field(
+            description='Identifier of the frontier this mechanism descends from. Empty for a root candidate.'
+        ),
+    ] = None
+    mechanism_name: Annotated[
+        str,
+        Field(
+            description='Human-readable name of the orphaned mechanism.', min_length=1
+        ),
+    ]
+    mechanism_type: Annotated[
+        Literal[
+            'deterministic_code',
+            'prompt_playbook',
+            'tool_wrapper',
+            'context_policy',
+            'judge_policy',
+            'mixed',
+        ],
+        Field(description='Category of mechanism being changed.'),
+    ]
+    target_surface: Annotated[
+        Literal[
+            'prompt',
+            'tool',
+            'harness_validator',
+            'runtime_adapter',
+            'artifact_landing',
+            'evaluator',
+            'routing',
+            'docs',
+        ],
+        Field(description='The surface of the harness this mechanism targets.'),
+    ]
+    gate_decision: Annotated[
+        str,
+        Field(
+            description='The gate outcome for this mechanism, such as retry, rollback, or reject.'
+        ),
+    ]
+    failure_family: Annotated[
+        str,
+        Field(
+            description='The family of failure this mechanism belongs to, for clustering orphans.'
+        ),
+    ]
+    rejection_reason: Annotated[
+        str, Field(description='Human-readable reason this mechanism was not promoted.')
+    ]
+    retry_count: Annotated[
+        int,
+        Field(
+            description='Number of times this mechanism was retried before being orphaned.',
+            ge=0,
+        ),
+    ]
+    support_count: Annotated[
+        int | None,
+        Field(
+            description='Number of runs or generations that support this mechanism.',
+            ge=0,
+        ),
+    ] = None
+    rescued_into_frontier_id: Annotated[
+        str | None,
+        Field(
+            description='Frontier id a later combination rescued this into. Empty while still orphaned.'
+        ),
+    ] = None

--- a/autocontext/src/autocontext/harness_optimization/mechanism_archive.py
+++ b/autocontext/src/autocontext/harness_optimization/mechanism_archive.py
@@ -127,6 +127,33 @@ def prune_orphans(orphans: tuple[OrphanMechanism, ...], max_orphans: int) -> tup
     return rank_orphans(orphans)[:max_orphans]
 
 
+def render_archive_digest(archive: MechanismArchive, *, max_entries: int) -> str:
+    """Render a bounded, ranked digest of the archive for proposer prompts.
+
+    The digest has a fixed shape so a TypeScript port can reproduce it
+    character-for-character: a header line, a `frontier:` section listing up to
+    `max_entries` frontier mechanisms in frontier order, then an
+    `orphans (reusable):` section listing up to `max_entries` not-rescued
+    orphans in `rank_orphans` order. Rescued orphans are excluded from the
+    reusable section. A non-positive `max_entries` emits the section headers
+    with no items. Missing support_count counts as 0.
+    """
+
+    cap = max(max_entries, 0)
+
+    lines = ["mechanism archive digest", "frontier:"]
+    for front in archive.frontier[:cap]:
+        lines.append(f"  - {front.mechanism_name} [{front.target_surface}] support={front.support_count}")
+
+    lines.append("orphans (reusable):")
+    reusable = tuple(m for m in rank_orphans(archive.orphans) if not _is_rescued(m))
+    for orphan in reusable[:cap]:
+        support = orphan.support_count or 0
+        lines.append(f"  - {orphan.mechanism_name} [{orphan.failure_family}] support={support}")
+
+    return "\n".join(lines)
+
+
 __all__ = [
     "MechanismArchive",
     "QueryResult",
@@ -135,5 +162,6 @@ __all__ = [
     "prune_orphans",
     "query",
     "rank_orphans",
+    "render_archive_digest",
     "rescue_orphan",
 ]

--- a/autocontext/src/autocontext/harness_optimization/mechanism_archive.py
+++ b/autocontext/src/autocontext/harness_optimization/mechanism_archive.py
@@ -1,0 +1,139 @@
+"""Pure in-memory archive of promoted (frontier) and orphaned mechanisms.
+
+The archive keeps two immutable lists: `frontier` mechanisms that were
+promoted and `orphans` that were gated out. Every operation returns a new
+`MechanismArchive`; nothing is mutated in place and there is no IO. Rescue is
+explicit: adding a frontier never removes an orphan, and rescuing an orphan
+leaves it in `orphans` (with `rescued_into_frontier_id` set) so history is
+preserved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+from autocontext.harness_optimization.contract.models import (
+    FrontierMechanism,
+    OrphanMechanism,
+)
+
+
+class QueryResult(TypedDict):
+    frontier: tuple[FrontierMechanism, ...]
+    orphans: tuple[OrphanMechanism, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MechanismArchive:
+    frontier: tuple[FrontierMechanism, ...] = ()
+    orphans: tuple[OrphanMechanism, ...] = ()
+
+
+def add_frontier(archive: MechanismArchive, mechanism: FrontierMechanism) -> MechanismArchive:
+    """Return a new archive with `mechanism` appended to the frontier."""
+
+    return MechanismArchive(frontier=(*archive.frontier, mechanism), orphans=archive.orphans)
+
+
+def add_orphan(archive: MechanismArchive, mechanism: OrphanMechanism) -> MechanismArchive:
+    """Return a new archive with `mechanism` appended to the orphans."""
+
+    return MechanismArchive(frontier=archive.frontier, orphans=(*archive.orphans, mechanism))
+
+
+def rescue_orphan(
+    archive: MechanismArchive,
+    orphan_id: str,
+    into_frontier_id: str,
+) -> MechanismArchive:
+    """Mark the orphan `orphan_id` as rescued into `into_frontier_id`.
+
+    The orphan stays in `orphans` with `rescued_into_frontier_id` set so the
+    rescue is auditable. An unknown id returns the archive unchanged.
+    """
+
+    if not any(m.mechanism_id == orphan_id for m in archive.orphans):
+        return archive
+    rescued = tuple(
+        m.model_copy(update={"rescued_into_frontier_id": into_frontier_id}) if m.mechanism_id == orphan_id else m
+        for m in archive.orphans
+    )
+    return MechanismArchive(frontier=archive.frontier, orphans=rescued)
+
+
+def query(
+    archive: MechanismArchive,
+    *,
+    mechanism_type: str | None = None,
+    target_surface: str | None = None,
+    failure_family: str | None = None,
+) -> QueryResult:
+    """Filter both lists by any provided facet.
+
+    `mechanism_type` and `target_surface` filter frontier and orphans alike.
+    `failure_family` filters orphans only (frontier has no failure family), so
+    the frontier list is left unfiltered by that facet but still narrowed by
+    any other provided facet. A `None` facet applies no filter.
+    """
+
+    frontier = tuple(
+        m
+        for m in archive.frontier
+        if (mechanism_type is None or m.mechanism_type == mechanism_type)
+        and (target_surface is None or m.target_surface == target_surface)
+    )
+    orphans = tuple(
+        m
+        for m in archive.orphans
+        if (mechanism_type is None or m.mechanism_type == mechanism_type)
+        and (target_surface is None or m.target_surface == target_surface)
+        and (failure_family is None or m.failure_family == failure_family)
+    )
+    return {"frontier": frontier, "orphans": orphans}
+
+
+def _is_rescued(mechanism: OrphanMechanism) -> bool:
+    return bool(mechanism.rescued_into_frontier_id)
+
+
+def _rank_key(mechanism: OrphanMechanism) -> tuple[int, int, int, str]:
+    support = mechanism.support_count or 0
+    return (
+        1 if _is_rescued(mechanism) else 0,
+        -support,
+        mechanism.retry_count,
+        mechanism.mechanism_id,
+    )
+
+
+def rank_orphans(orphans: tuple[OrphanMechanism, ...]) -> tuple[OrphanMechanism, ...]:
+    """Order orphans most-reusable first.
+
+    Ascending sort over: not-rescued before rescued, then support_count
+    descending, then retry_count ascending, then mechanism_id ascending as a
+    stable tiebreak. Missing support_count counts as 0 and a missing or empty
+    rescued_into_frontier_id counts as not-rescued.
+    """
+
+    return tuple(sorted(orphans, key=_rank_key))
+
+
+def prune_orphans(orphans: tuple[OrphanMechanism, ...], max_orphans: int) -> tuple[OrphanMechanism, ...]:
+    """Keep the top `max_orphans` orphans by reuse rank, in rank order."""
+
+    if max_orphans < 0:
+        max_orphans = 0
+    return rank_orphans(orphans)[:max_orphans]
+
+
+__all__ = [
+    "MechanismArchive",
+    "QueryResult",
+    "add_frontier",
+    "add_orphan",
+    "prune_orphans",
+    "query",
+    "rank_orphans",
+    "rescue_orphan",
+]

--- a/autocontext/tests/harness_optimization/test_mechanism_archive.py
+++ b/autocontext/tests/harness_optimization/test_mechanism_archive.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autocontext.harness_optimization.contract.models import (
+    FrontierMechanism,
+    OrphanMechanism,
+)
+from autocontext.harness_optimization.mechanism_archive import (
+    MechanismArchive,
+    add_orphan,
+    prune_orphans,
+    query,
+    rank_orphans,
+    rescue_orphan,
+)
+
+FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "mechanism-archive" / "archive-cases.json"
+
+_FIXTURE = json.loads(FIX.read_text())
+
+
+def _seed_archive() -> MechanismArchive:
+    seed = _FIXTURE["seed"]
+    return MechanismArchive(
+        frontier=tuple(FrontierMechanism.model_validate(item) for item in seed["frontier"]),
+        orphans=tuple(OrphanMechanism.model_validate(item) for item in seed["orphans"]),
+    )
+
+
+def _case_id(case: dict[str, Any]) -> str:
+    return str(case["name"])
+
+
+@pytest.mark.parametrize("case", _FIXTURE["cases"], ids=[_case_id(c) for c in _FIXTURE["cases"]])
+def test_archive_case(case: dict[str, Any]) -> None:
+    archive = _seed_archive()
+    op = case["op"]
+
+    if op == "add_orphan":
+        added = add_orphan(archive, OrphanMechanism.model_validate(case["orphan"]))
+        assert len(added.orphans) == case["expected_orphan_count"]
+        assert added.orphans[-1].mechanism_id == case["expected_added_orphan_id"]
+        # Input archive is not mutated.
+        assert len(archive.orphans) == len(_FIXTURE["seed"]["orphans"])
+
+    elif op == "query_by_type":
+        result = query(archive, mechanism_type=case["mechanism_type"])
+        assert [m.mechanism_id for m in result["frontier"]] == case["expected_frontier_ids"]
+        assert [m.mechanism_id for m in result["orphans"]] == case["expected_orphan_ids"]
+
+    elif op == "rank_orphans":
+        ranked = rank_orphans(archive.orphans)
+        assert [m.mechanism_id for m in ranked] == case["expected_order"]
+
+    elif op == "rescue":
+        rescued = rescue_orphan(archive, case["orphan_id"], case["into_frontier_id"])
+        target = next(m for m in rescued.orphans if m.mechanism_id == case["orphan_id"])
+        assert target.rescued_into_frontier_id == case["expected_rescued_into_frontier_id"]
+        ranked = rank_orphans(rescued.orphans)
+        assert [m.mechanism_id for m in ranked] == case["expected_order"]
+        assert ranked[-1].mechanism_id == case["expected_last_orphan_id"]
+
+    elif op == "prune":
+        pruned = prune_orphans(archive.orphans, case["max_orphans"])
+        assert [m.mechanism_id for m in pruned] == case["expected_surviving_ids"]
+
+    elif op == "digest":
+        pytest.skip("digest is driven by task 4")
+
+    else:  # pragma: no cover - guards against an unhandled fixture op
+        pytest.fail(f"unhandled op: {op}")

--- a/autocontext/tests/harness_optimization/test_mechanism_archive.py
+++ b/autocontext/tests/harness_optimization/test_mechanism_archive.py
@@ -14,6 +14,7 @@ from autocontext.harness_optimization.mechanism_archive import (
     prune_orphans,
     query,
     rank_orphans,
+    render_archive_digest,
     rescue_orphan,
 )
 
@@ -68,7 +69,33 @@ def test_archive_case(case: dict[str, Any]) -> None:
         assert [m.mechanism_id for m in pruned] == case["expected_surviving_ids"]
 
     elif op == "digest":
-        pytest.skip("digest is driven by task 4")
+        max_entries = case["max_entries"]
+        digest = render_archive_digest(archive, max_entries=max_entries)
+        assert isinstance(digest, str)
+        assert case["expected_header"] in digest
+        lines = digest.splitlines()
+
+        # Split into the frontier and orphan sections by their headers.
+        frontier_start = lines.index("frontier:")
+        orphan_start = lines.index("orphans (reusable):")
+        frontier_items = [ln for ln in lines[frontier_start + 1 : orphan_start] if ln.startswith("  - ")]
+        orphan_items = [ln for ln in lines[orphan_start + 1 :] if ln.startswith("  - ")]
+
+        # Boundedness: never more than max_entries items per section.
+        assert len(frontier_items) <= max_entries
+        assert len(orphan_items) <= max_entries
+        assert len(frontier_items) == case["expected_frontier_count"]
+
+        # The orphan section lists exactly the expected ids in rank order.
+        id_to_name = {o["mechanism_id"]: o["mechanism_name"] for o in _FIXTURE["seed"]["orphans"]}
+        expected_names = [id_to_name[i] for i in case["expected_orphan_ids_in_order"]]
+        rendered_orphan_names = [ln.split(" [", 1)[0].removeprefix("  - ") for ln in orphan_items]
+        assert rendered_orphan_names == expected_names
+
+        # Rescued orphans are excluded entirely from the reusable section.
+        orphan_section = "\n".join(lines[orphan_start:])
+        for excluded_id in case["expected_excludes"]:
+            assert id_to_name[excluded_id] not in orphan_section
 
     else:  # pragma: no cover - guards against an unhandled fixture op
         pytest.fail(f"unhandled op: {op}")

--- a/autocontext/tests/harness_optimization/test_mechanism_archive.py
+++ b/autocontext/tests/harness_optimization/test_mechanism_archive.py
@@ -52,6 +52,26 @@ def test_archive_case(case: dict[str, Any]) -> None:
         assert [m.mechanism_id for m in result["frontier"]] == case["expected_frontier_ids"]
         assert [m.mechanism_id for m in result["orphans"]] == case["expected_orphan_ids"]
 
+    elif op == "query_by_failure_family":
+        result = query(archive, failure_family=case["failure_family"])
+        # failure_family narrows orphans only; the frontier stays whole.
+        assert [m.mechanism_id for m in result["frontier"]] == case["expected_frontier_ids"]
+        assert [m.mechanism_id for m in result["orphans"]] == case["expected_orphan_ids"]
+
+    elif op == "query_by_surface":
+        result = query(archive, target_surface=case["target_surface"])
+        assert [m.mechanism_id for m in result["frontier"]] == case["expected_frontier_ids"]
+        assert [m.mechanism_id for m in result["orphans"]] == case["expected_orphan_ids"]
+
+    elif op == "rescue_noop":
+        rescued = rescue_orphan(archive, case["orphan_id"], case["into_frontier_id"])
+        # An unknown orphan id leaves the archive unchanged: identical ids and no
+        # new rescued_into_frontier_id set on anyone.
+        assert [m.mechanism_id for m in rescued.orphans] == case["expected_orphan_ids"]
+        before = {m.mechanism_id: m.rescued_into_frontier_id for m in archive.orphans}
+        after = {m.mechanism_id: m.rescued_into_frontier_id for m in rescued.orphans}
+        assert after == before
+
     elif op == "rank_orphans":
         ranked = rank_orphans(archive.orphans)
         assert [m.mechanism_id for m in ranked] == case["expected_order"]
@@ -92,6 +112,20 @@ def test_archive_case(case: dict[str, Any]) -> None:
         rendered_orphan_names = [ln.split(" [", 1)[0].removeprefix("  - ") for ln in orphan_items]
         assert rendered_orphan_names == expected_names
 
+        # With max_entries=1 each section holds at most one item and the orphan
+        # section is exactly the top-ranked not-rescued orphan. This fails if the
+        # per-section cap is ever dropped.
+        if max_entries == 1:
+            assert len(frontier_items) <= 1
+            assert len(orphan_items) <= 1
+            assert case["expected_orphan_ids_in_order"] == ["orphan-ac880-A"]
+            assert rendered_orphan_names == [id_to_name["orphan-ac880-A"]]
+
+        # When the fixture pins the exact string, the render must match it
+        # character-for-character (parity with the TypeScript renderer).
+        if "expected_digest" in case:
+            assert digest == case["expected_digest"]
+
         # Rescued orphans are excluded entirely from the reusable section.
         orphan_section = "\n".join(lines[orphan_start:])
         for excluded_id in case["expected_excludes"]:
@@ -99,3 +133,10 @@ def test_archive_case(case: dict[str, Any]) -> None:
 
     else:  # pragma: no cover - guards against an unhandled fixture op
         pytest.fail(f"unhandled op: {op}")
+
+
+def test_digest_headers_only_for_non_positive_max_entries() -> None:
+    # Mirrors the TypeScript suite: a non-positive max_entries emits the section
+    # headers with no items.
+    digest = render_archive_digest(_seed_archive(), max_entries=0)
+    assert digest == "mechanism archive digest\nfrontier:\norphans (reusable):"

--- a/autocontext/tests/harness_optimization/test_mechanism_archive_contract.py
+++ b/autocontext/tests/harness_optimization/test_mechanism_archive_contract.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.harness_optimization.contract.models import (
+    FrontierMechanism,
+    OrphanMechanism,
+)
+
+FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "mechanism-archive"
+
+
+def test_valid_frontier_round_trips() -> None:
+    data = json.loads((FIX / "valid-frontier.json").read_text())
+    model = FrontierMechanism.model_validate(data)
+    assert model.mechanism_id == "frontier-ac880-001"
+    assert model.promoted_at_generation == 7
+
+
+def test_valid_orphan_round_trips() -> None:
+    data = json.loads((FIX / "valid-orphan.json").read_text())
+    model = OrphanMechanism.model_validate(data)
+    assert model.failure_family == "regression-on-holdout"
+    assert model.retry_count == 2
+
+
+def test_orphan_missing_failure_family_rejected() -> None:
+    data = json.loads((FIX / "invalid-orphan-missing-failure-family.json").read_text())
+    with pytest.raises(ValidationError):
+        OrphanMechanism.model_validate(data)

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -348,6 +348,111 @@ counts, and gate decisions:
   languages parse to `docs.example.com`, so the audit is `clean` and the gate
   advances it promotion-grade.
 
+## Mechanism archive (AC-880)
+
+A harness optimization run produces two kinds of mechanism over time: the ones
+that cleared the promotion gate and now define the working harness, and the ones
+that were gated out. Throwing the second kind away loses real signal. A mechanism
+that was rolled back at generation 5 because it regressed a holdout trace can be
+exactly the piece a later candidate needs once a neighbouring surface has moved.
+The **mechanism archive** keeps both kinds so the proposer can learn from the full
+history, not just the surviving frontier.
+
+The archive keeps two record types, each generated from its own canonical schema
+under the same drift gate as the rest of the protocol. A **FrontierMechanism**
+(`ts/src/harness-optimization/contract/json-schemas/frontier-mechanism.schema.json`)
+is a mechanism that was promoted: it carries its `gate_decision`, the
+`affected_surfaces` it touches, the `regression_risks` it accepted, a
+`support_count` of how many candidates lean on it, and the
+`promoted_at_generation` it entered the frontier. An **OrphanMechanism**
+(`ts/src/harness-optimization/contract/json-schemas/orphan-mechanism.schema.json`)
+is a mechanism that was rejected or not promoted: alongside the same identity and
+surface fields it carries a `failure_family` (why the surface rejected it), a
+`rejection_reason`, a `retry_count`, and an optional `rescued_into_frontier_id`.
+Both schemas generate the TypeScript interface, the Python pydantic model, and a
+`validateFrontierMechanism` / `validateOrphanMechanism` validator, so the two
+languages can never disagree on a record.
+
+Every record carries the same two lineage fields that tie the archive back to the
+rest of the protocol. `candidate_evidence_id` points at the CandidateEvidence
+(AC-876) the mechanism was born from, so a promoted or orphaned mechanism can be
+traced to the hypothesis and changes that proposed it. `parent_frontier_id` points
+at the frontier mechanism this one was built on, so the archive records a lineage
+of successive changes rather than a flat list. An orphan preserves both fields
+after rollback, which is what makes it rescuable later: it still knows where it
+came from and what it was trying to extend.
+
+### The engine
+
+The archive is a pure in-memory value with no IO. `MechanismArchive` holds two
+immutable tuples, `frontier` and `orphans`, and every operation returns a new
+archive rather than mutating in place. The engine surface (Python in
+`autocontext/src/autocontext/harness_optimization/mechanism_archive.py`, mirrored
+in TypeScript at `ts/src/harness-optimization/mechanism-archive.ts`) is:
+
+- **add_frontier** / **addFrontier**: append a promoted mechanism to the frontier.
+- **add_orphan** / **addOrphan**: append a gated-out mechanism to the orphans.
+  Adding a frontier never removes an orphan and adding an orphan never touches the
+  frontier, so the two lists accumulate independently.
+- **rescue_orphan** / **rescueOrphan**: mark an orphan as rescued into a named
+  later frontier mechanism. The orphan stays in `orphans` with its
+  `rescued_into_frontier_id` set, so the rescue is auditable and history is
+  preserved rather than rewritten. An unknown id returns the archive unchanged.
+- **query** / **query**: filter both lists by any combination of `mechanism_type`,
+  `target_surface`, and `failure_family`. The first two facets narrow frontier and
+  orphans alike; `failure_family` narrows orphans only, since the frontier has no
+  failure family. A missing facet applies no filter.
+- **rank_orphans** / **rankOrphans**: order orphans most-reusable first (see below).
+- **prune_orphans** / **pruneOrphans**: keep the top `max_orphans` orphans by reuse
+  rank, in rank order, so a long-running archive stays bounded without dropping the
+  most reusable history. A negative bound clamps to zero.
+- **render_archive_digest** / **renderArchiveDigest**: render a bounded, ranked
+  summary for proposer prompts (see below).
+
+### The ranking rule
+
+`rank_orphans` orders orphans so the most reusable ones come first, by an
+ascending sort over a four-part key:
+
+1. **not-rescued before rescued**: an orphan that has not yet been rescued is a
+   live reuse opportunity and sorts ahead of one already folded into a frontier. A
+   missing or empty `rescued_into_frontier_id` counts as not-rescued.
+2. **support_count descending**: an orphan that more candidates leaned on is more
+   likely to be worth reviving. A missing support_count counts as 0.
+3. **retry_count ascending**: among equally supported orphans, the one that needed
+   fewer retries is the cleaner candidate.
+4. **mechanism_id ascending**: a stable tiebreak so both languages produce the
+   identical order.
+
+`prune_orphans` uses exactly this order, so pruning keeps the orphans a proposer
+is most likely to reuse and discards the stale, low-support, many-retry tail.
+
+### The bounded proposer digest
+
+`render_archive_digest` turns the archive into the string that actually reaches a
+proposer prompt. It is deliberately bounded and ranked so the proposer sees
+evidence-backed mechanisms above stale or noisy ones and never sees more than
+`max_entries` entries per section. The digest has a fixed shape a TypeScript port
+reproduces character-for-character: a header line, a `frontier:` section listing up
+to `max_entries` frontier mechanisms in frontier order, then an
+`orphans (reusable):` section listing up to `max_entries` not-rescued orphans in
+`rank_orphans` order. Rescued orphans are excluded from the reusable section
+because they already live in the frontier lineage, and a non-positive `max_entries`
+emits the section headers with no items. The bound is the point: a proposer prompt
+gets the highest-support frontier and the most reusable orphans, capped, instead of
+an unbounded dump that would bury the signal.
+
+### The worked cases
+
+A shared fixture
+(`fixtures/harness-optimization/mechanism-archive/archive-cases.json`) pins a seed
+archive plus a set of cases that both packages load to prove they compute
+identical results: appending an orphan grows the orphan list, a `mechanism_type`
+query filters both lists together, `rank_orphans` orders the seed orphans
+most-reusable first, a rescue sets the frontier id and sinks the rescued orphan to
+the tail of the reuse order, prune keeps the top-ranked orphans, and the digest
+renders the same bounded, ranked proposer feed on both sides.
+
 ## The contract pattern
 
 This is the foundation artifact. The later protocol artifacts follow the same

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -371,7 +371,10 @@ surface fields it carries a `failure_family` (why the surface rejected it), a
 `rejection_reason`, a `retry_count`, and an optional `rescued_into_frontier_id`.
 Both schemas generate the TypeScript interface, the Python pydantic model, and a
 `validateFrontierMechanism` / `validateOrphanMechanism` validator, so the two
-languages can never disagree on a record.
+languages can never disagree on a record. Optional fields follow an omit-none
+serialization convention: Python callers dump records with `exclude_none` so an
+absent optional is omitted from the shared shape rather than emitted as `null`,
+which keeps the TypeScript AJV validation happy.
 
 Every record carries the same two lineage fields that tie the archive back to the
 rest of the protocol. `candidate_evidence_id` points at the CandidateEvidence
@@ -422,7 +425,8 @@ ascending sort over a four-part key:
 3. **retry_count ascending**: among equally supported orphans, the one that needed
    fewer retries is the cleaner candidate.
 4. **mechanism_id ascending**: a stable tiebreak so both languages produce the
-   identical order.
+   identical order. `mechanism_id` is assumed ASCII so the cross-language string
+   comparison in the tiebreak orders identically in Python and TypeScript.
 
 `prune_orphans` uses exactly this order, so pruning keeps the orphans a proposer
 is most likely to reuse and discards the stale, low-support, many-retry tail.

--- a/fixtures/harness-optimization/mechanism-archive/archive-cases.json
+++ b/fixtures/harness-optimization/mechanism-archive/archive-cases.json
@@ -149,7 +149,55 @@
       "expected_frontier_count": 2,
       "expected_orphan_ids_in_order": ["orphan-ac880-A", "orphan-ac880-C", "orphan-ac880-B"],
       "expected_excludes": ["orphan-ac880-D"],
+      "expected_header": "mechanism archive digest",
+      "expected_digest": "mechanism archive digest\nfrontier:\n  - retry-on-truncated-output guard [harness_validator] support=4\n  - structured finish-guard playbook [prompt] support=3\norphans (reusable):\n  - prompt hint for empty-tool-call retry [empty-tool-call] support=3\n  - tighter finish-guard prompt [empty-tool-call] support=3\n  - aggressive context pruning [context-loss] support=1"
+    },
+    {
+      "name": "digest truncates each section to a single entry when max_entries is 1",
+      "op": "digest",
+      "max_entries": 1,
+      "expected_frontier_count": 1,
+      "expected_orphan_ids_in_order": ["orphan-ac880-A"],
+      "expected_excludes": ["orphan-ac880-D"],
       "expected_header": "mechanism archive digest"
+    },
+    {
+      "name": "query by failure_family filters orphans only and leaves the frontier whole",
+      "op": "query_by_failure_family",
+      "failure_family": "empty-tool-call",
+      "expected_frontier_ids": ["frontier-ac880-001", "frontier-ac880-002"],
+      "expected_orphan_ids": ["orphan-ac880-A", "orphan-ac880-C"]
+    },
+    {
+      "name": "query by target_surface filters both lists",
+      "op": "query_by_surface",
+      "target_surface": "prompt",
+      "expected_frontier_ids": ["frontier-ac880-002"],
+      "expected_orphan_ids": ["orphan-ac880-A", "orphan-ac880-C"]
+    },
+    {
+      "name": "rescue with an unknown orphan id leaves the archive unchanged",
+      "op": "rescue_noop",
+      "orphan_id": "orphan-ac880-UNKNOWN",
+      "into_frontier_id": "frontier-ac880-001",
+      "expected_orphan_ids": [
+        "orphan-ac880-A",
+        "orphan-ac880-B",
+        "orphan-ac880-C",
+        "orphan-ac880-D"
+      ]
+    },
+    {
+      "name": "prune with a zero bound keeps no orphans",
+      "op": "prune",
+      "max_orphans": 0,
+      "expected_surviving_ids": []
+    },
+    {
+      "name": "prune with a negative bound clamps to zero orphans",
+      "op": "prune",
+      "max_orphans": -1,
+      "expected_surviving_ids": []
     }
   ]
 }

--- a/fixtures/harness-optimization/mechanism-archive/archive-cases.json
+++ b/fixtures/harness-optimization/mechanism-archive/archive-cases.json
@@ -1,0 +1,152 @@
+{
+  "seed": {
+    "frontier": [
+      {
+        "schema_version": 1,
+        "mechanism_id": "frontier-ac880-001",
+        "candidate_evidence_id": "candidate-ac876-042",
+        "parent_frontier_id": "frontier-ac880-000",
+        "mechanism_name": "retry-on-truncated-output guard",
+        "mechanism_type": "deterministic_code",
+        "target_surface": "harness_validator",
+        "gate_decision": "advance",
+        "affected_surfaces": ["harness_validator", "evaluator"],
+        "regression_risks": ["adds one retry on legitimately empty outputs"],
+        "support_count": 4,
+        "promoted_at_generation": 7
+      },
+      {
+        "schema_version": 1,
+        "mechanism_id": "frontier-ac880-002",
+        "candidate_evidence_id": "candidate-ac876-051",
+        "parent_frontier_id": "frontier-ac880-001",
+        "mechanism_name": "structured finish-guard playbook",
+        "mechanism_type": "prompt_playbook",
+        "target_surface": "prompt",
+        "gate_decision": "advance",
+        "affected_surfaces": ["prompt"],
+        "regression_risks": ["may over-truncate long legitimate plans"],
+        "support_count": 3,
+        "promoted_at_generation": 9
+      }
+    ],
+    "orphans": [
+      {
+        "schema_version": 1,
+        "mechanism_id": "orphan-ac880-A",
+        "candidate_evidence_id": "candidate-ac876-080",
+        "parent_frontier_id": "frontier-ac880-001",
+        "mechanism_name": "prompt hint for empty-tool-call retry",
+        "mechanism_type": "prompt_playbook",
+        "target_surface": "prompt",
+        "gate_decision": "retry",
+        "failure_family": "empty-tool-call",
+        "rejection_reason": "helped fix cases but did not clear the delta gate on its own",
+        "retry_count": 0,
+        "support_count": 3,
+        "rescued_into_frontier_id": ""
+      },
+      {
+        "schema_version": 1,
+        "mechanism_id": "orphan-ac880-B",
+        "candidate_evidence_id": "candidate-ac876-081",
+        "parent_frontier_id": "frontier-ac880-001",
+        "mechanism_name": "aggressive context pruning",
+        "mechanism_type": "deterministic_code",
+        "target_surface": "harness_validator",
+        "gate_decision": "rollback",
+        "failure_family": "context-loss",
+        "rejection_reason": "regressed two holdout traces beyond the delta gate",
+        "retry_count": 2,
+        "support_count": 1,
+        "rescued_into_frontier_id": ""
+      },
+      {
+        "schema_version": 1,
+        "mechanism_id": "orphan-ac880-C",
+        "candidate_evidence_id": "candidate-ac876-082",
+        "parent_frontier_id": "frontier-ac880-001",
+        "mechanism_name": "tighter finish-guard prompt",
+        "mechanism_type": "prompt_playbook",
+        "target_surface": "prompt",
+        "gate_decision": "retry",
+        "failure_family": "empty-tool-call",
+        "rejection_reason": "matched frontier on fix cases but not clearly better",
+        "retry_count": 1,
+        "support_count": 3,
+        "rescued_into_frontier_id": ""
+      },
+      {
+        "schema_version": 1,
+        "mechanism_id": "orphan-ac880-D",
+        "candidate_evidence_id": "candidate-ac876-083",
+        "parent_frontier_id": "frontier-ac880-002",
+        "mechanism_name": "tool-call json repair wrapper",
+        "mechanism_type": "tool_wrapper",
+        "target_surface": "tool",
+        "gate_decision": "reject",
+        "failure_family": "malformed-tool-json",
+        "rejection_reason": "superseded by a combined wrapper that was promoted later",
+        "retry_count": 0,
+        "support_count": 5,
+        "rescued_into_frontier_id": "frontier-ac880-002"
+      }
+    ]
+  },
+  "cases": [
+    {
+      "name": "add_orphan appends and grows the count",
+      "op": "add_orphan",
+      "orphan": {
+        "schema_version": 1,
+        "mechanism_id": "orphan-ac880-E",
+        "candidate_evidence_id": "candidate-ac876-090",
+        "parent_frontier_id": "frontier-ac880-002",
+        "mechanism_name": "speculative judge-policy relaxation",
+        "mechanism_type": "judge_policy",
+        "target_surface": "evaluator",
+        "gate_decision": "retry",
+        "failure_family": "judge-variance",
+        "rejection_reason": "raised variance beyond the gate",
+        "retry_count": 0,
+        "support_count": 2,
+        "rescued_into_frontier_id": ""
+      },
+      "expected_orphan_count": 5,
+      "expected_added_orphan_id": "orphan-ac880-E"
+    },
+    {
+      "name": "query by mechanism_type prompt_playbook filters both lists",
+      "op": "query_by_type",
+      "mechanism_type": "prompt_playbook",
+      "expected_frontier_ids": ["frontier-ac880-002"],
+      "expected_orphan_ids": ["orphan-ac880-A", "orphan-ac880-C"]
+    },
+    {
+      "name": "rank_orphans orders most reusable first",
+      "op": "rank_orphans",
+      "expected_order": ["orphan-ac880-A", "orphan-ac880-C", "orphan-ac880-B", "orphan-ac880-D"]
+    },
+    {
+      "name": "rescue sets frontier id and sinks the orphan to last",
+      "op": "rescue",
+      "orphan_id": "orphan-ac880-A",
+      "into_frontier_id": "frontier-ac880-001",
+      "expected_rescued_into_frontier_id": "frontier-ac880-001",
+      "expected_order": ["orphan-ac880-C", "orphan-ac880-B", "orphan-ac880-D", "orphan-ac880-A"],
+      "expected_last_orphan_id": "orphan-ac880-A"
+    },
+    {
+      "name": "prune keeps the top-ranked orphans (task 3 extends)",
+      "op": "prune",
+      "max_orphans": 2,
+      "expected_surviving_ids": ["orphan-ac880-A", "orphan-ac880-C"]
+    },
+    {
+      "name": "digest placeholder (task 4 extends)",
+      "op": "digest",
+      "max_entries": 3,
+      "expected_named_ids": ["orphan-ac880-A", "orphan-ac880-C", "orphan-ac880-B"]
+    }
+  ]
+}

--- a/fixtures/harness-optimization/mechanism-archive/archive-cases.json
+++ b/fixtures/harness-optimization/mechanism-archive/archive-cases.json
@@ -143,10 +143,13 @@
       "expected_surviving_ids": ["orphan-ac880-A", "orphan-ac880-C"]
     },
     {
-      "name": "digest placeholder (task 4 extends)",
+      "name": "digest renders a bounded ranked proposer feed",
       "op": "digest",
       "max_entries": 3,
-      "expected_named_ids": ["orphan-ac880-A", "orphan-ac880-C", "orphan-ac880-B"]
+      "expected_frontier_count": 2,
+      "expected_orphan_ids_in_order": ["orphan-ac880-A", "orphan-ac880-C", "orphan-ac880-B"],
+      "expected_excludes": ["orphan-ac880-D"],
+      "expected_header": "mechanism archive digest"
     }
   ]
 }

--- a/fixtures/harness-optimization/mechanism-archive/invalid-orphan-missing-failure-family.json
+++ b/fixtures/harness-optimization/mechanism-archive/invalid-orphan-missing-failure-family.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "mechanism_id": "orphan-ac880-014",
+  "candidate_evidence_id": "candidate-ac876-089",
+  "parent_frontier_id": "frontier-ac880-001",
+  "mechanism_name": "aggressive prompt truncation",
+  "mechanism_type": "prompt_playbook",
+  "target_surface": "prompt",
+  "gate_decision": "reject",
+  "rejection_reason": "regressed holdout traces beyond the delta gate",
+  "retry_count": 1
+}

--- a/fixtures/harness-optimization/mechanism-archive/valid-frontier.json
+++ b/fixtures/harness-optimization/mechanism-archive/valid-frontier.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "mechanism_id": "frontier-ac880-001",
+  "candidate_evidence_id": "candidate-ac876-042",
+  "parent_frontier_id": "frontier-ac880-000",
+  "mechanism_name": "retry-on-truncated-output guard",
+  "mechanism_type": "deterministic_code",
+  "target_surface": "harness_validator",
+  "gate_decision": "advance",
+  "affected_surfaces": ["harness_validator", "evaluator"],
+  "regression_risks": ["adds one retry on legitimately empty outputs"],
+  "support_count": 4,
+  "promoted_at_generation": 7
+}

--- a/fixtures/harness-optimization/mechanism-archive/valid-orphan.json
+++ b/fixtures/harness-optimization/mechanism-archive/valid-orphan.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "mechanism_id": "orphan-ac880-013",
+  "candidate_evidence_id": "candidate-ac876-088",
+  "parent_frontier_id": "frontier-ac880-001",
+  "mechanism_name": "aggressive prompt truncation",
+  "mechanism_type": "prompt_playbook",
+  "target_surface": "prompt",
+  "gate_decision": "rollback",
+  "failure_family": "regression-on-holdout",
+  "rejection_reason": "improved fix cases but regressed two holdout traces beyond the delta gate",
+  "retry_count": 2,
+  "support_count": 0,
+  "rescued_into_frontier_id": ""
+}

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -110,6 +110,63 @@ export interface CandidateEvidence {
   };
 }
 
+// ---- frontier-mechanism.schema.json ----
+/**
+ * A promoted mechanism on the harness-optimization frontier (AC-880). It records a candidate that passed the promotion gate, its lineage parent, the surfaces it affects, the regression risks it carries, and how many generations of support it has. This is the archived record of what advanced. Shared source of truth for both the Python and TypeScript autocontext packages.
+ */
+export interface FrontierMechanism {
+  /**
+   * Schema version for forward compatibility. Always 1 for this revision.
+   */
+  schema_version: 1;
+  /**
+   * Stable unique identifier for this frontier mechanism.
+   */
+  mechanism_id: string;
+  /**
+   * Identifier of the candidate evidence record this mechanism was promoted from.
+   */
+  candidate_evidence_id: string;
+  /**
+   * Identifier of the frontier this mechanism descends from. Empty for a root frontier.
+   */
+  parent_frontier_id?: string;
+  /**
+   * Human-readable name of the promoted mechanism.
+   */
+  mechanism_name: string;
+  /**
+   * Category of mechanism being changed.
+   */
+  mechanism_type:
+    "deterministic_code" | "prompt_playbook" | "tool_wrapper" | "context_policy" | "judge_policy" | "mixed";
+  /**
+   * The surface of the harness this mechanism targets.
+   */
+  target_surface:
+    "prompt" | "tool" | "harness_validator" | "runtime_adapter" | "artifact_landing" | "evaluator" | "routing" | "docs";
+  /**
+   * The advancement decision that promoted this mechanism.
+   */
+  gate_decision: string;
+  /**
+   * Surfaces this mechanism touches beyond its primary target.
+   */
+  affected_surfaces: string[];
+  /**
+   * Known regression risks this mechanism carries forward.
+   */
+  regression_risks: string[];
+  /**
+   * Number of runs or generations that support this mechanism.
+   */
+  support_count: number;
+  /**
+   * Generation index at which this mechanism was promoted.
+   */
+  promoted_at_generation: number;
+}
+
 // ---- integrity-metadata.schema.json ----
 /**
  * Declared integrity scope for a harness-optimization run (AC-879). It records which sources the proposer and evaluator were allowed to read, which are forbidden (holdout, test splits), the web-access policy, the benchmark split manifest in play, and the computed leakage status so a reviewer can prove a candidate was proposed without touching held-out evidence. Verified-mode enforcement (fail closed on contamination or unknown status) is applied by the leakage gate, not by this schema. This schema is the single source of truth for both the Python and TypeScript autocontext packages.
@@ -167,6 +224,67 @@ export interface IntegrityMetadata {
    * Human-readable reasons for a contaminated or unknown status. Empty when clean.
    */
   contamination_reasons: string[];
+}
+
+// ---- orphan-mechanism.schema.json ----
+/**
+ * A rejected or rolled-back mechanism in the harness-optimization archive (AC-880). It records a candidate that failed the promotion gate, the failure family it belongs to, why it was rejected, how many times it was retried, and whether a later combination rescued it. This is the archived record of what did not advance. Shared source of truth for both the Python and TypeScript autocontext packages.
+ */
+export interface OrphanMechanism {
+  /**
+   * Schema version for forward compatibility. Always 1 for this revision.
+   */
+  schema_version: 1;
+  /**
+   * Stable unique identifier for this orphan mechanism.
+   */
+  mechanism_id: string;
+  /**
+   * Identifier of the candidate evidence record this mechanism came from.
+   */
+  candidate_evidence_id: string;
+  /**
+   * Identifier of the frontier this mechanism descends from. Empty for a root candidate.
+   */
+  parent_frontier_id?: string;
+  /**
+   * Human-readable name of the orphaned mechanism.
+   */
+  mechanism_name: string;
+  /**
+   * Category of mechanism being changed.
+   */
+  mechanism_type:
+    "deterministic_code" | "prompt_playbook" | "tool_wrapper" | "context_policy" | "judge_policy" | "mixed";
+  /**
+   * The surface of the harness this mechanism targets.
+   */
+  target_surface:
+    "prompt" | "tool" | "harness_validator" | "runtime_adapter" | "artifact_landing" | "evaluator" | "routing" | "docs";
+  /**
+   * The gate outcome for this mechanism, such as retry, rollback, or reject.
+   */
+  gate_decision: string;
+  /**
+   * The family of failure this mechanism belongs to, for clustering orphans.
+   */
+  failure_family: string;
+  /**
+   * Human-readable reason this mechanism was not promoted.
+   */
+  rejection_reason: string;
+  /**
+   * Number of times this mechanism was retried before being orphaned.
+   */
+  retry_count: number;
+  /**
+   * Number of runs or generations that support this mechanism.
+   */
+  support_count?: number;
+  /**
+   * Frontier id a later combination rescued this into. Empty while still orphaned.
+   */
+  rescued_into_frontier_id?: string;
 }
 
 // ---- promotion-score.schema.json ----

--- a/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
@@ -15,6 +15,12 @@
     },
     "IntegrityMetadata": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json"
+    },
+    "FrontierMechanism": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/frontier-mechanism.json"
+    },
+    "OrphanMechanism": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json"
     }
   }
 }

--- a/ts/src/harness-optimization/contract/json-schemas/frontier-mechanism.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/frontier-mechanism.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/frontier-mechanism.json",
+  "title": "FrontierMechanism",
+  "description": "A promoted mechanism on the harness-optimization frontier (AC-880). It records a candidate that passed the promotion gate, its lineage parent, the surfaces it affects, the regression risks it carries, and how many generations of support it has. This is the archived record of what advanced. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "mechanism_id",
+    "candidate_evidence_id",
+    "mechanism_name",
+    "mechanism_type",
+    "target_surface",
+    "gate_decision",
+    "affected_surfaces",
+    "regression_risks",
+    "support_count",
+    "promoted_at_generation"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "mechanism_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique identifier for this frontier mechanism."
+    },
+    "candidate_evidence_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the candidate evidence record this mechanism was promoted from."
+    },
+    "parent_frontier_id": {
+      "type": "string",
+      "description": "Identifier of the frontier this mechanism descends from. Empty for a root frontier."
+    },
+    "mechanism_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the promoted mechanism."
+    },
+    "mechanism_type": {
+      "type": "string",
+      "enum": [
+        "deterministic_code",
+        "prompt_playbook",
+        "tool_wrapper",
+        "context_policy",
+        "judge_policy",
+        "mixed"
+      ],
+      "description": "Category of mechanism being changed."
+    },
+    "target_surface": {
+      "type": "string",
+      "enum": [
+        "prompt",
+        "tool",
+        "harness_validator",
+        "runtime_adapter",
+        "artifact_landing",
+        "evaluator",
+        "routing",
+        "docs"
+      ],
+      "description": "The surface of the harness this mechanism targets."
+    },
+    "gate_decision": {
+      "type": "string",
+      "description": "The advancement decision that promoted this mechanism."
+    },
+    "affected_surfaces": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Surfaces this mechanism touches beyond its primary target."
+    },
+    "regression_risks": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Known regression risks this mechanism carries forward."
+    },
+    "support_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of runs or generations that support this mechanism."
+    },
+    "promoted_at_generation": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Generation index at which this mechanism was promoted."
+    }
+  }
+}

--- a/ts/src/harness-optimization/contract/json-schemas/orphan-mechanism.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/orphan-mechanism.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json",
+  "title": "OrphanMechanism",
+  "description": "A rejected or rolled-back mechanism in the harness-optimization archive (AC-880). It records a candidate that failed the promotion gate, the failure family it belongs to, why it was rejected, how many times it was retried, and whether a later combination rescued it. This is the archived record of what did not advance. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "mechanism_id",
+    "candidate_evidence_id",
+    "mechanism_name",
+    "mechanism_type",
+    "target_surface",
+    "gate_decision",
+    "failure_family",
+    "rejection_reason",
+    "retry_count"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "mechanism_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique identifier for this orphan mechanism."
+    },
+    "candidate_evidence_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the candidate evidence record this mechanism came from."
+    },
+    "parent_frontier_id": {
+      "type": "string",
+      "description": "Identifier of the frontier this mechanism descends from. Empty for a root candidate."
+    },
+    "mechanism_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the orphaned mechanism."
+    },
+    "mechanism_type": {
+      "type": "string",
+      "enum": [
+        "deterministic_code",
+        "prompt_playbook",
+        "tool_wrapper",
+        "context_policy",
+        "judge_policy",
+        "mixed"
+      ],
+      "description": "Category of mechanism being changed."
+    },
+    "target_surface": {
+      "type": "string",
+      "enum": [
+        "prompt",
+        "tool",
+        "harness_validator",
+        "runtime_adapter",
+        "artifact_landing",
+        "evaluator",
+        "routing",
+        "docs"
+      ],
+      "description": "The surface of the harness this mechanism targets."
+    },
+    "gate_decision": {
+      "type": "string",
+      "description": "The gate outcome for this mechanism, such as retry, rollback, or reject."
+    },
+    "failure_family": {
+      "type": "string",
+      "description": "The family of failure this mechanism belongs to, for clustering orphans."
+    },
+    "rejection_reason": {
+      "type": "string",
+      "description": "Human-readable reason this mechanism was not promoted."
+    },
+    "retry_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of times this mechanism was retried before being orphaned."
+    },
+    "support_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of runs or generations that support this mechanism."
+    },
+    "rescued_into_frontier_id": {
+      "type": "string",
+      "description": "Frontier id a later combination rescued this into. Empty while still orphaned."
+    }
+  }
+}

--- a/ts/src/harness-optimization/contract/validators.ts
+++ b/ts/src/harness-optimization/contract/validators.ts
@@ -5,9 +5,13 @@ import candidateEvidenceSchema from "./json-schemas/candidate-evidence.schema.js
 import promotionScoreSchema from "./json-schemas/promotion-score.schema.json" with { type: "json" };
 import repairResultSchema from "./json-schemas/repair-result.schema.json" with { type: "json" };
 import integrityMetadataSchema from "./json-schemas/integrity-metadata.schema.json" with { type: "json" };
+import frontierMechanismSchema from "./json-schemas/frontier-mechanism.schema.json" with { type: "json" };
+import orphanMechanismSchema from "./json-schemas/orphan-mechanism.schema.json" with { type: "json" };
 import type {
   CandidateEvidence,
+  FrontierMechanism,
   IntegrityMetadata,
+  OrphanMechanism,
   PromotionScore,
   RepairResult,
 } from "./generated-types.js";
@@ -29,6 +33,8 @@ ajv.addSchema(candidateEvidenceSchema as object);
 ajv.addSchema(promotionScoreSchema as object);
 ajv.addSchema(repairResultSchema as object);
 ajv.addSchema(integrityMetadataSchema as object);
+ajv.addSchema(frontierMechanismSchema as object);
+ajv.addSchema(orphanMechanismSchema as object);
 
 const candidateEvidenceValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json",
@@ -44,6 +50,14 @@ const repairResultValidator = ajv.getSchema(
 
 const integrityMetadataValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json",
+)!;
+
+const frontierMechanismValidator = ajv.getSchema(
+  "https://autocontext.dev/schema/harness-optimization/frontier-mechanism.json",
+)!;
+
+const orphanMechanismValidator = ajv.getSchema(
+  "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json",
 )!;
 
 function toResult(validate: ValidateFunction, input: unknown): ValidationResult {
@@ -74,5 +88,19 @@ export function validateIntegrityMetadata(input: unknown): ValidationResult {
   return toResult(integrityMetadataValidator, input);
 }
 
+export function validateFrontierMechanism(input: unknown): ValidationResult {
+  return toResult(frontierMechanismValidator, input);
+}
+
+export function validateOrphanMechanism(input: unknown): ValidationResult {
+  return toResult(orphanMechanismValidator, input);
+}
+
 // Type-level assertion — if a TS type drifts from its schema this won't compile.
-export type _TypeCheck = CandidateEvidence | PromotionScore | RepairResult | IntegrityMetadata;
+export type _TypeCheck =
+  | CandidateEvidence
+  | PromotionScore
+  | RepairResult
+  | IntegrityMetadata
+  | FrontierMechanism
+  | OrphanMechanism;

--- a/ts/src/harness-optimization/mechanism-archive.ts
+++ b/ts/src/harness-optimization/mechanism-archive.ts
@@ -1,0 +1,171 @@
+import type { FrontierMechanism, OrphanMechanism } from "./contract/generated-types.js";
+
+/**
+ * Pure in-memory archive of promoted (frontier) and orphaned mechanisms.
+ *
+ * TypeScript half of the AC-880 parity pair: the same operations live here and
+ * in `autocontext/src/autocontext/harness_optimization/mechanism_archive.py`,
+ * and a shared fixture
+ * (`fixtures/harness-optimization/mechanism-archive/archive-cases.json`) proves
+ * both languages compute identical outcomes.
+ *
+ * The archive keeps two immutable lists: `frontier` mechanisms that were
+ * promoted and `orphans` that were gated out. Every operation returns a new
+ * archive; nothing is mutated in place and there is no IO. Rescue is explicit:
+ * adding a frontier never removes an orphan, and rescuing an orphan leaves it
+ * in `orphans` (with `rescued_into_frontier_id` set) so history is preserved.
+ */
+
+export interface MechanismArchive {
+  frontier: readonly FrontierMechanism[];
+  orphans: readonly OrphanMechanism[];
+}
+
+export interface QueryResult {
+  frontier: readonly FrontierMechanism[];
+  orphans: readonly OrphanMechanism[];
+}
+
+export interface QueryOptions {
+  mechanismType?: string;
+  targetSurface?: string;
+  failureFamily?: string;
+}
+
+/** Return a new archive with `mechanism` appended to the frontier. */
+export function addFrontier(
+  archive: MechanismArchive,
+  mechanism: FrontierMechanism,
+): MechanismArchive {
+  return { frontier: [...archive.frontier, mechanism], orphans: archive.orphans };
+}
+
+/** Return a new archive with `mechanism` appended to the orphans. */
+export function addOrphan(archive: MechanismArchive, mechanism: OrphanMechanism): MechanismArchive {
+  return { frontier: archive.frontier, orphans: [...archive.orphans, mechanism] };
+}
+
+/**
+ * Mark the orphan `orphanId` as rescued into `intoFrontierId`.
+ *
+ * The orphan stays in `orphans` with `rescued_into_frontier_id` set so the
+ * rescue is auditable. An unknown id returns the archive unchanged.
+ */
+export function rescueOrphan(
+  archive: MechanismArchive,
+  orphanId: string,
+  intoFrontierId: string,
+): MechanismArchive {
+  if (!archive.orphans.some((m) => m.mechanism_id === orphanId)) {
+    return archive;
+  }
+  const rescued = archive.orphans.map((m) =>
+    m.mechanism_id === orphanId ? { ...m, rescued_into_frontier_id: intoFrontierId } : m,
+  );
+  return { frontier: archive.frontier, orphans: rescued };
+}
+
+/**
+ * Filter both lists by any provided facet.
+ *
+ * `mechanismType` and `targetSurface` filter frontier and orphans alike.
+ * `failureFamily` filters orphans only (frontier has no failure family), so the
+ * frontier list is left unfiltered by that facet but still narrowed by any
+ * other provided facet. An `undefined` facet applies no filter.
+ */
+export function query(archive: MechanismArchive, opts: QueryOptions = {}): QueryResult {
+  const { mechanismType, targetSurface, failureFamily } = opts;
+  const frontier = archive.frontier.filter(
+    (m) =>
+      (mechanismType === undefined || m.mechanism_type === mechanismType) &&
+      (targetSurface === undefined || m.target_surface === targetSurface),
+  );
+  const orphans = archive.orphans.filter(
+    (m) =>
+      (mechanismType === undefined || m.mechanism_type === mechanismType) &&
+      (targetSurface === undefined || m.target_surface === targetSurface) &&
+      (failureFamily === undefined || m.failure_family === failureFamily),
+  );
+  return { frontier, orphans };
+}
+
+function isRescued(mechanism: OrphanMechanism): boolean {
+  return Boolean(mechanism.rescued_into_frontier_id);
+}
+
+function rankKey(mechanism: OrphanMechanism): [number, number, number, string] {
+  const support = mechanism.support_count ?? 0;
+  return [isRescued(mechanism) ? 1 : 0, -support, mechanism.retry_count, mechanism.mechanism_id];
+}
+
+/**
+ * Order orphans most-reusable first.
+ *
+ * Ascending sort over: not-rescued before rescued, then support_count
+ * descending, then retry_count ascending, then mechanism_id ascending as a
+ * total tiebreak. Missing support_count counts as 0 and a missing or empty
+ * rescued_into_frontier_id counts as not-rescued.
+ */
+export function rankOrphans(orphans: readonly OrphanMechanism[]): readonly OrphanMechanism[] {
+  return [...orphans].sort((a, b) => {
+    const ka = rankKey(a);
+    const kb = rankKey(b);
+    for (let i = 0; i < 3; i += 1) {
+      if (ka[i] !== kb[i]) {
+        return (ka[i] as number) - (kb[i] as number);
+      }
+    }
+    // mechanism_id ascending as a total tiebreak.
+    if (ka[3] < kb[3]) {
+      return -1;
+    }
+    if (ka[3] > kb[3]) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
+/** Keep the top `maxOrphans` orphans by reuse rank, in rank order. */
+export function pruneOrphans(
+  orphans: readonly OrphanMechanism[],
+  maxOrphans: number,
+): readonly OrphanMechanism[] {
+  const cap = maxOrphans < 0 ? 0 : maxOrphans;
+  return rankOrphans(orphans).slice(0, cap);
+}
+
+export interface DigestOptions {
+  maxEntries: number;
+}
+
+/**
+ * Render a bounded, ranked digest of the archive for proposer prompts.
+ *
+ * The digest has a fixed shape reproduced character-for-character from the
+ * Python port: a header line, a `frontier:` section listing up to `maxEntries`
+ * frontier mechanisms in frontier order, then an `orphans (reusable):` section
+ * listing up to `maxEntries` not-rescued orphans in `rankOrphans` order.
+ * Rescued orphans are excluded from the reusable section. A non-positive
+ * `maxEntries` emits the section headers with no items. Missing support_count
+ * counts as 0.
+ */
+export function renderArchiveDigest(archive: MechanismArchive, opts: DigestOptions): string {
+  const cap = Math.max(opts.maxEntries, 0);
+
+  const lines = ["mechanism archive digest", "frontier:"];
+  for (const front of archive.frontier.slice(0, cap)) {
+    lines.push(
+      `  - ${front.mechanism_name} [${front.target_surface}] support=${front.support_count}`,
+    );
+  }
+
+  lines.push("orphans (reusable):");
+  const reusable = rankOrphans(archive.orphans).filter((m) => !isRescued(m));
+  for (const orphan of reusable.slice(0, cap)) {
+    const support = orphan.support_count ?? 0;
+    lines.push(`  - ${orphan.mechanism_name} [${orphan.failure_family}] support=${support}`);
+  }
+
+  return lines.join("\n");
+}

--- a/ts/tests/harness-optimization/mechanism-archive-contract.test.ts
+++ b/ts/tests/harness-optimization/mechanism-archive-contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  validateFrontierMechanism,
+  validateOrphanMechanism,
+} from "../../src/harness-optimization/contract/validators.js";
+
+const FIX = join(import.meta.dirname, "../../../fixtures/harness-optimization/mechanism-archive");
+
+describe("mechanism-archive contract", () => {
+  it("accepts a valid frontier mechanism", () => {
+    const data = JSON.parse(readFileSync(join(FIX, "valid-frontier.json"), "utf8"));
+    expect(validateFrontierMechanism(data)).toEqual({ valid: true });
+  });
+
+  it("accepts a valid orphan mechanism", () => {
+    const data = JSON.parse(readFileSync(join(FIX, "valid-orphan.json"), "utf8"));
+    expect(validateOrphanMechanism(data)).toEqual({ valid: true });
+  });
+
+  it("rejects an orphan missing failure_family", () => {
+    const data = JSON.parse(
+      readFileSync(join(FIX, "invalid-orphan-missing-failure-family.json"), "utf8"),
+    );
+    const r = validateOrphanMechanism(data);
+    expect(r.valid).toBe(false);
+  });
+});

--- a/ts/tests/harness-optimization/mechanism-archive.test.ts
+++ b/ts/tests/harness-optimization/mechanism-archive.test.ts
@@ -14,6 +14,10 @@ import {
   renderArchiveDigest,
   rescueOrphan,
 } from "../../src/harness-optimization/mechanism-archive.js";
+import {
+  validateFrontierMechanism,
+  validateOrphanMechanism,
+} from "../../src/harness-optimization/contract/validators.js";
 
 // Load the SAME repo-root fixture the Python suite loads. Matching it in both
 // languages is the load-bearing parity proof.
@@ -45,6 +49,23 @@ function seedArchive(): MechanismArchive {
 }
 
 describe("mechanism archive parity", () => {
+  it("validates every shared-fixture record against its schema", () => {
+    // Python model_validates the seed on load; do the same in TS so a drifted
+    // record in the shared fixture fails the TS suite too, not just Python.
+    for (const record of FIXTURE.seed.frontier) {
+      expect(validateFrontierMechanism(record)).toEqual({ valid: true });
+    }
+    const orphanRecords: OrphanMechanism[] = [...FIXTURE.seed.orphans];
+    for (const c of FIXTURE.cases) {
+      if (c.orphan) {
+        orphanRecords.push(c.orphan as OrphanMechanism);
+      }
+    }
+    for (const record of orphanRecords) {
+      expect(validateOrphanMechanism(record)).toEqual({ valid: true });
+    }
+  });
+
   for (const c of FIXTURE.cases) {
     it(`${String(c.name)}: matches fixture expectations`, () => {
       const archive = seedArchive();
@@ -62,6 +83,23 @@ describe("mechanism archive parity", () => {
         const result = query(archive, { mechanismType: c.mechanism_type as string });
         expect(result.frontier.map((m) => m.mechanism_id)).toEqual(c.expected_frontier_ids);
         expect(result.orphans.map((m) => m.mechanism_id)).toEqual(c.expected_orphan_ids);
+      } else if (op === "query_by_failure_family") {
+        const result = query(archive, { failureFamily: c.failure_family as string });
+        // failure_family narrows orphans only; the frontier stays whole.
+        expect(result.frontier.map((m) => m.mechanism_id)).toEqual(c.expected_frontier_ids);
+        expect(result.orphans.map((m) => m.mechanism_id)).toEqual(c.expected_orphan_ids);
+      } else if (op === "query_by_surface") {
+        const result = query(archive, { targetSurface: c.target_surface as string });
+        expect(result.frontier.map((m) => m.mechanism_id)).toEqual(c.expected_frontier_ids);
+        expect(result.orphans.map((m) => m.mechanism_id)).toEqual(c.expected_orphan_ids);
+      } else if (op === "rescue_noop") {
+        const rescued = rescueOrphan(archive, c.orphan_id as string, c.into_frontier_id as string);
+        // An unknown orphan id leaves the archive unchanged: identical ids and no
+        // new rescued_into_frontier_id set on anyone.
+        expect(rescued.orphans.map((m) => m.mechanism_id)).toEqual(c.expected_orphan_ids);
+        const before = archive.orphans.map((m) => m.rescued_into_frontier_id ?? "");
+        const after = rescued.orphans.map((m) => m.rescued_into_frontier_id ?? "");
+        expect(after).toEqual(before);
       } else if (op === "rank_orphans") {
         const ranked = rankOrphans(archive.orphans);
         expect(ranked.map((m) => m.mechanism_id)).toEqual(c.expected_order);
@@ -105,6 +143,22 @@ describe("mechanism archive parity", () => {
           ln.split(" [", 2)[0].replace(/^ {2}- /, ""),
         );
         expect(renderedOrphanNames).toEqual(expectedNames);
+
+        // With maxEntries=1 each section holds at most one item and the orphan
+        // section is exactly the top-ranked not-rescued orphan. This fails if the
+        // per-section cap is ever dropped.
+        if (maxEntries === 1) {
+          expect(frontierItems.length).toBeLessThanOrEqual(1);
+          expect(orphanItems.length).toBeLessThanOrEqual(1);
+          expect(c.expected_orphan_ids_in_order).toEqual(["orphan-ac880-A"]);
+          expect(renderedOrphanNames).toEqual([idToName.get("orphan-ac880-A")]);
+        }
+
+        // When the fixture pins the exact string, the render must match it
+        // character-for-character (parity with the Python renderer).
+        if (typeof c.expected_digest === "string") {
+          expect(digest).toBe(c.expected_digest);
+        }
 
         // Rescued orphans are excluded entirely from the reusable section.
         const orphanSection = lines.slice(orphanStart).join("\n");

--- a/ts/tests/harness-optimization/mechanism-archive.test.ts
+++ b/ts/tests/harness-optimization/mechanism-archive.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import type {
+  FrontierMechanism,
+  OrphanMechanism,
+} from "../../src/harness-optimization/contract/generated-types.js";
+import {
+  type MechanismArchive,
+  addOrphan,
+  pruneOrphans,
+  query,
+  rankOrphans,
+  renderArchiveDigest,
+  rescueOrphan,
+} from "../../src/harness-optimization/mechanism-archive.js";
+
+// Load the SAME repo-root fixture the Python suite loads. Matching it in both
+// languages is the load-bearing parity proof.
+// Walk up: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const FIXTURE = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dirname,
+      "..",
+      "..",
+      "..",
+      "fixtures",
+      "harness-optimization",
+      "mechanism-archive",
+      "archive-cases.json",
+    ),
+    "utf8",
+  ),
+) as {
+  seed: { frontier: FrontierMechanism[]; orphans: OrphanMechanism[] };
+  cases: Record<string, unknown>[];
+};
+
+function seedArchive(): MechanismArchive {
+  return {
+    frontier: FIXTURE.seed.frontier,
+    orphans: FIXTURE.seed.orphans,
+  };
+}
+
+describe("mechanism archive parity", () => {
+  for (const c of FIXTURE.cases) {
+    it(`${String(c.name)}: matches fixture expectations`, () => {
+      const archive = seedArchive();
+      const op = c.op as string;
+
+      if (op === "add_orphan") {
+        const added = addOrphan(archive, c.orphan as OrphanMechanism);
+        expect(added.orphans.length).toBe(c.expected_orphan_count);
+        expect(added.orphans[added.orphans.length - 1].mechanism_id).toBe(
+          c.expected_added_orphan_id,
+        );
+        // Input archive is not mutated.
+        expect(archive.orphans.length).toBe(FIXTURE.seed.orphans.length);
+      } else if (op === "query_by_type") {
+        const result = query(archive, { mechanismType: c.mechanism_type as string });
+        expect(result.frontier.map((m) => m.mechanism_id)).toEqual(c.expected_frontier_ids);
+        expect(result.orphans.map((m) => m.mechanism_id)).toEqual(c.expected_orphan_ids);
+      } else if (op === "rank_orphans") {
+        const ranked = rankOrphans(archive.orphans);
+        expect(ranked.map((m) => m.mechanism_id)).toEqual(c.expected_order);
+      } else if (op === "rescue") {
+        const rescued = rescueOrphan(archive, c.orphan_id as string, c.into_frontier_id as string);
+        const target = rescued.orphans.find((m) => m.mechanism_id === c.orphan_id);
+        expect(target?.rescued_into_frontier_id).toBe(c.expected_rescued_into_frontier_id);
+        const ranked = rankOrphans(rescued.orphans);
+        expect(ranked.map((m) => m.mechanism_id)).toEqual(c.expected_order);
+        expect(ranked[ranked.length - 1].mechanism_id).toBe(c.expected_last_orphan_id);
+      } else if (op === "prune") {
+        const pruned = pruneOrphans(archive.orphans, c.max_orphans as number);
+        expect(pruned.map((m) => m.mechanism_id)).toEqual(c.expected_surviving_ids);
+      } else if (op === "digest") {
+        const maxEntries = c.max_entries as number;
+        const digest = renderArchiveDigest(archive, { maxEntries });
+        expect(typeof digest).toBe("string");
+        expect(digest).toContain(c.expected_header as string);
+        const lines = digest.split("\n");
+
+        const frontierStart = lines.indexOf("frontier:");
+        const orphanStart = lines.indexOf("orphans (reusable):");
+        const frontierItems = lines
+          .slice(frontierStart + 1, orphanStart)
+          .filter((ln) => ln.startsWith("  - "));
+        const orphanItems = lines.slice(orphanStart + 1).filter((ln) => ln.startsWith("  - "));
+
+        // Boundedness: never more than maxEntries items per section.
+        expect(frontierItems.length).toBeLessThanOrEqual(maxEntries);
+        expect(orphanItems.length).toBeLessThanOrEqual(maxEntries);
+        expect(frontierItems.length).toBe(c.expected_frontier_count);
+
+        // The orphan section lists exactly the expected ids in rank order.
+        const idToName = new Map(
+          FIXTURE.seed.orphans.map((o) => [o.mechanism_id, o.mechanism_name]),
+        );
+        const expectedNames = (c.expected_orphan_ids_in_order as string[]).map((i) =>
+          idToName.get(i),
+        );
+        const renderedOrphanNames = orphanItems.map((ln) =>
+          ln.split(" [", 2)[0].replace(/^ {2}- /, ""),
+        );
+        expect(renderedOrphanNames).toEqual(expectedNames);
+
+        // Rescued orphans are excluded entirely from the reusable section.
+        const orphanSection = lines.slice(orphanStart).join("\n");
+        for (const excludedId of c.expected_excludes as string[]) {
+          expect(orphanSection).not.toContain(idToName.get(excludedId));
+        }
+      } else {
+        throw new Error(`unhandled op: ${op}`);
+      }
+    });
+  }
+
+  it("renders the seed digest character-for-character", () => {
+    const digest = renderArchiveDigest(seedArchive(), { maxEntries: 3 });
+    const expected = [
+      "mechanism archive digest",
+      "frontier:",
+      "  - retry-on-truncated-output guard [harness_validator] support=4",
+      "  - structured finish-guard playbook [prompt] support=3",
+      "orphans (reusable):",
+      "  - prompt hint for empty-tool-call retry [empty-tool-call] support=3",
+      "  - tighter finish-guard prompt [empty-tool-call] support=3",
+      "  - aggressive context pruning [context-loss] support=1",
+    ].join("\n");
+    expect(digest).toBe(expected);
+  });
+
+  it("emits headers with no items for a non-positive maxEntries", () => {
+    const digest = renderArchiveDigest(seedArchive(), { maxEntries: 0 });
+    expect(digest).toBe(
+      ["mechanism archive digest", "frontier:", "orphans (reusable):"].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
Implements AC-880, the fifth harness-optimization protocol artifact: a queryable archive of promoted (frontier) and rejected (orphan) mechanisms, so future candidates can stack ideas that were weak alone but useful in combination. Built on the AC-876 codegen/parity harness.

## What this adds

**Two record contracts** (`frontier-mechanism.schema.json`, `orphan-mechanism.schema.json` -> regenerated `models.py` + `generated-types.ts`, byte-diffed by the drift gate):
- `FrontierMechanism` (promoted): candidate_evidence_id, parent_frontier_id, gate_decision, affected_surfaces, regression_risks, support_count, promoted_at_generation.
- `OrphanMechanism` (rejected/not-promoted): failure_family, rejection_reason, retry_count, optional support_count, and rescued_into_frontier_id (set when a later combination rescues it). Both reuse the candidate-evidence mechanism_type / target_surface enums.

**Archive engine** (`mechanism_archive.py` + `mechanism-archive.ts`, pure, mirrored): add_frontier / add_orphan (immutable append), rescue_orphan (marks an orphan rescued while preserving its history), query (facet filter; failure_family filters orphans only), rank_orphans (not-rescued before rescued, then support_count descending, then fewer retries, then id), prune_orphans (top-N by rank), and render_archive_digest (a bounded, ranked summary for proposer prompts, never more than max_entries per section, rescued orphans excluded from the reusable list).

## Parity + tests

One shared fixture (`archive-cases.json`) drives both languages: add, query-by-type, query-by-failure-family, rank, rescue, prune, unknown-id no-op, prune-clamp, and two digest cases (max_entries 3 and 1). The exact digest string lives in the fixture and is asserted character-for-character in both Python and TS, so the cross-language "equivalent summaries" guarantee cannot silently drift. The max_entries=1 case makes the boundedness assertion able to fail. TS validates every fixture record through the AJV validators.

Gates: ruff (incl. generated models), mypy, module-size guard, gate-taxonomy invariant, schema drift gate, vitest (114), and lint all green.

Whole-branch review (fable) returned READY after an adversarial parity probe over 9 inputs confirmed byte-identical output in both languages; its coverage findings (digest-boundedness and digest-parity assertions, query and rescue/prune edge cases) were then hardened in a follow-up test wave.

Note: the `ts-test` full-suite CI job is red repo-wide (AC-892 infra, host OOM), unrelated to this change.

Closes AC-880.