### PR TITLE
ambient trainer: per-role live-serving router via serving manifest (AC-893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Ambient per-role live-serving bridge (opt-in, AC-893): the promote stage writes a serving manifest mapping (real scenario, role) to the promoted ambient target, and the serving resolver reads it so a promoted model reaches its role in a live run (ambient candidates are slotted by target name, but generation resolves by real scenario). Off by default; enable by pointing BOTH the ambient daemon and the generation-loop process at one shared file via `AUTOCONTEXT_AMBIENT_SERVING_MANIFEST_PATH`.
 - `autoctx ambient` foundation: a charter-driven resident daemon skeleton (interview wizard, autonomy dial with guardrail floors, durable stage queue, five stages with auto-pause breakers, status/run/once cli). Stages are no-ops pending the ingest, curation, and training plans (docs/ambient-trainer-design.md).
 - The ambient ingest stage is live: charter-enabled sources (autocontext-native runs, jsonl trace feeds) flow through the redaction gate into an append-only trace store with per-source cursors and disk-quota retention; the llm proxy tap follows in the next slice.
 - ambient trainer plan 3: curate and advise stages (agent-output ingestion, guarded per-target datasets, heuristic charter proposals, proposal approval cli)

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -150,7 +150,10 @@ class AgentOrchestrator:
         self.settings = settings
         self._artifacts = artifacts
         self._harness_coverage_cache: dict[str, HarnessCoverage | None] = {}
-        self._routed_clients: dict[tuple[str, str | None, str | None, str | None], LanguageModelClient] = {}
+        # Keyed by a routing tuple whose shape varies by resolver (role-provider routing uses
+        # (provider, model, scenario, role); the mlx/ambient path adds the served model id, AC-893),
+        # so the key is a variable-length tuple of optional strings.
+        self._routed_clients: dict[tuple[str | None, ...], LanguageModelClient] = {}
         self._disposable_client_ids: set[int] = set()
         runtime = SubagentRuntime(client=self.client)
         self.competitor = CompetitorRunner(runtime, settings.model_competitor)

--- a/autocontext/src/autocontext/agents/scenario_bound_clients.py
+++ b/autocontext/src/autocontext/agents/scenario_bound_clients.py
@@ -105,6 +105,32 @@ def _resolve_local_record(settings: AppSettings, scenario_name: str) -> Distille
     return None
 
 
+def _resolve_ambient_record(settings: AppSettings, scenario_name: str, role: str) -> DistilledModelRecord | None:
+    """Ambient per-role record for (scenario, role) via the serving manifest, or ``None`` (AC-893).
+
+    The ambient trainer slots a promoted per-role model under ``scenario = target.name`` (AC-884
+    anti-collision), so resolving by the real scenario never finds it. When the opt-in serving
+    manifest is configured, it carries the (scenario, role) -> target bridge the promote stage wrote,
+    so we resolve the record slotted under the target name. Off (path None) or any error returns
+    ``None`` so the caller falls through to the existing scenario-keyed resolution.
+    """
+    manifest_path = settings.ambient_serving_manifest_path
+    if manifest_path is None:
+        return None
+    from autocontext.ambient.serving_manifest import lookup_serving_entry
+    from autocontext.training.model_registry import ModelRegistry, resolve_model
+
+    try:
+        entry = lookup_serving_entry(manifest_path, scenario=scenario_name, role=role)
+        if entry is None:
+            return None
+        registry = ModelRegistry(settings.knowledge_root)
+        return resolve_model(registry, scenario=entry["target_name"], backend=entry["backend"], runtime_type="provider")
+    except Exception:
+        logger.debug("agents.scenario_bound_clients: ambient serving-manifest resolve failed", exc_info=True)
+        return None
+
+
 def build_planned_client(plan: LocalClientPlan, settings: AppSettings) -> LanguageModelClient:
     """Construct the MLX / MLXLM / SFT-torch client described by ``plan`` (loads the model)."""
     if plan.kind == "sft":
@@ -156,7 +182,7 @@ def scenario_bound_mlx_client(orch: AgentOrchestrator, role: str, *, scenario_na
         orch._routed_clients[key] = client
         return client
 
-    record = _resolve_local_record(orch.settings, scenario_name)
+    record = _resolve_ambient_record(orch.settings, scenario_name, role) or _resolve_local_record(orch.settings, scenario_name)
     if record is None:
         return None
     plan = plan_local_client(record)

--- a/autocontext/src/autocontext/agents/scenario_bound_clients.py
+++ b/autocontext/src/autocontext/agents/scenario_bound_clients.py
@@ -167,9 +167,12 @@ def scenario_bound_mlx_client(orch: AgentOrchestrator, role: str, *, scenario_na
     while ``mlxlm`` / ``opd`` adapters rebuild ``MLXLMClient(base, adapter, score_conditioned=...)``.
     Returns ``None`` when nothing is resolvable, so the caller falls back to the default client.
     """
-    key: tuple[str, str | None, str, str]
+    # The served model id is part of the cache key: the serving manifest (AC-893) can route the same
+    # (scenario, role) to different full checkpoints over time (e.g. a fallback vs an ambient model),
+    # so a key without the model would keep serving the stale cached client.
+    key: tuple[str, str | None, str, str, str]
     if orch.settings.mlx_model_path:
-        key = ("mlx", None, scenario_name, role)
+        key = ("mlx", None, orch.settings.mlx_model_path, scenario_name, role)
         cached = orch._routed_clients.get(key)
         if cached is not None:
             return cached
@@ -189,7 +192,7 @@ def scenario_bound_mlx_client(orch: AgentOrchestrator, role: str, *, scenario_na
     if plan is None:
         return None
 
-    key = (plan.kind, plan.adapter_path, scenario_name, role)
+    key = (plan.kind, plan.adapter_path, plan.model, scenario_name, role)
     cached = orch._routed_clients.get(key)
     if cached is not None:
         return cached

--- a/autocontext/src/autocontext/ambient/promote.py
+++ b/autocontext/src/autocontext/ambient/promote.py
@@ -17,9 +17,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 
 from autocontext.ambient.charter import CharterTarget
+from autocontext.ambient.eligibility import split_role_selector
 from autocontext.ambient.policy import decide
+from autocontext.ambient.serving_manifest import write_serving_entry
 from autocontext.ambient.stage import StageContext, StageResult
 from autocontext.training.model_registry import DistilledModelRecord, ModelRegistry
 
@@ -33,6 +36,10 @@ class PromoteStage:
     name: str
     registry: ModelRegistry
     now_fn: Callable[[], str] = _default_now
+    # opt-in (AC-893): when set, record the (real_scenario, role) -> ambient target mapping so the
+    # serving resolver can bridge to a model slotted under the target name (AC-884 anti-collision).
+    # None (the default) leaves the promote path byte-unchanged: nothing is written.
+    serving_manifest_path: Path | None = None
 
     def run_once(self, ctx: StageContext) -> StageResult:
         processed = 0
@@ -90,6 +97,20 @@ class PromoteStage:
         # and demotes the incumbent to disabled, kept warm as the rollback target.
         self.registry.register(best)
         self.registry.activate(best.artifact_id)
+
+        if self.serving_manifest_path is not None:
+            # the registry slots the ambient record under the target name (AC-884), but generation
+            # resolves by the real scenario, so record the (scenario, role) -> target bridge. A bare
+            # role selector serves every scenario, held under the "*" bucket.
+            role, scenario = split_role_selector(target.selector)
+            write_serving_entry(
+                self.serving_manifest_path,
+                scenario=scenario or "*",
+                role=role,
+                target_name=target.name,
+                artifact_id=best.artifact_id,
+                backend=best.backend,
+            )
 
         ctx.emitter.emit(
             "promote_activated",

--- a/autocontext/src/autocontext/ambient/promote.py
+++ b/autocontext/src/autocontext/ambient/promote.py
@@ -96,12 +96,13 @@ class PromoteStage:
         # persist the probation marker while best is still a candidate; activate flips it to active
         # and demotes the incumbent to disabled, kept warm as the rollback target.
         self.registry.register(best)
-        self.registry.activate(best.artifact_id)
 
         if self.serving_manifest_path is not None:
             # the registry slots the ambient record under the target name (AC-884), but generation
             # resolves by the real scenario, so record the (scenario, role) -> target bridge. A bare
-            # role selector serves every scenario, held under the "*" bucket.
+            # role selector serves every scenario, held under the "*" bucket. Write the bridge BEFORE
+            # flipping the record active: a manifest-write failure then leaves the candidate
+            # un-activated (retried next cycle) rather than active-but-unrouted with no bridge.
             role, scenario = split_role_selector(target.selector)
             write_serving_entry(
                 self.serving_manifest_path,
@@ -111,6 +112,8 @@ class PromoteStage:
                 artifact_id=best.artifact_id,
                 backend=best.backend,
             )
+
+        self.registry.activate(best.artifact_id)
 
         ctx.emitter.emit(
             "promote_activated",

--- a/autocontext/src/autocontext/ambient/serving_manifest.py
+++ b/autocontext/src/autocontext/ambient/serving_manifest.py
@@ -1,0 +1,102 @@
+"""the ambient per-role serving manifest: bridges (real_scenario, role) to the ambient target (AC-893).
+
+A promoted ambient model is slotted in the registry under ``scenario = target.name`` so distinct
+targets cannot collide on one scenario slot (AC-884). But the generation loop resolves a local model
+by the REAL scenario, so it never finds that ambient record: the (real_scenario, role) -> target
+mapping lives only in ``CharterTarget.selector`` ("role@scenario"), which the serving path cannot see.
+
+This manifest is that bridge. The promote stage writes it when it activates an ambient candidate, and
+the serving resolver reads it to route the real (scenario, role) request to the slotted target name.
+
+Shape (JSON), keyed by scenario then role::
+
+    { "<scenario or '*'>": { "<role>": {"target_name": str, "artifact_id": str, "backend": str} } }
+
+The ``"*"`` bucket holds a bare-role selector (a role that serves every scenario); an exact-scenario
+entry wins over it. This is a tiny opt-in file (off unless ``ambient_serving_manifest_path`` is set),
+so it stays pure stdlib: no torch/mlx, no registry coupling.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_Manifest = dict[str, dict[str, dict[str, str]]]
+
+
+def _load(path: Path) -> _Manifest:
+    """Load the manifest, or an empty one if the file is absent or unreadable."""
+    try:
+        raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return raw
+
+
+def _write_atomic(path: Path, manifest: _Manifest) -> None:
+    """Write the manifest via a temp file + ``os.replace`` so a reader never sees a partial file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_serving_entry(
+    path: Path,
+    *,
+    scenario: str,
+    role: str,
+    target_name: str,
+    artifact_id: str,
+    backend: str,
+) -> None:
+    """Upsert the (scenario, role) serving entry, creating parent dirs and writing atomically.
+
+    ``scenario`` is the real scenario the request will arrive under, or ``"*"`` for a bare-role
+    selector that serves every scenario. A prior entry for the same (scenario, role) is superseded.
+    """
+    manifest = _load(path)
+    manifest.setdefault(scenario, {})[role] = {
+        "target_name": target_name,
+        "artifact_id": artifact_id,
+        "backend": backend,
+    }
+    _write_atomic(path, manifest)
+
+
+def lookup_serving_entry(path: Path, *, scenario: str, role: str) -> dict[str, str] | None:
+    """Return the serving entry for (scenario, role), or ``None`` if there is none.
+
+    An exact-scenario entry wins; otherwise the ``"*"`` bare-role bucket answers. An absent file
+    (feature never written for this run) returns ``None`` so the caller falls through to default.
+    """
+    if not path.exists():
+        return None
+    manifest = _load(path)
+    exact = manifest.get(scenario, {}).get(role)
+    if exact is not None:
+        return exact
+    return manifest.get("*", {}).get(role)
+
+
+def remove_serving_entry(path: Path, *, scenario: str, role: str) -> None:
+    """Remove the (scenario, role) entry if present (atomic write); a no-op if absent.
+
+    For rollback; the promote upsert already handles supersede, so this is only needed to retire an
+    entry entirely. Leaves sibling roles and scenarios untouched.
+    """
+    if not path.exists():
+        return
+    manifest = _load(path)
+    roles = manifest.get(scenario)
+    if not roles or role not in roles:
+        return
+    del roles[role]
+    if not roles:
+        del manifest[scenario]
+    _write_atomic(path, manifest)

--- a/autocontext/src/autocontext/ambient/stage_factory.py
+++ b/autocontext/src/autocontext/ambient/stage_factory.py
@@ -95,5 +95,7 @@ def build_stages(
         generate_fn=generate_fn,
         generation_config_id=gen_config_id,
     )
-    stages["promote"] = PromoteStage(name="promote", registry=registry)
+    stages["promote"] = PromoteStage(
+        name="promote", registry=registry, serving_manifest_path=settings.ambient_serving_manifest_path
+    )
     return stages

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -593,6 +593,10 @@ class AppSettings(BaseModel):
     architect_base_url: str = Field(default="", description="Base URL override for architect role")
     # MLX local model inference (AC-182)
     mlx_model_path: str = Field(default="", description="Path to trained MLX model checkpoint directory")
+    ambient_serving_manifest_path: Path | None = Field(
+        default=None,
+        description="Ambient per-role serving manifest; when set, promote writes it and the serving resolver reads it (AC-893)",
+    )
     mlx_temperature: float = Field(default=0.8, ge=0.0, le=2.0, description="Sampling temperature for MLX model")
     mlx_max_tokens: int = Field(default=512, ge=1, description="Max generation tokens for MLX model")
     # OpenClaw agent adapter (AC-193)

--- a/autocontext/tests/test_ambient_promote_stage.py
+++ b/autocontext/tests/test_ambient_promote_stage.py
@@ -390,3 +390,25 @@ def test_promote_default_none_writes_no_manifest(tmp_path: Path) -> None:
     promoted = registry.load("cand-1")
     assert promoted is not None and promoted.activation_state == "active"
     assert not manifest_path.exists()
+
+
+def test_promote_does_not_activate_when_manifest_write_fails(monkeypatch: Any, tmp_path: Path) -> None:
+    # AC-893 review P2-1: the routing bridge is written BEFORE activation, so a manifest-write
+    # failure leaves the candidate un-activated (retried next cycle) rather than active-but-unrouted.
+    import autocontext.ambient.promote as promote_mod
+
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_scoped_target("competitor-local", "competitor@grid_ctf")])
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise OSError("manifest disk full")
+
+    monkeypatch.setattr(promote_mod, "write_serving_entry", boom)
+    stage = PromoteStage(name="promote", registry=registry, now_fn=lambda: _NOW, serving_manifest_path=tmp_path / "serving.json")
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (0, 1)  # the write failure surfaced as a target error
+    reloaded = registry.load("cand-1")
+    assert reloaded is not None and reloaded.activation_state == "candidate"  # NOT activated

--- a/autocontext/tests/test_ambient_promote_stage.py
+++ b/autocontext/tests/test_ambient_promote_stage.py
@@ -326,3 +326,67 @@ def test_no_candidates_is_quiet(tmp_path: Path) -> None:
 
     assert (result.processed, result.errors) == (0, 0)
     assert _events(tmp_path) == []
+
+
+# --- serving manifest bridge (AC-893) ----------------------------------------------------------
+
+
+def _scoped_target(name: str, selector: str) -> CharterTarget:
+    return CharterTarget(
+        name=name,
+        kind="role",
+        selector=selector,
+        base_model="tiny",
+        min_dataset_records=5,
+        eval_suite="anchor-v1",
+    )
+
+
+def test_promote_writes_serving_manifest_for_scoped_selector(tmp_path: Path) -> None:
+    from autocontext.ambient.serving_manifest import lookup_serving_entry
+
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_scoped_target("competitor-local", "competitor@grid_ctf")])
+    manifest_path = tmp_path / "serving.json"
+    stage = PromoteStage(name="promote", registry=registry, now_fn=lambda: _NOW, serving_manifest_path=manifest_path)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    entry = lookup_serving_entry(manifest_path, scenario="grid_ctf", role="competitor")
+    assert entry == {"target_name": "competitor-local", "artifact_id": "cand-1", "backend": "mlx"}
+
+
+def test_promote_writes_bare_selector_under_wildcard(tmp_path: Path) -> None:
+    from autocontext.ambient.serving_manifest import lookup_serving_entry
+
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_scoped_target("competitor-local", "competitor")])
+    manifest_path = tmp_path / "serving.json"
+    stage = PromoteStage(name="promote", registry=registry, now_fn=lambda: _NOW, serving_manifest_path=manifest_path)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    assert (result.processed, result.errors) == (1, 0)
+    # a bare-role selector serves every scenario, so it lands in the "*" bucket and answers for any.
+    entry = lookup_serving_entry(manifest_path, scenario="othello", role="competitor")
+    assert entry == {"target_name": "competitor-local", "artifact_id": "cand-1", "backend": "mlx"}
+
+
+def test_promote_default_none_writes_no_manifest(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path / "registry")
+    _record(registry, "cand-1", "competitor-local", state="candidate", eval_meta=_eval(0.8))
+    charter = _charter([_scoped_target("competitor-local", "competitor@grid_ctf")])
+    manifest_path = tmp_path / "serving.json"
+    # default serving_manifest_path is None: promote must not write the manifest.
+    stage = PromoteStage(name="promote", registry=registry, now_fn=lambda: _NOW)
+
+    result = stage.run_once(_ctx(tmp_path, charter))
+
+    # existing promote behavior is unchanged and nothing is written.
+    assert (result.processed, result.errors) == (1, 0)
+    promoted = registry.load("cand-1")
+    assert promoted is not None and promoted.activation_state == "active"
+    assert not manifest_path.exists()

--- a/autocontext/tests/test_ambient_serving_manifest.py
+++ b/autocontext/tests/test_ambient_serving_manifest.py
@@ -1,0 +1,129 @@
+"""tests for the ambient serving manifest: the (scenario, role) -> ambient target bridge (AC-893).
+
+A promoted ambient model is slotted in the registry under ``scenario = target.name`` (AC-884
+anti-collision), so the generation loop, which resolves by the REAL scenario, never finds it. The
+serving manifest carries the (real_scenario, role) -> target mapping that otherwise lived only in
+``CharterTarget.selector``, so the serving resolver can bridge to the ambient record.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.ambient.serving_manifest import (
+    lookup_serving_entry,
+    remove_serving_entry,
+    write_serving_entry,
+)
+
+
+def test_write_then_lookup_exact_scenario_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "serving.json"
+    write_serving_entry(
+        path,
+        scenario="grid_ctf",
+        role="competitor",
+        target_name="competitor-local",
+        artifact_id="cand-1",
+        backend="mlx",
+    )
+
+    entry = lookup_serving_entry(path, scenario="grid_ctf", role="competitor")
+
+    assert entry == {"target_name": "competitor-local", "artifact_id": "cand-1", "backend": "mlx"}
+
+
+def test_bare_role_wildcard_fallback_serves_every_scenario(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(
+        path,
+        scenario="*",
+        role="competitor",
+        target_name="competitor-any",
+        artifact_id="cand-9",
+        backend="mlxlm",
+    )
+
+    # no exact grid_ctf entry, so the "*" bucket answers for any scenario.
+    entry = lookup_serving_entry(path, scenario="grid_ctf", role="competitor")
+
+    assert entry == {"target_name": "competitor-any", "artifact_id": "cand-9", "backend": "mlxlm"}
+
+
+def test_exact_scenario_wins_over_wildcard(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(path, scenario="*", role="competitor", target_name="any", artifact_id="a", backend="mlx")
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="scoped", artifact_id="s", backend="mlxlm")
+
+    entry = lookup_serving_entry(path, scenario="grid_ctf", role="competitor")
+
+    assert entry is not None and entry["target_name"] == "scoped"
+
+
+def test_lookup_absent_file_returns_none(tmp_path: Path) -> None:
+    assert lookup_serving_entry(tmp_path / "missing.json", scenario="grid_ctf", role="competitor") is None
+
+
+def test_lookup_unknown_role_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="c", artifact_id="a", backend="mlx")
+
+    assert lookup_serving_entry(path, scenario="grid_ctf", role="judge") is None
+
+
+def test_upsert_supersedes_prior_entry_for_same_scenario_role(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="old", artifact_id="old-a", backend="mlx")
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="new", artifact_id="new-a", backend="mlxlm")
+
+    entry = lookup_serving_entry(path, scenario="grid_ctf", role="competitor")
+
+    assert entry == {"target_name": "new", "artifact_id": "new-a", "backend": "mlxlm"}
+
+
+def test_write_preserves_other_scenarios_and_roles(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="c", artifact_id="ca", backend="mlx")
+    write_serving_entry(path, scenario="othello", role="analyst", target_name="a", artifact_id="aa", backend="mlxlm")
+
+    assert lookup_serving_entry(path, scenario="grid_ctf", role="competitor") is not None
+    assert lookup_serving_entry(path, scenario="othello", role="analyst") is not None
+
+
+def test_remove_deletes_an_entry(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="c", artifact_id="ca", backend="mlx")
+
+    remove_serving_entry(path, scenario="grid_ctf", role="competitor")
+
+    assert lookup_serving_entry(path, scenario="grid_ctf", role="competitor") is None
+
+
+def test_remove_is_noop_when_absent(tmp_path: Path) -> None:
+    path = tmp_path / "missing.json"
+    # no exception, no file created.
+    remove_serving_entry(path, scenario="grid_ctf", role="competitor")
+    assert not path.exists()
+
+
+def test_remove_leaves_sibling_entries_intact(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="c", artifact_id="ca", backend="mlx")
+    write_serving_entry(path, scenario="grid_ctf", role="analyst", target_name="a", artifact_id="aa", backend="mlx")
+
+    remove_serving_entry(path, scenario="grid_ctf", role="competitor")
+
+    assert lookup_serving_entry(path, scenario="grid_ctf", role="competitor") is None
+    assert lookup_serving_entry(path, scenario="grid_ctf", role="analyst") is not None
+
+
+def test_atomic_write_leaves_valid_json_on_disk(tmp_path: Path) -> None:
+    path = tmp_path / "serving.json"
+    write_serving_entry(path, scenario="grid_ctf", role="competitor", target_name="c", artifact_id="ca", backend="mlx")
+
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+
+    assert loaded == {"grid_ctf": {"competitor": {"target_name": "c", "artifact_id": "ca", "backend": "mlx"}}}
+    # no leftover temp files beside the manifest.
+    assert [p.name for p in tmp_path.iterdir()] == ["serving.json"]

--- a/autocontext/tests/test_ambient_serving_resolver.py
+++ b/autocontext/tests/test_ambient_serving_resolver.py
@@ -1,0 +1,151 @@
+"""the serving resolver reads the ambient manifest to route (scenario, role) -> ambient target (AC-893).
+
+``scenario_bound_mlx_client`` resolves a local model by the REAL scenario, but the ambient trainer
+slots a promoted per-role model under ``scenario = target.name`` (AC-884). With the opt-in serving
+manifest configured, the resolver first consults the manifest and resolves the record slotted under
+the target name; with no manifest configured it must behave exactly as before (scenario-keyed). These
+tests exercise both paths with fakes only, so no mlx / torch is ever imported.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import autocontext.agents.scenario_bound_clients as sbc
+from autocontext.ambient.serving_manifest import write_serving_entry
+from autocontext.config.settings import AppSettings
+from autocontext.training.model_registry import DistilledModelRecord
+
+
+class _FakeClient:
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+
+class _FakeOrch:
+    """Minimal stand-in exposing the three attributes ``scenario_bound_mlx_client`` touches."""
+
+    def __init__(self, settings: AppSettings) -> None:
+        self.settings = settings
+        self._routed_clients: dict[Any, Any] = {}
+
+    def _wrap_client(self, client: Any, *, provider_name: str) -> Any:
+        client.provider_name = provider_name
+        return client
+
+
+def _record(scenario: str, artifact_id: str) -> DistilledModelRecord:
+    return DistilledModelRecord(
+        artifact_id=artifact_id,
+        scenario=scenario,
+        scenario_family="",
+        backend="mlx",
+        checkpoint_path=f"/ckpt/{artifact_id}",
+        runtime_types=["provider"],
+        activation_state="active",
+        training_metrics={},
+        provenance={},
+    )
+
+
+def test_manifest_hit_resolves_ambient_record_by_target_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import autocontext.training.model_registry as mr
+
+    manifest_path = tmp_path / "serving.json"
+    write_serving_entry(
+        manifest_path,
+        scenario="grid_ctf",
+        role="competitor",
+        target_name="competitor-local",
+        artifact_id="amb-1",
+        backend="mlx",
+    )
+
+    queried: list[str] = []
+
+    def fake_resolve(registry: Any, *, scenario: str, backend: str, runtime_type: str) -> Any:
+        queried.append(scenario)
+        # only the ambient target-name slot resolves; the real scenario would miss.
+        return _record(scenario, "amb-1") if scenario == "competitor-local" else None
+
+    monkeypatch.setattr(mr, "resolve_model", fake_resolve)
+    monkeypatch.setattr(mr, "ModelRegistry", lambda root: object())
+    monkeypatch.setattr(sbc, "build_planned_client", lambda plan, settings: _FakeClient("ambient"))
+
+    settings = AppSettings(
+        agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path, ambient_serving_manifest_path=manifest_path
+    )
+    orch = _FakeOrch(settings)
+
+    client = sbc.scenario_bound_mlx_client(orch, "competitor", scenario_name="grid_ctf")
+
+    assert isinstance(client, _FakeClient) and client.tag == "ambient"
+    assert client.provider_name == "mlx:competitor"
+    # the ambient bridge resolved by the target name, not the real scenario.
+    assert queried == ["competitor-local"]
+    # and the built client is cached.
+    assert orch._routed_clients[("mlx", None, "grid_ctf", "competitor")] is client
+
+
+def test_no_manifest_path_falls_back_to_scenario_keyed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import autocontext.training.model_registry as mr
+
+    queried: list[str] = []
+
+    def fake_resolve(registry: Any, *, scenario: str, backend: str, runtime_type: str) -> Any:
+        queried.append(scenario)
+        # the existing resolver queries by the real scenario across backends; answer on the first.
+        return _record(scenario, "local-1") if backend == "opd" else None
+
+    monkeypatch.setattr(mr, "resolve_model", fake_resolve)
+    monkeypatch.setattr(mr, "ModelRegistry", lambda root: object())
+    monkeypatch.setattr(sbc, "build_planned_client", lambda plan, settings: _FakeClient("local"))
+
+    # ambient_serving_manifest_path defaults to None: byte-unchanged behavior.
+    settings = AppSettings(agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path)
+    orch = _FakeOrch(settings)
+
+    client = sbc.scenario_bound_mlx_client(orch, "competitor", scenario_name="grid_ctf")
+
+    assert isinstance(client, _FakeClient) and client.tag == "local"
+    # resolution used the real scenario only (no ambient target-name lookup happened).
+    assert queried == ["grid_ctf"]
+
+
+def test_manifest_miss_for_role_falls_back_to_scenario_keyed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import autocontext.training.model_registry as mr
+
+    manifest_path = tmp_path / "serving.json"
+    # an entry exists for a different role, so the requested role misses and we fall through.
+    write_serving_entry(
+        manifest_path,
+        scenario="grid_ctf",
+        role="analyst",
+        target_name="analyst-local",
+        artifact_id="amb-2",
+        backend="mlx",
+    )
+
+    queried: list[str] = []
+
+    def fake_resolve(registry: Any, *, scenario: str, backend: str, runtime_type: str) -> Any:
+        queried.append(scenario)
+        return _record(scenario, "local-1") if backend == "opd" else None
+
+    monkeypatch.setattr(mr, "resolve_model", fake_resolve)
+    monkeypatch.setattr(mr, "ModelRegistry", lambda root: object())
+    monkeypatch.setattr(sbc, "build_planned_client", lambda plan, settings: _FakeClient("local"))
+
+    settings = AppSettings(
+        agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path, ambient_serving_manifest_path=manifest_path
+    )
+    orch = _FakeOrch(settings)
+
+    client = sbc.scenario_bound_mlx_client(orch, "competitor", scenario_name="grid_ctf")
+
+    assert isinstance(client, _FakeClient) and client.tag == "local"
+    # no ambient target-name lookup (role missed); only the real scenario was queried.
+    assert queried == ["grid_ctf"]

--- a/autocontext/tests/test_ambient_serving_resolver.py
+++ b/autocontext/tests/test_ambient_serving_resolver.py
@@ -86,8 +86,9 @@ def test_manifest_hit_resolves_ambient_record_by_target_name(monkeypatch: pytest
     assert client.provider_name == "mlx:competitor"
     # the ambient bridge resolved by the target name, not the real scenario.
     assert queried == ["competitor-local"]
-    # and the built client is cached.
-    assert orch._routed_clients[("mlx", None, "grid_ctf", "competitor")] is client
+    # and the built client is cached under a key that includes the served model id (the ambient
+    # checkpoint), so a later route to a different model does not return this stale client.
+    assert orch._routed_clients[("mlx", None, "/ckpt/amb-1", "grid_ctf", "competitor")] is client
 
 
 def test_no_manifest_path_falls_back_to_scenario_keyed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -149,3 +150,45 @@ def test_manifest_miss_for_role_falls_back_to_scenario_keyed(monkeypatch: pytest
     assert isinstance(client, _FakeClient) and client.tag == "local"
     # no ambient target-name lookup (role missed); only the real scenario was queried.
     assert queried == ["grid_ctf"]
+
+
+def test_route_change_serves_new_model_not_stale_cached_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # AC-893 review P2-2: two full checkpoints for the same (scenario, role) must not collide in the
+    # routed-client cache. A fallback client is served first; once the manifest routes the role to a
+    # different ambient checkpoint, the resolver must serve the NEW model, not the cached fallback.
+    import autocontext.training.model_registry as mr
+
+    manifest_path = tmp_path / "serving.json"
+
+    def fake_resolve(registry: Any, *, scenario: str, backend: str, runtime_type: str) -> Any:
+        # ambient target-name slot resolves to /ckpt/ambient; the real scenario resolves to /ckpt/local.
+        if scenario == "competitor-local":
+            return _record("competitor-local", "ambient")
+        return _record(scenario, "local") if backend == "opd" else None
+
+    # each build tags the client with the plan's served model so we can tell them apart.
+    monkeypatch.setattr(mr, "resolve_model", fake_resolve)
+    monkeypatch.setattr(mr, "ModelRegistry", lambda root: object())
+    monkeypatch.setattr(sbc, "build_planned_client", lambda plan, settings: _FakeClient(plan.model))
+
+    settings = AppSettings(
+        agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path, ambient_serving_manifest_path=manifest_path
+    )
+    orch = _FakeOrch(settings)
+
+    # 1) no manifest entry yet -> fallback resolves by real scenario -> /ckpt/local.
+    first = sbc.scenario_bound_mlx_client(orch, "competitor", scenario_name="grid_ctf")
+    assert isinstance(first, _FakeClient) and first.tag == "/ckpt/local"
+
+    # 2) manifest now routes the role to the ambient target -> /ckpt/ambient (a DIFFERENT full checkpoint).
+    write_serving_entry(
+        manifest_path,
+        scenario="grid_ctf",
+        role="competitor",
+        target_name="competitor-local",
+        artifact_id="ambient",
+        backend="mlx",
+    )
+    second = sbc.scenario_bound_mlx_client(orch, "competitor", scenario_name="grid_ctf")
+    assert isinstance(second, _FakeClient) and second.tag == "/ckpt/ambient"  # NOT the stale /ckpt/local
+    assert second is not first

--- a/docs/ambient-trainer-design.md
+++ b/docs/ambient-trainer-design.md
@@ -133,6 +133,18 @@ unless the charter's priority says training wins.
   vllm provider path routes role traffic. The previous checkpoint stays warm
   through a probation window (charter-defined: N runs or M days within
   quality-delta and error-rate bounds); rollback is one registry flip.
+- **Per-role live-serving bridge (opt-in, AC-893)**: ambient candidates are
+  slotted in the registry by target name (so activation never cross-demotes a
+  sibling, AC-884), but the generation loop resolves a local model by the real
+  scenario. The bridge is a serving manifest that the promote stage writes on
+  activation ((real scenario, role) -> target/artifact/backend) and the serving
+  resolver reads before its scenario-keyed lookup. It is off by default. To turn
+  it on, set the SAME manifest path for BOTH sides via
+  `AUTOCONTEXT_AMBIENT_SERVING_MANIFEST_PATH`: the ambient daemon (which runs the
+  promote stage) and the generation-loop process (which resolves the served
+  client) must point at one shared file, or the bridge writes and reads never
+  meet. A bare-role selector (`competitor`) serves every scenario; a scoped
+  selector (`competitor@grid_ctf`) serves only that scenario.
 - **Frontier fraction**: the router keeps the charter's minimum share of role
   traffic on frontier APIs so the reference distribution never dries up and a
   live comparison population always exists.


### PR DESCRIPTION
Implements AC-893, the last piece of the eval/serve-on-real-hardware wave: a promoted ambient model can now serve its role in a live run. Opt-in, default off (byte-unchanged). Python-only (ambient has no TS mirror).

## Problem

Ambient candidates are slotted in the registry by `scenario = target.name` (the AC-884 anti-collision design), but the generation loop resolves a local model by the REAL scenario (`resolve_model(..., scenario=<real scenario>)`). So a promoted ambient model was never found by the serving path, the `(real_scenario, role) -> target` mapping lived only in `CharterTarget.selector` ("role@scenario"), which the resolver couldn't see.

## Fix (serving manifest, option A of the issue)

- **`ambient/serving_manifest.py`**: a tiny JSON manifest keyed `scenario -> role -> {target_name, artifact_id, backend}` (`"*"` bucket for a bare-role selector that serves every scenario), with atomic `write_serving_entry` / `lookup_serving_entry` (exact-scenario then `*` fallback) / `remove_serving_entry`.
- **PromoteStage**: gains an optional `serving_manifest_path`; on a successful `activate`, it splits `target.selector` into `(role, scenario)` and upserts the entry. Nothing is written when the path is unset.
- **Resolver** (`scenario_bound_mlx_client`): when the manifest path is set, it looks up `(scenario, role)` first and resolves the ambient record by its `target_name` slot (via the existing `plan_local_client`/`build_planned_client` path); with no manifest, behavior is byte-unchanged.
- **Setting**: `ambient_serving_manifest_path: Path | None = None` (default off) wires both sides to one path.

Rejected alternatives (documented in the issue): re-registering under the real scenario reintroduces the AC-884 cross-demote risk; giving the resolver the charter couples the generation loop to ambient policy.

## Tests

Manifest round-trips (exact + `*` fallback, upsert-supersede, remove, absent-file), promote writes the right entry for scoped and bare selectors (and writes nothing when off), and the resolver picks the ambient record by target name via the manifest (fakes only, no torch/mlx). ruff, mypy, module-size guard, gate-taxonomy invariant, full ambient/scenario_bound suites green.

## Scope / follow-up

This is the CI-green wiring slice. The real-hardware end-to-end (promote writes manifest -> resolver reads -> serves an sft adapter on a T4) is the recommended validation before merge; the sft serving primitive it rides on is already T4-proven (#1191). Happy to add that Modal validation next.

Left open for your review (not merged). Closes AC-893 once the end-to-end validation lands.