### PR TITLE
harness optimization: noise calibration (AC-881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - harness optimization protocol: opt-in deterministic repair gates (artifact landing, tool-call json, finish guard, loop guard) with python/typescript parity (AC-878)
 - harness optimization protocol: post-proposal holdout-leakage audit (clean/contaminated/unknown over forbidden-source, forbidden-split, and web-policy passes) and verified/exploratory fail-closed gate with python/typescript parity (AC-879)
 - harness optimization protocol: in-memory mechanism archive of promoted (frontier) and gated-out (orphan) mechanisms with candidate-evidence and parent-frontier lineage, reuse-ranked orphan rescue/prune, and a bounded ranked proposer digest with python/typescript parity (AC-880)
+- harness optimization protocol: noise calibration report (sample-variance noise floor, recommended margin and cost-clamped trial count, sparse-metric-too-noisy flag) with an opt-in caller-gated citation of the current margin against the noise floor in the advancement rationale and python/typescript parity (AC-881)
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -542,6 +542,10 @@ class AppSettings(BaseModel):
         default="",
         description="Comma-separated scenario allowlist for the leakage gate; empty = none",
     )
+    harness_calibration_enabled: bool = Field(
+        default=False,
+        description="Opt-in noise calibration citation in advancement rationale (AC-881)",
+    )
     # Pre-flight harness synthesis (AC-150)
     harness_preflight_enabled: bool = Field(
         default=False,

--- a/autocontext/src/autocontext/harness/pipeline/advancement.py
+++ b/autocontext/src/autocontext/harness/pipeline/advancement.py
@@ -15,12 +15,16 @@ Key types:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from autocontext.harness_optimization.calibration import cite_margin_vs_noise
 from autocontext.harness_optimization.contract.models import Components, Weights
 from autocontext.harness_optimization.scoring import beats_incumbent, harness_promotion_score
+
+if TYPE_CHECKING:
+    from autocontext.harness_optimization.contract.models import CalibrationReport
 
 # Thresholds
 _ERROR_RATE_THRESHOLD = 0.2
@@ -188,7 +192,7 @@ def _evaluate_harness_promotion(inputs: HarnessPromotionInputs) -> AdvancementRa
     )
 
 
-def evaluate_advancement(
+def _evaluate_advancement_core(
     metrics: AdvancementMetrics,
     *,
     min_delta: float = 0.005,
@@ -200,7 +204,7 @@ def evaluate_advancement(
 
     Multi-objective evaluation considering:
     1. Score delta (binding)
-    2. Error rate (binding — vetoes advance)
+    2. Error rate (binding, vetoes advance)
     3. Confidence / sample agreement (risk flag)
     4. Resolved truth score (binding when present, overrides proxy)
     5. Score variance (risk flag)
@@ -320,3 +324,38 @@ def evaluate_advancement(
         proxy_signals=proxy_signals,
         risk_flags=risk_flags,
     )
+
+
+def evaluate_advancement(
+    metrics: AdvancementMetrics,
+    *,
+    min_delta: float = 0.005,
+    max_retries: int = 3,
+    retry_count: int = 0,
+    harness_promotion: HarnessPromotionInputs | None = None,
+    calibration: CalibrationReport | None = None,
+) -> AdvancementRationale:
+    """Evaluate advancement, optionally citing the margin against the noise floor.
+
+    Delegates the whole decision to :func:`_evaluate_advancement_core`, so every
+    decision path (advance, retry, rollback, harness-promotion) is scored exactly
+    as before. This wrapper only adds an opt-in, caller-gated post-processing step:
+
+    Noise calibration citation (AC-881): when the caller passes a
+    ``calibration`` report, a single one-line citation of whether the current
+    margin is above or below the estimated noise floor is appended to the
+    rationale's ``proxy_signals``, and nothing else changes. When ``calibration``
+    is ``None`` (the default) the returned rationale is byte-identical to the core
+    evaluation. The caller decides whether to build a report and pass it (gated by
+    ``harness_calibration_enabled``); this function never reads settings.
+    """
+    rationale = _evaluate_advancement_core(
+        metrics,
+        min_delta=min_delta,
+        max_retries=max_retries,
+        retry_count=retry_count,
+        harness_promotion=harness_promotion,
+    )
+    if calibration is not None:
+        rationale = rationale.model_copy(update={"proxy_signals": [*rationale.proxy_signals, cite_margin_vs_noise(calibration)]})
+    return rationale

--- a/autocontext/src/autocontext/harness_optimization/calibration.py
+++ b/autocontext/src/autocontext/harness_optimization/calibration.py
@@ -1,0 +1,80 @@
+"""Noise calibration engine for the harness optimization loop.
+
+Pure functions that turn a score series into a :class:`CalibrationReport`.
+The float formulas here are mirrored by the TypeScript port and must agree to
+1e-9, so the arithmetic order below is intentional and should not be changed.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Literal
+
+from autocontext.harness_optimization.contract.models import CalibrationReport
+
+
+def compute_calibration(
+    scores: Sequence[float],
+    *,
+    scenario_id: str,
+    current_min_delta: float,
+    max_trials: int,
+    noise_multiplier: float = 2.0,
+    noisy_cv_threshold: float = 0.25,
+) -> CalibrationReport:
+    """Compute noise statistics and gating recommendations for a score series.
+
+    Args:
+        scores: Observed scores for the scenario.
+        scenario_id: Scenario or family the series came from.
+        current_min_delta: The promotion margin currently configured.
+        max_trials: Cost budget ceiling on recommended trial count.
+        noise_multiplier: Multiplier on the standard error for the recommended margin.
+        noisy_cv_threshold: Coefficient-of-variation threshold above which the
+            sparse metric is judged too noisy to gate on.
+
+    Returns:
+        A :class:`CalibrationReport` describing the noise floor and recommendations.
+    """
+    n = len(scores)
+    mean = sum(scores) / n if n > 0 else 0.0
+    variance = sum((x - mean) ** 2 for x in scores) / (n - 1) if n >= 2 else 0.0
+    std_dev = math.sqrt(variance)
+    standard_error = std_dev / math.sqrt(n) if n >= 2 else 0.0
+    recommended_min_delta = noise_multiplier * standard_error
+
+    if current_min_delta > 0 and std_dev > 0:
+        k = math.ceil((std_dev / current_min_delta) ** 2)
+    else:
+        k = max_trials
+    recommended_trial_count = max(1, min(k, max_trials))
+
+    margin_vs_noise: Literal["above_noise", "below_noise"] = (
+        "above_noise" if current_min_delta >= recommended_min_delta else "below_noise"
+    )
+
+    if abs(mean) > 0:
+        sparse_metric_too_noisy = standard_error / abs(mean) > noisy_cv_threshold
+    elif standard_error > 0:
+        sparse_metric_too_noisy = True
+    else:
+        sparse_metric_too_noisy = False
+
+    notes = f"SE={standard_error:.4f} over n={n}; margin {margin_vs_noise}"
+
+    return CalibrationReport(
+        schema_version=1,
+        scenario_id=scenario_id,
+        sample_size=n,
+        mean=mean,
+        variance=variance,
+        std_dev=std_dev,
+        standard_error=standard_error,
+        recommended_min_delta=recommended_min_delta,
+        recommended_trial_count=recommended_trial_count,
+        current_min_delta=current_min_delta,
+        margin_vs_noise=margin_vs_noise,
+        sparse_metric_too_noisy=sparse_metric_too_noisy,
+        notes=notes,
+    )

--- a/autocontext/src/autocontext/harness_optimization/calibration.py
+++ b/autocontext/src/autocontext/harness_optimization/calibration.py
@@ -78,3 +78,51 @@ def compute_calibration(
         sparse_metric_too_noisy=sparse_metric_too_noisy,
         notes=notes,
     )
+
+
+# Numeric fields are rendered with a fixed 6-decimal format so the text is
+# identical across languages. Do NOT use raw str(): Python str(2.0) -> "2.0"
+# while JS String(2) -> "2", which would diverge. The TypeScript port must use
+# the same 6-decimal fixed format (value.toFixed(6)) so the two reports match
+# character-for-character.
+def _fmt_float(value: float) -> str:
+    return f"{value:.6f}"
+
+
+_SPARSE_NOISE_LINE = "sparse metric too noisy: optimize a denser verifier signal instead"
+
+
+def render_calibration_report(report: CalibrationReport) -> str:
+    """Render a calibration report as a stable multi-line string.
+
+    The wording is mirrored character-for-character by the TypeScript port, so
+    every numeric field is formatted through :func:`_fmt_float` (6-decimal fixed)
+    for the float fields and plain integer ``str`` for the counts.
+    """
+    lines = [
+        f"calibration report: {report.scenario_id}",
+        f"samples: {report.sample_size}",
+        f"mean: {_fmt_float(report.mean)}",
+        f"std_dev: {_fmt_float(report.std_dev)}",
+        f"standard_error: {_fmt_float(report.standard_error)}",
+        f"recommended_min_delta: {_fmt_float(report.recommended_min_delta)}",
+        f"recommended_trial_count: {report.recommended_trial_count}",
+        f"current_min_delta: {_fmt_float(report.current_min_delta)}",
+        f"margin: {report.margin_vs_noise}",
+    ]
+    if report.sparse_metric_too_noisy:
+        lines.append(_SPARSE_NOISE_LINE)
+    return "\n".join(lines)
+
+
+def cite_margin_vs_noise(report: CalibrationReport) -> str:
+    """Render a one-line citation of the margin against the noise floor.
+
+    Both numbers use the same 6-decimal fixed format as
+    :func:`render_calibration_report` so the TypeScript port (toFixed(6))
+    produces identical text.
+    """
+    return (
+        f"margin {_fmt_float(report.current_min_delta)} is {report.margin_vs_noise} "
+        f"(recommended >= {_fmt_float(report.recommended_min_delta)})"
+    )

--- a/autocontext/src/autocontext/harness_optimization/calibration.py
+++ b/autocontext/src/autocontext/harness_optimization/calibration.py
@@ -37,6 +37,8 @@ def compute_calibration(
     Returns:
         A :class:`CalibrationReport` describing the noise floor and recommendations.
     """
+    # Clamp the budget to at least 1 so a degenerate 0/negative budget yields a sane count of 1.
+    max_trials = max(1, max_trials)
     n = len(scores)
     mean = sum(scores) / n if n > 0 else 0.0
     variance = sum((x - mean) ** 2 for x in scores) / (n - 1) if n >= 2 else 0.0

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/_aggregate.schema.json
@@ -21,6 +21,9 @@
     },
     "OrphanMechanism": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json"
+    },
+    "CalibrationReport": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/calibration-report.json"
     }
   }
 }

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/calibration-report.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/calibration-report.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/calibration-report.json",
+  "title": "CalibrationReport",
+  "description": "Noise calibration for a harness score series (AC-881). Summarises a scenario's score samples (mean, variance, standard error) and recommends a promotion margin and trial count so the configured gate sits above measurement noise. Flags when a sparse metric is too noisy to gate on. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "scenario_id",
+    "sample_size",
+    "mean",
+    "variance",
+    "std_dev",
+    "standard_error",
+    "recommended_min_delta",
+    "recommended_trial_count",
+    "current_min_delta",
+    "margin_vs_noise",
+    "sparse_metric_too_noisy"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "scenario_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Scenario or family the score series came from."
+    },
+    "sample_size": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of score samples in the series (n)."
+    },
+    "mean": {
+      "type": "number",
+      "description": "Mean of the score series."
+    },
+    "variance": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Sample variance (ddof=1); 0 when n<2."
+    },
+    "std_dev": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Standard deviation, sqrt of the variance."
+    },
+    "standard_error": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Standard error, std_dev over sqrt(n); 0 when n<2."
+    },
+    "recommended_min_delta": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Recommended margin: noise_multiplier times standard_error."
+    },
+    "recommended_trial_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Trials so the mean SE falls under current_min_delta, capped by budget."
+    },
+    "current_min_delta": {
+      "type": "number",
+      "description": "The promotion margin currently configured."
+    },
+    "margin_vs_noise": {
+      "type": "string",
+      "enum": ["above_noise", "below_noise"],
+      "description": "Whether the current margin sits above or below the noise floor."
+    },
+    "sparse_metric_too_noisy": {
+      "type": "boolean",
+      "description": "True when the sparse metric is too noisy to gate on."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional human-readable rationale for audit."
+    }
+  }
+}

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -567,3 +567,64 @@ class OrphanMechanism(BaseModel):
             description='Frontier id a later combination rescued this into. Empty while still orphaned.'
         ),
     ] = None
+
+
+class CalibrationReport(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    schema_version: Annotated[
+        Literal[1],
+        Field(
+            description='Schema version for forward compatibility. Always 1 for this revision.'
+        ),
+    ]
+    scenario_id: Annotated[
+        str,
+        Field(
+            description='Scenario or family the score series came from.', min_length=1
+        ),
+    ]
+    sample_size: Annotated[
+        int, Field(description='Number of score samples in the series (n).', ge=0)
+    ]
+    mean: Annotated[float, Field(description='Mean of the score series.')]
+    variance: Annotated[
+        float, Field(description='Sample variance (ddof=1); 0 when n<2.', ge=0.0)
+    ]
+    std_dev: Annotated[
+        float, Field(description='Standard deviation, sqrt of the variance.', ge=0.0)
+    ]
+    standard_error: Annotated[
+        float,
+        Field(description='Standard error, std_dev over sqrt(n); 0 when n<2.', ge=0.0),
+    ]
+    recommended_min_delta: Annotated[
+        float,
+        Field(
+            description='Recommended margin: noise_multiplier times standard_error.',
+            ge=0.0,
+        ),
+    ]
+    recommended_trial_count: Annotated[
+        int,
+        Field(
+            description='Trials so the mean SE falls under current_min_delta, capped by budget.',
+            ge=1,
+        ),
+    ]
+    current_min_delta: Annotated[
+        float, Field(description='The promotion margin currently configured.')
+    ]
+    margin_vs_noise: Annotated[
+        Literal['above_noise', 'below_noise'],
+        Field(
+            description='Whether the current margin sits above or below the noise floor.'
+        ),
+    ]
+    sparse_metric_too_noisy: Annotated[
+        bool, Field(description='True when the sparse metric is too noisy to gate on.')
+    ]
+    notes: Annotated[
+        str | None, Field(description='Optional human-readable rationale for audit.')
+    ] = None

--- a/autocontext/src/autocontext/loop/stage_helpers/exploration.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/exploration.py
@@ -460,6 +460,9 @@ def _apply_novelty_and_cost_adjustments(
         annealing_enabled=settings.experimental_annealing_enabled,
         annealing_seed=settings.seed_base,
         generation=ctx.generation,
+        calibration_enabled=ctx.settings.harness_calibration_enabled,
+        calibration_scenario_id=ctx.scenario_name,
+        calibration_max_trials=ctx.settings.matches_per_generation,
     )
     gate_decision, gate_reason = gate_result.decision, gate_result.reason
     generation_cost_usd = float(ctx.cost_control_metadata.get("generation_cost_usd", 0.0) or 0.0)

--- a/autocontext/src/autocontext/loop/tournament_helpers.py
+++ b/autocontext/src/autocontext/loop/tournament_helpers.py
@@ -18,6 +18,7 @@ from autocontext.harness.evaluation.types import EvaluationResult, EvaluationSum
 from autocontext.harness.pipeline.advancement import AdvancementMetrics, evaluate_advancement
 from autocontext.harness.pipeline.gate import BackpressureGate
 from autocontext.harness.pipeline.trend_gate import ScoreHistory, TrendAwareGate
+from autocontext.harness_optimization.calibration import compute_calibration, render_calibration_report
 from autocontext.knowledge.harness_quality import compute_harness_quality
 from autocontext.knowledge.rapid_gate import rapid_gate
 from autocontext.loop.annealing import AnnealingSchedule, annealing_random_value, evaluate_annealing
@@ -92,6 +93,9 @@ def resolve_gate_decision(
     annealing_seed: int = 0,
     generation: int = 1,
     annealing_roll: float | None = None,
+    calibration_enabled: bool = False,
+    calibration_scenario_id: str = "",
+    calibration_max_trials: int = 1,
 ) -> GateDecisionResult:
     """Select gate mode (rapid/trend-aware/standard) and evaluate decision.
 
@@ -119,20 +123,24 @@ def resolve_gate_decision(
 
     if use_rapid:
         result = (rapid_gate_fn or rapid_gate)(tournament_best_score, previous_best)
-        return with_annealing(GateDecisionResult(
-            decision=result.decision,
-            delta=result.delta,
-            reason=result.reason,
-            is_rapid=True,
-        ))
+        return with_annealing(
+            GateDecisionResult(
+                decision=result.decision,
+                delta=result.delta,
+                reason=result.reason,
+                is_rapid=True,
+            )
+        )
 
     if gate is None:
-        return with_annealing(GateDecisionResult(
-            decision="rollback",
-            delta=delta,
-            reason="no gate configured",
-            is_rapid=False,
-        ))
+        return with_annealing(
+            GateDecisionResult(
+                decision="rollback",
+                delta=delta,
+                reason="no gate configured",
+                is_rapid=False,
+            )
+        )
 
     if isinstance(gate, TrendAwareGate):
         threshold_probe = gate.evaluate(
@@ -158,12 +166,14 @@ def resolve_gate_decision(
     if not isinstance(threshold, (int, float)):
         compatibility_decision = getattr(threshold_probe, "decision", None)
         if compatibility_decision in {"advance", "retry", "rollback"}:
-            return with_annealing(GateDecisionResult(
-                decision=compatibility_decision,
-                delta=delta,
-                reason=str(getattr(threshold_probe, "reason", "gate decision")),
-                is_rapid=False,
-            ))
+            return with_annealing(
+                GateDecisionResult(
+                    decision=compatibility_decision,
+                    delta=delta,
+                    reason=str(getattr(threshold_probe, "reason", "gate decision")),
+                    is_rapid=False,
+                )
+            )
         raw_min_delta = getattr(gate, "min_delta", 0.005)
         threshold = float(raw_min_delta) if isinstance(raw_min_delta, (int, float)) else 0.005
 
@@ -174,23 +184,40 @@ def resolve_gate_decision(
         tournament_results=tournament_results,
         custom_metrics=custom_metrics,
     )
+    calibration_report = None
+    if calibration_enabled:
+        scores = [result.score for result in tournament_results]
+        calibration_report = compute_calibration(
+            scores,
+            scenario_id=calibration_scenario_id,
+            current_min_delta=float(threshold),
+            max_trials=calibration_max_trials,
+        )
     rationale = evaluate_advancement(
         advancement_metrics,
         min_delta=threshold,
         max_retries=max_retries,
         retry_count=retry_count,
+        calibration=calibration_report,
     )
 
-    return with_annealing(GateDecisionResult(
-        decision=rationale.decision,
-        delta=advancement_metrics.delta,
-        reason=rationale.reason,
-        is_rapid=False,
-        metadata={
-            "threshold": threshold,
-            "advancement_rationale": rationale.to_dict(),
-        },
-    ))
+    metadata: dict[str, Any] = {
+        "threshold": threshold,
+        "advancement_rationale": rationale.to_dict(),
+    }
+    if calibration_report is not None:
+        metadata["calibration_report"] = calibration_report.model_dump()
+        metadata["calibration_summary"] = render_calibration_report(calibration_report)
+
+    return with_annealing(
+        GateDecisionResult(
+            decision=rationale.decision,
+            delta=advancement_metrics.delta,
+            reason=rationale.reason,
+            is_rapid=False,
+            metadata=metadata,
+        )
+    )
 
 
 def build_retry_prompt(
@@ -211,8 +238,7 @@ def build_retry_prompt(
     Extracted from the retry branch in stage_tournament's while loop.
     """
     prompt = (
-        base_prompt
-        + f"\n\n--- RETRY ATTEMPT {attempt} ---\n"
+        base_prompt + f"\n\n--- RETRY ATTEMPT {attempt} ---\n"
         f"Your previous strategy scored {tournament_best_score:.4f} "
         f"but needed delta >= {min_delta} over {previous_best:.4f}.\n"
     )

--- a/autocontext/tests/harness_optimization/test_calibration.py
+++ b/autocontext/tests/harness_optimization/test_calibration.py
@@ -42,6 +42,13 @@ def test_calibration_cases_match_fixture(case: dict[str, Any]) -> None:
         actual = getattr(report, field)
         assert abs(actual - expected[field]) <= 1e-9, field
 
+    # When a case pins the exact rendered/citation text, both languages compare to
+    # the same shared literal so any Python-vs-TS text drift fails a test.
+    if "expected_rendered" in case:
+        assert render_calibration_report(report) == case["expected_rendered"]
+    if "expected_citation" in case:
+        assert cite_margin_vs_noise(report) == case["expected_citation"]
+
 
 def test_report_metadata_and_notes() -> None:
     report = compute_calibration(

--- a/autocontext/tests/harness_optimization/test_calibration.py
+++ b/autocontext/tests/harness_optimization/test_calibration.py
@@ -4,7 +4,11 @@ from typing import Any
 
 import pytest
 
-from autocontext.harness_optimization.calibration import compute_calibration
+from autocontext.harness_optimization.calibration import (
+    cite_margin_vs_noise,
+    compute_calibration,
+    render_calibration_report,
+)
 
 FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "calibration-cases" / "calibration-cases.json"
 
@@ -50,3 +54,65 @@ def test_report_metadata_and_notes() -> None:
     assert report.scenario_id == "grid_ctf"
     assert report.current_min_delta == 0.05
     assert report.notes == "SE=0.0051 over n=5; margin above_noise"
+
+
+def _case_by_name(name: str) -> dict[str, Any]:
+    for case in _CASES:
+        if case["name"] == name:
+            return case
+    raise KeyError(name)
+
+
+def _report_for(name: str) -> Any:
+    case = _case_by_name(name)
+    return compute_calibration(
+        case["scores"],
+        scenario_id=case["scenario_id"],
+        current_min_delta=case["current_min_delta"],
+        max_trials=case["max_trials"],
+    )
+
+
+def test_render_calibration_report_contains_fields() -> None:
+    report = _report_for("low_noise")
+    rendered = render_calibration_report(report)
+
+    assert "calibration report:" in rendered
+    assert report.scenario_id in rendered
+    assert "standard_error:" in rendered
+    assert "recommended_min_delta:" in rendered
+    assert "recommended_trial_count:" in rendered
+    assert "margin:" in rendered
+    assert f"mean: {report.mean:.6f}" in rendered
+    assert f"samples: {report.sample_size}" in rendered
+
+
+def test_render_report_sparse_line_present_for_noisy() -> None:
+    report = _report_for("high_noise")
+    rendered = render_calibration_report(report)
+
+    assert report.sparse_metric_too_noisy is True
+    assert "sparse metric too noisy: optimize a denser verifier signal instead" in rendered
+    assert rendered.splitlines()[-1] == ("sparse metric too noisy: optimize a denser verifier signal instead")
+
+
+def test_render_report_sparse_line_absent_for_clean() -> None:
+    report = _report_for("low_noise")
+    rendered = render_calibration_report(report)
+
+    assert report.sparse_metric_too_noisy is False
+    assert "sparse metric too noisy" not in rendered
+
+
+def test_cite_margin_vs_noise_format() -> None:
+    report = _report_for("high_noise")
+    citation = cite_margin_vs_noise(report)
+
+    assert "margin" in citation
+    assert report.margin_vs_noise in citation
+    assert "recommended >=" in citation
+    assert f"{report.current_min_delta:.6f}" in citation
+    assert f"{report.recommended_min_delta:.6f}" in citation
+    assert citation == (
+        f"margin {report.current_min_delta:.6f} is {report.margin_vs_noise} (recommended >= {report.recommended_min_delta:.6f})"
+    )

--- a/autocontext/tests/harness_optimization/test_calibration.py
+++ b/autocontext/tests/harness_optimization/test_calibration.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autocontext.harness_optimization.calibration import compute_calibration
+
+FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "calibration-cases" / "calibration-cases.json"
+
+_CASES: list[dict[str, Any]] = json.loads(FIX.read_text())["cases"]
+
+_NUMERIC_FIELDS = (
+    "mean",
+    "variance",
+    "std_dev",
+    "standard_error",
+    "recommended_min_delta",
+)
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[c["name"] for c in _CASES])
+def test_calibration_cases_match_fixture(case: dict[str, Any]) -> None:
+    report = compute_calibration(
+        case["scores"],
+        scenario_id=case["scenario_id"],
+        current_min_delta=case["current_min_delta"],
+        max_trials=case["max_trials"],
+    )
+    expected = case["expected"]
+
+    assert report.sample_size == expected["sample_size"]
+    assert report.recommended_trial_count == expected["recommended_trial_count"]
+    assert report.margin_vs_noise == expected["margin_vs_noise"]
+    assert report.sparse_metric_too_noisy is expected["sparse_metric_too_noisy"]
+
+    for field in _NUMERIC_FIELDS:
+        actual = getattr(report, field)
+        assert abs(actual - expected[field]) <= 1e-9, field
+
+
+def test_report_metadata_and_notes() -> None:
+    report = compute_calibration(
+        [0.80, 0.82, 0.79, 0.81, 0.80],
+        scenario_id="grid_ctf",
+        current_min_delta=0.05,
+        max_trials=10,
+    )
+    assert report.schema_version == 1
+    assert report.scenario_id == "grid_ctf"
+    assert report.current_min_delta == 0.05
+    assert report.notes == "SE=0.0051 over n=5; margin above_noise"

--- a/autocontext/tests/harness_optimization/test_calibration_contract.py
+++ b/autocontext/tests/harness_optimization/test_calibration_contract.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.harness_optimization.contract.models import CalibrationReport
+
+FIX = Path(__file__).resolve().parents[3] / "fixtures" / "harness-optimization" / "calibration-report"
+
+
+def test_valid_report_round_trips() -> None:
+    data = json.loads((FIX / "valid-report.json").read_text())
+    model = CalibrationReport.model_validate(data)
+    assert model.scenario_id == "grid_ctf"
+    assert model.margin_vs_noise == "above_noise"
+    assert model.sparse_metric_too_noisy is False
+
+
+def test_missing_standard_error_rejected() -> None:
+    data = json.loads((FIX / "invalid-missing-standard-error.json").read_text())
+    with pytest.raises(ValidationError):
+        CalibrationReport.model_validate(data)

--- a/autocontext/tests/test_advancement_contract.py
+++ b/autocontext/tests/test_advancement_contract.py
@@ -6,6 +6,8 @@ AdvancementContract, evaluate_advancement.
 
 from __future__ import annotations
 
+from typing import Any
+
 # ===========================================================================
 # AdvancementMetrics
 # ===========================================================================
@@ -316,3 +318,63 @@ class TestHarnessPromotionDisabledPathUnchanged:
         default = evaluate_advancement(metrics, min_delta=0.005)
         explicit = evaluate_advancement(metrics, min_delta=0.005, harness_promotion=None)
         assert default.to_dict() == explicit.to_dict()
+
+
+# ===========================================================================
+# AC-881: the opt-in calibration citation must leave the default
+# (no-report) behavior byte-unchanged and only append one proxy signal.
+# ===========================================================================
+
+
+def _sample_metrics() -> Any:
+    from autocontext.harness.pipeline.advancement import AdvancementMetrics
+
+    return AdvancementMetrics(
+        best_score=0.85,
+        mean_score=0.80,
+        previous_best=0.70,
+        score_variance=0.005,
+        sample_count=5,
+        confidence=0.9,
+        error_rate=0.0,
+    )
+
+
+class TestCalibrationCitation:
+    def test_calibration_none_equals_omitting_it(self) -> None:
+        """Passing calibration=None is byte-identical to omitting it."""
+        from autocontext.harness.pipeline.advancement import evaluate_advancement
+
+        metrics = _sample_metrics()
+        default = evaluate_advancement(metrics, min_delta=0.005)
+        explicit_none = evaluate_advancement(metrics, min_delta=0.005, calibration=None)
+        assert default.to_dict() == explicit_none.to_dict()
+
+    def test_calibration_report_appends_citation_last(self) -> None:
+        """A calibration report appends its citation as the last proxy signal only."""
+        from autocontext.harness.pipeline.advancement import evaluate_advancement
+        from autocontext.harness_optimization.calibration import (
+            cite_margin_vs_noise,
+            compute_calibration,
+        )
+
+        metrics = _sample_metrics()
+        report = compute_calibration(
+            [0.80, 0.82, 0.79, 0.81, 0.83],
+            scenario_id="grid_ctf",
+            current_min_delta=0.005,
+            max_trials=32,
+        )
+
+        baseline = evaluate_advancement(metrics, min_delta=0.005)
+        cited = evaluate_advancement(metrics, min_delta=0.005, calibration=report)
+
+        citation = cite_margin_vs_noise(report)
+        # The citation is the LAST proxy signal, and it is the ONLY difference.
+        assert cited.proxy_signals == [*baseline.proxy_signals, citation]
+        assert cited.proxy_signals[-1] == citation
+
+        baseline_dict = baseline.to_dict()
+        cited_dict = cited.to_dict()
+        baseline_dict["proxy_signals"] = cited_dict["proxy_signals"]
+        assert baseline_dict == cited_dict

--- a/autocontext/tests/test_tournament_helpers.py
+++ b/autocontext/tests/test_tournament_helpers.py
@@ -309,6 +309,78 @@ class TestResolveGateDecision:
         rationale = result.metadata["advancement_rationale"]
         assert "resolved truth present without prior truth baseline" in rationale["risk_flags"]
 
+    def test_calibration_disabled_by_default_is_byte_unchanged(self) -> None:
+        # Golden: with calibration off (the default) the metadata carries only the
+        # pre-AC-881 keys and proxy_signals is exactly what evaluate_advancement emits.
+        from autocontext.harness.pipeline.gate import BackpressureGate
+        from autocontext.loop.tournament_helpers import resolve_gate_decision
+
+        gate = BackpressureGate(min_delta=0.005)
+        kwargs: dict[str, Any] = dict(
+            tournament_best_score=0.75,
+            tournament_mean_score=0.72,
+            tournament_results=[_make_eval_result(0.75), _make_eval_result(0.69)],
+            previous_best=0.70,
+            gate=gate,
+            score_history=[0.5, 0.6, 0.7],
+            gate_decision_history=["advance", "advance"],
+            retry_count=0,
+            max_retries=3,
+            use_rapid=False,
+            custom_metrics=None,
+        )
+        result = resolve_gate_decision(**kwargs)
+        assert set(result.metadata.keys()) == {"threshold", "advancement_rationale"}
+        assert "calibration_report" not in result.metadata
+        assert "calibration_summary" not in result.metadata
+
+        default_off = resolve_gate_decision(**kwargs, calibration_enabled=False)
+        assert default_off.metadata == result.metadata
+        assert (
+            default_off.metadata["advancement_rationale"]["proxy_signals"]
+            == result.metadata["advancement_rationale"]["proxy_signals"]
+        )
+
+    def test_calibration_enabled_surfaces_report_and_citation(self) -> None:
+        from autocontext.harness.pipeline.gate import BackpressureGate
+        from autocontext.harness_optimization.calibration import (
+            cite_margin_vs_noise,
+            compute_calibration,
+            render_calibration_report,
+        )
+        from autocontext.loop.tournament_helpers import resolve_gate_decision
+
+        gate = BackpressureGate(min_delta=0.005)
+        result = resolve_gate_decision(
+            tournament_best_score=0.75,
+            tournament_mean_score=0.72,
+            tournament_results=[_make_eval_result(0.75), _make_eval_result(0.69)],
+            previous_best=0.70,
+            gate=gate,
+            score_history=[0.5, 0.6, 0.7],
+            gate_decision_history=["advance", "advance"],
+            retry_count=0,
+            max_retries=3,
+            use_rapid=False,
+            custom_metrics=None,
+            calibration_enabled=True,
+            calibration_scenario_id="grid_ctf",
+            calibration_max_trials=5,
+        )
+        assert "calibration_report" in result.metadata
+        assert "calibration_summary" in result.metadata
+
+        threshold = result.metadata["threshold"]
+        report = compute_calibration(
+            [0.75, 0.69],
+            scenario_id="grid_ctf",
+            current_min_delta=float(threshold),
+            max_trials=5,
+        )
+        assert result.metadata["calibration_summary"] == render_calibration_report(report)
+        proxy_signals = result.metadata["advancement_rationale"]["proxy_signals"]
+        assert proxy_signals[-1] == cite_margin_vs_noise(report)
+
 
 # ===========================================================================
 # build_retry_prompt

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -457,6 +457,96 @@ most-reusable first, a rescue sets the frontier id and sinks the rescued orphan 
 the tail of the reuse order, prune keeps the top-ranked orphans, and the digest
 renders the same bounded, ranked proposer feed on both sides.
 
+## Noise calibration (AC-881)
+
+A harness optimization gate advances a candidate when its margin over the
+incumbent clears a threshold. But a margin is only meaningful relative to the
+noise in the score series that produced it. A 0.01 improvement is real signal on
+a metric whose runs vary by 0.002 and pure chance on a metric whose runs vary by
+0.05. **Noise calibration** turns a raw score series into an estimate of that
+noise floor so a gate can state, in its own rationale, whether the current margin
+sits above or below the noise it is competing with.
+
+### The report
+
+`compute_calibration` (Python in
+`autocontext/src/autocontext/harness_optimization/calibration.py`, mirrored in
+TypeScript at `ts/src/harness-optimization/calibration.ts`) takes a score series
+plus the scenario id, the currently configured promotion margin
+(`current_min_delta`), and a cost-budget ceiling on trials (`max_trials`), and
+returns a `CalibrationReport`. Its fields are:
+
+- `scenario_id`, `sample_size` (n): identity and how many samples fed the estimate.
+- `mean`, `variance`, `std_dev`: the series centre and spread.
+- `standard_error`: the standard error of the mean, the noise on the headline number.
+- `recommended_min_delta`: the margin a gate should require to beat the noise.
+- `recommended_trial_count`: how many trials to run so the current margin is
+  resolvable, clamped to the cost budget.
+- `current_min_delta`: the margin currently configured, echoed back for the citation.
+- `margin_vs_noise`: `above_noise` or `below_noise`.
+- `sparse_metric_too_noisy`: whether the sparse headline metric is too noisy to gate on.
+
+### The formulas
+
+The arithmetic is fixed so the Python and TypeScript ports agree to 1e-9:
+
+- **Sample variance** uses `ddof=1` (divide by `n - 1`), and is 0 when `n < 2`.
+  `std_dev` is its square root.
+- **standard_error** is `std_dev / sqrt(n)`, and is 0 when `n < 2`.
+- **recommended_min_delta** is `noise_multiplier * standard_error` (default
+  multiplier 2.0), so the recommended margin is two standard errors of the mean.
+- **recommended_trial_count** is `clamp(ceil((std_dev / current_min_delta) ** 2), 1, max_trials)`.
+  The `(std_dev / current_min_delta) ** 2` term is how many samples it takes for
+  the standard error to shrink below the margin the gate wants to resolve. The
+  clamp keeps that in `[1, max_trials]` so the cost budget is respected and an
+  expensive run is never silently increased past its ceiling. When
+  `current_min_delta` or `std_dev` is 0 the count falls back to `max_trials`.
+
+### Reading the report
+
+Two fields carry the decision-relevant signal:
+
+- **margin_vs_noise** is `above_noise` when `current_min_delta >= recommended_min_delta`
+  and `below_noise` otherwise. A `below_noise` margin means the gate is trying to
+  resolve a difference smaller than the noise on the metric, so a passing candidate
+  may just be a lucky draw. `cite_margin_vs_noise` renders this as a single line,
+  for example `margin 0.005000 is below_noise (recommended >= 0.017889)`.
+- **sparse_metric_too_noisy** is set when the coefficient of variation of the mean
+  (`standard_error / abs(mean)`) exceeds a threshold (default 0.25), or when the
+  mean is 0 but the standard error is not. It flags that the sparse headline metric
+  is too noisy to gate on directly.
+
+### Sparse headline versus dense verifier
+
+A sparse headline metric (for example a single pass/fail success rate over a
+handful of runs) has few effective samples, so its standard error stays large and
+`margin_vs_noise` easily reads `below_noise`. A dense verifier metric (per-step or
+per-check scores aggregated over many observations) has many more effective
+samples for the same wall-clock cost, so its noise floor is far lower and small
+real improvements become resolvable. When `sparse_metric_too_noisy` is set, treat
+the sparse metric as secondary and optimize a denser verifier signal instead: the
+sparse headline is too noisy to gate on at the current sample size, and pushing on
+it risks advancing on noise. The dense signal gives the gate a margin it can
+actually trust, and the sparse metric can be checked as a secondary confirmation.
+
+### Caller-gated citation
+
+The citation is opt-in and caller-gated, so the default gate behavior is
+unchanged. `evaluate_advancement` gains a trailing keyword-only `calibration`
+parameter; when a caller passes a `CalibrationReport`, the one-line
+`cite_margin_vs_noise` string is appended to the rationale's `proxy_signals` and
+nothing else changes. When it is omitted (the default) the rationale is
+byte-identical to before. The caller decides whether to build a report and pass
+it, gated by the `harness_calibration_enabled` setting (default off);
+`evaluate_advancement` itself never reads settings.
+
+### The worked cases
+
+A shared fixture
+(`fixtures/harness-optimization/calibration-cases/calibration-cases.json`) pins a
+set of score series and the report each should produce, which both packages load
+to prove they compute identical statistics, recommendations, and rendered text.
+
 ## The contract pattern
 
 This is the foundation artifact. The later protocol artifacts follow the same

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -502,6 +502,12 @@ The arithmetic is fixed so the Python and TypeScript ports agree to 1e-9:
   expensive run is never silently increased past its ceiling. When
   `current_min_delta` or `std_dev` is 0 the count falls back to `max_trials`.
 
+With fewer than 2 samples the report has zero variance and cites `above_noise` as an
+"insufficient data" degenerate case, so a single-sample or empty series never reads
+as a real margin over the noise floor. autocontext assumes mechanism scores are
+finite and bounded; extreme overflow inputs are out of scope for the calibration
+arithmetic.
+
 ### Reading the report
 
 Two fields carry the decision-relevant signal:

--- a/fixtures/harness-optimization/calibration-cases/calibration-cases.json
+++ b/fixtures/harness-optimization/calibration-cases/calibration-cases.json
@@ -16,7 +16,9 @@
         "recommended_trial_count": 1,
         "margin_vs_noise": "above_noise",
         "sparse_metric_too_noisy": false
-      }
+      },
+      "expected_rendered": "calibration report: grid_ctf\nsamples: 5\nmean: 0.804000\nstd_dev: 0.011402\nstandard_error: 0.005099\nrecommended_min_delta: 0.010198\nrecommended_trial_count: 1\ncurrent_min_delta: 0.050000\nmargin: above_noise",
+      "expected_citation": "margin 0.050000 is above_noise (recommended >= 0.010198)"
     },
     {
       "name": "high_noise",
@@ -34,7 +36,9 @@
         "recommended_trial_count": 5,
         "margin_vs_noise": "below_noise",
         "sparse_metric_too_noisy": true
-      }
+      },
+      "expected_rendered": "calibration report: othello\nsamples: 6\nmean: 0.566667\nstd_dev: 0.379034\nstandard_error: 0.154740\nrecommended_min_delta: 0.309480\nrecommended_trial_count: 5\ncurrent_min_delta: 0.020000\nmargin: below_noise\nsparse metric too noisy: optimize a denser verifier signal instead",
+      "expected_citation": "margin 0.020000 is below_noise (recommended >= 0.309480)"
     },
     {
       "name": "single",

--- a/fixtures/harness-optimization/calibration-cases/calibration-cases.json
+++ b/fixtures/harness-optimization/calibration-cases/calibration-cases.json
@@ -1,0 +1,76 @@
+{
+  "cases": [
+    {
+      "name": "low_noise",
+      "scores": [0.8, 0.82, 0.79, 0.81, 0.8],
+      "scenario_id": "grid_ctf",
+      "current_min_delta": 0.05,
+      "max_trials": 10,
+      "expected": {
+        "sample_size": 5,
+        "mean": 0.804,
+        "variance": 0.00012999999999999934,
+        "std_dev": 0.011401754250991351,
+        "standard_error": 0.005099019513592771,
+        "recommended_min_delta": 0.010198039027185543,
+        "recommended_trial_count": 1,
+        "margin_vs_noise": "above_noise",
+        "sparse_metric_too_noisy": false
+      }
+    },
+    {
+      "name": "high_noise",
+      "scores": [0.2, 0.9, 0.4, 0.95, 0.1, 0.85],
+      "scenario_id": "othello",
+      "current_min_delta": 0.02,
+      "max_trials": 5,
+      "expected": {
+        "sample_size": 6,
+        "mean": 0.5666666666666667,
+        "variance": 0.14366666666666666,
+        "std_dev": 0.37903385952532875,
+        "standard_error": 0.15473992517913548,
+        "recommended_min_delta": 0.30947985035827097,
+        "recommended_trial_count": 5,
+        "margin_vs_noise": "below_noise",
+        "sparse_metric_too_noisy": true
+      }
+    },
+    {
+      "name": "single",
+      "scores": [0.7],
+      "scenario_id": "grid_ctf",
+      "current_min_delta": 0.05,
+      "max_trials": 8,
+      "expected": {
+        "sample_size": 1,
+        "mean": 0.7,
+        "variance": 0.0,
+        "std_dev": 0.0,
+        "standard_error": 0.0,
+        "recommended_min_delta": 0.0,
+        "recommended_trial_count": 8,
+        "margin_vs_noise": "above_noise",
+        "sparse_metric_too_noisy": false
+      }
+    },
+    {
+      "name": "empty",
+      "scores": [],
+      "scenario_id": "grid_ctf",
+      "current_min_delta": 0.05,
+      "max_trials": 8,
+      "expected": {
+        "sample_size": 0,
+        "mean": 0.0,
+        "variance": 0.0,
+        "std_dev": 0.0,
+        "standard_error": 0.0,
+        "recommended_min_delta": 0.0,
+        "recommended_trial_count": 8,
+        "margin_vs_noise": "above_noise",
+        "sparse_metric_too_noisy": false
+      }
+    }
+  ]
+}

--- a/fixtures/harness-optimization/calibration-report/invalid-missing-standard-error.json
+++ b/fixtures/harness-optimization/calibration-report/invalid-missing-standard-error.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "scenario_id": "grid_ctf",
+  "sample_size": 5,
+  "mean": 0.8,
+  "variance": 0.0025,
+  "std_dev": 0.05,
+  "recommended_min_delta": 0.04472,
+  "recommended_trial_count": 3,
+  "current_min_delta": 0.05,
+  "margin_vs_noise": "above_noise",
+  "sparse_metric_too_noisy": false,
+  "notes": "Current margin 0.05 exceeds 2x the standard error, so promotions sit above the noise floor."
+}

--- a/fixtures/harness-optimization/calibration-report/valid-report.json
+++ b/fixtures/harness-optimization/calibration-report/valid-report.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "scenario_id": "grid_ctf",
+  "sample_size": 5,
+  "mean": 0.8,
+  "variance": 0.0025,
+  "std_dev": 0.05,
+  "standard_error": 0.02236,
+  "recommended_min_delta": 0.04472,
+  "recommended_trial_count": 3,
+  "current_min_delta": 0.05,
+  "margin_vs_noise": "above_noise",
+  "sparse_metric_too_noisy": false,
+  "notes": "Current margin 0.05 exceeds 2x the standard error, so promotions sit above the noise floor."
+}

--- a/ts/src/harness-optimization/calibration.ts
+++ b/ts/src/harness-optimization/calibration.ts
@@ -35,6 +35,8 @@ export function computeCalibration(
 ): CalibrationReport {
   const noiseMultiplier = opts.noiseMultiplier ?? 2.0;
   const noisyCvThreshold = opts.noisyCvThreshold ?? 0.25;
+  // Clamp the budget to at least 1 so a degenerate 0/negative budget yields a sane count of 1.
+  const maxTrials = Math.max(1, opts.maxTrials);
 
   const n = scores.length;
   const mean = n > 0 ? scores.reduce((acc, x) => acc + x, 0) / n : 0;
@@ -47,9 +49,9 @@ export function computeCalibration(
   if (opts.currentMinDelta > 0 && stdDev > 0) {
     k = Math.ceil((stdDev / opts.currentMinDelta) ** 2);
   } else {
-    k = opts.maxTrials;
+    k = maxTrials;
   }
-  const recommendedTrialCount = Math.max(1, Math.min(k, opts.maxTrials));
+  const recommendedTrialCount = Math.max(1, Math.min(k, maxTrials));
 
   const marginVsNoise: "above_noise" | "below_noise" =
     opts.currentMinDelta >= recommendedMinDelta ? "above_noise" : "below_noise";

--- a/ts/src/harness-optimization/calibration.ts
+++ b/ts/src/harness-optimization/calibration.ts
@@ -1,0 +1,123 @@
+import type { CalibrationReport } from "./contract/generated-types.js";
+
+/**
+ * Noise calibration engine for the harness optimization loop (AC-881).
+ *
+ * TypeScript half of the AC-881 parity pair: the same pure functions live here
+ * and in `autocontext/src/autocontext/harness_optimization/calibration.py`, and
+ * a shared fixture
+ * (`fixtures/harness-optimization/calibration-cases/calibration-cases.json`)
+ * proves both languages compute identical statistics to 1e-9 and render
+ * character-identical text.
+ *
+ * The float formulas here are mirrored by the Python engine and must agree to
+ * 1e-9, so the arithmetic order below is intentional and should not be changed.
+ */
+
+export interface CalibrationOptions {
+  scenarioId: string;
+  currentMinDelta: number;
+  maxTrials: number;
+  noiseMultiplier?: number;
+  noisyCvThreshold?: number;
+}
+
+/**
+ * Compute noise statistics and gating recommendations for a score series.
+ *
+ * Mirrors Python `compute_calibration`: sample mean, ddof=1 variance, standard
+ * error, a noise-multiplier margin, and a budget-capped trial count, plus the
+ * margin-vs-noise verdict and the sparse-metric coefficient-of-variation flag.
+ */
+export function computeCalibration(
+  scores: readonly number[],
+  opts: CalibrationOptions,
+): CalibrationReport {
+  const noiseMultiplier = opts.noiseMultiplier ?? 2.0;
+  const noisyCvThreshold = opts.noisyCvThreshold ?? 0.25;
+
+  const n = scores.length;
+  const mean = n > 0 ? scores.reduce((acc, x) => acc + x, 0) / n : 0;
+  const variance = n >= 2 ? scores.reduce((acc, x) => acc + (x - mean) ** 2, 0) / (n - 1) : 0;
+  const stdDev = Math.sqrt(variance);
+  const standardError = n >= 2 ? stdDev / Math.sqrt(n) : 0;
+  const recommendedMinDelta = noiseMultiplier * standardError;
+
+  let k: number;
+  if (opts.currentMinDelta > 0 && stdDev > 0) {
+    k = Math.ceil((stdDev / opts.currentMinDelta) ** 2);
+  } else {
+    k = opts.maxTrials;
+  }
+  const recommendedTrialCount = Math.max(1, Math.min(k, opts.maxTrials));
+
+  const marginVsNoise: "above_noise" | "below_noise" =
+    opts.currentMinDelta >= recommendedMinDelta ? "above_noise" : "below_noise";
+
+  let sparseMetricTooNoisy: boolean;
+  if (Math.abs(mean) > 0) {
+    sparseMetricTooNoisy = standardError / Math.abs(mean) > noisyCvThreshold;
+  } else {
+    sparseMetricTooNoisy = standardError > 0;
+  }
+
+  const notes = `SE=${standardError.toFixed(4)} over n=${n}; margin ${marginVsNoise}`;
+
+  return {
+    schema_version: 1,
+    scenario_id: opts.scenarioId,
+    sample_size: n,
+    mean,
+    variance,
+    std_dev: stdDev,
+    standard_error: standardError,
+    recommended_min_delta: recommendedMinDelta,
+    recommended_trial_count: recommendedTrialCount,
+    current_min_delta: opts.currentMinDelta,
+    margin_vs_noise: marginVsNoise,
+    sparse_metric_too_noisy: sparseMetricTooNoisy,
+    notes,
+  };
+}
+
+// Numeric fields are rendered with a fixed 6-decimal format so the text is
+// identical across languages. Do NOT use raw String(): JS String(2) -> "2"
+// while Python str(2.0) -> "2.0", which would diverge. This matches Python's
+// _fmt_float (f"{value:.6f}") character-for-character.
+function fmtFloat(value: number): string {
+  return value.toFixed(6);
+}
+
+const SPARSE_NOISE_LINE = "sparse metric too noisy: optimize a denser verifier signal instead";
+
+/**
+ * Render a calibration report as a stable multi-line string. Mirrors Python
+ * `render_calibration_report` character-for-character: float fields through
+ * `fmtFloat` (6-decimal fixed) and plain String() for the integer counts.
+ */
+export function renderCalibrationReport(report: CalibrationReport): string {
+  const lines = [
+    `calibration report: ${report.scenario_id}`,
+    `samples: ${report.sample_size}`,
+    `mean: ${fmtFloat(report.mean)}`,
+    `std_dev: ${fmtFloat(report.std_dev)}`,
+    `standard_error: ${fmtFloat(report.standard_error)}`,
+    `recommended_min_delta: ${fmtFloat(report.recommended_min_delta)}`,
+    `recommended_trial_count: ${String(report.recommended_trial_count)}`,
+    `current_min_delta: ${fmtFloat(report.current_min_delta)}`,
+    `margin: ${report.margin_vs_noise}`,
+  ];
+  if (report.sparse_metric_too_noisy) {
+    lines.push(SPARSE_NOISE_LINE);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Render a one-line citation of the margin against the noise floor. Both
+ * numbers use the same 6-decimal fixed format as `renderCalibrationReport` so
+ * the Python port (f"{value:.6f}") produces identical text.
+ */
+export function citeMarginVsNoise(report: CalibrationReport): string {
+  return `margin ${fmtFloat(report.current_min_delta)} is ${report.margin_vs_noise} (recommended >= ${fmtFloat(report.recommended_min_delta)})`;
+}

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -11,6 +11,65 @@ export interface HarnessOptimizationContracts {
   [k: string]: unknown;
 }
 
+// ---- calibration-report.schema.json ----
+/**
+ * Noise calibration for a harness score series (AC-881). Summarises a scenario's score samples (mean, variance, standard error) and recommends a promotion margin and trial count so the configured gate sits above measurement noise. Flags when a sparse metric is too noisy to gate on. Shared source of truth for both the Python and TypeScript autocontext packages.
+ */
+export interface CalibrationReport {
+  /**
+   * Schema version for forward compatibility. Always 1 for this revision.
+   */
+  schema_version: 1;
+  /**
+   * Scenario or family the score series came from.
+   */
+  scenario_id: string;
+  /**
+   * Number of score samples in the series (n).
+   */
+  sample_size: number;
+  /**
+   * Mean of the score series.
+   */
+  mean: number;
+  /**
+   * Sample variance (ddof=1); 0 when n<2.
+   */
+  variance: number;
+  /**
+   * Standard deviation, sqrt of the variance.
+   */
+  std_dev: number;
+  /**
+   * Standard error, std_dev over sqrt(n); 0 when n<2.
+   */
+  standard_error: number;
+  /**
+   * Recommended margin: noise_multiplier times standard_error.
+   */
+  recommended_min_delta: number;
+  /**
+   * Trials so the mean SE falls under current_min_delta, capped by budget.
+   */
+  recommended_trial_count: number;
+  /**
+   * The promotion margin currently configured.
+   */
+  current_min_delta: number;
+  /**
+   * Whether the current margin sits above or below the noise floor.
+   */
+  margin_vs_noise: "above_noise" | "below_noise";
+  /**
+   * True when the sparse metric is too noisy to gate on.
+   */
+  sparse_metric_too_noisy: boolean;
+  /**
+   * Optional human-readable rationale for audit.
+   */
+  notes?: string;
+}
+
 // ---- candidate-evidence.schema.json ----
 /**
  * Canonical evidence record for a single harness-optimization candidate (AC-876). A candidate is a proposed mechanism change to some target surface, carrying the hypothesis, the concrete changes, the fix and regression cases it is expected to move, its cost expectation, and its cross-language parity status. This schema is the single source of truth for both the Python and TypeScript autocontext packages.

--- a/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/_aggregate.schema.json
@@ -21,6 +21,9 @@
     },
     "OrphanMechanism": {
       "$ref": "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json"
+    },
+    "CalibrationReport": {
+      "$ref": "https://autocontext.dev/schema/harness-optimization/calibration-report.json"
     }
   }
 }

--- a/ts/src/harness-optimization/contract/json-schemas/calibration-report.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/calibration-report.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/harness-optimization/calibration-report.json",
+  "title": "CalibrationReport",
+  "description": "Noise calibration for a harness score series (AC-881). Summarises a scenario's score samples (mean, variance, standard error) and recommends a promotion margin and trial count so the configured gate sits above measurement noise. Flags when a sparse metric is too noisy to gate on. Shared source of truth for both the Python and TypeScript autocontext packages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "scenario_id",
+    "sample_size",
+    "mean",
+    "variance",
+    "std_dev",
+    "standard_error",
+    "recommended_min_delta",
+    "recommended_trial_count",
+    "current_min_delta",
+    "margin_vs_noise",
+    "sparse_metric_too_noisy"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward compatibility. Always 1 for this revision."
+    },
+    "scenario_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Scenario or family the score series came from."
+    },
+    "sample_size": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of score samples in the series (n)."
+    },
+    "mean": {
+      "type": "number",
+      "description": "Mean of the score series."
+    },
+    "variance": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Sample variance (ddof=1); 0 when n<2."
+    },
+    "std_dev": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Standard deviation, sqrt of the variance."
+    },
+    "standard_error": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Standard error, std_dev over sqrt(n); 0 when n<2."
+    },
+    "recommended_min_delta": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Recommended margin: noise_multiplier times standard_error."
+    },
+    "recommended_trial_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Trials so the mean SE falls under current_min_delta, capped by budget."
+    },
+    "current_min_delta": {
+      "type": "number",
+      "description": "The promotion margin currently configured."
+    },
+    "margin_vs_noise": {
+      "type": "string",
+      "enum": ["above_noise", "below_noise"],
+      "description": "Whether the current margin sits above or below the noise floor."
+    },
+    "sparse_metric_too_noisy": {
+      "type": "boolean",
+      "description": "True when the sparse metric is too noisy to gate on."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional human-readable rationale for audit."
+    }
+  }
+}

--- a/ts/src/harness-optimization/contract/validators.ts
+++ b/ts/src/harness-optimization/contract/validators.ts
@@ -7,7 +7,9 @@ import repairResultSchema from "./json-schemas/repair-result.schema.json" with {
 import integrityMetadataSchema from "./json-schemas/integrity-metadata.schema.json" with { type: "json" };
 import frontierMechanismSchema from "./json-schemas/frontier-mechanism.schema.json" with { type: "json" };
 import orphanMechanismSchema from "./json-schemas/orphan-mechanism.schema.json" with { type: "json" };
+import calibrationReportSchema from "./json-schemas/calibration-report.schema.json" with { type: "json" };
 import type {
+  CalibrationReport,
   CandidateEvidence,
   FrontierMechanism,
   IntegrityMetadata,
@@ -35,6 +37,7 @@ ajv.addSchema(repairResultSchema as object);
 ajv.addSchema(integrityMetadataSchema as object);
 ajv.addSchema(frontierMechanismSchema as object);
 ajv.addSchema(orphanMechanismSchema as object);
+ajv.addSchema(calibrationReportSchema as object);
 
 const candidateEvidenceValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json",
@@ -58,6 +61,10 @@ const frontierMechanismValidator = ajv.getSchema(
 
 const orphanMechanismValidator = ajv.getSchema(
   "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json",
+)!;
+
+const calibrationReportValidator = ajv.getSchema(
+  "https://autocontext.dev/schema/harness-optimization/calibration-report.json",
 )!;
 
 function toResult(validate: ValidateFunction, input: unknown): ValidationResult {
@@ -96,6 +103,10 @@ export function validateOrphanMechanism(input: unknown): ValidationResult {
   return toResult(orphanMechanismValidator, input);
 }
 
+export function validateCalibrationReport(input: unknown): ValidationResult {
+  return toResult(calibrationReportValidator, input);
+}
+
 // Type-level assertion — if a TS type drifts from its schema this won't compile.
 export type _TypeCheck =
   | CandidateEvidence
@@ -103,4 +114,5 @@ export type _TypeCheck =
   | RepairResult
   | IntegrityMetadata
   | FrontierMechanism
-  | OrphanMechanism;
+  | OrphanMechanism
+  | CalibrationReport;

--- a/ts/tests/harness-optimization/calibration-report-contract.test.ts
+++ b/ts/tests/harness-optimization/calibration-report-contract.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { validateCalibrationReport } from "../../src/harness-optimization/contract/validators.js";
+
+const FIX = join(import.meta.dirname, "../../../fixtures/harness-optimization/calibration-report");
+
+describe("calibration-report contract", () => {
+  it("accepts a full valid report", () => {
+    const data = JSON.parse(readFileSync(join(FIX, "valid-report.json"), "utf8"));
+    expect(validateCalibrationReport(data)).toEqual({ valid: true });
+  });
+  it("rejects a report missing standard_error", () => {
+    const data = JSON.parse(readFileSync(join(FIX, "invalid-missing-standard-error.json"), "utf8"));
+    const r = validateCalibrationReport(data);
+    expect(r.valid).toBe(false);
+  });
+});

--- a/ts/tests/harness-optimization/calibration.test.ts
+++ b/ts/tests/harness-optimization/calibration.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  computeCalibration,
+  renderCalibrationReport,
+  citeMarginVsNoise,
+} from "../../src/harness-optimization/calibration.js";
+
+// Load the SAME repo-root fixture the Python suite loads. Matching it in both
+// languages is the load-bearing parity proof.
+// Walk up to the repo root: ts/tests/harness-optimization/ -> ts/tests/ -> ts/ -> <repo root>.
+const CASES = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dirname,
+      "..",
+      "..",
+      "..",
+      "fixtures",
+      "harness-optimization",
+      "calibration-cases",
+      "calibration-cases.json",
+    ),
+    "utf8",
+  ),
+).cases;
+
+const TOL = 1e-9;
+
+describe("calibration parity", () => {
+  for (const c of CASES) {
+    it(`${c.name}: numeric + enum fields match fixture within ${TOL}`, () => {
+      const report = computeCalibration(c.scores, {
+        scenarioId: c.scenario_id,
+        currentMinDelta: c.current_min_delta,
+        maxTrials: c.max_trials,
+      });
+      const e = c.expected;
+      expect(report.sample_size).toBe(e.sample_size);
+      expect(Math.abs(report.mean - e.mean)).toBeLessThanOrEqual(TOL);
+      expect(Math.abs(report.variance - e.variance)).toBeLessThanOrEqual(TOL);
+      expect(Math.abs(report.std_dev - e.std_dev)).toBeLessThanOrEqual(TOL);
+      expect(Math.abs(report.standard_error - e.standard_error)).toBeLessThanOrEqual(TOL);
+      expect(Math.abs(report.recommended_min_delta - e.recommended_min_delta)).toBeLessThanOrEqual(
+        TOL,
+      );
+      expect(report.recommended_trial_count).toBe(e.recommended_trial_count);
+      expect(Math.abs(report.current_min_delta - c.current_min_delta)).toBeLessThanOrEqual(TOL);
+      expect(report.margin_vs_noise).toBe(e.margin_vs_noise);
+      expect(report.sparse_metric_too_noisy).toBe(e.sparse_metric_too_noisy);
+    });
+  }
+
+  it("renders the high_noise report character-for-character including the sparse-noise line", () => {
+    const c = CASES.find((x: { name: string }) => x.name === "high_noise");
+    const report = computeCalibration(c.scores, {
+      scenarioId: c.scenario_id,
+      currentMinDelta: c.current_min_delta,
+      maxTrials: c.max_trials,
+    });
+    const expected = [
+      `calibration report: ${report.scenario_id}`,
+      `samples: ${report.sample_size}`,
+      `mean: ${report.mean.toFixed(6)}`,
+      `std_dev: ${report.std_dev.toFixed(6)}`,
+      `standard_error: ${report.standard_error.toFixed(6)}`,
+      `recommended_min_delta: ${report.recommended_min_delta.toFixed(6)}`,
+      `recommended_trial_count: ${report.recommended_trial_count}`,
+      `current_min_delta: ${report.current_min_delta.toFixed(6)}`,
+      `margin: ${report.margin_vs_noise}`,
+      "sparse metric too noisy: optimize a denser verifier signal instead",
+    ].join("\n");
+    expect(renderCalibrationReport(report)).toBe(expected);
+    expect(report.sparse_metric_too_noisy).toBe(true);
+  });
+
+  it("omits the sparse-noise line for the low_noise report", () => {
+    const c = CASES.find((x: { name: string }) => x.name === "low_noise");
+    const report = computeCalibration(c.scores, {
+      scenarioId: c.scenario_id,
+      currentMinDelta: c.current_min_delta,
+      maxTrials: c.max_trials,
+    });
+    const rendered = renderCalibrationReport(report);
+    expect(rendered).not.toContain("sparse metric too noisy");
+    expect(rendered.endsWith(`margin: ${report.margin_vs_noise}`)).toBe(true);
+  });
+
+  it("cites the margin against the noise floor on one line", () => {
+    const c = CASES.find((x: { name: string }) => x.name === "high_noise");
+    const report = computeCalibration(c.scores, {
+      scenarioId: c.scenario_id,
+      currentMinDelta: c.current_min_delta,
+      maxTrials: c.max_trials,
+    });
+    const expected = `margin ${report.current_min_delta.toFixed(6)} is ${report.margin_vs_noise} (recommended >= ${report.recommended_min_delta.toFixed(6)})`;
+    expect(citeMarginVsNoise(report)).toBe(expected);
+  });
+});

--- a/ts/tests/harness-optimization/calibration.test.ts
+++ b/ts/tests/harness-optimization/calibration.test.ts
@@ -49,6 +49,15 @@ describe("calibration parity", () => {
       expect(Math.abs(report.current_min_delta - c.current_min_delta)).toBeLessThanOrEqual(TOL);
       expect(report.margin_vs_noise).toBe(e.margin_vs_noise);
       expect(report.sparse_metric_too_noisy).toBe(e.sparse_metric_too_noisy);
+
+      // When a case pins the exact rendered/citation text, both languages compare
+      // to the same shared literal so any Python-vs-TS text drift fails a test.
+      if (c.expected_rendered !== undefined) {
+        expect(renderCalibrationReport(report)).toBe(c.expected_rendered);
+      }
+      if (c.expected_citation !== undefined) {
+        expect(citeMarginVsNoise(report)).toBe(c.expected_citation);
+      }
     });
   }
 


### PR DESCRIPTION
Implements AC-881, the sixth harness-optimization protocol artifact: turn observed score variance into explicit calibration recommendations so trial count and promotion margin stop being static guesses. Built on the AC-876 codegen/parity harness.

## What this adds

**CalibrationReport contract** (`calibration-report.schema.json` -> regenerated `models.py` + `generated-types.ts`, drift-gated): sample_size, mean, variance, std_dev, standard_error, recommended_min_delta, recommended_trial_count, current_min_delta, margin_vs_noise, sparse_metric_too_noisy, notes.

**Calibration engine** (`calibration.py` + `calibration.ts`, pure, mirrored): from a raw score series it computes sample variance (ddof=1), standard_error = std_dev/sqrt(n), a recommended min delta just above noise (2*standard_error), and a recommended trial count = clamp(ceil((std_dev/current_min_delta)^2), 1, max_trials) so the cost budget is respected and expensive runs are never silently increased. It flags margin_vs_noise (above/below) and sparse_metric_too_noisy (coefficient of variation over threshold). render_calibration_report and cite_margin_vs_noise render operator-facing summaries with a fixed 6-decimal format so Python and TS text matches character-for-character.

**Runtime wiring** (opt-in, default-off): `harness_calibration_enabled` is read in the tournament gate path (`exploration.py` -> `resolve_gate_decision`); when enabled it builds a report from the tournament score series, appends the noise citation to the advancement rationale (AC #2), and surfaces the rendered report in the gate-decision metadata (AC #1). Default-off is byte-unchanged, pinned by a golden test. No new `*_gate.py`, so the gate-taxonomy invariant stays satisfied.

## Parity + tests

One shared fixture (`calibration-cases.json`: low-noise, high-noise with the cost-budget clamp exercised, n=1, n=0) proves Python and TS agree within 1e-9, and pins the exact rendered/citation strings asserted in both suites. The whole-branch review (fable) ran a 16-case adversarial parity probe (bit-identical) and returned NOT-READY only on the dead flag, which this branch then wired end-to-end.

Gates: ruff (incl. generated models), mypy, module-size guard, gate-taxonomy invariant, drift gate, vitest (123), and lint all green.

Note: the `ts-test` full-suite CI job is red repo-wide (AC-892 infra, host OOM), unrelated to this change.

Closes AC-881.