### PR TITLE
fix: absent-input repair events stamp correct implemented/implemented parity (AC-878 review)

### DIFF
--- a/autocontext/src/autocontext/harness_optimization/repair_gate.py
+++ b/autocontext/src/autocontext/harness_optimization/repair_gate.py
@@ -83,7 +83,11 @@ def _absent_result(repair_name: str, reason: str) -> RepairResult:
         target="",
         before={"present": False},
         after={"present": False},
-        parity=Parity(python="implemented", typescript="pending", schema_hash=""),
+        # These absent-input repairs (tool_call_json, artifact_landing, finish_guard) are implemented
+        # in BOTH languages, so their parity is implemented/implemented, the same as their applied and
+        # not_applicable results. Stamping the other language "pending" made a normal skipped event
+        # look like a parity gap in audit output. loop_guard (Python-only) never uses this helper.
+        parity=Parity(python="implemented", typescript="implemented", schema_hash=""),
     )
 
 

--- a/autocontext/tests/test_harness_optimization_repair_gate.py
+++ b/autocontext/tests/test_harness_optimization_repair_gate.py
@@ -113,6 +113,9 @@ def test_run_emits_repair_skipped_for_not_applicable_absent_input(tmp_path: Path
     results = gate.run("grid_ctf", ctx)
 
     assert results[0].status == "not_applicable"
+    # a normal skipped event for a both-languages repair is implemented/implemented, not a parity gap.
+    assert results[0].parity.python == "implemented"
+    assert results[0].parity.typescript == "implemented"
     assert [e for e, _ in capture.events] == ["repair_skipped"]
     RepairResult.model_validate(capture.events[0][1]["result"])
 

--- a/ts/src/harness-optimization/repair-gate.ts
+++ b/ts/src/harness-optimization/repair-gate.ts
@@ -73,7 +73,10 @@ function absentResult(repairName: string, reason: string): RepairResult {
     target: "",
     before: { present: false },
     after: { present: false },
-    parity: { python: "pending", typescript: "implemented", schema_hash: "" },
+    // These absent-input repairs (tool_call_json, artifact_landing, finish_guard) are implemented in
+    // BOTH languages, so parity is implemented/implemented, matching their applied and not_applicable
+    // results. Stamping python "pending" made a normal skipped event look like a parity gap.
+    parity: { python: "implemented", typescript: "implemented", schema_hash: "" },
   };
 }
 

--- a/ts/tests/harness-optimization/repair-gate.test.ts
+++ b/ts/tests/harness-optimization/repair-gate.test.ts
@@ -100,6 +100,12 @@ describe("RepairGate.run", () => {
     const results = g.run("grid_ctf", ctx);
 
     expect(results[0].status).toBe("not_applicable");
+    // a normal skipped event for a both-languages repair is implemented/implemented, not a parity gap.
+    expect(results[0].parity).toEqual({
+      python: "implemented",
+      typescript: "implemented",
+      schema_hash: "",
+    });
     expect(captured.map((c) => c.event)).toEqual(["repair_skipped"]);
     expect(validateRepairResult(captured[0].payload.result).valid).toBe(true);
   });


### PR DESCRIPTION
Addresses a reviewer finding on the merged deterministic-repair-gates PR (#1184).

## Problem

The gate's absent-input repair result (when a repair's input is not present in context) stamped the OPPOSITE language as `pending`:
- Python `_absent_result` -> `typescript="pending"`
- TS `absentResult` -> `python="pending"`

But the three repairs that take this path, `tool_call_json`, `artifact_landing`, `finish_guard`, are all implemented in BOTH languages, and their applied / `not_applicable` results already stamp `implemented/implemented` (via `_parity()`). So the absent-input stamp was internally inconsistent, and it made a perfectly normal skipped event look like a cross-language parity gap in audit output. (`loop_guard`, the only Python-only repair, never uses this path, it is omitted from the default set.)

## Fix

Both languages now stamp `implemented/implemented` for absent-input results, matching the same repairs' other results. The absent-input gate tests (Python + TS) now assert the parity so it cannot regress.

Gates: Python repair-gate + repairs suites, ruff, mypy; TS repair-gate suite + lint, all green.

Left open for your review (not merged).