### PR TITLE
harness optimization: cross-package parity fixtures + docs (AC-882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - harness optimization protocol: post-proposal holdout-leakage audit (clean/contaminated/unknown over forbidden-source, forbidden-split, and web-policy passes) and verified/exploratory fail-closed gate with python/typescript parity (AC-879)
 - harness optimization protocol: in-memory mechanism archive of promoted (frontier) and gated-out (orphan) mechanisms with candidate-evidence and parent-frontier lineage, reuse-ranked orphan rescue/prune, and a bounded ranked proposer digest with python/typescript parity (AC-880)
 - harness optimization protocol: noise calibration report (sample-variance noise floor, recommended margin and cost-clamped trial count, sparse-metric-too-noisy flag) with an opt-in caller-gated citation of the current margin against the noise floor in the advancement rationale and python/typescript parity (AC-881)
+- harness optimization protocol: cross-package parity fixtures driven by a single manifest that both packages iterate (every clean fixture validates and every invalid fixture is rejected in python and typescript), a membership guard that fails ci when a schema has no manifest entry, plus a cross-package parity doc section and a new-artifact release checklist (AC-882)
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/tests/harness_optimization/test_parity_suite.py
+++ b/autocontext/tests/harness_optimization/test_parity_suite.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.harness_optimization.contract import models as m
+
+REPO = Path(__file__).resolve().parents[3]
+FIX = REPO / "fixtures" / "harness-optimization"
+MANIFEST = json.loads((FIX / "parity-manifest.json").read_text())
+SCHEMA_DIR = REPO / "ts" / "src" / "harness-optimization" / "contract" / "json-schemas"
+
+MODELS = {
+    "candidate-evidence": m.CandidateEvidence,
+    "promotion-score": m.PromotionScore,
+    "repair-result": m.RepairResult,
+    "integrity-metadata": m.IntegrityMetadata,
+    "frontier-mechanism": m.FrontierMechanism,
+    "orphan-mechanism": m.OrphanMechanism,
+    "calibration-report": m.CalibrationReport,
+}
+
+
+def _load(rel: str) -> dict:
+    return json.loads((REPO / "fixtures" / rel).read_text())
+
+
+def test_manifest_covers_every_schema() -> None:
+    schema_files = {p.name for p in SCHEMA_DIR.glob("*.schema.json") if p.name != "_aggregate.schema.json"}
+    manifest_files = {a["schema_file"] for a in MANIFEST["artifacts"]}
+    assert manifest_files == schema_files, (
+        f"parity manifest out of sync with schemas: missing {schema_files - manifest_files}, "
+        f"extra {manifest_files - schema_files}"
+    )
+
+
+def test_every_artifact_has_clean_and_invalid() -> None:
+    for a in MANIFEST["artifacts"]:
+        assert a["valid"] and a["invalid"], f"{a['name']} needs >=1 valid and >=1 invalid fixture"
+
+
+@pytest.mark.parametrize("artifact", MANIFEST["artifacts"], ids=lambda a: a["name"])
+def test_clean_fixtures_validate(artifact: dict) -> None:
+    model = MODELS[artifact["name"]]
+    for rel in artifact["valid"]:
+        model.model_validate(_load(rel))
+
+
+@pytest.mark.parametrize("artifact", MANIFEST["artifacts"], ids=lambda a: a["name"])
+def test_invalid_fixtures_rejected(artifact: dict) -> None:
+    model = MODELS[artifact["name"]]
+    for rel in artifact["invalid"]:
+        with pytest.raises(ValidationError):
+            model.model_validate(_load(rel))

--- a/autocontext/tests/harness_optimization/test_parity_suite.py
+++ b/autocontext/tests/harness_optimization/test_parity_suite.py
@@ -28,11 +28,23 @@ def _load(rel: str) -> dict:
 
 def test_manifest_covers_every_schema() -> None:
     schema_files = {p.name for p in SCHEMA_DIR.glob("*.schema.json") if p.name != "_aggregate.schema.json"}
-    manifest_files = {a["schema_file"] for a in MANIFEST["artifacts"]}
+    manifest_file_list = [a["schema_file"] for a in MANIFEST["artifacts"]]
+    manifest_files = set(manifest_file_list)
+    assert len(manifest_file_list) == len(manifest_files), (
+        f"parity manifest has a duplicate schema_file entry: {manifest_file_list}"
+    )
     assert manifest_files == schema_files, (
         f"parity manifest out of sync with schemas: missing {schema_files - manifest_files}, "
         f"extra {manifest_files - schema_files}"
     )
+
+
+def test_manifest_schema_id_matches_schema_file() -> None:
+    for a in MANIFEST["artifacts"]:
+        schema = json.loads((SCHEMA_DIR / a["schema_file"]).read_text())
+        assert a["schema_id"] == schema["$id"], (
+            f"{a['name']} manifest schema_id {a['schema_id']} does not match {a['schema_file']} $id {schema['$id']}"
+        )
 
 
 def test_every_artifact_has_clean_and_invalid() -> None:

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -553,6 +553,104 @@ A shared fixture
 set of score series and the report each should produce, which both packages load
 to prove they compute identical statistics, recommendations, and rendered text.
 
+## Cross-package parity (AC-882)
+
+Every artifact above is generated once and consumed twice: a python pydantic
+model and a TypeScript interface plus AJV validator, from the same canonical
+schema. That only stays honest if both packages are proven to agree on real
+records. `fixtures/harness-optimization/parity-manifest.json` is the single
+source that lists all seven artifacts (candidate-evidence, promotion-score,
+repair-result, integrity-metadata, frontier-mechanism, orphan-mechanism, and
+calibration-report) together with each one's schema file and its clean and
+invalid fixtures. Both packages iterate that one manifest: the python suite at
+`autocontext/tests/harness_optimization/test_parity_suite.py` and the TypeScript
+suite at `ts/tests/harness-optimization/parity-suite.test.ts`. For every artifact
+in the manifest, every clean fixture must validate and every invalid fixture must
+be rejected, in BOTH languages. A record that one side accepts and the other
+rejects fails the build.
+
+### The membership guard
+
+The manifest cannot be allowed to fall behind the schemas. Both suites carry a
+membership guard that reads `ts/src/harness-optimization/contract/json-schemas`
+and asserts that every `*.schema.json` file (except the `_aggregate` bundle) has
+a manifest entry. Adding a new schema without a manifest entry, or without at
+least one clean and one invalid fixture, fails CI, so a future artifact cannot
+ship contract types without also shipping cross-language parity fixtures.
+
+### What parity guarantees
+
+The parity coverage is split across two kinds of fixture:
+
+- **Structure**: python and TS agree on the schema, the required fields, and the
+  enum values. This is enforced upstream by the byte-diff drift gate
+  (`npm run check:harness-optimization-schemas`), which regenerates both packages'
+  types and the synced python schemas and fails on any hand-edit, and downstream
+  by the manifest's clean and invalid fixtures validating identically on both
+  sides.
+- **Arithmetic**: python and TS agree on the numeric computations. The promotion
+  score and beat decisions are pinned by
+  `fixtures/harness-optimization/promotion-score/score-cases.json`, and the
+  calibration statistics and rendered citations by
+  `fixtures/harness-optimization/calibration-cases/calibration-cases.json`. Both
+  packages load these numeric fixtures and must reproduce the pinned values within
+  a 1e-9 tolerance.
+
+### Intentionally unsupported behavior
+
+Parity is a claim about the contract and the pure computations, not about every
+pipeline hook. Some behavior is python-side only by design, and the parity suite
+does not assert a TS equivalent for it:
+
+- TS runners and adapters may DECLARE source policy and contamination status
+  (they carry the IntegrityMetadata fields), but they do not enforce every
+  python-only hook, per AC-879. The leakage audit and gate functions exist in both
+  languages, but their wiring into a live run is python-side.
+- The leakage stage (`autocontext/src/autocontext/loop/stage_leakage.py`) and the
+  calibration citation in `evaluate_advancement` are python-side pipeline wirings.
+  Both are opt-in and default-off, and there is no TS pipeline equivalent to
+  mirror. The shared, mirrored surface is the pure `audit_leakage` /
+  `evaluate_leakage_gate` and `compute_calibration` functions and their fixtures,
+  not the python loop that calls them.
+
+### Verifying parity
+
+Run all three from their package directories:
+
+```bash
+cd autocontext && uv run pytest
+cd ts && npm test
+cd ts && npm run lint
+```
+
+## Adding a new protocol artifact
+
+A new artifact follows the same contract pattern end to end. The steps, in order:
+
+1. Author the JSON schema under
+   `ts/src/harness-optimization/contract/json-schemas/`.
+2. Add one `$ref` to `_aggregate.schema.json` so the new schema joins the bundle.
+3. Regenerate both packages' types:
+   `node scripts/generate-harness-optimization-types.mjs` then
+   `node scripts/sync-python-harness-optimization-schemas.mjs`.
+4. Wire the AJV validator and its `_TypeCheck` member in `validators.ts`.
+5. Add at least one clean and one invalid fixture under
+   `fixtures/harness-optimization/<artifact>/`.
+6. Add a `parity-manifest.json` entry (name, schema id, schema file, and the
+   clean and invalid fixture paths).
+7. Add the pydantic model to `test_parity_suite.py`'s `MODELS` map and the
+   validator to `parity-suite.test.ts`'s `VALIDATORS` map.
+8. Run the pre-merge gate:
+   - `uv run --frozen ruff check src tests`
+   - `uv run --frozen pytest tests/test_module_size_limits.py tests/test_gate_taxonomy.py tests/harness_optimization`
+   - `npm run check:harness-optimization-schemas`
+   - `npx vitest run tests/harness-optimization`
+   - `npm run lint`
+
+The membership guard means skipping steps 5 through 7 is caught by the build: a
+schema with no manifest entry, or a manifest artifact with no model or validator
+map member, fails the parity suite.
+
 ## The contract pattern
 
 This is the foundation artifact. The later protocol artifacts follow the same

--- a/docs/harness-optimization-protocol.md
+++ b/docs/harness-optimization-protocol.md
@@ -630,7 +630,7 @@ A new artifact follows the same contract pattern end to end. The steps, in order
 1. Author the JSON schema under
    `ts/src/harness-optimization/contract/json-schemas/`.
 2. Add one `$ref` to `_aggregate.schema.json` so the new schema joins the bundle.
-3. Regenerate both packages' types:
+3. Regenerate both packages' types (from `ts/`):
    `node scripts/generate-harness-optimization-types.mjs` then
    `node scripts/sync-python-harness-optimization-schemas.mjs`.
 4. Wire the AJV validator and its `_TypeCheck` member in `validators.ts`.
@@ -641,11 +641,11 @@ A new artifact follows the same contract pattern end to end. The steps, in order
 7. Add the pydantic model to `test_parity_suite.py`'s `MODELS` map and the
    validator to `parity-suite.test.ts`'s `VALIDATORS` map.
 8. Run the pre-merge gate:
-   - `uv run --frozen ruff check src tests`
-   - `uv run --frozen pytest tests/test_module_size_limits.py tests/test_gate_taxonomy.py tests/harness_optimization`
-   - `npm run check:harness-optimization-schemas`
-   - `npx vitest run tests/harness-optimization`
-   - `npm run lint`
+   - from `autocontext/`: `uv run --frozen ruff check src tests`
+   - from `autocontext/`: `uv run --frozen pytest tests/test_module_size_limits.py tests/test_gate_taxonomy.py tests/harness_optimization`
+   - from `ts/`: `npm run check:harness-optimization-schemas`
+   - from `ts/`: `npx vitest run tests/harness-optimization`
+   - from `ts/`: `npm run lint`
 
 The membership guard means skipping steps 5 through 7 is caught by the build: a
 schema with no manifest entry, or a manifest artifact with no model or validator

--- a/fixtures/harness-optimization/mechanism-archive/invalid-frontier-missing-support-count.json
+++ b/fixtures/harness-optimization/mechanism-archive/invalid-frontier-missing-support-count.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "mechanism_id": "frontier-ac880-001",
+  "candidate_evidence_id": "candidate-ac876-042",
+  "parent_frontier_id": "frontier-ac880-000",
+  "mechanism_name": "retry-on-truncated-output guard",
+  "mechanism_type": "deterministic_code",
+  "target_surface": "harness_validator",
+  "gate_decision": "advance",
+  "affected_surfaces": ["harness_validator", "evaluator"],
+  "regression_risks": ["adds one retry on legitimately empty outputs"],
+  "promoted_at_generation": 7
+}

--- a/fixtures/harness-optimization/parity-manifest.json
+++ b/fixtures/harness-optimization/parity-manifest.json
@@ -1,0 +1,80 @@
+{
+  "description": "Cross-package parity manifest for harness-optimization contract artifacts (AC-882). Both the Python and TypeScript packages iterate this list: every clean fixture must validate and every invalid fixture must be rejected in both languages, and a membership guard fails CI if any schema in ts/src/harness-optimization/contract/json-schemas has no entry here. Paths are relative to the repo-root fixtures/ directory.",
+  "artifacts": [
+    {
+      "name": "candidate-evidence",
+      "schema_id": "https://autocontext.dev/schema/harness-optimization/candidate-evidence.json",
+      "schema_file": "candidate-evidence.schema.json",
+      "valid": [
+        "harness-optimization/candidate-evidence/valid-full.json",
+        "harness-optimization/candidate-evidence/valid-minimal.json"
+      ],
+      "invalid": [
+        "harness-optimization/candidate-evidence/invalid-bad-mechanism-type.json",
+        "harness-optimization/candidate-evidence/invalid-empty-parity.json",
+        "harness-optimization/candidate-evidence/invalid-extra-field.json",
+        "harness-optimization/candidate-evidence/invalid-missing-hypothesis.json"
+      ]
+    },
+    {
+      "name": "promotion-score",
+      "schema_id": "https://autocontext.dev/schema/harness-optimization/promotion-score.json",
+      "schema_file": "promotion-score.schema.json",
+      "valid": [
+        "harness-optimization/promotion-score/valid-full.json",
+        "harness-optimization/promotion-score/valid-minimal.json"
+      ],
+      "invalid": [
+        "harness-optimization/promotion-score/invalid-empty-parity.json",
+        "harness-optimization/promotion-score/invalid-extra-field.json",
+        "harness-optimization/promotion-score/invalid-missing-component.json"
+      ]
+    },
+    {
+      "name": "repair-result",
+      "schema_id": "https://autocontext.dev/schema/harness-optimization/repair-result.json",
+      "schema_file": "repair-result.schema.json",
+      "valid": [
+        "harness-optimization/repair-result/valid-applied.json",
+        "harness-optimization/repair-result/valid-skipped.json"
+      ],
+      "invalid": [
+        "harness-optimization/repair-result/invalid-bad-status.json",
+        "harness-optimization/repair-result/invalid-empty-parity.json",
+        "harness-optimization/repair-result/invalid-missing-status.json"
+      ]
+    },
+    {
+      "name": "integrity-metadata",
+      "schema_id": "https://autocontext.dev/schema/harness-optimization/integrity-metadata.json",
+      "schema_file": "integrity-metadata.schema.json",
+      "valid": ["harness-optimization/integrity-metadata/valid-verified-clean.json"],
+      "invalid": ["harness-optimization/integrity-metadata/invalid-missing-mode.json"]
+    },
+    {
+      "name": "frontier-mechanism",
+      "schema_id": "https://autocontext.dev/schema/harness-optimization/frontier-mechanism.json",
+      "schema_file": "frontier-mechanism.schema.json",
+      "valid": ["harness-optimization/mechanism-archive/valid-frontier.json"],
+      "invalid": [
+        "harness-optimization/mechanism-archive/invalid-frontier-missing-support-count.json"
+      ]
+    },
+    {
+      "name": "orphan-mechanism",
+      "schema_id": "https://autocontext.dev/schema/harness-optimization/orphan-mechanism.json",
+      "schema_file": "orphan-mechanism.schema.json",
+      "valid": ["harness-optimization/mechanism-archive/valid-orphan.json"],
+      "invalid": [
+        "harness-optimization/mechanism-archive/invalid-orphan-missing-failure-family.json"
+      ]
+    },
+    {
+      "name": "calibration-report",
+      "schema_id": "https://autocontext.dev/schema/harness-optimization/calibration-report.json",
+      "schema_file": "calibration-report.schema.json",
+      "valid": ["harness-optimization/calibration-report/valid-report.json"],
+      "invalid": ["harness-optimization/calibration-report/invalid-missing-standard-error.json"]
+    }
+  ]
+}

--- a/ts/tests/harness-optimization/parity-suite.test.ts
+++ b/ts/tests/harness-optimization/parity-suite.test.ts
@@ -39,6 +39,13 @@ describe("harness-optimization parity suite", () => {
     expect(manifestFiles).toEqual(schemaFiles);
   });
 
+  it("manifest schema_id matches each schema file $id", () => {
+    for (const a of manifest.artifacts) {
+      const schema = JSON.parse(readFileSync(join(SCHEMA_DIR, a.schema_file), "utf8"));
+      expect(a.schema_id).toBe(schema.$id);
+    }
+  });
+
   for (const a of manifest.artifacts) {
     it(`${a.name}: clean fixtures validate, invalid rejected`, () => {
       expect(a.valid.length).toBeGreaterThan(0);

--- a/ts/tests/harness-optimization/parity-suite.test.ts
+++ b/ts/tests/harness-optimization/parity-suite.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  validateCandidateEvidence,
+  validatePromotionScore,
+  validateRepairResult,
+  validateIntegrityMetadata,
+  validateFrontierMechanism,
+  validateOrphanMechanism,
+  validateCalibrationReport,
+} from "../../src/harness-optimization/contract/validators.js";
+
+const REPO = join(import.meta.dirname, "../../..");
+const FIX = join(REPO, "fixtures", "harness-optimization");
+const SCHEMA_DIR = join(REPO, "ts", "src", "harness-optimization", "contract", "json-schemas");
+const manifest = JSON.parse(readFileSync(join(FIX, "parity-manifest.json"), "utf8"));
+
+const VALIDATORS: Record<string, (x: unknown) => { valid: boolean }> = {
+  "candidate-evidence": validateCandidateEvidence,
+  "promotion-score": validatePromotionScore,
+  "repair-result": validateRepairResult,
+  "integrity-metadata": validateIntegrityMetadata,
+  "frontier-mechanism": validateFrontierMechanism,
+  "orphan-mechanism": validateOrphanMechanism,
+  "calibration-report": validateCalibrationReport,
+};
+
+const load = (rel: string) => JSON.parse(readFileSync(join(REPO, "fixtures", rel), "utf8"));
+
+describe("harness-optimization parity suite", () => {
+  it("manifest covers every schema", () => {
+    const schemaFiles = readdirSync(SCHEMA_DIR)
+      .filter((f) => f.endsWith(".schema.json") && f !== "_aggregate.schema.json")
+      .sort();
+    const manifestFiles = manifest.artifacts
+      .map((a: { schema_file: string }) => a.schema_file)
+      .sort();
+    expect(manifestFiles).toEqual(schemaFiles);
+  });
+
+  for (const a of manifest.artifacts) {
+    it(`${a.name}: clean fixtures validate, invalid rejected`, () => {
+      expect(a.valid.length).toBeGreaterThan(0);
+      expect(a.invalid.length).toBeGreaterThan(0);
+      const validate = VALIDATORS[a.name];
+      for (const rel of a.valid) expect(validate(load(rel))).toEqual({ valid: true });
+      for (const rel of a.invalid) expect(validate(load(rel)).valid).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
Implements AC-882, the capstone of the harness-optimization cluster (AC-875): a single cross-package parity-fixture suite and formalized docs so Python and TypeScript stay aligned for every protocol artifact.

## What this adds

**Parity manifest** (`fixtures/harness-optimization/parity-manifest.json`): the single source listing all seven contract artifacts (candidate-evidence, promotion-score, repair-result, integrity-metadata, frontier-mechanism, orphan-mechanism, calibration-report) with each one's schema id, schema file, and clean/invalid fixture paths. Fills the one gap in the fixture set (a dedicated invalid frontier-mechanism fixture).

**Cross-package parity suites** (`test_parity_suite.py` + `parity-suite.test.ts`): both packages iterate the same manifest over the same fixtures. Every clean fixture must validate and every invalid fixture must be rejected in both languages (through the pydantic models on the Python side and the AJV validators on the TS side). A membership guard fails CI if any `*.schema.json` (except the aggregate) has no manifest entry, so a future artifact shipped without fixtures breaks the build. The guard also asserts each manifest `schema_id` matches the schema file's real `$id` and rejects duplicate entries.

**Docs + release checklist** (`docs/harness-optimization-protocol.md`): a cross-package parity section stating the parity expectations (schema/required/enum via the drift gate; score and calibration calculations via the numeric fixtures within 1e-9) and the intentionally-unsupported behavior (TS runners may declare source policy and contamination status but do not enforce every Python-only hook; the leakage stage and calibration citation are Python-side pipeline wirings). Plus a numbered "adding a new protocol artifact" checklist with working-directory-annotated commands and the three verification commands verbatim.

## Verification

Gates green: ruff (incl. generated models), module-size guard, gate-taxonomy invariant, drift gate, pytest (parity suite 17), vitest (parity suite 9, whole harness-opt 131+), lint.

Whole-branch review (fable) returned READY after adversarially proving the membership guard fails loudly in three sabotage scenarios and confirming CI runs both suites; its minor findings (checklist working directories, a schema_id-vs-$id assertion, a duplicate-entry guard) were then folded in.

This completes the AC-875 harness-optimization protocol: all seven children (AC-876 through AC-882) shipped.

Note: the `ts-test` full-suite CI job is red repo-wide (AC-892 infra, host OOM), unrelated to this change.

Closes AC-882.