### PR TITLE
fix: under-sampled calibration reports insufficient_data, not a false above_noise (AC-881 review)

### DIFF
--- a/autocontext/src/autocontext/harness_optimization/calibration.py
+++ b/autocontext/src/autocontext/harness_optimization/calibration.py
@@ -52,9 +52,14 @@ def compute_calibration(
         k = max_trials
     recommended_trial_count = max(1, min(k, max_trials))
 
-    margin_vs_noise: Literal["above_noise", "below_noise"] = (
-        "above_noise" if current_min_delta >= recommended_min_delta else "below_noise"
-    )
+    # With fewer than 2 samples there is no variance estimate: standard_error and
+    # recommended_min_delta are 0, so any positive current_min_delta would look "above_noise". Report
+    # insufficient_data instead, so calibration never falsely reassures that the margin cleared noise.
+    margin_vs_noise: Literal["above_noise", "below_noise", "insufficient_data"]
+    if n < 2:
+        margin_vs_noise = "insufficient_data"
+    else:
+        margin_vs_noise = "above_noise" if current_min_delta >= recommended_min_delta else "below_noise"
 
     if abs(mean) > 0:
         sparse_metric_too_noisy = standard_error / abs(mean) > noisy_cv_threshold

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/calibration-report.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/calibration-report.schema.json
@@ -70,8 +70,12 @@
     },
     "margin_vs_noise": {
       "type": "string",
-      "enum": ["above_noise", "below_noise", "insufficient_data"],
-      "description": "Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate."
+      "enum": [
+        "above_noise",
+        "below_noise",
+        "insufficient_data"
+      ],
+      "description": "Margin vs noise floor: above_noise, below_noise, or insufficient_data (n<2 = no variance estimate)."
     },
     "sparse_metric_too_noisy": {
       "type": "boolean",

--- a/autocontext/src/autocontext/harness_optimization/contract/json_schemas/calibration-report.schema.json
+++ b/autocontext/src/autocontext/harness_optimization/contract/json_schemas/calibration-report.schema.json
@@ -70,8 +70,8 @@
     },
     "margin_vs_noise": {
       "type": "string",
-      "enum": ["above_noise", "below_noise"],
-      "description": "Whether the current margin sits above or below the noise floor."
+      "enum": ["above_noise", "below_noise", "insufficient_data"],
+      "description": "Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate."
     },
     "sparse_metric_too_noisy": {
       "type": "boolean",

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -619,7 +619,7 @@ class CalibrationReport(BaseModel):
     margin_vs_noise: Annotated[
         Literal['above_noise', 'below_noise', 'insufficient_data'],
         Field(
-            description='Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate.'
+            description='Margin vs noise floor: above_noise, below_noise, or insufficient_data (n<2 = no variance estimate).'
         ),
     ]
     sparse_metric_too_noisy: Annotated[

--- a/autocontext/src/autocontext/harness_optimization/contract/models.py
+++ b/autocontext/src/autocontext/harness_optimization/contract/models.py
@@ -617,9 +617,9 @@ class CalibrationReport(BaseModel):
         float, Field(description='The promotion margin currently configured.')
     ]
     margin_vs_noise: Annotated[
-        Literal['above_noise', 'below_noise'],
+        Literal['above_noise', 'below_noise', 'insufficient_data'],
         Field(
-            description='Whether the current margin sits above or below the noise floor.'
+            description='Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate.'
         ),
     ]
     sparse_metric_too_noisy: Annotated[

--- a/autocontext/tests/harness_optimization/test_calibration.py
+++ b/autocontext/tests/harness_optimization/test_calibration.py
@@ -123,3 +123,17 @@ def test_cite_margin_vs_noise_format() -> None:
     assert citation == (
         f"margin {report.current_min_delta:.6f} is {report.margin_vs_noise} (recommended >= {report.recommended_min_delta:.6f})"
     )
+
+
+def test_under_sampled_series_is_insufficient_data_not_above_noise() -> None:
+    # AC-881 review: with n < 2 there is no variance estimate, so a positive current_min_delta must
+    # NOT be reported as "above_noise" (which would falsely reassure the operator that the margin
+    # cleared noise). Both n=1 and n=0 report insufficient_data.
+    one = compute_calibration([0.9], scenario_id="s", current_min_delta=0.05, max_trials=8)
+    assert one.margin_vs_noise == "insufficient_data"
+    assert one.standard_error == 0.0
+    none = compute_calibration([], scenario_id="s", current_min_delta=0.05, max_trials=8)
+    assert none.margin_vs_noise == "insufficient_data"
+    # a well-sampled series still classifies normally
+    many = compute_calibration([0.80, 0.81, 0.79, 0.80, 0.82], scenario_id="s", current_min_delta=0.5, max_trials=8)
+    assert many.margin_vs_noise in ("above_noise", "below_noise")

--- a/fixtures/harness-optimization/calibration-cases/calibration-cases.json
+++ b/fixtures/harness-optimization/calibration-cases/calibration-cases.json
@@ -2,7 +2,13 @@
   "cases": [
     {
       "name": "low_noise",
-      "scores": [0.8, 0.82, 0.79, 0.81, 0.8],
+      "scores": [
+        0.8,
+        0.82,
+        0.79,
+        0.81,
+        0.8
+      ],
       "scenario_id": "grid_ctf",
       "current_min_delta": 0.05,
       "max_trials": 10,
@@ -22,7 +28,14 @@
     },
     {
       "name": "high_noise",
-      "scores": [0.2, 0.9, 0.4, 0.95, 0.1, 0.85],
+      "scores": [
+        0.2,
+        0.9,
+        0.4,
+        0.95,
+        0.1,
+        0.85
+      ],
       "scenario_id": "othello",
       "current_min_delta": 0.02,
       "max_trials": 5,
@@ -42,7 +55,9 @@
     },
     {
       "name": "single",
-      "scores": [0.7],
+      "scores": [
+        0.7
+      ],
       "scenario_id": "grid_ctf",
       "current_min_delta": 0.05,
       "max_trials": 8,
@@ -54,7 +69,7 @@
         "standard_error": 0.0,
         "recommended_min_delta": 0.0,
         "recommended_trial_count": 8,
-        "margin_vs_noise": "above_noise",
+        "margin_vs_noise": "insufficient_data",
         "sparse_metric_too_noisy": false
       }
     },
@@ -72,7 +87,7 @@
         "standard_error": 0.0,
         "recommended_min_delta": 0.0,
         "recommended_trial_count": 8,
-        "margin_vs_noise": "above_noise",
+        "margin_vs_noise": "insufficient_data",
         "sparse_metric_too_noisy": false
       }
     }

--- a/ts/src/harness-optimization/calibration.ts
+++ b/ts/src/harness-optimization/calibration.ts
@@ -53,8 +53,15 @@ export function computeCalibration(
   }
   const recommendedTrialCount = Math.max(1, Math.min(k, maxTrials));
 
-  const marginVsNoise: "above_noise" | "below_noise" =
-    opts.currentMinDelta >= recommendedMinDelta ? "above_noise" : "below_noise";
+  // With fewer than 2 samples there is no variance estimate (standardError and recommendedMinDelta
+  // are 0), so any positive currentMinDelta would look "above_noise". Report insufficient_data
+  // instead, so calibration never falsely reassures that the margin cleared noise.
+  const marginVsNoise: "above_noise" | "below_noise" | "insufficient_data" =
+    n < 2
+      ? "insufficient_data"
+      : opts.currentMinDelta >= recommendedMinDelta
+        ? "above_noise"
+        : "below_noise";
 
   let sparseMetricTooNoisy: boolean;
   if (Math.abs(mean) > 0) {

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -57,9 +57,9 @@ export interface CalibrationReport {
    */
   current_min_delta: number;
   /**
-   * Whether the current margin sits above or below the noise floor.
+   * Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate.
    */
-  margin_vs_noise: "above_noise" | "below_noise";
+  margin_vs_noise: "above_noise" | "below_noise" | "insufficient_data";
   /**
    * True when the sparse metric is too noisy to gate on.
    */

--- a/ts/src/harness-optimization/contract/generated-types.ts
+++ b/ts/src/harness-optimization/contract/generated-types.ts
@@ -57,7 +57,7 @@ export interface CalibrationReport {
    */
   current_min_delta: number;
   /**
-   * Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate.
+   * Margin vs noise floor: above_noise, below_noise, or insufficient_data (n<2 = no variance estimate).
    */
   margin_vs_noise: "above_noise" | "below_noise" | "insufficient_data";
   /**

--- a/ts/src/harness-optimization/contract/json-schemas/calibration-report.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/calibration-report.schema.json
@@ -70,8 +70,12 @@
     },
     "margin_vs_noise": {
       "type": "string",
-      "enum": ["above_noise", "below_noise", "insufficient_data"],
-      "description": "Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate."
+      "enum": [
+        "above_noise",
+        "below_noise",
+        "insufficient_data"
+      ],
+      "description": "Margin vs noise floor: above_noise, below_noise, or insufficient_data (n<2 = no variance estimate)."
     },
     "sparse_metric_too_noisy": {
       "type": "boolean",

--- a/ts/src/harness-optimization/contract/json-schemas/calibration-report.schema.json
+++ b/ts/src/harness-optimization/contract/json-schemas/calibration-report.schema.json
@@ -70,8 +70,8 @@
     },
     "margin_vs_noise": {
       "type": "string",
-      "enum": ["above_noise", "below_noise"],
-      "description": "Whether the current margin sits above or below the noise floor."
+      "enum": ["above_noise", "below_noise", "insufficient_data"],
+      "description": "Margin vs the noise floor: above_noise, below_noise, or insufficient_data when n<2 gives no variance estimate."
     },
     "sparse_metric_too_noisy": {
       "type": "boolean",


### PR DESCRIPTION
Addresses a reviewer finding on the merged noise-calibration PR (#1187).

## Problem

With fewer than 2 samples, `standard_error` and `recommended_min_delta` are `0`, so `compute_calibration` classified any positive `current_min_delta` as `margin_vs_noise = "above_noise"` despite having no variance estimate at all. Because `resolve_gate_decision()` can pass a one-match tournament, enabling calibration could emit an "above_noise" citation that falsely reassures an operator the margin cleared noise. The TS mirror had the same bug.

## Fix

Add a third `margin_vs_noise` state, `insufficient_data`, emitted when `n < 2`:
- shared JSON schema enum (`above_noise | below_noise | insufficient_data`), regenerated into `models.py` and `generated-types.ts` (drift gate green);
- the compute logic in both `calibration.py` and `calibration.ts`;
- the shared fixture, the `single` (n=1) and `empty` (n=0) cases now expect `insufficient_data`, which the Python and TS parity tests both assert.

A direct unit test pins the reviewer's exact scenario (a positive `current_min_delta` at n=1 is NOT `above_noise`), while a well-sampled series still classifies normally.

Gates: Python calibration + parity + contract suites, ruff, mypy, module-size, gate-taxonomy; TS calibration + parity suites, drift gate, lint, all green.

Left open for your review (not merged).