### PR TITLE
ambient trainer: real candidate-generation seam in evaluate + fingerprint fix (AC-891)

### DIFF
--- a/autocontext/src/autocontext/ambient/evaluate.py
+++ b/autocontext/src/autocontext/ambient/evaluate.py
@@ -38,16 +38,19 @@ def _default_now() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def eval_fingerprint(anchor: CharterAnchor, eval_suite: str) -> str:
+def eval_fingerprint(anchor: CharterAnchor, eval_suite: str, scores_candidate_generation: bool = False) -> str:
     """A stable identity for the evaluation config a candidate was scored under.
 
-    Combines the frozen anchor (provider, model, rubric) with the target's eval suite name. A
-    candidate whose stored fingerprint no longer matches the current one was scored under a stale
-    config (the charter anchor, its rubric, or the suite changed), so it must be re-evaluated rather
-    than left stuck with a score computed under the old config.
+    Combines the frozen anchor (provider, model, rubric), the target's eval suite name, and whether
+    the score judged the candidate's real generation or the placeholder reference text. A candidate
+    whose stored fingerprint no longer matches the current one was scored under a stale config (the
+    charter anchor, its rubric, the suite, OR the placeholder-vs-real-generation mode changed), so it
+    must be re-evaluated rather than left stuck with a score computed under the old config. Including
+    the generation mode is what makes flipping real candidate generation on re-trigger evaluation
+    (AC-891) even when the anchor and suite are unchanged.
     """
     rubric_hash = hashlib.sha256(anchor.rubric.encode()).hexdigest()[:16]
-    return "|".join([anchor.provider, anchor.model, rubric_hash, eval_suite])
+    return "|".join([anchor.provider, anchor.model, rubric_hash, eval_suite, f"scg={scores_candidate_generation}"])
 
 
 class _Scorer(Protocol):
@@ -104,9 +107,21 @@ class EvaluateStage:
     now_fn: Callable[[], str] = _default_now
     # False because the default judge_factory scores the eval suite's reference text (a placeholder),
     # not the candidate model's own generation. it becomes True only once a real candidate-generation
-    # scorer is wired (plan 5b, or a test that stands in for it). the promote stage refuses to activate
-    # a candidate whose eval was a placeholder, so this flag is what makes a candidate promotable.
+    # scorer is wired (via generate_fn below, or a test that stands in for it). the promote stage
+    # refuses to activate a candidate whose eval was a placeholder, so this flag is what makes a
+    # candidate promotable.
     scores_candidate_generation: bool = False
+    # Real candidate-generation seam (AC-891): when set, the candidate's model is served for each
+    # eval case and the scorer judges that real generation (record, anchor, prompt) -> output text,
+    # instead of the placeholder reference. Its presence flips the run into real-generation mode, so
+    # from_candidate_generation is stamped True and the candidate becomes promotable. Injected as a
+    # fake in tests; a production run wires a factory that builds the served client from the record.
+    generate_fn: Callable[[DistilledModelRecord, CharterAnchor, str], str] | None = None
+
+    @property
+    def _scores_real_generation(self) -> bool:
+        """Whether this cycle scores the candidate's real generation (vs the placeholder reference)."""
+        return self.generate_fn is not None or self.scores_candidate_generation
 
     def run_once(self, ctx: StageContext) -> StageResult:
         anchor = ctx.charter.anchor
@@ -152,7 +167,7 @@ class EvaluateStage:
                 continue
             # the fingerprint is per-target because the eval suite is per-target, while the anchor is
             # charter-wide; compute it here where the target (and its suite) are known.
-            fingerprint = eval_fingerprint(anchor, target.eval_suite)
+            fingerprint = eval_fingerprint(anchor, target.eval_suite, self._scores_real_generation)
             existing = record.metadata.get("eval")
             if existing and existing.get("fingerprint") == fingerprint:
                 # already scored under the CURRENT config: skip. if the fingerprint differs (the
@@ -192,10 +207,15 @@ class EvaluateStage:
             )
             return 0
 
-        # v1 stand-in: the injected scorer receives (case.prompt, case.reference); plan 5b wires the
-        # candidate model's real generation as the scored output.
+        # Real-generation mode (generate_fn set) serves the candidate's model and scores that output;
+        # otherwise the scorer judges the placeholder reference text (v1 stand-in). Either way the
+        # scorer receives (case.prompt, output).
         scorer = get_scorer()
-        scores = [scorer.score(case.prompt, case.reference) for case in suite.cases]
+        if self.generate_fn is not None:
+            outputs = [self.generate_fn(record, anchor, case.prompt) for case in suite.cases]
+        else:
+            outputs = [case.reference for case in suite.cases]
+        scores = [scorer.score(case.prompt, output) for case, output in zip(suite.cases, outputs, strict=True)]
         avg_score = sum(scores) / len(scores)
 
         # the drift canary depends only on the anchor, so this returns the same memoized probe for
@@ -211,7 +231,7 @@ class EvaluateStage:
             "evaluated_at": self.now_fn(),
             # whether the score judged the candidate's real generation or a placeholder (reference
             # text). the promote stage only activates a candidate when this is True.
-            "from_candidate_generation": self.scores_candidate_generation,
+            "from_candidate_generation": self._scores_real_generation,
             # identity of the config this score was computed under; a later cycle re-evaluates when
             # the current fingerprint no longer matches this one.
             "fingerprint": fingerprint,

--- a/autocontext/tests/test_ambient_evaluate_stage.py
+++ b/autocontext/tests/test_ambient_evaluate_stage.py
@@ -551,7 +551,9 @@ def test_anchor_rotation_deadlock_is_broken_by_incumbent_reeval(tmp_path: Path) 
         budgets=CharterBudgets(gpu_hours_per_window=10.0, window_hours=24, disk_quota_gb=1.0),
         anchor=CharterAnchor(provider="anthropic", model="claude-sonnet-5", rubric="Score 0 to 1."),
     )
-    current_fp = eval_fingerprint(charter.anchor, "anchor-v1")
+    # the stage below runs in real-generation mode (scores_candidate_generation=True), so the
+    # candidate's already-current fingerprint must carry that same mode to be correctly skipped.
+    current_fp = eval_fingerprint(charter.anchor, "anchor-v1", True)
     # incumbent scored under the OLD anchor (stale fingerprint) -> re-scored to 0.8 under the new one.
     _candidate(
         registry,
@@ -607,3 +609,82 @@ def test_anchor_rotation_deadlock_is_broken_by_incumbent_reeval(tmp_path: Path) 
     assert promoted is not None and promoted.activation_state == "active"  # 0.9 beat the re-scored 0.8
     assert incumbent is not None and incumbent.activation_state == "disabled"
     assert not any(e["event"] == "promote_anchor_mismatch" for e in _events(tmp_path))
+
+
+class _RecordingScorer:
+    """A scorer that records the (prompt, output) pairs it judged, to prove WHAT was scored."""
+
+    def __init__(self, value: float) -> None:
+        self.value = value
+        self.seen: list[tuple[str, str]] = []
+
+    def score(self, prompt: str, output: str) -> float:
+        self.seen.append((prompt, output))
+        return self.value
+
+
+def test_generate_fn_scores_real_candidate_generation_not_reference(tmp_path: Path) -> None:
+    # AC-891: with a generate_fn wired, the scorer judges the candidate's real generation (not the
+    # placeholder reference), and the eval is stamped from_candidate_generation True (promotable).
+    registry = ModelRegistry(tmp_path / "registry")
+    _candidate(registry, "cand-1", "competitor-local")
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "REFERENCE-TEXT")])
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    scorer = _RecordingScorer(0.7)
+    gen_calls: list[tuple[str, str, str]] = []
+
+    def fake_generate(record: DistilledModelRecord, anchor: CharterAnchor, prompt: str) -> str:
+        gen_calls.append((record.artifact_id, anchor.model, prompt))
+        return f"GENERATED::{prompt}"
+
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: scorer,
+        probe_fn=_probe(0.1),
+        now_fn=lambda: _NOW,
+        generate_fn=fake_generate,
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    assert gen_calls == [("cand-1", "claude-sonnet-5", "p1")]
+    assert scorer.seen == [("p1", "GENERATED::p1")]  # the generation was scored, NOT "REFERENCE-TEXT"
+    eval_meta = registry.load("cand-1").metadata["eval"]  # type: ignore[union-attr]
+    assert eval_meta["score"] == 0.7
+    assert eval_meta["from_candidate_generation"] is True
+    assert eval_meta["fingerprint"] == eval_fingerprint(charter.anchor, "anchor-v1", True)
+
+
+def test_wiring_real_generation_retriggers_a_placeholder_scored_candidate(tmp_path: Path) -> None:
+    # AC-891 fingerprint fix: a candidate scored in placeholder mode is re-evaluated once real
+    # generation is wired, even though the anchor and suite are unchanged.
+    registry = ModelRegistry(tmp_path / "registry")
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    placeholder_fp = eval_fingerprint(charter.anchor, "anchor-v1")  # scg=False (placeholder mode)
+    _candidate(
+        registry,
+        "cand-1",
+        "competitor-local",
+        metadata={"eval": {"score": 0.3, "fingerprint": placeholder_fp, "from_candidate_generation": False}},
+    )
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "ref")])
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: _FixedScorer(0.9),
+        probe_fn=_probe(0.1),
+        now_fn=lambda: _NOW,
+        generate_fn=lambda record, anchor, prompt: f"gen::{prompt}",
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)  # re-evaluated despite same anchor + suite
+    eval_meta = registry.load("cand-1").metadata["eval"]  # type: ignore[union-attr]
+    assert eval_meta["score"] == 0.9
+    assert eval_meta["from_candidate_generation"] is True
+    assert eval_meta["fingerprint"] == eval_fingerprint(charter.anchor, "anchor-v1", True)


### PR DESCRIPTION
Advances the AC-891 eval/serve wave: the evaluate stage can now score a candidate's real generation (which opens the promotion gate), and the eval fingerprint correctly re-triggers evaluation when real generation is turned on. Builds directly on the merged sft serving slice (#1191).

## Problem

The evaluate stage scored the eval suite's REFERENCE text as a v1 placeholder, so every candidate's `from_candidate_generation` was `False` and the promote stage refused to activate any of them. Separately, `eval_fingerprint` omitted the placeholder-vs-real-generation mode (flagged in the plan-5a review), so flipping real generation on would NOT re-score an already-evaluated candidate when the anchor and suite were unchanged, it would stay stuck with its stale placeholder score.

## What this adds (CI-green, fake-generator tests)

- **`generate_fn` seam** on `EvaluateStage`: an injectable `(record, anchor, prompt) -> output` function. When wired, each eval case scores the candidate's real generation instead of the reference, and `from_candidate_generation` is stamped `True` (promotable). Its presence is the single source of truth for real-generation mode (`_scores_real_generation`), which also subsumes the existing `scores_candidate_generation` test stand-in.
- **Fingerprint fix**: `eval_fingerprint(anchor, suite, scores_candidate_generation=False)` folds the mode into the identity (`scg=<bool>`). Flipping real generation on now changes the fingerprint, so a placeholder-scored candidate is re-evaluated even with an unchanged anchor/suite. The defaulted parameter keeps existing placeholder-mode call sites byte-consistent.

Tests prove the generation (not the reference) is scored and stamped `from_candidate_generation True`, and that wiring real generation re-evaluates a placeholder-scored candidate. Full ambient suite green (267 tests); ruff, mypy, module-size guard, gate-taxonomy invariant all clean. Python-only.

## Scope / follow-up

This lands the **mechanism** (the seam + the fingerprint fix), the reviewable, CI-verifiable piece. The remaining GPU-bound wiring is a follow-up: thread settings through the stage factory (`build_stages`) to wire a production `generate_fn` that builds the served client from the candidate record (reusing the resolver from #1191), plus the per-role live-serving router. That piece is validated on Modal, the sft serving path is already T4-proven (#1191), so the production `generate_fn` will generate from a real served adapter.

Part of AC-891.