### PR TITLE
feat(erp-67): SubagentTask.system transport seam for role isolation (Stage 2)

### DIFF
--- a/autocontext/src/autocontext/harness/core/llm_client.py
+++ b/autocontext/src/autocontext/harness/core/llm_client.py
@@ -32,4 +32,10 @@ class LanguageModelClient:
         Default implementation concatenates into a single-turn call for backwards compat.
         """
         combined = system + "\n\n" + "\n\n".join(m["content"] for m in messages if m["role"] == "user")
-        return self.generate(model=model, prompt=combined, max_tokens=max_tokens, temperature=temperature)
+        return self.generate(
+            model=model,
+            prompt=combined,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            role=role,
+        )

--- a/autocontext/src/autocontext/harness/core/subagent.py
+++ b/autocontext/src/autocontext/harness/core/subagent.py
@@ -16,6 +16,12 @@ class SubagentTask:
     prompt: str
     max_tokens: int
     temperature: float
+    # ERP-67 structural role isolation: when set, `prompt` is the untrusted user
+    # turn and `system` is the trusted system turn, delivered via
+    # `generate_multiturn` so role-capable backends keep untrusted content out of
+    # the system prompt. Empty (the default, and every call site today) → the
+    # single-prompt `generate` path, byte-identical to prior behaviour.
+    system: str = ""
 
 
 class SubagentRuntime:
@@ -25,13 +31,23 @@ class SubagentRuntime:
         self.client = client
 
     def run_task(self, task: SubagentTask) -> RoleExecution:
-        response = self.client.generate(
-            model=task.model,
-            prompt=task.prompt,
-            max_tokens=task.max_tokens,
-            temperature=task.temperature,
-            role=task.role,
-        )
+        if task.system:
+            response = self.client.generate_multiturn(
+                model=task.model,
+                system=task.system,
+                messages=[{"role": "user", "content": task.prompt}],
+                max_tokens=task.max_tokens,
+                temperature=task.temperature,
+                role=task.role,
+            )
+        else:
+            response = self.client.generate(
+                model=task.model,
+                prompt=task.prompt,
+                max_tokens=task.max_tokens,
+                temperature=task.temperature,
+                role=task.role,
+            )
         return RoleExecution(
             role=task.role,
             content=response.text.strip(),

--- a/autocontext/tests/test_subagent_role_isolation.py
+++ b/autocontext/tests/test_subagent_role_isolation.py
@@ -31,6 +31,18 @@ class _RecordingClient(LanguageModelClient):
         return ModelResponse(text="multi", usage=RoleUsage(0, 0, 0, model))
 
 
+class _FallbackClient(LanguageModelClient):
+    """Single-prompt backend: overrides only `generate`, inheriting the base
+    `generate_multiturn` fallback that flattens system+user into one prompt."""
+
+    def __init__(self) -> None:
+        self.generate_calls: list[dict[str, object]] = []
+
+    def generate(self, *, model, prompt, max_tokens, temperature, role=""):  # type: ignore[no-untyped-def]
+        self.generate_calls.append({"prompt": prompt, "role": role})
+        return ModelResponse(text="fallback", usage=RoleUsage(0, 0, 0, model))
+
+
 def _task(**overrides: object) -> SubagentTask:
     base: dict[str, object] = {
         "role": "competitor",
@@ -81,3 +93,18 @@ def test_system_defaults_empty_so_existing_call_sites_are_unchanged() -> None:
     client = _RecordingClient()
     SubagentRuntime(client).run_task(task)
     assert len(client.generate_calls) == 1 and not client.multiturn_calls
+
+
+def test_fallback_backend_preserves_role_through_base_generate_multiturn() -> None:
+    # A single-prompt client that inherits the base generate_multiturn fallback
+    # must still receive the task role on its generate() — role-preservation must
+    # hold on the flattened path, not only when a client overrides multiturn.
+    client = _FallbackClient()
+    exec_result = SubagentRuntime(client).run_task(_task(role="coach", system="SYSTEM"))
+    assert len(client.generate_calls) == 1
+    assert client.generate_calls[0]["role"] == "coach"
+    # Flattened content still carries both the system turn and the user body.
+    assert "SYSTEM" in str(client.generate_calls[0]["prompt"])
+    assert "USER-BODY untrusted reference here" in str(client.generate_calls[0]["prompt"])
+    assert exec_result.role == "coach"
+    assert exec_result.content == "fallback"

--- a/autocontext/tests/test_subagent_role_isolation.py
+++ b/autocontext/tests/test_subagent_role_isolation.py
@@ -1,0 +1,83 @@
+"""Stage 2 of ERP-67 — the transport seam for structural role isolation.
+
+`SubagentTask` gains an optional `system` field. When it is set, `run_task`
+delivers the task as a system turn + a user turn via `generate_multiturn`
+(so role-capable backends keep untrusted content out of the system turn). When
+it is empty — every call site today — `run_task` uses the single-prompt
+`generate` path exactly as before, so behaviour is unchanged until a later
+stage populates `system`.
+"""
+
+from __future__ import annotations
+
+from autocontext.harness.core.llm_client import LanguageModelClient
+from autocontext.harness.core.subagent import SubagentRuntime, SubagentTask
+from autocontext.harness.core.types import ModelResponse, RoleUsage
+
+
+class _RecordingClient(LanguageModelClient):
+    """Captures which transport method was called and with what."""
+
+    def __init__(self) -> None:
+        self.generate_calls: list[dict[str, object]] = []
+        self.multiturn_calls: list[dict[str, object]] = []
+
+    def generate(self, *, model, prompt, max_tokens, temperature, role=""):  # type: ignore[no-untyped-def]
+        self.generate_calls.append({"prompt": prompt, "role": role})
+        return ModelResponse(text="single", usage=RoleUsage(0, 0, 0, model))
+
+    def generate_multiturn(self, *, model, system, messages, max_tokens, temperature, role=""):  # type: ignore[no-untyped-def]
+        self.multiturn_calls.append({"system": system, "messages": messages, "role": role})
+        return ModelResponse(text="multi", usage=RoleUsage(0, 0, 0, model))
+
+
+def _task(**overrides: object) -> SubagentTask:
+    base: dict[str, object] = {
+        "role": "competitor",
+        "model": "m",
+        "prompt": "USER-BODY untrusted reference here",
+        "max_tokens": 100,
+        "temperature": 0.0,
+    }
+    base.update(overrides)
+    return SubagentTask(**base)  # type: ignore[arg-type]
+
+
+def test_task_without_system_uses_single_prompt_path() -> None:
+    client = _RecordingClient()
+    exec_result = SubagentRuntime(client).run_task(_task())
+    assert len(client.generate_calls) == 1
+    assert not client.multiturn_calls
+    assert client.generate_calls[0]["prompt"] == "USER-BODY untrusted reference here"
+    assert exec_result.content == "single"
+
+
+def test_task_with_system_uses_multiturn_isolated_path() -> None:
+    client = _RecordingClient()
+    exec_result = SubagentRuntime(client).run_task(_task(system="SYSTEM trusted instructions", prompt="UNTRUSTED body"))
+    assert len(client.multiturn_calls) == 1
+    assert not client.generate_calls
+    call = client.multiturn_calls[0]
+    assert call["system"] == "SYSTEM trusted instructions"
+    assert call["messages"] == [{"role": "user", "content": "UNTRUSTED body"}]
+    assert exec_result.content == "multi"
+
+
+def test_role_and_metadata_preserved_on_both_paths() -> None:
+    client = _RecordingClient()
+    single = SubagentRuntime(client).run_task(_task(role="analyst"))
+    multi = SubagentRuntime(client).run_task(_task(role="coach", system="S"))
+    assert single.role == "analyst"
+    assert multi.role == "coach"
+    assert client.generate_calls[0]["role"] == "analyst"
+    assert client.multiturn_calls[0]["role"] == "coach"
+
+
+def test_system_defaults_empty_so_existing_call_sites_are_unchanged() -> None:
+    # Positional construction (as existing call sites do) must still work and
+    # leave system empty → single-prompt path.
+    task = SubagentTask("competitor", "m", "p", 100, 0.0)
+    assert task.system == ""
+    client = _RecordingClient()
+    SubagentRuntime(client).run_task(task)
+    assert len(client.generate_calls) == 1 and not client.multiturn_calls


### PR DESCRIPTION
## ERP-67 Stage 2 — the transport seam (safe, no behaviour change)

The transport primitive Stage 2b wires the prompt-parts split into. **No call site sets `system` yet, so behaviour is unchanged** (full suite green, exit 0).

> **Stacked PR.** Base is `feature/erp-67-stage1-prompt-parts` (#1201), which is itself on the ERP-59 branch (#1198). Merge order: #1198 → #1201 → this.

### What it does
`SubagentTask` gains an optional `system: str = ""`. `SubagentRuntime.run_task` dispatches on it:
- **`system` set** → `client.generate_multiturn(system=…, messages=[{"role":"user","content":prompt}])`. Role-capable backends (Anthropic, agent_sdk, direct_api) keep untrusted content out of the system turn; single-prompt backends use the base `generate_multiturn` default (`system + "\n\n" + user`), preserving content.
- **`system` empty** (every call site today) → `client.generate(prompt=…)`, **byte-identical** to prior behaviour.

### Why it's safe
- New field is last and defaulted, so positional `SubagentTask(...)` construction is unchanged.
- Nothing populates `system` yet → `run_task` always takes the `else` branch → identical to today. Full suite verified green.

### Tests (`tests/test_subagent_role_isolation.py`, 4)
`system` set routes to `generate_multiturn` with the untrusted body as the sole user turn · `system` empty routes to single-prompt `generate` · role/metadata preserved on both paths · positional construction defaults `system` empty.

### Next (Stage 2b)
Thread the ERP-67 prompt-parts split (`system` / `untrusted_reference` from #1201) through the runners and orchestrator behind a `structural_role_isolation` settings flag to actually populate `SubagentTask.system` — the first change that alters prompt shape, so it lands with the flag + a score-parity soak. The RLM path already has its own `system_tpl` separation and is out of scope.