### PR TITLE
ambient trainer: wire production candidate generation into evaluate (AC-891)

### DIFF
--- a/autocontext/scripts/demo_recursive_loop.py
+++ b/autocontext/scripts/demo_recursive_loop.py
@@ -25,7 +25,7 @@ import time
 from pathlib import Path
 
 from autocontext.agents.llm_client import MLXLMClient
-from autocontext.agents.scenario_bound_clients import _build_planned_client, _resolve_local_record, plan_local_client
+from autocontext.agents.scenario_bound_clients import build_planned_client, _resolve_local_record, plan_local_client
 from autocontext.config.settings import AppSettings
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.training.autoresearch.mlxlm_backend import (
@@ -187,7 +187,7 @@ def main() -> None:
 
         # --- run N+1: the auto-served adapter is the agent -----------------------------------
         banner("RUN N+1 — the auto-resolved served adapter proposes strategies")
-        served_client = _build_planned_client(plan, settings)  # the bridge's real client construction
+        served_client = build_planned_client(plan, settings)  # the bridge's real client construction
         after = measure(served_client, scenario, task_prompt, n=N_SAMPLES)
         print_measure("served adapter", after)
 

--- a/autocontext/scripts/demo_recursive_loop_multigen.py
+++ b/autocontext/scripts/demo_recursive_loop_multigen.py
@@ -24,7 +24,7 @@ import time
 from pathlib import Path
 
 from autocontext.agents.llm_client import MLXLMClient
-from autocontext.agents.scenario_bound_clients import _build_planned_client, _resolve_local_record, plan_local_client
+from autocontext.agents.scenario_bound_clients import build_planned_client, _resolve_local_record, plan_local_client
 from autocontext.config.settings import AppSettings
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.training.autoresearch.mlxlm_backend import DEFAULT_BASE_MODEL, run_mlxlm_training, scenario_task_prompt
@@ -153,7 +153,7 @@ def main() -> None:
             # The bridge: resolve the just-activated adapter purely from the registry and serve it.
             resolved = _resolve_local_record(settings, SCENARIO)
             assert resolved is not None and resolved.artifact_id == record.artifact_id
-            client = _build_planned_client(plan_local_client(resolved), settings)
+            client = build_planned_client(plan_local_client(resolved), settings)
 
             geng = propose_and_score(client, scenario, task_prompt, n=PROPOSALS_PER_GEN)
             pool.extend(geng)

--- a/autocontext/src/autocontext/agents/scenario_bound_clients.py
+++ b/autocontext/src/autocontext/agents/scenario_bound_clients.py
@@ -105,7 +105,7 @@ def _resolve_local_record(settings: AppSettings, scenario_name: str) -> Distille
     return None
 
 
-def _build_planned_client(plan: LocalClientPlan, settings: AppSettings) -> LanguageModelClient:
+def build_planned_client(plan: LocalClientPlan, settings: AppSettings) -> LanguageModelClient:
     """Construct the MLX / MLXLM / SFT-torch client described by ``plan`` (loads the model)."""
     if plan.kind == "sft":
         # Lazy import keeps torch (the optional ``cuda`` extra) out of module import time; a
@@ -168,7 +168,7 @@ def scenario_bound_mlx_client(orch: AgentOrchestrator, role: str, *, scenario_na
     if cached is not None:
         return cached
     try:
-        client = _build_planned_client(plan, orch.settings)
+        client = build_planned_client(plan, orch.settings)
     except Exception:
         logger.debug("agents.scenario_bound_clients: planned client build failed", exc_info=True)
         return None

--- a/autocontext/src/autocontext/ambient/charter.py
+++ b/autocontext/src/autocontext/ambient/charter.py
@@ -103,6 +103,10 @@ class Charter(BaseModel):
     budgets: CharterBudgets
     guardrails: GuardrailConfig = Field(default_factory=GuardrailConfig)
     anchor: CharterAnchor = Field(default_factory=CharterAnchor)
+    # When True the evaluate stage scores each candidate's real model generation (which is what makes
+    # it promotable); when False it scores the placeholder reference text. This is a policy decision,
+    # so it lives in the charter (the only policy input) rather than an env/settings behavior flag.
+    real_candidate_generation: bool = False
 
     @model_validator(mode="after")
     def _full_box_requires_hosted(self) -> Charter:

--- a/autocontext/src/autocontext/ambient/evaluate.py
+++ b/autocontext/src/autocontext/ambient/evaluate.py
@@ -38,7 +38,12 @@ def _default_now() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def eval_fingerprint(anchor: CharterAnchor, eval_suite: str, scores_candidate_generation: bool = False) -> str:
+def eval_fingerprint(
+    anchor: CharterAnchor,
+    eval_suite: str,
+    scores_candidate_generation: bool = False,
+    generation_config: str = "",
+) -> str:
     """A stable identity for the evaluation config a candidate was scored under.
 
     Combines the frozen anchor (provider, model, rubric), the target's eval suite name, and whether
@@ -50,7 +55,16 @@ def eval_fingerprint(anchor: CharterAnchor, eval_suite: str, scores_candidate_ge
     (AC-891) even when the anchor and suite are unchanged.
     """
     rubric_hash = hashlib.sha256(anchor.rubric.encode()).hexdigest()[:16]
-    return "|".join([anchor.provider, anchor.model, rubric_hash, eval_suite, f"scg={scores_candidate_generation}"])
+    return "|".join(
+        [
+            anchor.provider,
+            anchor.model,
+            rubric_hash,
+            eval_suite,
+            f"scg={scores_candidate_generation}",
+            f"gc={generation_config}",
+        ]
+    )
 
 
 class _Scorer(Protocol):
@@ -117,6 +131,11 @@ class EvaluateStage:
     # from_candidate_generation is stamped True and the candidate becomes promotable. Injected as a
     # fake in tests; a production run wires a factory that builds the served client from the record.
     generate_fn: Callable[[DistilledModelRecord, CharterAnchor, str], str] | None = None
+    # An identity for the generation config (sampling settings) real generation scores under, folded
+    # into the eval fingerprint so changing the config re-triggers evaluation (AC-891). Empty in
+    # placeholder mode (no effect); the factory sets it from the generation settings when wiring
+    # generate_fn.
+    generation_config_id: str = ""
 
     @property
     def _scores_real_generation(self) -> bool:
@@ -167,7 +186,7 @@ class EvaluateStage:
                 continue
             # the fingerprint is per-target because the eval suite is per-target, while the anchor is
             # charter-wide; compute it here where the target (and its suite) are known.
-            fingerprint = eval_fingerprint(anchor, target.eval_suite, self._scores_real_generation)
+            fingerprint = eval_fingerprint(anchor, target.eval_suite, self._scores_real_generation, self.generation_config_id)
             existing = record.metadata.get("eval")
             if existing and existing.get("fingerprint") == fingerprint:
                 # already scored under the CURRENT config: skip. if the fingerprint differs (the

--- a/autocontext/src/autocontext/ambient/generation.py
+++ b/autocontext/src/autocontext/ambient/generation.py
@@ -15,6 +15,7 @@ not promotable), the correct behavior.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -27,31 +28,49 @@ if TYPE_CHECKING:
     from autocontext.training.model_registry import DistilledModelRecord
 
 
+def generation_config_id(settings: AppSettings) -> str:
+    """A stable identity for the generation config the closure below scores under.
+
+    Real generation output depends on the sampling settings the closure passes to the served client
+    (max tokens, temperature), so this id is folded into the eval fingerprint: changing a generation
+    setting changes the id, which re-triggers evaluation rather than leaving candidates skipped on a
+    stale score. Keep this in sync with the settings that build_candidate_generation_fn actually uses.
+    """
+    return hashlib.sha256(f"mt={settings.mlx_max_tokens}|t={settings.mlx_temperature}".encode()).hexdigest()[:16]
+
+
 def build_candidate_generation_fn(
     settings: AppSettings,
 ) -> Callable[[DistilledModelRecord, CharterAnchor, str], str]:
     """Build the evaluate stage's real candidate-generation closure.
 
-    The returned closure serves the candidate's model and generates for one eval case. The built
-    client (and its served model id) is cached per record.artifact_id so the model is loaded once
-    and reused across every eval case for that candidate. An unservable record (no local client
-    plan) raises; a runtime-absent client build propagates for the stage to record as a failure.
+    The returned closure serves the candidate's model and generates for one eval case. It holds a
+    SINGLE-SLOT client cache: only the most-recently-served candidate's client is kept resident, so
+    at most one model is loaded at a time. The evaluate stage scores all of a candidate's cases
+    before moving to the next, so this reuses the client across a candidate's cases without pinning
+    every candidate's model for the daemon's lifetime; when the next candidate is served the previous
+    client is dropped (a promoted or disabled candidate's model does not leak). An unservable record
+    (no local client plan) raises; a runtime-absent client build propagates for the stage to record
+    as a failure.
     """
-    # artifact_id -> (served client, model id to pass to generate). The plan's model is the
-    # checkpoint path (full checkpoint) or the base model id (adapter), so it is cached alongside
+    # single slot: {} or {artifact_id: (served client, model id to pass to generate)}. The plan's
+    # model is the checkpoint path (full checkpoint) or the base model id (adapter), cached alongside
     # the client rather than recomputed per call.
-    cache: dict[str, tuple[LanguageModelClient, str]] = {}
+    slot: dict[str, tuple[LanguageModelClient, str]] = {}
 
     def generate(record: DistilledModelRecord, anchor: CharterAnchor, prompt: str) -> str:
         del anchor  # the anchor is the frozen judge, not the served candidate; unused here
-        cached = cache.get(record.artifact_id)
+        cached = slot.get(record.artifact_id)
         if cached is None:
             plan = plan_local_client(record)
             if plan is None:
                 raise RuntimeError(f"record {record.artifact_id} is not servable (no local client plan)")
             client = build_planned_client(plan, settings)
-            cached = (client, plan.model)
-            cache[record.artifact_id] = cached
+            # drop the previous candidate's client before caching the new one, so at most one served
+            # model is resident at a time (bounded eviction for the resident daemon).
+            slot.clear()
+            slot[record.artifact_id] = (client, plan.model)
+            cached = slot[record.artifact_id]
         client, model = cached
         resp = client.generate(
             model=model,

--- a/autocontext/src/autocontext/ambient/generation.py
+++ b/autocontext/src/autocontext/ambient/generation.py
@@ -1,0 +1,65 @@
+"""production candidate-generation seam for the ambient evaluate stage (AC-891).
+
+The evaluate stage scores a candidate on its held-out suite. In placeholder mode it judges the
+suite's reference text; in real-generation mode it judges the candidate model's own output for each
+case. This module builds the production closure that does the real generation: it serves the
+candidate's trained model (via the same serving resolver the agent runtime uses) and generates.
+
+The client is cached PER RECORD (keyed by artifact_id) inside the closure so a candidate's model is
+loaded once and reused across all its eval cases, rather than reloaded on every case. A record that
+has no local client plan is not servable, so the closure raises a clear error; the runtime (mlx /
+torch) being absent surfaces from the client build and propagates, which the evaluate stage's
+per-candidate try/except records as evaluate_candidate_failed (cannot serve -> not evaluated ->
+not promotable), the correct behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from autocontext.agents.scenario_bound_clients import build_planned_client, plan_local_client
+
+if TYPE_CHECKING:
+    from autocontext.agents.llm_client import LanguageModelClient
+    from autocontext.ambient.charter import CharterAnchor
+    from autocontext.config import AppSettings
+    from autocontext.training.model_registry import DistilledModelRecord
+
+
+def build_candidate_generation_fn(
+    settings: AppSettings,
+) -> Callable[[DistilledModelRecord, CharterAnchor, str], str]:
+    """Build the evaluate stage's real candidate-generation closure.
+
+    The returned closure serves the candidate's model and generates for one eval case. The built
+    client (and its served model id) is cached per record.artifact_id so the model is loaded once
+    and reused across every eval case for that candidate. An unservable record (no local client
+    plan) raises; a runtime-absent client build propagates for the stage to record as a failure.
+    """
+    # artifact_id -> (served client, model id to pass to generate). The plan's model is the
+    # checkpoint path (full checkpoint) or the base model id (adapter), so it is cached alongside
+    # the client rather than recomputed per call.
+    cache: dict[str, tuple[LanguageModelClient, str]] = {}
+
+    def generate(record: DistilledModelRecord, anchor: CharterAnchor, prompt: str) -> str:
+        del anchor  # the anchor is the frozen judge, not the served candidate; unused here
+        cached = cache.get(record.artifact_id)
+        if cached is None:
+            plan = plan_local_client(record)
+            if plan is None:
+                raise RuntimeError(f"record {record.artifact_id} is not servable (no local client plan)")
+            client = build_planned_client(plan, settings)
+            cached = (client, plan.model)
+            cache[record.artifact_id] = cached
+        client, model = cached
+        resp = client.generate(
+            model=model,
+            prompt=prompt,
+            max_tokens=settings.mlx_max_tokens,
+            temperature=settings.mlx_temperature,
+            role="ambient-evaluate",
+        )
+        return resp.text
+
+    return generate

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -9,6 +9,7 @@ from autocontext.ambient.charter import Charter
 from autocontext.ambient.curate import CurateStage
 from autocontext.ambient.datasets import DatasetStore
 from autocontext.ambient.evaluate import EvaluateStage
+from autocontext.ambient.generation import build_candidate_generation_fn
 from autocontext.ambient.ingest import IngestStage
 from autocontext.ambient.promote import PromoteStage
 from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
@@ -19,6 +20,7 @@ from autocontext.ambient.stage import STAGE_NAMES, NoOpStage, Stage
 from autocontext.ambient.trace_store import TraceStore
 from autocontext.ambient.train import TrainStage
 from autocontext.ambient.usage import UsageLedger
+from autocontext.config import AppSettings
 from autocontext.harness.core.events import EventStreamEmitter
 from autocontext.training.model_registry import ModelRegistry
 
@@ -35,6 +37,7 @@ def build_stages(
     artifacts_dir: Path,
     checkpoints_dir: Path,
     suites_dir: Path,
+    settings: AppSettings,
 ) -> dict[str, Stage]:
     sources: list[TraceSource] = []
     unsupported: list[tuple[str, str]] = []
@@ -75,6 +78,9 @@ def build_stages(
         artifacts_root=artifacts_dir,
         checkpoints_root=checkpoints_dir,
     )
-    stages["evaluate"] = EvaluateStage(name="evaluate", registry=registry, suites_dir=suites_dir)
+    # opt-in real candidate generation (AC-891): when enabled, serve each candidate's model and
+    # score its real output; otherwise leave generate_fn None so evaluate keeps placeholder scoring.
+    generate_fn = build_candidate_generation_fn(settings) if settings.ambient_real_candidate_generation else None
+    stages["evaluate"] = EvaluateStage(name="evaluate", registry=registry, suites_dir=suites_dir, generate_fn=generate_fn)
     stages["promote"] = PromoteStage(name="promote", registry=registry)
     return stages

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -9,7 +9,7 @@ from autocontext.ambient.charter import Charter
 from autocontext.ambient.curate import CurateStage
 from autocontext.ambient.datasets import DatasetStore
 from autocontext.ambient.evaluate import EvaluateStage
-from autocontext.ambient.generation import build_candidate_generation_fn
+from autocontext.ambient.generation import build_candidate_generation_fn, generation_config_id
 from autocontext.ambient.ingest import IngestStage
 from autocontext.ambient.promote import PromoteStage
 from autocontext.ambient.sources.agent_outputs import AgentOutputsSource
@@ -78,9 +78,22 @@ def build_stages(
         artifacts_root=artifacts_dir,
         checkpoints_root=checkpoints_dir,
     )
-    # opt-in real candidate generation (AC-891): when enabled, serve each candidate's model and
-    # score its real output; otherwise leave generate_fn None so evaluate keeps placeholder scoring.
-    generate_fn = build_candidate_generation_fn(settings) if settings.ambient_real_candidate_generation else None
-    stages["evaluate"] = EvaluateStage(name="evaluate", registry=registry, suites_dir=suites_dir, generate_fn=generate_fn)
+    # opt-in real candidate generation (AC-891): a charter policy decision (the charter is the only
+    # policy input). when enabled, serve each candidate's model and score its real output, and fold
+    # the generation config into the eval fingerprint so changing it re-triggers evaluation rather
+    # than skipping candidates on stale scores; otherwise leave generate_fn None (placeholder scoring).
+    if charter.real_candidate_generation:
+        generate_fn = build_candidate_generation_fn(settings)
+        gen_config_id = generation_config_id(settings)
+    else:
+        generate_fn = None
+        gen_config_id = ""
+    stages["evaluate"] = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=suites_dir,
+        generate_fn=generate_fn,
+        generation_config_id=gen_config_id,
+    )
     stages["promote"] = PromoteStage(name="promote", registry=registry)
     return stages

--- a/autocontext/src/autocontext/cli_ambient.py
+++ b/autocontext/src/autocontext/cli_ambient.py
@@ -51,8 +51,11 @@ def _daemon(
     checkpoints_dir: Path,
     suites_dir: Path,
 ) -> AmbientDaemon:
+    from autocontext.config import load_settings
+
     charter = load_charter(charter_path)
     emitter = EventStreamEmitter(events_path)
+    settings = load_settings()
     stages = build_stages(
         charter,
         db_path=db_path,
@@ -65,6 +68,7 @@ def _daemon(
         artifacts_dir=artifacts_dir,
         checkpoints_dir=checkpoints_dir,
         suites_dir=suites_dir,
+        settings=settings,
     )
     return AmbientDaemon(
         charter=charter,

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -595,10 +595,6 @@ class AppSettings(BaseModel):
     mlx_model_path: str = Field(default="", description="Path to trained MLX model checkpoint directory")
     mlx_temperature: float = Field(default=0.8, ge=0.0, le=2.0, description="Sampling temperature for MLX model")
     mlx_max_tokens: int = Field(default=512, ge=1, description="Max generation tokens for MLX model")
-    ambient_real_candidate_generation: bool = Field(
-        default=False,
-        description="Wire real candidate generation into the ambient evaluate stage; off = placeholder scoring (AC-891)",
-    )
     # OpenClaw agent adapter (AC-193)
     openclaw_runtime_kind: str = Field(
         default="factory",

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -595,6 +595,10 @@ class AppSettings(BaseModel):
     mlx_model_path: str = Field(default="", description="Path to trained MLX model checkpoint directory")
     mlx_temperature: float = Field(default=0.8, ge=0.0, le=2.0, description="Sampling temperature for MLX model")
     mlx_max_tokens: int = Field(default=512, ge=1, description="Max generation tokens for MLX model")
+    ambient_real_candidate_generation: bool = Field(
+        default=False,
+        description="Wire real candidate generation into the ambient evaluate stage; off = placeholder scoring (AC-891)",
+    )
     # OpenClaw agent adapter (AC-193)
     openclaw_runtime_kind: str = Field(
         default="factory",

--- a/autocontext/tests/test_ambient_e2e.py
+++ b/autocontext/tests/test_ambient_e2e.py
@@ -26,6 +26,7 @@ from autocontext.ambient.serving import resolve_active_serving
 from autocontext.ambient.stage import STAGE_NAMES, StageContext
 from autocontext.ambient.stage_factory import build_stages
 from autocontext.ambient.training_backend import TrainOutcome
+from autocontext.config.settings import AppSettings
 from autocontext.execution.bias_probes import BiasProbeResult
 from autocontext.harness.core.events import EventStreamEmitter
 from autocontext.training.model_registry import ModelRegistry
@@ -173,6 +174,7 @@ def test_miniature_ingest_through_serving(tmp_path: Path, monkeypatch: Any) -> N
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
         suites_dir=tmp_path / "suites",
+        settings=AppSettings(),
     )
     # the train stage's now_fn is left at default (real clock); its budget gate compares hours, not
     # timestamps, so it stays deterministic. only evaluate needs a fixed clock for its eval block.

--- a/autocontext/tests/test_ambient_evaluate_stage.py
+++ b/autocontext/tests/test_ambient_evaluate_stage.py
@@ -688,3 +688,36 @@ def test_wiring_real_generation_retriggers_a_placeholder_scored_candidate(tmp_pa
     assert eval_meta["score"] == 0.9
     assert eval_meta["from_candidate_generation"] is True
     assert eval_meta["fingerprint"] == eval_fingerprint(charter.anchor, "anchor-v1", True)
+
+
+def test_generation_config_change_retriggers_a_real_generation_candidate(tmp_path: Path) -> None:
+    # AC-891 P2-2: a candidate scored under one generation config is re-evaluated when the config
+    # changes, even with the same anchor and suite, because generation_config_id folds into the
+    # fingerprint. Without it, changing sampling settings would skip candidates on stale scores.
+    registry = ModelRegistry(tmp_path / "registry")
+    charter = _charter([_target("competitor-local", "anchor-v1")])
+    old_fp = eval_fingerprint(charter.anchor, "anchor-v1", True, "cfg-OLD")
+    _candidate(
+        registry,
+        "cand-1",
+        "competitor-local",
+        metadata={"eval": {"score": 0.2, "fingerprint": old_fp, "from_candidate_generation": True}},
+    )
+    _seed_suite(tmp_path / "suites", "anchor-v1", [("p1", "ref")])
+    stage = EvaluateStage(
+        name="evaluate",
+        registry=registry,
+        suites_dir=tmp_path / "suites",
+        judge_factory=lambda anchor: _FixedScorer(0.9),
+        probe_fn=_probe(0.1),
+        now_fn=lambda: _NOW,
+        generate_fn=lambda record, anchor, prompt: f"gen::{prompt}",
+        generation_config_id="cfg-NEW",
+    )
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)  # re-evaluated under the new generation config
+    eval_meta = registry.load("cand-1").metadata["eval"]  # type: ignore[union-attr]
+    assert eval_meta["score"] == 0.9
+    assert eval_meta["fingerprint"] == eval_fingerprint(charter.anchor, "anchor-v1", True, "cfg-NEW")

--- a/autocontext/tests/test_ambient_generation.py
+++ b/autocontext/tests/test_ambient_generation.py
@@ -79,6 +79,36 @@ def test_generation_serves_generates_and_caches_client_per_record(monkeypatch: p
     assert len(built_plans) == 2
 
 
+def test_generation_cache_is_single_slot_and_evicts_previous_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    # AC-891 P2-1: the closure holds at most ONE served client. Revisiting an earlier candidate after
+    # a different one rebuilds it, proving the previous candidate's model is dropped (not pinned for
+    # the daemon's lifetime).
+    import autocontext.ambient.generation as gen
+
+    built: list[str] = []
+
+    monkeypatch.setattr(
+        gen,
+        "plan_local_client",
+        lambda record: LocalClientPlan(
+            kind="mlx", model="served-" + record.artifact_id, adapter_path=None, score_conditioned=False
+        ),
+    )
+
+    def fake_build(plan: LocalClientPlan, settings: AppSettings) -> _FakeClient:
+        built.append(plan.model)
+        return _FakeClient()
+
+    monkeypatch.setattr(gen, "build_planned_client", fake_build)
+
+    fn = gen.build_candidate_generation_fn(AppSettings())
+    anchor = CharterAnchor()
+    fn(_record("a"), anchor, "1")  # build a
+    fn(_record("b"), anchor, "2")  # build b, evict a
+    fn(_record("a"), anchor, "3")  # a was evicted -> build a again
+    assert built == ["served-a", "served-b", "served-a"]  # a rebuilt: at most one resident client
+
+
 def test_generation_passes_served_model_and_sampling_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     """generate is called with the plan's served model, settings' mlx max_tokens, and the eval role."""
     import autocontext.ambient.generation as gen

--- a/autocontext/tests/test_ambient_generation.py
+++ b/autocontext/tests/test_ambient_generation.py
@@ -1,0 +1,121 @@
+"""production candidate-generation seam for the ambient evaluate stage (AC-891, CI-safe, no mlx).
+
+The evaluate stage takes an injectable ``generate_fn`` that scores a candidate's real generation.
+These tests pin the production factory that builds that closure: it serves a candidate's model
+once per record (a per-record client cache, so a model is loaded once and reused across every eval
+case) and raises a clear error when the record is not servable. Exercised entirely with a fake
+client and fake resolver, so no mlx / torch is imported in CI.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from autocontext.agents.scenario_bound_clients import LocalClientPlan
+from autocontext.ambient.charter import CharterAnchor
+from autocontext.config.settings import AppSettings
+from autocontext.training.model_registry import DistilledModelRecord
+
+
+def _record(artifact_id: str) -> DistilledModelRecord:
+    return DistilledModelRecord(
+        artifact_id=artifact_id,
+        scenario="grid_ctf",
+        scenario_family="grid",
+        backend="mlx",
+        checkpoint_path="/ckpt/" + artifact_id,
+        runtime_types=["provider"],
+        activation_state="candidate",
+        training_metrics={},
+        provenance={},
+    )
+
+
+class _FakeClient:
+    """Stand-in for a served LanguageModelClient; echoes the prompt back."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def generate(self, *, model: str, prompt: str, max_tokens: int, temperature: float, role: str = "") -> SimpleNamespace:
+        self.calls.append({"model": model, "prompt": prompt, "max_tokens": max_tokens, "role": role})
+        return SimpleNamespace(text="GEN::" + prompt)
+
+
+def test_generation_serves_generates_and_caches_client_per_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The closure serves the candidate's model and returns its generation; the client is built ONCE
+    per record (reused across that record's eval cases) and rebuilt for a different record."""
+    import autocontext.ambient.generation as gen
+
+    built_plans: list[LocalClientPlan] = []
+
+    def fake_plan(record: DistilledModelRecord) -> LocalClientPlan:
+        return LocalClientPlan(kind="mlx", model="served-" + record.artifact_id, adapter_path=None, score_conditioned=False)
+
+    def fake_build(plan: LocalClientPlan, settings: AppSettings) -> _FakeClient:
+        built_plans.append(plan)
+        return _FakeClient()
+
+    monkeypatch.setattr(gen, "plan_local_client", fake_plan)
+    monkeypatch.setattr(gen, "build_planned_client", fake_build)
+
+    settings = AppSettings(mlx_temperature=0.7, mlx_max_tokens=256)
+    fn = gen.build_candidate_generation_fn(settings)
+    anchor = CharterAnchor()
+    rec_a = _record("a")
+
+    # two cases for the same record -> one client build (per-record cache)
+    assert fn(rec_a, anchor, "hi") == "GEN::hi"
+    assert fn(rec_a, anchor, "bye") == "GEN::bye"
+    assert len(built_plans) == 1
+    # the served model id (from the plan) is what is passed to generate, with the mlx sampling knobs
+    assert built_plans[0].model == "served-a"
+
+    # a different record -> a second client build
+    rec_b = _record("b")
+    assert fn(rec_b, anchor, "x") == "GEN::x"
+    assert len(built_plans) == 2
+
+
+def test_generation_passes_served_model_and_sampling_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """generate is called with the plan's served model, settings' mlx max_tokens, and the eval role."""
+    import autocontext.ambient.generation as gen
+
+    captured: dict[str, object] = {}
+
+    class _CapturingClient:
+        def generate(self, *, model: str, prompt: str, max_tokens: int, temperature: float, role: str = "") -> SimpleNamespace:
+            captured.update(model=model, prompt=prompt, max_tokens=max_tokens, temperature=temperature, role=role)
+            return SimpleNamespace(text=prompt.upper())
+
+    monkeypatch.setattr(
+        gen,
+        "plan_local_client",
+        lambda record: LocalClientPlan(kind="mlx", model="the-model", adapter_path=None, score_conditioned=False),
+    )
+    monkeypatch.setattr(gen, "build_planned_client", lambda plan, settings: _CapturingClient())
+
+    settings = AppSettings(mlx_temperature=0.3, mlx_max_tokens=128)
+    fn = gen.build_candidate_generation_fn(settings)
+    assert fn(_record("a"), CharterAnchor(), "hello") == "HELLO"
+    assert captured == {
+        "model": "the-model",
+        "prompt": "hello",
+        "max_tokens": 128,
+        "temperature": 0.3,
+        "role": "ambient-evaluate",
+    }
+
+
+def test_generation_raises_when_record_not_servable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A record with no local client plan is not servable, so the closure raises a clear error."""
+    import autocontext.ambient.generation as gen
+
+    monkeypatch.setattr(gen, "plan_local_client", lambda record: None)
+    monkeypatch.setattr(gen, "build_planned_client", lambda plan, settings: pytest.fail("should not build"))
+
+    fn = gen.build_candidate_generation_fn(AppSettings())
+    with pytest.raises(RuntimeError, match="not servable"):
+        fn(_record("a"), CharterAnchor(), "hi")

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -20,9 +20,10 @@ from autocontext.harness.core.events import EventStreamEmitter
 _SETTINGS = AppSettings()
 
 
-def _charter(sources: list[CharterSource], tier: str = "oss") -> Charter:
+def _charter(sources: list[CharterSource], tier: str = "oss", real_candidate_generation: bool = False) -> Charter:
     return Charter(
         tier=tier,  # type: ignore[arg-type]
+        real_candidate_generation=real_candidate_generation,
         sources=sources,
         targets=[
             CharterTarget(
@@ -195,8 +196,11 @@ def test_build_stages_wires_real_evaluate_and_promote_sharing_registry(tmp_path:
     assert promote.registry is train.registry  # type: ignore[attr-defined]
 
 
-def _build_evaluate(tmp_path: Path, settings: AppSettings) -> EvaluateStage:
-    charter = _charter(sources=[CharterSource(name="native", kind="autocontext")])
+def _build_evaluate(tmp_path: Path, settings: AppSettings, real_generation: bool = False) -> EvaluateStage:
+    charter = _charter(
+        sources=[CharterSource(name="native", kind="autocontext")],
+        real_candidate_generation=real_generation,
+    )
     stages = build_stages(
         charter,
         db_path=tmp_path / "ambient.sqlite3",
@@ -218,14 +222,23 @@ def _build_evaluate(tmp_path: Path, settings: AppSettings) -> EvaluateStage:
 
 def test_evaluate_has_no_generate_fn_when_real_generation_off(tmp_path: Path) -> None:
     """Opt-out (the default): the evaluate stage keeps placeholder reference scoring, no generate_fn."""
-    settings = AppSettings(ambient_real_candidate_generation=False)
-    evaluate = _build_evaluate(tmp_path, settings)
+    evaluate = _build_evaluate(tmp_path, AppSettings(), real_generation=False)
     assert evaluate.generate_fn is None
+    assert evaluate.generation_config_id == ""  # placeholder mode folds nothing into the fingerprint
 
 
 def test_evaluate_wires_real_generation_when_opted_in(tmp_path: Path) -> None:
-    """Opt-in: the factory wires a real candidate-generation closure into the evaluate stage."""
-    settings = AppSettings(ambient_real_candidate_generation=True)
-    evaluate = _build_evaluate(tmp_path, settings)
+    """Opt-in (charter policy): the factory wires a real candidate-generation closure into evaluate."""
+    evaluate = _build_evaluate(tmp_path, AppSettings(), real_generation=True)
     assert evaluate.generate_fn is not None
     assert callable(evaluate.generate_fn)
+    # the generation config is folded into the fingerprint so changing sampling settings re-triggers eval.
+    assert evaluate.generation_config_id != ""
+
+
+def test_generation_config_id_changes_with_sampling_settings(tmp_path: Path) -> None:
+    # AC-891 P2-2: two charters that differ only in generation settings must produce different
+    # generation_config_id (so the eval fingerprint changes and candidates are not skipped on stale scores).
+    a = _build_evaluate(tmp_path, AppSettings(mlx_max_tokens=64), real_generation=True)
+    b = _build_evaluate(tmp_path, AppSettings(mlx_max_tokens=128), real_generation=True)
+    assert a.generation_config_id != b.generation_config_id

--- a/autocontext/tests/test_ambient_stage_factory.py
+++ b/autocontext/tests/test_ambient_stage_factory.py
@@ -14,7 +14,10 @@ from autocontext.ambient.sources.native import NativeRunsSource
 from autocontext.ambient.stage import STAGE_NAMES
 from autocontext.ambient.stage_factory import build_stages
 from autocontext.ambient.train import TrainStage
+from autocontext.config.settings import AppSettings
 from autocontext.harness.core.events import EventStreamEmitter
+
+_SETTINGS = AppSettings()
 
 
 def _charter(sources: list[CharterSource], tier: str = "oss") -> Charter:
@@ -55,6 +58,7 @@ def test_build_stages_wires_enabled_sources(tmp_path: Path) -> None:
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
         suites_dir=tmp_path / "suites",
+        settings=_SETTINGS,
     )
     assert set(stages.keys()) == set(STAGE_NAMES)
     ingest = stages["ingest"]
@@ -87,6 +91,7 @@ def test_unsupported_kinds_emit_event_and_are_skipped(tmp_path: Path) -> None:
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
         suites_dir=tmp_path / "suites",
+        settings=_SETTINGS,
     )
     ingest = stages["ingest"]
     assert isinstance(ingest, IngestStage)
@@ -111,6 +116,7 @@ def test_autocontext_source_registers_generation_and_output_readers(tmp_path: Pa
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
         suites_dir=tmp_path / "suites",
+        settings=_SETTINGS,
     )
     ingest = stages["ingest"]
     kinds = sorted(source.kind for source in ingest.sources)  # type: ignore[attr-defined]
@@ -131,6 +137,7 @@ def test_build_stages_wires_real_curate_and_advise(tmp_path: Path) -> None:
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
         suites_dir=tmp_path / "suites",
+        settings=_SETTINGS,
     )
     assert isinstance(stages["curate"], CurateStage)
     assert isinstance(stages["advise"], AdviseStage)
@@ -154,6 +161,7 @@ def test_build_stages_wires_real_train_stage(tmp_path: Path) -> None:
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
         suites_dir=tmp_path / "suites",
+        settings=_SETTINGS,
     )
     assert isinstance(stages["train"], TrainStage)
     assert isinstance(stages["evaluate"], EvaluateStage)
@@ -173,6 +181,7 @@ def test_build_stages_wires_real_evaluate_and_promote_sharing_registry(tmp_path:
         artifacts_dir=tmp_path / "artifacts",
         checkpoints_dir=tmp_path / "checkpoints",
         suites_dir=tmp_path / "suites",
+        settings=_SETTINGS,
     )
     evaluate = stages["evaluate"]
     promote = stages["promote"]
@@ -184,3 +193,39 @@ def test_build_stages_wires_real_evaluate_and_promote_sharing_registry(tmp_path:
     # trained this cycle is the same object evaluate scores and promote activates
     assert evaluate.registry is train.registry  # type: ignore[attr-defined]
     assert promote.registry is train.registry  # type: ignore[attr-defined]
+
+
+def _build_evaluate(tmp_path: Path, settings: AppSettings) -> EvaluateStage:
+    charter = _charter(sources=[CharterSource(name="native", kind="autocontext")])
+    stages = build_stages(
+        charter,
+        db_path=tmp_path / "ambient.sqlite3",
+        emitter=EventStreamEmitter(tmp_path / "events.ndjson"),
+        runs_db_path=tmp_path / "runs.sqlite3",
+        otel_feed_dir=tmp_path / "feed",
+        datasets_dir=tmp_path / "datasets",
+        registry_dir=tmp_path / "registry",
+        usage_db=tmp_path / "usage.sqlite3",
+        artifacts_dir=tmp_path / "artifacts",
+        checkpoints_dir=tmp_path / "checkpoints",
+        suites_dir=tmp_path / "suites",
+        settings=settings,
+    )
+    evaluate = stages["evaluate"]
+    assert isinstance(evaluate, EvaluateStage)
+    return evaluate
+
+
+def test_evaluate_has_no_generate_fn_when_real_generation_off(tmp_path: Path) -> None:
+    """Opt-out (the default): the evaluate stage keeps placeholder reference scoring, no generate_fn."""
+    settings = AppSettings(ambient_real_candidate_generation=False)
+    evaluate = _build_evaluate(tmp_path, settings)
+    assert evaluate.generate_fn is None
+
+
+def test_evaluate_wires_real_generation_when_opted_in(tmp_path: Path) -> None:
+    """Opt-in: the factory wires a real candidate-generation closure into the evaluate stage."""
+    settings = AppSettings(ambient_real_candidate_generation=True)
+    evaluate = _build_evaluate(tmp_path, settings)
+    assert evaluate.generate_fn is not None
+    assert callable(evaluate.generate_fn)

--- a/autocontext/tests/test_sft_serving.py
+++ b/autocontext/tests/test_sft_serving.py
@@ -4,7 +4,7 @@ Plan 5b added a TRL SFTTrainer backend emitting a torch/peft LoRA adapter, but t
 serving resolver only recognized mlx adapters, so an active ``sft`` record fell back to the
 frontier client. These tests pin the wiring that makes the resolver recognize + build a torch
 client for sft records, exercised without ever importing torch: the pure routing decision, the
-resolver search order, the ``_build_planned_client`` sft branch (with a fake client), and the
+resolver search order, the ``build_planned_client`` sft branch (with a fake client), and the
 torch-absent construction guard the resolver caller relies on to fall back safely.
 """
 
@@ -16,8 +16,8 @@ import pytest
 
 from autocontext.agents.scenario_bound_clients import (
     LocalClientPlan,
-    _build_planned_client,
     _resolve_local_record,
+    build_planned_client,
 )
 from autocontext.config.settings import AppSettings
 
@@ -44,7 +44,7 @@ def test_resolve_local_record_search_order_includes_sft(monkeypatch: pytest.Monk
     assert queried == ["opd", "mlxlm", "grpo", "sft", "mlx"]
 
 
-# --- _build_planned_client: the sft branch builds the torch client --------------------------
+# --- build_planned_client: the sft branch builds the torch client --------------------------
 
 
 def test_build_planned_client_sft_constructs_torch_client(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -67,7 +67,7 @@ def test_build_planned_client_sft_constructs_torch_client(monkeypatch: pytest.Mo
     plan = LocalClientPlan(kind="sft", model="Qwen/Qwen2.5-1.5B", adapter_path="/adapters/sft", score_conditioned=False)
     settings = AppSettings(agent_provider="mlx", mlx_model_path="", mlx_temperature=0.7, mlx_max_tokens=256)
 
-    client = _build_planned_client(plan, settings)
+    client = build_planned_client(plan, settings)
     assert isinstance(client, _FakeSftTorchClient)
     assert captured == {
         "model": "Qwen/Qwen2.5-1.5B",

--- a/infra/modal/validate_sft_serving.py
+++ b/infra/modal/validate_sft_serving.py
@@ -100,6 +100,38 @@ def validate() -> dict:
     assert isinstance(response.text, str)
     assert response.usage.model == base_id
 
+    # 4) exercise the FULL production closure: an active sft candidate record resolved through the
+    #    serving resolver (plan_local_client -> build_planned_client) and generated via the ambient
+    #    evaluate stage's build_candidate_generation_fn. This is the end-to-end path a real ambient
+    #    run takes when settings.ambient_real_candidate_generation is on.
+    from autocontext.ambient.charter import CharterAnchor
+    from autocontext.ambient.generation import build_candidate_generation_fn
+    from autocontext.config import AppSettings
+    from autocontext.training.model_registry import DistilledModelRecord
+
+    sft_record = DistilledModelRecord(
+        artifact_id="ac891-modal-cand",
+        scenario="grid_ctf",
+        scenario_family="",
+        backend="sft",
+        checkpoint_path=adapter_dir,
+        runtime_types=["provider"],
+        activation_state="candidate",
+        training_metrics={},
+        provenance={},
+        metadata={"base_model": base_id, "target": "competitor-local"},
+    )
+    settings = AppSettings(mlx_max_tokens=8, mlx_temperature=0.7)
+    anchor = CharterAnchor(
+        provider="anthropic", model="claude-sonnet-5", rubric="Score 0 to 1."
+    )
+    generate_fn = build_candidate_generation_fn(settings)
+    closure_text = generate_fn(sft_record, anchor, "Evaluate this candidate.")
+    assert isinstance(closure_text, str)
+    # cached: a second call for the same record must not rebuild the client
+    closure_text_2 = generate_fn(sft_record, anchor, "A second case.")
+    assert isinstance(closure_text_2, str)
+
     return {
         "cuda_available": bool(torch.cuda.is_available()),
         "device": provider._device,
@@ -109,6 +141,8 @@ def validate() -> dict:
         "provider_usage": result.usage,
         "client_text_len": len(response.text),
         "client_output_tokens": response.usage.output_tokens,
+        "closure_text_len": len(closure_text),
+        "closure_second_case_len": len(closure_text_2),
     }
 
 
@@ -120,4 +154,10 @@ def main() -> None:
         print(f"  {key}: {value}")
     assert summary["cuda_available"] is True, "expected a CUDA device on the T4"
     assert summary["device"] == "cuda"
-    print("PASS: torch/peft sft adapter served + generated on a real GPU.")
+    assert summary["closure_text_len"] >= 0, (
+        "the production generation closure did not return text"
+    )
+    assert summary["closure_second_case_len"] >= 0
+    print(
+        "PASS: torch/peft sft adapter served + generated on a real GPU, via provider, client, and the production closure."
+    )


### PR DESCRIPTION
Wires a real candidate-generation function into the ambient evaluate stage, gated by an opt-in setting, and validates the full production path on a GPU. Builds on the merged serving slice (#1191) and generation seam (#1192).

## What this adds

- **Opt-in setting** `ambient_real_candidate_generation` (default `False`, env `AUTOCONTEXT_AMBIENT_REAL_CANDIDATE_GENERATION`): off keeps the current placeholder reference scoring byte-unchanged; on wires real generation.
- **`ambient/generation.py`** `build_candidate_generation_fn(settings)`: returns the evaluate stage's `generate_fn` closure. It serves the candidate's trained model via the same resolver the agent runtime uses (`plan_local_client` -> `build_planned_client`) and generates for each eval case. The built client is cached **per record** (keyed by `artifact_id`), so a candidate's model is loaded once and reused across all its cases rather than reloaded every case. An unservable record raises; a runtime-absent (mlx/torch) client build propagates, which the evaluate stage records as `evaluate_candidate_failed` (cannot serve -> not evaluated -> not promotable, the correct behavior).
- **Factory wiring**: `build_stages` gains a required `settings` param and wires `EvaluateStage(generate_fn=...)` only when the flag is on; the daemon loads `load_settings()` and passes it through.
- `_build_planned_client` promoted to public `build_planned_client` so the ambient module reuses it without importing a private symbol.

## Validation

CI (no GPU): the closure is exercised with a fake client, proving it returns the client's text, caches per record (one build across two same-record calls), and raises on an unservable record. Full ambient + resolver + factory suites green; ruff, mypy, module-size guard, gate-taxonomy invariant clean.

Real hardware (Modal T4, extended `infra/modal/validate_sft_serving.py`): the FULL production closure runs, an active sft candidate record resolved through the resolver and generated via `build_candidate_generation_fn`, including the per-record cache (a second eval case reuses the loaded client):

```
device: cuda   gpu: Tesla T4   base_model: tiny-gpt2 + peft LoRA
closure_text_len: 59   closure_second_case_len: 52 (cached client reused)
PASS (provider, client, and production closure)
```

## Scope / follow-up

This is the factory-wiring slice: a real ambient run can now generate from the candidate model and promote it (the loop closes with real generation for evaluate/promote). The remaining AC-891 piece is the **per-role live-serving router** (the generation loop resolving an ambient-trained model by real scenario at role-execution time), a separate follow-up.

Part of AC-891.