### PR TITLE
ambient trainer: serve sft (torch/peft LoRA) candidates + T4 validation (AC-891)

### DIFF
--- a/autocontext/src/autocontext/agents/scenario_bound_clients.py
+++ b/autocontext/src/autocontext/agents/scenario_bound_clients.py
@@ -29,10 +29,14 @@ logger = logging.getLogger(__name__)
 
 # Backends whose checkpoint is a standalone model served directly by MLXClient
 # (from-scratch GPT / full fine-tunes), vs. backends whose checkpoint is a LoRA
-# adapter that must be loaded on top of its base model via MLXLMClient.
+# adapter that must be loaded on top of its base model.
 _FULL_CHECKPOINT_BACKENDS = {"mlx"}
-# mlx-lm LoRA adapter backends served as base + adapter via MLXLMClient.
-_ADAPTER_BACKENDS = {"mlxlm", "opd", "grpo"}
+# mlx-lm LoRA adapter backends served as base + adapter via MLXLMClient (Apple Silicon).
+_MLX_ADAPTER_BACKENDS = {"mlxlm", "opd", "grpo"}
+# torch/peft LoRA adapter backends served as base + adapter via SftTorchClient (CUDA, cuda extra).
+_TORCH_ADAPTER_BACKENDS = {"sft"}
+# All LoRA adapter backends: they need the base model recorded at publish time to be servable.
+_ADAPTER_BACKENDS = _MLX_ADAPTER_BACKENDS | _TORCH_ADAPTER_BACKENDS
 
 
 @dataclass(frozen=True)
@@ -43,7 +47,7 @@ class LocalClientPlan:
     base model id (adapter); ``adapter_path`` and ``score_conditioned`` apply to adapters.
     """
 
-    kind: str  # "mlx" | "mlxlm"
+    kind: str  # "mlx" | "mlxlm" | "sft"
     model: str
     adapter_path: str | None
     score_conditioned: bool
@@ -53,10 +57,11 @@ def plan_local_client(record: DistilledModelRecord) -> LocalClientPlan | None:
     """Decide which local client serves a trained record (pure; no model loading).
 
     Full-checkpoint backends (``mlx``) serve their checkpoint directly. Adapter backends
-    (``mlxlm`` / ``opd``) need the base model they trained against (recorded in metadata at
-    publish time) and the score-conditioning flag so inference re-applies the quality prefix.
-    Returns ``None`` for an unknown backend or an adapter record missing its base model, so
-    the caller falls back to the default client rather than serving something broken.
+    (``mlxlm`` / ``opd`` / ``sft``) need the base model they trained against (recorded in metadata
+    at publish time); mlx adapters also carry the score-conditioning flag so inference re-applies
+    the quality prefix, while torch/peft ``sft`` adapters serve via ``SftTorchClient``. Returns
+    ``None`` for an unknown backend or an adapter record missing its base model, so the caller
+    falls back to the default client rather than serving something broken.
     """
     backend = (record.backend or "").lower()
     if backend in _ADAPTER_BACKENDS:
@@ -64,8 +69,9 @@ def plan_local_client(record: DistilledModelRecord) -> LocalClientPlan | None:
         if not base_model:
             logger.debug("agents.scenario_bound_clients: adapter record %s has no base_model", record.artifact_id)
             return None
+        kind = "sft" if backend in _TORCH_ADAPTER_BACKENDS else "mlxlm"
         return LocalClientPlan(
-            kind="mlxlm",
+            kind=kind,
             model=base_model,
             adapter_path=record.checkpoint_path,
             score_conditioned=bool(record.metadata.get("score_conditioned")),
@@ -88,7 +94,7 @@ def _resolve_local_record(settings: AppSettings, scenario_name: str) -> Distille
     except Exception:
         logger.debug("agents.scenario_bound_clients: could not open model registry", exc_info=True)
         return None
-    for backend in ("opd", "mlxlm", "grpo", "mlx"):
+    for backend in ("opd", "mlxlm", "grpo", "sft", "mlx"):
         try:
             record = resolve_model(registry, scenario=scenario_name, backend=backend, runtime_type="provider")
         except Exception:
@@ -100,7 +106,18 @@ def _resolve_local_record(settings: AppSettings, scenario_name: str) -> Distille
 
 
 def _build_planned_client(plan: LocalClientPlan, settings: AppSettings) -> LanguageModelClient:
-    """Construct the MLX/MLXLM client described by ``plan`` (loads the model)."""
+    """Construct the MLX / MLXLM / SFT-torch client described by ``plan`` (loads the model)."""
+    if plan.kind == "sft":
+        # Lazy import keeps torch (the optional ``cuda`` extra) out of module import time; a
+        # torch-absent environment raises here and the caller falls back to the frontier client.
+        from autocontext.agents.sft_torch_client import SftTorchClient
+
+        return SftTorchClient(
+            plan.model,
+            adapter_path=plan.adapter_path,
+            temperature=settings.mlx_temperature,
+            max_tokens=settings.mlx_max_tokens,
+        )
     if plan.kind == "mlxlm":
         return MLXLMClient(
             plan.model,

--- a/autocontext/src/autocontext/agents/sft_torch_client.py
+++ b/autocontext/src/autocontext/agents/sft_torch_client.py
@@ -1,0 +1,80 @@
+"""SftTorchClient -- LanguageModelClient over a torch/peft SFT LoRA adapter (base + adapter).
+
+The serving counterpart to the TRL ``sft`` training backend, so a harness-trained torch/peft
+adapter can drive an agent role (the recursive loop for capable models on CUDA). Mirrors
+``MLXLMClient`` exactly; the only difference is the underlying provider. Lives in its own module
+(not ``llm_client.py``) to keep that module under the 800-line size limit.
+
+``SftTorchProvider`` is imported lazily inside ``__init__`` so this module imports without torch
+(Linux/CI); constructing the client in a torch-absent environment raises ``ImportError``, which the
+serving resolver caller catches to fall back to the frontier client.
+"""
+
+from __future__ import annotations
+
+import time
+
+from autocontext.harness.core.llm_client import LanguageModelClient
+from autocontext.harness.core.types import ModelResponse, RoleUsage
+from autocontext.providers.base import ProviderError
+
+
+class SftTorchClient(LanguageModelClient):
+    """LanguageModelClient over a local torch/peft base model, optionally with a LoRA adapter."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        adapter_path: str | None = None,
+        temperature: float = 0.8,
+        max_tokens: int = 512,
+    ) -> None:
+        from autocontext.providers.sft_torch_provider import SftTorchProvider
+
+        self._provider = SftTorchProvider(
+            model,
+            adapter_path=adapter_path,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    def generate(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        del model, role
+        started = time.perf_counter()
+        try:
+            result = self._provider.complete("", prompt, temperature=temperature, max_tokens=max_tokens)
+        except ProviderError as exc:
+            raise RuntimeError(str(exc)) from exc
+        elapsed = int((time.perf_counter() - started) * 1000)
+        usage = RoleUsage(
+            input_tokens=result.usage.get("input_tokens", 0),
+            output_tokens=result.usage.get("output_tokens", 0),
+            latency_ms=elapsed,
+            model=result.model or self._provider.default_model(),
+        )
+        return ModelResponse(text=result.text, usage=usage)
+
+    def generate_multiturn(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        del role
+        user_parts = [m["content"] for m in messages if m["role"] == "user"]
+        combined = "\n\n".join(user_parts)
+        prompt = f"{system}\n\n{combined}" if system else combined
+        return self.generate(model=model, prompt=prompt, max_tokens=max_tokens, temperature=temperature)

--- a/autocontext/src/autocontext/providers/sft_torch_provider.py
+++ b/autocontext/src/autocontext/providers/sft_torch_provider.py
@@ -1,0 +1,93 @@
+"""SftTorchProvider -- serve a torch/peft SFT LoRA adapter (base model + adapter) as a provider.
+
+The serving counterpart to the TRL ``sft`` training backend (see ``training/autoresearch/
+sft_backend.py``), which fine-tunes a transformers base model and writes a peft LoRA adapter
+directory. ``MLXLMProvider`` serves the mlx-lm adapters (Apple Silicon); this provider serves the
+torch/peft adapters (the ``cuda`` extra), so a harness-trained SFT adapter can drive an agent role.
+
+All torch / transformers / peft imports are lazy inside ``__init__`` so this module imports without
+torch (Linux/CI). Constructing the provider in a torch-absent environment raises ``ImportError``,
+which the serving resolver caller catches to fall back to the frontier client.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from autocontext.providers.base import CompletionResult, ProviderError
+
+logger = logging.getLogger(__name__)
+
+
+class SftTorchProvider:
+    """Provider over a local transformers base model plus an optional peft LoRA adapter."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        adapter_path: str | None = None,
+        temperature: float = 0.8,
+        max_tokens: int = 512,
+    ) -> None:
+        self._model_id = model
+        self._adapter_path = adapter_path
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        # Lazy + guarded: importing torch/transformers/peft here (not at module import time) keeps
+        # this an optional (``cuda`` extra) dependency. A torch-absent environment raises ImportError
+        # right here, which the resolver caller catches so it falls back to the frontier client.
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore[import-not-found]
+
+        self._torch = torch
+        self._device = "cuda" if torch.cuda.is_available() else "cpu"
+        if adapter_path is not None and not Path(adapter_path).exists():
+            raise ProviderError(f"adapter path does not exist: {adapter_path}")
+        self._tokenizer = AutoTokenizer.from_pretrained(model)
+        base = AutoModelForCausalLM.from_pretrained(model)
+        if adapter_path is not None:
+            from peft import PeftModel  # type: ignore[import-not-found]
+
+            base = PeftModel.from_pretrained(base, adapter_path)
+        self._model = base.to(self._device)
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        temperature: float = 0.0,
+        max_tokens: int = 512,
+    ) -> CompletionResult:
+        """Generate a completion for ``system + prompt`` and return text + token-count usage."""
+        text = f"{system_prompt}\n\n{user_prompt}" if system_prompt else user_prompt
+        effective_temp = temperature if temperature > 0 else self._temperature
+        effective_max = max_tokens if max_tokens > 0 else self._max_tokens
+        try:
+            inputs = self._tokenizer(text, return_tensors="pt").to(self._device)
+            input_len = int(inputs["input_ids"].shape[1])
+            gen_kwargs: dict[str, Any] = {"max_new_tokens": effective_max}
+            if effective_temp > 0:
+                gen_kwargs["do_sample"] = True
+                gen_kwargs["temperature"] = float(effective_temp)
+            else:
+                gen_kwargs["do_sample"] = False
+            with self._torch.no_grad():
+                output = self._model.generate(**inputs, **gen_kwargs)
+            generated = output[0][input_len:]
+            decoded = self._tokenizer.decode(generated, skip_special_tokens=True)
+            output_len = int(generated.shape[0])
+        except Exception as exc:
+            logger.debug("providers.sft_torch_provider: caught Exception", exc_info=True)
+            raise ProviderError(f"SFT torch generation error: {exc}") from exc
+        return CompletionResult(
+            text=str(decoded).strip(),
+            model=self._model_id,
+            usage={"input_tokens": input_len, "output_tokens": output_len},
+        )
+
+    def default_model(self) -> str:
+        return self._model_id

--- a/autocontext/tests/test_recursive_loop_bridge.py
+++ b/autocontext/tests/test_recursive_loop_bridge.py
@@ -105,6 +105,17 @@ def test_unknown_backend_falls_back() -> None:
     assert plan_local_client(_record(backend="something-else")) is None
 
 
+def test_sft_adapter_routes_to_torch_client_plan() -> None:
+    # The torch/peft SFT LoRA adapter routes to the torch client (kind="sft"), base + adapter.
+    plan = plan_local_client(_record(backend="sft", checkpoint="/adapters/sft", metadata={"base_model": "Qwen/Qwen2.5-1.5B"}))
+    assert plan == LocalClientPlan(kind="sft", model="Qwen/Qwen2.5-1.5B", adapter_path="/adapters/sft", score_conditioned=False)
+
+
+def test_sft_adapter_without_base_model_is_unservable() -> None:
+    # Like mlxlm: an adapter without its base model falls back rather than serving something broken.
+    assert plan_local_client(_record(backend="sft", metadata={})) is None
+
+
 # --- _resolve_local_record: which active model wins -----------------------------------------
 
 

--- a/autocontext/tests/test_sft_serving.py
+++ b/autocontext/tests/test_sft_serving.py
@@ -1,0 +1,113 @@
+"""Serving path for the torch/peft SFT LoRA backend (AC-891 phase A, CI-safe, no torch).
+
+Plan 5b added a TRL SFTTrainer backend emitting a torch/peft LoRA adapter, but the runtime
+serving resolver only recognized mlx adapters, so an active ``sft`` record fell back to the
+frontier client. These tests pin the wiring that makes the resolver recognize + build a torch
+client for sft records, exercised without ever importing torch: the pure routing decision, the
+resolver search order, the ``_build_planned_client`` sft branch (with a fake client), and the
+torch-absent construction guard the resolver caller relies on to fall back safely.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from autocontext.agents.scenario_bound_clients import (
+    LocalClientPlan,
+    _build_planned_client,
+    _resolve_local_record,
+)
+from autocontext.config.settings import AppSettings
+
+_HAS_TORCH = importlib.util.find_spec("torch") is not None
+
+
+# --- _resolve_local_record: sft is in the backend search order ------------------------------
+
+
+def test_resolve_local_record_search_order_includes_sft(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """The resolver must query the ``sft`` backend (else an active sft record is never found)."""
+    import autocontext.training.model_registry as mr
+
+    queried: list[str] = []
+
+    def fake_resolve(registry, *, scenario, backend, runtime_type):  # type: ignore[no-untyped-def]
+        queried.append(backend)
+        return None
+
+    monkeypatch.setattr(mr, "resolve_model", fake_resolve)
+    settings = AppSettings(agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path)
+
+    assert _resolve_local_record(settings, "grid_ctf") is None
+    assert queried == ["opd", "mlxlm", "grpo", "sft", "mlx"]
+
+
+# --- _build_planned_client: the sft branch builds the torch client --------------------------
+
+
+def test_build_planned_client_sft_constructs_torch_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A kind=="sft" plan constructs SftTorchClient with the base model + adapter + mlx temp/tokens.
+
+    Patches the client symbol where the branch looks it up, so no real torch is imported in CI.
+    """
+    import autocontext.agents.sft_torch_client as sc
+
+    captured: dict[str, object] = {}
+
+    class _FakeSftTorchClient:
+        def __init__(
+            self, model: str, *, adapter_path: str | None = None, temperature: float = 0.8, max_tokens: int = 512
+        ) -> None:
+            captured.update(model=model, adapter_path=adapter_path, temperature=temperature, max_tokens=max_tokens)
+
+    monkeypatch.setattr(sc, "SftTorchClient", _FakeSftTorchClient)
+
+    plan = LocalClientPlan(kind="sft", model="Qwen/Qwen2.5-1.5B", adapter_path="/adapters/sft", score_conditioned=False)
+    settings = AppSettings(agent_provider="mlx", mlx_model_path="", mlx_temperature=0.7, mlx_max_tokens=256)
+
+    client = _build_planned_client(plan, settings)
+    assert isinstance(client, _FakeSftTorchClient)
+    assert captured == {
+        "model": "Qwen/Qwen2.5-1.5B",
+        "adapter_path": "/adapters/sft",
+        "temperature": 0.7,
+        "max_tokens": 256,
+    }
+
+
+# --- torch-absent construction guard: raises ImportError so the caller falls back ------------
+
+
+@pytest.mark.skipif(_HAS_TORCH, reason="torch is installed; the absent-guard is only meaningful without torch")
+def test_sft_torch_provider_requires_torch() -> None:
+    """Without torch, constructing the provider raises ImportError (the resolver caller catches it)."""
+    from autocontext.providers.sft_torch_provider import SftTorchProvider
+
+    with pytest.raises((ImportError, ModuleNotFoundError)):
+        SftTorchProvider("Qwen/Qwen2.5-1.5B")
+
+
+@pytest.mark.skipif(_HAS_TORCH, reason="torch is installed; the absent-guard is only meaningful without torch")
+def test_sft_torch_client_requires_torch() -> None:
+    """The client construction propagates the provider's ImportError (built inside __init__)."""
+    from autocontext.agents.sft_torch_client import SftTorchClient
+
+    with pytest.raises((ImportError, ModuleNotFoundError)):
+        SftTorchClient("Qwen/Qwen2.5-1.5B", adapter_path="/adapters/sft")
+
+
+# --- real-generation smoke (skipped in CI: needs torch + transformers + a base model) -------
+
+
+@pytest.mark.skipif(not _HAS_TORCH, reason="needs torch + transformers + a downloadable base model")
+def test_sft_torch_provider_generates_end_to_end() -> None:  # pragma: no cover - env-gated
+    from autocontext.providers.sft_torch_provider import SftTorchProvider
+
+    provider = SftTorchProvider("hf-internal-testing/tiny-random-LlamaForCausalLM", max_tokens=8)
+    result = provider.complete("", "Hello", temperature=0.0, max_tokens=8)
+    assert isinstance(result.text, str)
+    assert result.model == "hf-internal-testing/tiny-random-LlamaForCausalLM"
+    assert result.usage["input_tokens"] >= 1
+    assert provider.default_model() == "hf-internal-testing/tiny-random-LlamaForCausalLM"

--- a/infra/modal/validate_sft_serving.py
+++ b/infra/modal/validate_sft_serving.py
@@ -1,0 +1,123 @@
+"""AC-891 real-hardware validation: serve an sft (torch/peft LoRA) adapter on a GPU.
+
+This runs the REAL autocontext serving code (SftTorchProvider + SftTorchClient) on a Modal T4:
+it builds a tiny base model plus a peft LoRA adapter, loads them through the provider, and
+generates, proving the torch/peft serving path works on CUDA hardware. Torch is an optional
+(cuda) extra, so this is validated here rather than in CI.
+
+Run (from the repo root, token injected from Doppler):
+    doppler run -p autocontext-arc-agi -c dev -- uv run --with modal modal run infra/modal/validate_sft_serving.py
+
+A T4 is deliberately small and cheap: the model is tiny-gpt2 and generation is a few tokens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+# This module is imported both locally (at submit, where the local package source is mounted into
+# the image) and remotely (inside the container, where __file__ is /root/validate_sft_serving.py and
+# has no such parents). Resolve the local package source only when it actually exists; remotely fall
+# back to /pkg (already baked into the image), so module import never crashes on the container side.
+_here = Path(__file__).resolve()
+_candidate = (
+    _here.parents[2] / "autocontext" / "src" if len(_here.parents) >= 3 else None
+)
+_PKG_SRC = (
+    _candidate if (_candidate is not None and _candidate.exists()) else Path("/pkg")
+)
+
+# Base autocontext runtime deps (from pyproject [project.dependencies]); the mlx extra is mac-only
+# and deliberately not installed. The torch stack is the cuda-serving path AC-891 adds.
+_BASE_DEPS = [
+    "pydantic>=2.11.0",
+    "anthropic>=0.66.0",
+    "fastapi>=0.116.1",
+    "python-ulid>=3.0.0",
+    "pyyaml>=6.0.2",
+    "rich>=13.9.4",
+    "typer>=0.16.0",
+    "uvicorn>=0.35.0",
+]
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install("torch", "transformers", "peft", "accelerate", "safetensors")
+    .pip_install(*_BASE_DEPS)
+    .add_local_dir(
+        str(_PKG_SRC), "/pkg", copy=True, ignore=["**/__pycache__", "**/*.pyc"]
+    )
+    .env({"PYTHONPATH": "/pkg", "HF_HUB_DISABLE_TELEMETRY": "1"})
+)
+
+app = modal.App("ac891-sft-serving-validation")
+
+
+@app.function(gpu="T4", image=image, timeout=1800)
+def validate() -> dict:
+    import tempfile
+
+    import torch
+    from peft import LoraConfig, get_peft_model
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    # 1) build a tiny base + a small peft LoRA adapter and save it to disk (stands in for a
+    #    harness-trained sft adapter without any real training cost).
+    base_id = "sshleifer/tiny-gpt2"
+    tokenizer = AutoTokenizer.from_pretrained(base_id)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(base_id)
+    lora = LoraConfig(
+        r=4, lora_alpha=8, target_modules=["c_attn"], task_type="CAUSAL_LM"
+    )
+    adapter_dir = tempfile.mkdtemp()
+    get_peft_model(model, lora).save_pretrained(adapter_dir)
+
+    # 2) exercise the REAL autocontext provider: load base + adapter and generate on the GPU.
+    from autocontext.providers.sft_torch_provider import SftTorchProvider
+
+    provider = SftTorchProvider(
+        base_id, adapter_path=adapter_dir, temperature=0.7, max_tokens=16
+    )
+    result = provider.complete("", "Hello, world.", temperature=0.7, max_tokens=16)
+    assert isinstance(result.text, str)
+    assert result.model == base_id
+    assert result.usage["input_tokens"] > 0
+    assert result.usage["output_tokens"] >= 0
+
+    # 3) exercise the REAL client wrapper end to end (ModelResponse with usage).
+    from autocontext.agents.sft_torch_client import SftTorchClient
+
+    client = SftTorchClient(
+        base_id, adapter_path=adapter_dir, temperature=0.7, max_tokens=8
+    )
+    response = client.generate(
+        model=base_id, prompt="Hi there.", max_tokens=8, temperature=0.7
+    )
+    assert isinstance(response.text, str)
+    assert response.usage.model == base_id
+
+    return {
+        "cuda_available": bool(torch.cuda.is_available()),
+        "device": provider._device,
+        "gpu": torch.cuda.get_device_name(0) if torch.cuda.is_available() else "cpu",
+        "base_model": base_id,
+        "provider_text_len": len(result.text),
+        "provider_usage": result.usage,
+        "client_text_len": len(response.text),
+        "client_output_tokens": response.usage.output_tokens,
+    }
+
+
+@app.local_entrypoint()
+def main() -> None:
+    summary = validate.remote()
+    print("AC-891 sft serving validation:")
+    for key, value in summary.items():
+        print(f"  {key}: {value}")
+    assert summary["cuda_available"] is True, "expected a CUDA device on the T4"
+    assert summary["device"] == "cuda"
+    print("PASS: torch/peft sft adapter served + generated on a real GPU.")


### PR DESCRIPTION
Implements the serving slice of AC-891: the runtime resolver can now recognize and serve a torch/peft SFT LoRA adapter (the plan-5b `sft` training backend's output), validated on a real GPU. Part of the eval/serve-on-real-hardware wave.

## Problem

Plan 5b added a TRL SFTTrainer backend producing a torch/peft LoRA adapter, but the serving resolver (`agents/scenario_bound_clients.py`) only recognized mlx adapters (`mlxlm`/`opd`/`grpo`, all served by `MLXLMClient`). An active `sft` record returned `None` from `plan_local_client` (a safe frontier fallback, but never actually served locally), because the mlx client cannot serve a torch adapter.

## What this adds (Phase A: CI-green code, no GPU)

- **`providers/sft_torch_provider.py`** (`SftTorchProvider`): loads a transformers base model + an optional peft LoRA adapter and generates, returning the standard `CompletionResult`. All torch/transformers/peft imports are lazy inside `__init__`, so the module imports without torch (CI) and a torch-absent environment raises `ImportError` at construction.
- **`agents/sft_torch_client.py`** (`SftTorchClient`): the `LanguageModelClient` wrapper mirroring `MLXLMClient`, delegating to the provider. (New module because `llm_client.py` was at 787 lines, near the 800 guard.)
- **Resolver wiring**: `sft` is recognized as a torch-adapter backend (`_TORCH_ADAPTER_BACKENDS`), `plan_local_client` returns `kind="sft"` for it, `_resolve_local_record` includes `sft` in its backend search, and `_build_planned_client` has a `plan.kind == "sft"` branch building the torch client. The torch-absent fallback is free: the caller already wraps `_build_planned_client` in `try/except -> None`, so a torch-absent build falls back to the frontier client.

Torch stays the optional `cuda` extra, so pytest/ts-test CI never installs it. Tests use a fake client to prove the wiring and skip real-generation when torch is absent.

## Real-hardware validation (Phase B)

`infra/modal/validate_sft_serving.py` runs the **real** `SftTorchProvider` + `SftTorchClient` on a Modal **T4**: it builds a tiny base + a peft LoRA adapter, loads them through the provider, and generates. Verified run (token from the `autocontext-arc-agi/dev` Doppler config):

```
cuda_available: True   device: cuda   gpu: Tesla T4
provider: tiny-gpt2 + LoRA -> text, usage in=4 out=16
client:   ModelResponse text, out=8
PASS
```

Run it with: `doppler run -p autocontext-arc-agi -c dev -- uv run --with modal modal run infra/modal/validate_sft_serving.py` (a T4 is deliberately small/cheap for a serving smoke).

Gates green: ruff (`src tests`), mypy, module-size guard, gate-taxonomy invariant, resolver + sft tests (30 pass, 2 torch-guard skips).

## Scope / follow-up

This lands the **serving resolver + torch client**, the reviewable first piece. The rest of the AC-891 wave, wiring real candidate generation into the evaluate stage (so the plan-5a placeholder-promotion gate opens for sft candidates) and the per-role live-serving router, is a follow-up. Until then an `sft` record still cannot reach `active` (the promotion gate requires `from_candidate_generation`), so this serving path is dormant-but-ready, exactly as the issue anticipates.

Closes AC-891 (serving slice).