### PR TITLE
feat(erp-67): per-role system / untrusted-reference prompt split (Stage 1)

### DIFF
--- a/autocontext/src/autocontext/prompts/__init__.py
+++ b/autocontext/src/autocontext/prompts/__init__.py
@@ -1,5 +1,5 @@
 from .context_budget import ContextBudget, ContextBudgetPolicy, ContextBudgetResult, ContextBudgetTelemetry, estimate_tokens
-from .templates import PromptBundle, build_prompt_bundle
+from .templates import PromptBundle, PromptPartsBundle, RolePromptParts, build_prompt_bundle
 
 __all__ = [
     "ContextBudget",
@@ -7,6 +7,8 @@ __all__ = [
     "ContextBudgetResult",
     "ContextBudgetTelemetry",
     "PromptBundle",
+    "PromptPartsBundle",
+    "RolePromptParts",
     "build_prompt_bundle",
     "estimate_tokens",
 ]

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -59,6 +59,28 @@ class PromptBundle:
     architect: str
 
 
+@dataclass(frozen=True)
+class RolePromptParts:
+    """A role prompt separated into trusted `system` and `untrusted_reference`
+    (attacker-influenceable playbook / coach hints / dead-ends), plus the exact
+    `flat` string the transport currently sends. Stage 1 of ERP-67: the split is
+    exposed for consumers but `flat` remains byte-identical to today's prompt, so
+    behaviour is unchanged until a later stage threads system/user message roles.
+    """
+
+    system: str
+    untrusted_reference: str
+    flat: str
+
+
+@dataclass(frozen=True)
+class PromptPartsBundle:
+    competitor: RolePromptParts
+    analyst: RolePromptParts
+    coach: RolePromptParts
+    architect: RolePromptParts
+
+
 def _prompt_bundle_roles(bundle: PromptBundle) -> dict[str, str]:
     return {
         "competitor": bundle.competitor,
@@ -171,6 +193,7 @@ def build_prompt_bundle(
     simplicity_mode: str = "off",
     hint_style: str = "default",
     scout_mutation_guidance: str = "",
+    prompt_parts_sink: Callable[[PromptPartsBundle], None] | None = None,
 ) -> PromptBundle:
     _nb = dict(notebook_contexts or {})
     _evidence = dict(evidence_manifests or {})
@@ -308,7 +331,10 @@ def build_prompt_bundle(
     analyst_evidence_block = f"{analyst_evidence_manifest}\n\n" if analyst_evidence_manifest else ""
     architect_evidence_block = f"{architect_evidence_manifest}\n\n" if architect_evidence_manifest else ""
     playbook_fenced = _fence_untrusted("current playbook", f"Current playbook:\n{current_playbook}")
-    base_context = (
+    # Segmented so the untrusted blocks (playbook, dead-ends) can be isolated
+    # for prompt_parts_sink (ERP-67 Stage 1). The concatenation below is
+    # byte-identical to the previous single f-string — flat behaviour unchanged.
+    _base_context_head = (
         f"{_UNTRUSTED_GUARDRAIL}"
         f"Scenario rules:\n{scenario_rules}\n\n"
         f"Strategy interface:\n{strategy_interface}\n\n"
@@ -317,7 +343,9 @@ def build_prompt_bundle(
         f"Observation state:\n{observation.state}\n\n"
         f"Constraints:\n{observation.constraints}\n\n"
         f"{snapshot_block}"
-        f"{playbook_fenced}\n\n"
+    )
+    _playbook_block = f"{playbook_fenced}\n\n"
+    _base_context_mid = (
         f"{lessons_block}"
         f"{analysis_block}"
         f"{replay_block}"
@@ -325,12 +353,13 @@ def build_prompt_bundle(
         f"Previous generation summary:\n{previous_summary}\n"
         f"{trajectory_block}"
         f"{registry_block}"
-        f"{dead_ends_block}"
-        f"{progress_block}"
-        f"{experiment_log_block}"
-        f"{protocol_block}"
-        f"{session_reports_block}"
     )
+    _base_context_tail = f"{progress_block}{experiment_log_block}{protocol_block}{session_reports_block}"
+    base_context = _base_context_head + _playbook_block + _base_context_mid + dead_ends_block + _base_context_tail
+    # Trusted (system) vs untrusted (attacker-influenceable) portions of the
+    # shared base context, used only to build the prompt-parts split.
+    base_context_trusted = _base_context_head + _base_context_mid + _base_context_tail
+    base_context_untrusted = _playbook_block + dead_ends_block
     hints_block = ""
     if coach_competitor_hints:
         _hints_fenced = _fence_untrusted("coach hints", f"Coach hints for competitor:\n{coach_competitor_hints}")
@@ -365,6 +394,51 @@ def build_prompt_bundle(
         if is_action_plan_interface(strategy_interface)
         else "Describe your strategy reasoning and recommend specific parameter values."
     )
+    analyst_task = (
+        "Analyze strengths/failures and return markdown with sections: Findings, Root Causes, Actionable Recommendations."
+    )
+    coach_task = (
+        "You are the playbook coach. Produce THREE structured sections:\n\n"
+        "1. A COMPLETE replacement playbook between markers. Consolidate all prior guidance, "
+        "deduplicate, and remove stale advice. This replaces the current playbook entirely.\n\n"
+        "<!-- PLAYBOOK_START -->\n"
+        "(Your consolidated playbook here: Strategy Updates, Prompt Optimizations, "
+        "Next Generation Checklist)\n"
+        "<!-- PLAYBOOK_END -->\n\n"
+        "2. Operational lessons learned between markers. Each lesson should be a concrete, "
+        "prescriptive rule derived from what worked or failed.\n\n"
+        "<!-- LESSONS_START -->\n"
+        "(e.g. '- When aggression > 0.8 with defense < 0.4, scores drop.')\n"
+        "<!-- LESSONS_END -->\n\n" + coach_hint_instruction
+    )
+    architect_task = (
+        "Propose infrastructure/tooling improvements in markdown with sections: "
+        "Observed Bottlenecks, Tool Proposals, Impact Hypothesis. "
+        "Then append a JSON code block with shape "
+        '{"tools":[{"name":"<snake_case>","description":"<text>","code":"<python code>"}]}. '
+        "If no new tools, return tools as empty array."
+        " You may CREATE new tools or UPDATE existing tools by using the same name.\n\n"
+        "Additionally, you may propose harness validators — executable Python checks "
+        "that run against each strategy BEFORE tournament matches. Each validator must "
+        "define `validate_strategy(strategy: dict, scenario) -> tuple[bool, list[str]]`. "
+        "Wrap harness specs between markers:\n\n"
+        "<!-- HARNESS_START -->\n"
+        '{"harness":[{"name":"<snake_case>","description":"<text>",'
+        '"code":"def validate_strategy(strategy, scenario):\\n    ..."}]}\n'
+        "<!-- HARNESS_END -->\n\n"
+        "If no harness validators, omit the HARNESS markers entirely.\n\n"
+        "Additionally, you may propose harness mutations — lightweight prompt, "
+        "context, completion, or tool-usage adjustments that carry forward to future generations. "
+        "Wrap mutation specs between markers:\n\n"
+        "<!-- MUTATIONS_START -->\n"
+        '{"mutations":[{"type":"prompt_fragment","target_role":"<competitor|analyst|coach|architect>",'
+        '"content":"<text>","rationale":"<why>"},{"type":"context_policy","component":"<component>",'
+        '"content":"<policy>","rationale":"<why>"},{"type":"completion_check","content":"<check>",'
+        '"rationale":"<why>"},{"type":"tool_instruction","tool_name":"<tool_name>",'
+        '"content":"<instruction>","rationale":"<why>"}]}\n'
+        "<!-- MUTATIONS_END -->\n\n"
+        "If no harness mutations, omit the MUTATIONS markers entirely."
+    )
 
     bundle = PromptBundle(
         competitor=base_context + hints_block + scout_block + competitor_nb + competitor_constraint + competitor_task,
@@ -374,61 +448,21 @@ def build_prompt_bundle(
         + analyst_attribution_block
         + analyst_nb
         + analyst_constraint
-        + ("Analyze strengths/failures and return markdown with sections: Findings, Root Causes, Actionable Recommendations."),
+        + analyst_task,
         coach=base_context
         + coach_attribution_block
         + coach_hint_feedback_block
         + coach_nb
         + coach_constraint
         + hint_policy_block
-        + (
-            "You are the playbook coach. Produce THREE structured sections:\n\n"
-            "1. A COMPLETE replacement playbook between markers. Consolidate all prior guidance, "
-            "deduplicate, and remove stale advice. This replaces the current playbook entirely.\n\n"
-            "<!-- PLAYBOOK_START -->\n"
-            "(Your consolidated playbook here: Strategy Updates, Prompt Optimizations, "
-            "Next Generation Checklist)\n"
-            "<!-- PLAYBOOK_END -->\n\n"
-            "2. Operational lessons learned between markers. Each lesson should be a concrete, "
-            "prescriptive rule derived from what worked or failed.\n\n"
-            "<!-- LESSONS_START -->\n"
-            "(e.g. '- When aggression > 0.8 with defense < 0.4, scores drop.')\n"
-            "<!-- LESSONS_END -->\n\n" + coach_hint_instruction
-        ),
+        + coach_task,
         architect=base_context
         + architect_evidence_block
         + tool_usage_block
         + architect_attribution_block
         + architect_nb
         + architect_constraint
-        + (
-            "Propose infrastructure/tooling improvements in markdown with sections: "
-            "Observed Bottlenecks, Tool Proposals, Impact Hypothesis. "
-            "Then append a JSON code block with shape "
-            '{"tools":[{"name":"<snake_case>","description":"<text>","code":"<python code>"}]}. '
-            "If no new tools, return tools as empty array."
-            " You may CREATE new tools or UPDATE existing tools by using the same name.\n\n"
-            "Additionally, you may propose harness validators — executable Python checks "
-            "that run against each strategy BEFORE tournament matches. Each validator must "
-            "define `validate_strategy(strategy: dict, scenario) -> tuple[bool, list[str]]`. "
-            "Wrap harness specs between markers:\n\n"
-            "<!-- HARNESS_START -->\n"
-            '{"harness":[{"name":"<snake_case>","description":"<text>",'
-            '"code":"def validate_strategy(strategy, scenario):\\n    ..."}]}\n'
-            "<!-- HARNESS_END -->\n\n"
-            "If no harness validators, omit the HARNESS markers entirely.\n\n"
-            "Additionally, you may propose harness mutations — lightweight prompt, "
-            "context, completion, or tool-usage adjustments that carry forward to future generations. "
-            "Wrap mutation specs between markers:\n\n"
-            "<!-- MUTATIONS_START -->\n"
-            '{"mutations":[{"type":"prompt_fragment","target_role":"<competitor|analyst|coach|architect>",'
-            '"content":"<text>","rationale":"<why>"},{"type":"context_policy","component":"<component>",'
-            '"content":"<policy>","rationale":"<why>"},{"type":"completion_check","content":"<check>",'
-            '"rationale":"<why>"},{"type":"tool_instruction","tool_name":"<tool_name>",'
-            '"content":"<instruction>","rationale":"<why>"}]}\n'
-            "<!-- MUTATIONS_END -->\n\n"
-            "If no harness mutations, omit the MUTATIONS markers entirely."
-        ),
+        + architect_task,
     )
     final_bundle = PromptBundle(
         competitor=append_simplicity_guidance(bundle.competitor, simplicity_mode),
@@ -459,6 +493,69 @@ def build_prompt_bundle(
             _selected_context_components(
                 context_components,
                 _prompt_bundle_roles(final_bundle),
+            )
+        )
+    if prompt_parts_sink is not None:
+        # ERP-67 Stage 1: expose the trusted `system` / untrusted-reference split
+        # per role. `flat` stays the exact string the transport sends today; the
+        # split is additive and behaviour-preserving. Simplicity guidance is
+        # trusted operator text, so it belongs in `system`.
+        competitor_system = append_simplicity_guidance(
+            base_context_trusted + scout_block + competitor_nb + competitor_constraint + competitor_task,
+            simplicity_mode,
+        )
+        analyst_system = append_simplicity_guidance(
+            base_context_trusted
+            + analyst_evidence_block
+            + analyst_feedback_block
+            + analyst_attribution_block
+            + analyst_nb
+            + analyst_constraint
+            + analyst_task,
+            simplicity_mode,
+        )
+        coach_system = append_simplicity_guidance(
+            base_context_trusted
+            + coach_attribution_block
+            + coach_hint_feedback_block
+            + coach_nb
+            + coach_constraint
+            + hint_policy_block
+            + coach_task,
+            simplicity_mode,
+        )
+        architect_system = append_simplicity_guidance(
+            base_context_trusted
+            + architect_evidence_block
+            + tool_usage_block
+            + architect_attribution_block
+            + architect_nb
+            + architect_constraint
+            + architect_task,
+            simplicity_mode,
+        )
+        prompt_parts_sink(
+            PromptPartsBundle(
+                competitor=RolePromptParts(
+                    system=competitor_system,
+                    untrusted_reference=base_context_untrusted + hints_block,
+                    flat=final_bundle.competitor,
+                ),
+                analyst=RolePromptParts(
+                    system=analyst_system,
+                    untrusted_reference=base_context_untrusted,
+                    flat=final_bundle.analyst,
+                ),
+                coach=RolePromptParts(
+                    system=coach_system,
+                    untrusted_reference=base_context_untrusted,
+                    flat=final_bundle.coach,
+                ),
+                architect=RolePromptParts(
+                    system=architect_system,
+                    untrusted_reference=base_context_untrusted,
+                    flat=final_bundle.architect,
+                ),
             )
         )
     return final_bundle

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -66,11 +66,20 @@ class RolePromptParts:
     `flat` string the transport currently sends. Stage 1 of ERP-67: the split is
     exposed for consumers but `flat` remains byte-identical to today's prompt, so
     behaviour is unchanged until a later stage threads system/user message roles.
+
+    `isolation_safe` is False when a `HookEvents.CONTEXT` hook rewrote this role's
+    final prompt: the pre-hook (system, untrusted_reference) split can no longer be
+    trusted to match `flat`, so consumers MUST use `flat` (or the safe fallback
+    below) rather than re-isolating stale content. In that case `system` is empty
+    and `untrusted_reference` holds the full post-hook prompt, which degrades to
+    the single-prompt transport path — nothing the hook redacted is reintroduced,
+    and no untrusted content is promoted into a system turn.
     """
 
     system: str
     untrusted_reference: str
     flat: str
+    isolation_safe: bool = True
 
 
 @dataclass(frozen=True)
@@ -470,6 +479,11 @@ def build_prompt_bundle(
         coach=append_simplicity_guidance(bundle.coach, simplicity_mode),
         architect=append_simplicity_guidance(bundle.architect, simplicity_mode),
     )
+    # Snapshot before the CONTEXT hook may rewrite role prompts. The prompt-parts
+    # split is derived from pre-hook variables, so a role the hook rewrites can no
+    # longer be trusted to match `flat` — compared per role below to mark parts
+    # unsafe and fall back rather than reintroducing hook-redacted content.
+    pre_hook_bundle = final_bundle
     if hook_bus is not None:
         context_event = hook_bus.emit(
             HookEvents.CONTEXT,
@@ -534,27 +548,40 @@ def build_prompt_bundle(
             + architect_task,
             simplicity_mode,
         )
+
+        def _role_parts(system: str, untrusted: str, pre_hook: str, final: str) -> RolePromptParts:
+            # If a CONTEXT hook rewrote this role's prompt, the pre-hook split is
+            # stale — fall back to the post-hook `flat` so nothing the hook
+            # redacted is reintroduced and no untrusted content lands in `system`.
+            if final == pre_hook:
+                return RolePromptParts(system=system, untrusted_reference=untrusted, flat=final, isolation_safe=True)
+            return RolePromptParts(system="", untrusted_reference=final, flat=final, isolation_safe=False)
+
         prompt_parts_sink(
             PromptPartsBundle(
-                competitor=RolePromptParts(
-                    system=competitor_system,
-                    untrusted_reference=base_context_untrusted + hints_block,
-                    flat=final_bundle.competitor,
+                competitor=_role_parts(
+                    competitor_system,
+                    base_context_untrusted + hints_block,
+                    pre_hook_bundle.competitor,
+                    final_bundle.competitor,
                 ),
-                analyst=RolePromptParts(
-                    system=analyst_system,
-                    untrusted_reference=base_context_untrusted,
-                    flat=final_bundle.analyst,
+                analyst=_role_parts(
+                    analyst_system,
+                    base_context_untrusted,
+                    pre_hook_bundle.analyst,
+                    final_bundle.analyst,
                 ),
-                coach=RolePromptParts(
-                    system=coach_system,
-                    untrusted_reference=base_context_untrusted,
-                    flat=final_bundle.coach,
+                coach=_role_parts(
+                    coach_system,
+                    base_context_untrusted,
+                    pre_hook_bundle.coach,
+                    final_bundle.coach,
                 ),
-                architect=RolePromptParts(
-                    system=architect_system,
-                    untrusted_reference=base_context_untrusted,
-                    flat=final_bundle.architect,
+                architect=_role_parts(
+                    architect_system,
+                    base_context_untrusted,
+                    pre_hook_bundle.architect,
+                    final_bundle.architect,
                 ),
             )
         )

--- a/autocontext/tests/test_prompt_parts_isolation.py
+++ b/autocontext/tests/test_prompt_parts_isolation.py
@@ -17,6 +17,7 @@ Invariants asserted here:
 from __future__ import annotations
 
 import autocontext.agents  # noqa: F401  # break circular import with prompts.templates
+from autocontext.extensions import HookBus, HookEvents, HookResult
 from autocontext.prompts.templates import (
     PromptPartsBundle,
     RolePromptParts,
@@ -106,3 +107,51 @@ def test_sink_is_optional() -> None:
         available_tools="tools",
     )
     assert _PLAYBOOK in bundle.competitor
+
+
+def test_parts_are_isolation_safe_without_a_hook() -> None:
+    parts, _ = _build()
+    for role in (parts.competitor, parts.analyst, parts.coach, parts.architect):
+        assert role.isolation_safe is True
+
+
+def _redacting_hook_bus() -> HookBus:
+    """A CONTEXT hook that redacts every role's final prompt — the reviewer's
+    scenario for PR #1201: the split must not leak content the hook removed."""
+    bus = HookBus()
+
+    def _redact(event: object) -> HookResult:
+        redacted = {role: "REDACTED" for role in ("competitor", "analyst", "coach", "architect")}
+        return HookResult(payload={"roles": redacted})
+
+    bus.on(HookEvents.CONTEXT, _redact)
+    return bus
+
+
+def test_hook_rewritten_roles_do_not_leak_redacted_content() -> None:
+    captured: dict[str, PromptPartsBundle] = {}
+    build_prompt_bundle(
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=_observation(),
+        current_playbook=_PLAYBOOK,
+        available_tools="tools",
+        coach_competitor_hints=_HINTS,
+        dead_ends=_DEAD_ENDS,
+        hook_bus=_redacting_hook_bus(),
+        prompt_parts_sink=lambda parts: captured.__setitem__("parts", parts),
+    )
+    parts = captured["parts"]
+    for role in (parts.competitor, parts.analyst, parts.coach, parts.architect):
+        # Hook redacted the prompt: the split is untrustworthy and must fall back.
+        assert role.isolation_safe is False
+        assert role.flat == "REDACTED"
+        assert role.system == ""
+        assert role.untrusted_reference == "REDACTED"
+        # Content the hook removed must NOT reappear via the split.
+        assert _PLAYBOOK not in role.system
+        assert _PLAYBOOK not in role.untrusted_reference
+        assert _DEAD_ENDS not in role.untrusted_reference
+        assert _HINTS not in role.untrusted_reference

--- a/autocontext/tests/test_prompt_parts_isolation.py
+++ b/autocontext/tests/test_prompt_parts_isolation.py
@@ -1,0 +1,108 @@
+"""Stage 1 of ERP-67 — structural role-message isolation.
+
+`build_prompt_bundle` exposes, per role, a (system, untrusted_reference, flat)
+split via an optional `prompt_parts_sink`, WITHOUT changing the flat prompt the
+transport still sends. This is the behaviour-preserving separation of concerns
+that Stage 2 will thread through the LLM message roles.
+
+Invariants asserted here:
+- `flat` is byte-identical to the corresponding `PromptBundle` role string
+  (nothing about today's behaviour changes).
+- The attacker-influenceable fields (playbook, coach hints, dead-ends) appear
+  in `untrusted_reference` and NOT in `system`.
+- The trust-boundary guardrail and the role task live in `system`.
+- Only the competitor carries coach hints; other roles do not.
+"""
+
+from __future__ import annotations
+
+import autocontext.agents  # noqa: F401  # break circular import with prompts.templates
+from autocontext.prompts.templates import (
+    PromptPartsBundle,
+    RolePromptParts,
+    build_prompt_bundle,
+)
+from autocontext.scenarios.base import Observation
+
+_PLAYBOOK = "PLAYBOOK-SENTINEL-1234 keep aggression high"
+_HINTS = "HINTS-SENTINEL-5678 try corner play"
+_DEAD_ENDS = "DEADEND-SENTINEL-9012 never rush the center"
+
+
+def _observation() -> Observation:
+    return Observation(narrative="test narrative", state={}, constraints=[])
+
+
+def _build() -> tuple[PromptPartsBundle, object]:
+    captured: dict[str, PromptPartsBundle] = {}
+    bundle = build_prompt_bundle(
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=_observation(),
+        current_playbook=_PLAYBOOK,
+        available_tools="tools",
+        coach_competitor_hints=_HINTS,
+        dead_ends=_DEAD_ENDS,
+        prompt_parts_sink=lambda parts: captured.__setitem__("parts", parts),
+    )
+    return captured["parts"], bundle
+
+
+def test_sink_receives_parts_for_every_role() -> None:
+    parts, _ = _build()
+    assert isinstance(parts, PromptPartsBundle)
+    for role in (parts.competitor, parts.analyst, parts.coach, parts.architect):
+        assert isinstance(role, RolePromptParts)
+
+
+def test_flat_is_byte_identical_to_prompt_bundle() -> None:
+    parts, bundle = _build()
+    assert parts.competitor.flat == bundle.competitor
+    assert parts.analyst.flat == bundle.analyst
+    assert parts.coach.flat == bundle.coach
+    assert parts.architect.flat == bundle.architect
+
+
+def test_untrusted_fields_are_isolated_from_system() -> None:
+    parts, _ = _build()
+    for role in (parts.competitor, parts.analyst, parts.coach, parts.architect):
+        # Playbook and dead-ends are untrusted for every role.
+        assert _PLAYBOOK in role.untrusted_reference
+        assert _DEAD_ENDS in role.untrusted_reference
+        assert _PLAYBOOK not in role.system
+        assert _DEAD_ENDS not in role.system
+
+
+def test_only_competitor_carries_coach_hints() -> None:
+    parts, _ = _build()
+    assert _HINTS in parts.competitor.untrusted_reference
+    assert _HINTS not in parts.competitor.system
+    # Other roles never receive the competitor hints at all.
+    for role in (parts.analyst, parts.coach, parts.architect):
+        assert _HINTS not in role.untrusted_reference
+        assert _HINTS not in role.system
+
+
+def test_system_carries_guardrail_and_task() -> None:
+    parts, _ = _build()
+    for role in (parts.competitor, parts.analyst, parts.coach, parts.architect):
+        assert "trust boundary" in role.system.lower()
+    # Role-specific task text lands in system, not the untrusted region.
+    assert "consolidated playbook" in parts.coach.system.lower()
+    assert "consolidated playbook" not in parts.coach.untrusted_reference.lower()
+
+
+def test_sink_is_optional() -> None:
+    # Omitting the sink must not raise and must still return the flat bundle.
+    bundle = build_prompt_bundle(
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=_observation(),
+        current_playbook=_PLAYBOOK,
+        available_tools="tools",
+    )
+    assert _PLAYBOOK in bundle.competitor


### PR DESCRIPTION
## ERP-67 Stage 1 — expose the (system, untrusted_reference) split

First implementation stage from the design in `docs/erp-67-structural-role-isolation-design.md` (PR #1199). Behaviour-preserving separation of concerns; **no transport or model-behaviour change**.

> **Stacked PR.** Base is `feature/erp-59-untrusted-fence` (PR #1198), because the untrusted-reference blocks are the ERP-59 fenced fields. Merge #1198 first; this rebases onto `main` cleanly.

### What it does
`build_prompt_bundle` now exposes, per role, a `(system, untrusted_reference, flat)` split via an optional `prompt_parts_sink` (same pattern as the existing `*_sink` params):
- **`system`** — trusted operator instructions: scenario rules, strategy interface, evaluation criteria, role task, constraints, the ERP-59 guardrail, simplicity guidance.
- **`untrusted_reference`** — the attacker-influenceable fenced blocks: current playbook + known dead-ends for every role, plus coach hints for the competitor.
- **`flat`** — the exact string the transport sends today, **byte-identical** to the returned `PromptBundle` role.

### Why it's safe
- The flat `PromptBundle` is unchanged. `base_context` is segmented into trusted `head/mid/tail` + untrusted `playbook`/`dead-ends`, but the flat concatenation is identical; the three role tasks are extracted into locals reused by both the flat bundle and the split.
- The split is additive (a sink); callers that don't pass one are unaffected.
- Nothing consumes the split for transport yet — Stage 2 (behind `structural_role_isolation`, per the design) will thread `system` vs `untrusted_reference` into distinct LLM message roles for role-capable backends.

### Tests (`tests/test_prompt_parts_isolation.py`, 6)
sink fires for every role · `flat` byte-identical to `PromptBundle` · untrusted fields (playbook/dead-ends/hints) isolated from `system` · only competitor carries coach hints · guardrail + role task live in `system` · sink is optional.

### Verification
Full suite green (exit 0) · targeted prompt/generation/template/benchmark/injection sweep green · `ruff` + `mypy` clean.

### Next
Stage 2: thread `system`+`messages` through `SubagentTask`/`SubagentRuntime.run_task` behind the flag, gated on per-client capability; API clients (Anthropic/agent_sdk/direct_api) + claude_cli `--system-prompt` first, single-prompt backends keep the ERP-59 fence.