### PR TITLE
feat(erp-67): wire structural role isolation through the pipeline path (Stage 2b)

### DIFF
--- a/autocontext/src/autocontext/agents/analyst.py
+++ b/autocontext/src/autocontext/agents/analyst.py
@@ -9,7 +9,7 @@ class AnalystRunner:
         self.runtime = runtime
         self.model = model
 
-    def run(self, prompt: str) -> RoleExecution:
+    def run(self, prompt: str, *, system: str = "") -> RoleExecution:
         return self.runtime.run_task(
             SubagentTask(
                 role="analyst",
@@ -17,5 +17,6 @@ class AnalystRunner:
                 prompt=prompt,
                 max_tokens=1200,
                 temperature=0.2,
+                system=system,
             )
         )

--- a/autocontext/src/autocontext/agents/architect.py
+++ b/autocontext/src/autocontext/agents/architect.py
@@ -125,7 +125,7 @@ class ArchitectRunner:
         self.runtime = runtime
         self.model = model
 
-    def run(self, prompt: str) -> RoleExecution:
+    def run(self, prompt: str, *, system: str = "") -> RoleExecution:
         return self.runtime.run_task(
             SubagentTask(
                 role="architect",
@@ -133,5 +133,6 @@ class ArchitectRunner:
                 prompt=prompt,
                 max_tokens=1600,
                 temperature=0.4,
+                system=system,
             )
         )

--- a/autocontext/src/autocontext/agents/competitor.py
+++ b/autocontext/src/autocontext/agents/competitor.py
@@ -19,6 +19,7 @@ class CompetitorRunner:
         tool_context: str = "",
         *,
         temperature: float | None = None,
+        system: str = "",
     ) -> tuple[str, RoleExecution]:
         final_prompt = prompt
         if tool_context:
@@ -30,6 +31,7 @@ class CompetitorRunner:
                 prompt=final_prompt,
                 max_tokens=800,
                 temperature=0.2 if temperature is None else temperature,
+                system=system,
             )
         )
         return execution.content, execution

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 
 class AnthropicClient(LanguageModelClient):
+    # Real message roles: generate_multiturn passes system + messages to the API.
+    supports_structural_isolation = True
+
     def __init__(
         self,
         api_key: str,

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -35,7 +35,7 @@ from autocontext.execution.harness_coverage import HarnessCoverage
 from autocontext.extensions import HookBus, wrap_language_model_client
 from autocontext.harness.orchestration.dag import RoleDAG
 from autocontext.harness.orchestration.types import RoleSpec
-from autocontext.prompts.templates import PromptBundle
+from autocontext.prompts.templates import PromptBundle, PromptPartsBundle
 
 if TYPE_CHECKING:
     from autocontext.agents.role_router import ProviderConfig
@@ -529,6 +529,7 @@ class AgentOrchestrator:
         scenario_rules: str = "",
         current_strategy: dict[str, Any] | None = None,
         generation_deadline: float | None = None,
+        parts: PromptPartsBundle | None = None,
     ) -> AgentOutputs:
         # Feature-gated pipeline codepath (skips RLM path when active)
         if self.settings.use_pipeline_engine and not (self.settings.rlm_enabled and self._rlm_loader is not None):
@@ -540,6 +541,7 @@ class AgentOrchestrator:
                 strategy_interface,
                 on_role_event,
                 generation_deadline,
+                parts=parts,
             )
 
         def _notify(role: str, status: str) -> None:
@@ -607,6 +609,7 @@ class AgentOrchestrator:
         strategy_interface: str,
         on_role_event: Callable[[str, str], None] | None,
         generation_deadline: float | None = None,
+        parts: PromptPartsBundle | None = None,
     ) -> AgentOutputs:
         """Execute the 5-role generation via PipelineEngine."""
         from autocontext.agents.pipeline_adapter import build_mts_dag, build_role_handler
@@ -614,9 +617,8 @@ class AgentOrchestrator:
 
         dag = build_mts_dag()
 
-        architect_prompt = prompts.architect
-        if generation_index % self.settings.architect_every_n_gens != 0:
-            architect_prompt += _ARCHITECT_CADENCE_SKIP
+        cadence_skip = _ARCHITECT_CADENCE_SKIP if generation_index % self.settings.architect_every_n_gens != 0 else ""
+        architect_prompt = prompts.architect + cadence_skip
 
         prompt_map = {
             "competitor": prompts.competitor,
@@ -626,6 +628,24 @@ class AgentOrchestrator:
             "coach": prompts.coach,
         }
 
+        # ERP-67 Stage 2b: when structural isolation is on, deliver the untrusted
+        # reference as the user turn and the trusted instructions as the system
+        # turn for the cleanly-mappable roles (competitor/analyst/architect). Only
+        # isolation_safe roles are split; coach (mid-flight enriched) and the
+        # translator stay on the flat single-prompt path. Off → maps unchanged.
+        system_map: dict[str, str] = {}
+        if self.settings.structural_role_isolation and parts is not None:
+            role_parts = {
+                "competitor": parts.competitor,
+                "analyst": parts.analyst,
+                "architect": parts.architect,
+            }
+            for role, rp in role_parts.items():
+                if not rp.isolation_safe:
+                    continue
+                system_map[role] = rp.system + (cadence_skip if role == "architect" else "")
+                prompt_map[role] = rp.untrusted_reference
+
         handler = build_role_handler(
             self,
             generation=generation_index,
@@ -633,6 +653,7 @@ class AgentOrchestrator:
             tool_context=tool_context,
             strategy_interface=strategy_interface,
             generation_deadline=generation_deadline,
+            system_map=system_map,
         )
         engine = PipelineEngine(dag, handler, max_workers=2)
         results = engine.execute(prompt_map, on_role_event=on_role_event)

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -628,12 +628,15 @@ class AgentOrchestrator:
             "coach": prompts.coach,
         }
 
-        # ERP-67 Stage 2b: when structural isolation is on, deliver the untrusted
-        # reference as the user turn and the trusted instructions as the system
-        # turn for the cleanly-mappable roles (competitor/analyst/architect). Only
-        # isolation_safe roles are split; coach (mid-flight enriched) and the
-        # translator stay on the flat single-prompt path. Off → maps unchanged.
+        # ERP-67 Stage 2b: when structural isolation is on, offer the untrusted
+        # reference as a user turn and the trusted instructions as a system turn
+        # for the cleanly-mappable roles (competitor/analyst/architect). The
+        # handler applies the split only for role-capable clients and otherwise
+        # falls back to `flat_map` (byte-identical legacy). Only isolation_safe
+        # roles are offered; coach (mid-flight enriched) and translator stay
+        # flat. Off / no parts → maps unchanged, legacy behaviour.
         system_map: dict[str, str] = {}
+        flat_map: dict[str, str] = {}
         if self.settings.structural_role_isolation and parts is not None:
             role_parts = {
                 "competitor": parts.competitor,
@@ -643,7 +646,9 @@ class AgentOrchestrator:
             for role, rp in role_parts.items():
                 if not rp.isolation_safe:
                     continue
-                system_map[role] = rp.system + (cadence_skip if role == "architect" else "")
+                suffix = cadence_skip if role == "architect" else ""
+                system_map[role] = rp.system + suffix
+                flat_map[role] = rp.flat + suffix
                 prompt_map[role] = rp.untrusted_reference
 
         handler = build_role_handler(
@@ -654,6 +659,7 @@ class AgentOrchestrator:
             strategy_interface=strategy_interface,
             generation_deadline=generation_deadline,
             system_map=system_map,
+            flat_map=flat_map,
         )
         engine = PipelineEngine(dag, handler, max_workers=2)
         results = engine.execute(prompt_map, on_role_event=on_role_event)

--- a/autocontext/src/autocontext/agents/pipeline_adapter.py
+++ b/autocontext/src/autocontext/agents/pipeline_adapter.py
@@ -40,14 +40,30 @@ def build_role_handler(
     strategy_interface: str = "",
     generation_deadline: float | None = None,
     system_map: dict[str, str] | None = None,
+    flat_map: dict[str, str] | None = None,
 ) -> RoleHandler:
     """Build a RoleHandler callable that delegates to the orchestrator's role runners.
 
-    ``system_map`` (ERP-67 Stage 2b) maps a role name to a trusted system prompt.
-    When present for a role, ``prompt`` is the untrusted user turn and the mapped
-    value is the system turn; absent/empty → the legacy single-prompt path.
+    ERP-67 Stage 2b — structural role isolation. ``system_map`` maps a role to a
+    trusted system prompt and ``flat_map`` to that role's exact legacy flat
+    prompt. When a role is in ``system_map`` AND its resolved client supports
+    real message roles, ``prompt`` (the untrusted user turn) is sent with the
+    system turn. Otherwise the role falls back to its flat prompt with no system
+    turn — byte-identical to legacy — so single-prompt / runtime-bridge backends
+    are never silently reordered. Absent maps → legacy path, no ``system`` kwarg.
     """
     systems = system_map or {}
+    flats = flat_map or {}
+
+    def _resolve_turn(name: str, runner: object, prompt: str) -> tuple[str, str]:
+        """Return (user_prompt, system) for a role, honouring client capability."""
+        system = systems.get(name, "")
+        if not system:
+            return prompt, ""
+        client = getattr(getattr(runner, "runtime", None), "client", None)
+        if getattr(client, "supports_structural_isolation", False):
+            return prompt, system  # capable: untrusted user turn + system turn
+        return flats.get(name, prompt), ""  # incapable: exact legacy flat prompt
 
     def handler(name: str, prompt: str, completed: dict[str, RoleExecution]) -> RoleExecution:
         if name == "competitor":
@@ -58,9 +74,13 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
-                _raw_text, exec_result = orch.competitor.run(
-                    prompt, tool_context=tool_context, system=systems.get("competitor", "")
-                )
+                user_prompt, system = _resolve_turn("competitor", orch.competitor, prompt)
+                # Pass `system` only when isolating, so legacy runner signatures
+                # (and test fakes) that predate the kwarg keep working.
+                if system:
+                    _raw_text, exec_result = orch.competitor.run(user_prompt, tool_context=tool_context, system=system)
+                else:
+                    _raw_text, exec_result = orch.competitor.run(user_prompt, tool_context=tool_context)
                 return exec_result
         elif name == "translator":
             competitor_exec = completed.get("competitor")
@@ -82,7 +102,10 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
-                return orch.analyst.run(prompt, system=systems.get("analyst", ""))
+                user_prompt, system = _resolve_turn("analyst", orch.analyst, prompt)
+                if system:
+                    return orch.analyst.run(user_prompt, system=system)
+                return orch.analyst.run(user_prompt)
         elif name == "architect":
             with orch._use_role_runtime(
                 "architect",
@@ -91,7 +114,10 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
-                return orch.architect.run(prompt, system=systems.get("architect", ""))
+                user_prompt, system = _resolve_turn("architect", orch.architect, prompt)
+                if system:
+                    return orch.architect.run(user_prompt, system=system)
+                return orch.architect.run(user_prompt)
         elif name == "coach":
             analyst_exec = completed.get("analyst")
             enriched = prompt

--- a/autocontext/src/autocontext/agents/pipeline_adapter.py
+++ b/autocontext/src/autocontext/agents/pipeline_adapter.py
@@ -1,4 +1,5 @@
 """Adapter building a harness PipelineEngine from autocontext orchestrator components."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -20,13 +21,15 @@ def build_mts_dag() -> RoleDAG:
     competitor -> translator -> analyst -> coach
                              -> architect (parallel with analyst; coach depends on analyst)
     """
-    return RoleDAG([
-        RoleSpec(name="competitor"),
-        RoleSpec(name="translator", depends_on=("competitor",)),
-        RoleSpec(name="analyst", depends_on=("translator",)),
-        RoleSpec(name="architect", depends_on=("translator",)),
-        RoleSpec(name="coach", depends_on=("analyst",)),
-    ])
+    return RoleDAG(
+        [
+            RoleSpec(name="competitor"),
+            RoleSpec(name="translator", depends_on=("competitor",)),
+            RoleSpec(name="analyst", depends_on=("translator",)),
+            RoleSpec(name="architect", depends_on=("translator",)),
+            RoleSpec(name="coach", depends_on=("analyst",)),
+        ]
+    )
 
 
 def build_role_handler(
@@ -36,8 +39,15 @@ def build_role_handler(
     tool_context: str = "",
     strategy_interface: str = "",
     generation_deadline: float | None = None,
+    system_map: dict[str, str] | None = None,
 ) -> RoleHandler:
-    """Build a RoleHandler callable that delegates to the orchestrator's role runners."""
+    """Build a RoleHandler callable that delegates to the orchestrator's role runners.
+
+    ``system_map`` (ERP-67 Stage 2b) maps a role name to a trusted system prompt.
+    When present for a role, ``prompt`` is the untrusted user turn and the mapped
+    value is the system turn; absent/empty → the legacy single-prompt path.
+    """
+    systems = system_map or {}
 
     def handler(name: str, prompt: str, completed: dict[str, RoleExecution]) -> RoleExecution:
         if name == "competitor":
@@ -48,7 +58,9 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
-                _raw_text, exec_result = orch.competitor.run(prompt, tool_context=tool_context)
+                _raw_text, exec_result = orch.competitor.run(
+                    prompt, tool_context=tool_context, system=systems.get("competitor", "")
+                )
                 return exec_result
         elif name == "translator":
             competitor_exec = completed.get("competitor")
@@ -70,7 +82,7 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
-                return orch.analyst.run(prompt)
+                return orch.analyst.run(prompt, system=systems.get("analyst", ""))
         elif name == "architect":
             with orch._use_role_runtime(
                 "architect",
@@ -79,7 +91,7 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
-                return orch.architect.run(prompt)
+                return orch.architect.run(prompt, system=systems.get("architect", ""))
         elif name == "coach":
             analyst_exec = completed.get("analyst")
             enriched = prompt

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -97,6 +97,15 @@ class AppSettings(BaseModel):
     )
     soft_hints_enabled: bool = False
     hint_style: Literal["default", "structural", "solution_like"] = "default"
+    structural_role_isolation: bool = Field(
+        default=False,
+        description=(
+            "ERP-67 Stage 2b: deliver the untrusted reference block (playbook / coach "
+            "hints / dead-ends) in a separate user turn from the trusted system prompt "
+            "for role-capable backends, instead of one flat prompt. Off = byte-identical "
+            "legacy behaviour. Pipeline path, competitor/analyst/architect only for now."
+        ),
+    )
     evidence_freshness_enabled: bool = Field(
         default=True,
         description="Demote stale hints, lessons, and notebook context during prompt assembly",

--- a/autocontext/src/autocontext/harness/core/llm_client.py
+++ b/autocontext/src/autocontext/harness/core/llm_client.py
@@ -6,6 +6,13 @@ from autocontext.harness.core.types import ModelResponse
 
 
 class LanguageModelClient:
+    # ERP-67: True only for backends whose generate_multiturn genuinely routes a
+    # separate system turn (real message roles). Default False → the base
+    # generate_multiturn flattens system+user, so structural isolation must NOT
+    # be applied (the flat prompt is preserved instead). Wrappers inherit False
+    # unless they explicitly forward the capability.
+    supports_structural_isolation: bool = False
+
     def generate(
         self,
         *,

--- a/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
@@ -13,7 +13,7 @@ from autocontext.knowledge.semantic_compaction_benchmark import (
 )
 from autocontext.loop.levy_scout import LevyScoutConfig, render_levy_scout_guidance
 from autocontext.loop.stage_helpers.context_loaders import _hint_style
-from autocontext.prompts.templates import PromptBundle, build_prompt_bundle
+from autocontext.prompts.templates import PromptBundle, PromptPartsBundle, build_prompt_bundle
 from autocontext.storage.context_selection_store import persist_context_selection_decision
 from autocontext.util.json_io import write_json
 
@@ -109,11 +109,7 @@ def _evidence_source_run_ids(ctx: GenerationContext, *, artifacts: ArtifactStore
     if not snapshots_dir.is_dir():
         return []
     try:
-        return sorted(
-            path.name
-            for path in snapshots_dir.iterdir()
-            if path.is_dir() and path.name != ctx.run_id
-        )
+        return sorted(path.name for path in snapshots_dir.iterdir() if path.is_dir() and path.name != ctx.run_id)
     except OSError:
         return []
 
@@ -230,11 +226,7 @@ def _as_str(value: Any) -> str:
 def _as_str_dict(value: Any) -> dict[str, str] | None:
     if not isinstance(value, dict):
         return None
-    return {
-        str(key): str(item)
-        for key, item in value.items()
-        if isinstance(key, str) and isinstance(item, str)
-    }
+    return {str(key): str(item) for key, item in value.items() if isinstance(key, str) and isinstance(item, str)}
 
 
 def prepare_generation_prompts(
@@ -273,7 +265,7 @@ def prepare_generation_prompts(
     evidence_manifests: dict[str, str] | None,
     evidence_cache_hits: int,
     evidence_cache_lookups: int,
-) -> tuple[PromptBundle, dict[str, Any] | None]:
+) -> tuple[PromptBundle, dict[str, Any] | None, PromptPartsBundle | None]:
     prompt_kwargs: dict[str, Any] = {
         "scenario_rules": scenario_rules,
         "strategy_interface": strategy_interface,
@@ -345,9 +337,12 @@ def prepare_generation_prompts(
     context_budget_telemetry: list[dict[str, Any]] = []
     prompt_kwargs["context_component_sink"] = selected_context_components.update
     prompt_kwargs["context_budget_telemetry_sink"] = lambda telemetry: context_budget_telemetry.append(telemetry.to_dict())
+    captured_parts: list[PromptPartsBundle] = []
+    prompt_kwargs["prompt_parts_sink"] = captured_parts.append
     compaction_cache_before = prompt_compaction_cache_stats()
     build_start = time.perf_counter()
     prompts = build_prompt_bundle(**prompt_kwargs)
+    parts = captured_parts[-1] if captured_parts else None
     semantic_build_latency_ms = (time.perf_counter() - build_start) * 1000.0
     compaction_cache_after = prompt_compaction_cache_stats()
     _persist_generation_context_selection(
@@ -362,12 +357,13 @@ def prepare_generation_prompts(
         evidence_cache_lookups=evidence_cache_lookups,
     )
     if not ctx.settings.semantic_compaction_benchmark_enabled:
-        return prompts, None
+        return prompts, None, parts
 
     baseline_start = time.perf_counter()
     baseline_prompt_kwargs = dict(prompt_kwargs)
     baseline_prompt_kwargs.pop("context_component_sink", None)
     baseline_prompt_kwargs.pop("context_budget_telemetry_sink", None)
+    baseline_prompt_kwargs.pop("prompt_parts_sink", None)
     budget_only_prompts = build_prompt_bundle(**baseline_prompt_kwargs, semantic_compaction=False)
     budget_only_build_latency_ms = (time.perf_counter() - baseline_start) * 1000.0
     benchmark_report = build_semantic_compaction_benchmark_report(
@@ -385,13 +381,10 @@ def prepare_generation_prompts(
     )
     report_payload = benchmark_report.to_dict()
     report_path = (
-        artifacts.knowledge_root
-        / ctx.scenario_name
-        / "semantic_compaction_reports"
-        / f"{ctx.run_id}_gen_{ctx.generation}.json"
+        artifacts.knowledge_root / ctx.scenario_name / "semantic_compaction_reports" / f"{ctx.run_id}_gen_{ctx.generation}.json"
     )
     write_json(report_path, report_payload)
-    return prompts, report_payload
+    return prompts, report_payload, parts
 
 
 def _persist_generation_context_selection(

--- a/autocontext/src/autocontext/loop/stage_types.py
+++ b/autocontext/src/autocontext/loop/stage_types.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from autocontext.harness.pipeline.holdout import HoldoutResult
     from autocontext.knowledge.tuning import TuningConfig
     from autocontext.loop.fixture_loader import Fixture
-    from autocontext.prompts.templates import PromptBundle
+    from autocontext.prompts.templates import PromptBundle, PromptPartsBundle
     from autocontext.scenarios.base import ScenarioInterface
 
 
@@ -40,6 +40,11 @@ class GenerationContext:
 
     # Stage outputs (populated progressively by stages)
     prompts: PromptBundle | None = None
+    # ERP-67 Stage 2b: the per-role (system, untrusted_reference, flat) split for
+    # `prompts`. Set only when it is safe to isolate — None when harness mutations
+    # rewrote the flat prompts (the split would be stale). Consumed by
+    # run_generation under settings.structural_role_isolation.
+    parts: PromptPartsBundle | None = None
     outputs: AgentOutputs | None = None
     tournament: EvaluationSummary | None = None
     gate_decision: str = ""

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -390,7 +390,7 @@ def stage_knowledge_setup(
             logger.warning("failed to materialize evidence workspace for %s", ctx.scenario_name, exc_info=True)
     runtime_profile = resolve_harness_runtime_profile(ctx.settings)
     tool_context = render_harness_tool_context(runtime_profile, tool_context)
-    prompts, semantic_benchmark_payload = prepare_generation_prompts(
+    prompts, semantic_benchmark_payload, prompt_parts = prepare_generation_prompts(
         ctx,
         artifacts=artifacts,
         scenario_rules=scenario.describe_rules(),
@@ -430,6 +430,10 @@ def stage_knowledge_setup(
 
     ctx.applied_competitor_hints = "" if ablation else coach_hints_for_prompt
     ctx.prompts = prompts
+    # ERP-67 Stage 2b: the parts split is derived from the pre-mutation prompts,
+    # so drop it when harness mutations rewrote the flat prompts — structural
+    # isolation then safely no-ops to the (mutated) flat path.
+    ctx.parts = None if active_harness_mutations else prompt_parts
     ctx.evidence_manifest = evidence_manifest
     ctx.semantic_compaction_benchmark = semantic_benchmark_payload
     ctx.strategy_interface = strategy_interface
@@ -486,6 +490,7 @@ def stage_agent_generation(
             scenario_rules=ctx.scenario.describe_rules(),
             current_strategy=ctx.current_strategy or None,
             generation_deadline=generation_deadline,
+            parts=ctx.parts,
         )
 
     selected_strategy = outputs.strategy

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -239,9 +239,9 @@ class TestStageKnowledgeSetup:
 
         from autocontext.prompts.templates import PromptBundle
 
-        def fake_prepare_generation_prompts(*args: object, **kwargs: object) -> tuple[PromptBundle, None]:
+        def fake_prepare_generation_prompts(*args: object, **kwargs: object) -> tuple[PromptBundle, None, None]:
             captured["context_budget_tokens"] = kwargs["context_budget_tokens"]
-            return PromptBundle(competitor="c", analyst="a", coach="co", architect="ar"), None
+            return PromptBundle(competitor="c", analyst="a", coach="co", architect="ar"), None, None
 
         with patch(
             "autocontext.loop.stages.prepare_generation_prompts",

--- a/autocontext/tests/test_role_isolation_wiring.py
+++ b/autocontext/tests/test_role_isolation_wiring.py
@@ -1,0 +1,76 @@
+"""ERP-67 Stage 2b — role runners forward the trusted `system` turn.
+
+When the orchestrator splits a role prompt (structural isolation on), it calls
+`runner.run(prompt=untrusted, system=trusted)`. Each runner must forward that
+into `SubagentTask.system`, so the runtime routes it as a system turn via
+`generate_multiturn`. With no `system` (the default, and today's call sites) the
+runner stays on the single-prompt path — byte-identical behaviour.
+"""
+
+from __future__ import annotations
+
+from autocontext.agents.analyst import AnalystRunner
+from autocontext.agents.architect import ArchitectRunner
+from autocontext.agents.competitor import CompetitorRunner
+from autocontext.agents.subagent_runtime import SubagentRuntime
+from autocontext.harness.core.llm_client import LanguageModelClient
+from autocontext.harness.core.types import ModelResponse, RoleUsage
+
+
+class _RecordingClient(LanguageModelClient):
+    def __init__(self) -> None:
+        self.generate_calls: list[dict[str, object]] = []
+        self.multiturn_calls: list[dict[str, object]] = []
+
+    def generate(self, *, model, prompt, max_tokens, temperature, role=""):  # type: ignore[no-untyped-def]
+        self.generate_calls.append({"prompt": prompt, "role": role})
+        return ModelResponse(text="single", usage=RoleUsage(0, 0, 0, model))
+
+    def generate_multiturn(self, *, model, system, messages, max_tokens, temperature, role=""):  # type: ignore[no-untyped-def]
+        self.multiturn_calls.append({"system": system, "messages": messages, "role": role})
+        return ModelResponse(text="multi", usage=RoleUsage(0, 0, 0, model))
+
+
+def _runtime() -> tuple[SubagentRuntime, _RecordingClient]:
+    client = _RecordingClient()
+    return SubagentRuntime(client), client
+
+
+def test_analyst_forwards_system_as_isolated_turn() -> None:
+    runtime, client = _runtime()
+    AnalystRunner(runtime, "m").run("UNTRUSTED body", system="TRUSTED system")
+    assert not client.generate_calls
+    call = client.multiturn_calls[0]
+    assert call["system"] == "TRUSTED system"
+    assert call["messages"] == [{"role": "user", "content": "UNTRUSTED body"}]
+    assert call["role"] == "analyst"
+
+
+def test_architect_forwards_system_as_isolated_turn() -> None:
+    runtime, client = _runtime()
+    ArchitectRunner(runtime, "m").run("UNTRUSTED body", system="TRUSTED system")
+    call = client.multiturn_calls[0]
+    assert call["system"] == "TRUSTED system"
+    assert call["messages"] == [{"role": "user", "content": "UNTRUSTED body"}]
+    assert call["role"] == "architect"
+
+
+def test_competitor_forwards_system_and_keeps_tool_context_in_user_turn() -> None:
+    runtime, client = _runtime()
+    CompetitorRunner(runtime, "m").run("UNTRUSTED body", tool_context="TOOLS", system="TRUSTED system")
+    call = client.multiturn_calls[0]
+    assert call["system"] == "TRUSTED system"
+    # tool context is appended to the user turn, never the system turn.
+    user = call["messages"][0]["content"]
+    assert "UNTRUSTED body" in user and "TOOLS" in user
+    assert "TRUSTED system" not in user
+    assert call["role"] == "competitor"
+
+
+def test_runners_without_system_stay_on_single_prompt_path() -> None:
+    runtime, client = _runtime()
+    AnalystRunner(runtime, "m").run("just a flat prompt")
+    assert len(client.generate_calls) == 1
+    assert not client.multiturn_calls
+    assert client.generate_calls[0]["prompt"] == "just a flat prompt"
+    assert client.generate_calls[0]["role"] == "analyst"

--- a/autocontext/tests/test_role_isolation_wiring.py
+++ b/autocontext/tests/test_role_isolation_wiring.py
@@ -9,6 +9,8 @@ runner stays on the single-prompt path — byte-identical behaviour.
 
 from __future__ import annotations
 
+import contextlib
+
 from autocontext.agents.analyst import AnalystRunner
 from autocontext.agents.architect import ArchitectRunner
 from autocontext.agents.competitor import CompetitorRunner
@@ -74,3 +76,49 @@ def test_runners_without_system_stay_on_single_prompt_path() -> None:
     assert not client.multiturn_calls
     assert client.generate_calls[0]["prompt"] == "just a flat prompt"
     assert client.generate_calls[0]["role"] == "analyst"
+
+
+class _CapableClient(_RecordingClient):
+    supports_structural_isolation = True
+
+
+class _FakeOrch:
+    """Minimal orchestrator surface build_role_handler needs."""
+
+    def __init__(self, client: LanguageModelClient) -> None:
+        runtime = SubagentRuntime(client)
+        self.competitor = CompetitorRunner(runtime, "m")
+        self.analyst = AnalystRunner(runtime, "m")
+        self.architect = ArchitectRunner(runtime, "m")
+
+    @contextlib.contextmanager
+    def _use_role_runtime(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        yield
+
+
+def _handler(client: LanguageModelClient):  # type: ignore[no-untyped-def]
+    from autocontext.agents.pipeline_adapter import build_role_handler
+
+    return build_role_handler(
+        _FakeOrch(client),  # type: ignore[arg-type]
+        system_map={"analyst": "SYS trusted"},
+        flat_map={"analyst": "FLAT legacy prompt"},
+    )
+
+
+def test_handler_isolates_only_for_capable_clients() -> None:
+    client = _CapableClient()
+    _handler(client)("analyst", "UNTRUSTED user turn", {})
+    # capable backend → real system/user split, untrusted stays in the user turn.
+    assert client.multiturn_calls and not client.generate_calls
+    call = client.multiturn_calls[0]
+    assert call["system"] == "SYS trusted"
+    assert call["messages"] == [{"role": "user", "content": "UNTRUSTED user turn"}]
+
+
+def test_handler_falls_back_to_flat_for_incapable_clients() -> None:
+    client = _RecordingClient()  # supports_structural_isolation defaults False
+    _handler(client)("analyst", "UNTRUSTED user turn", {})
+    # incapable backend → exact legacy flat prompt, no system turn, no reordering.
+    assert client.generate_calls and not client.multiturn_calls
+    assert client.generate_calls[0]["prompt"] == "FLAT legacy prompt"


### PR DESCRIPTION
## ERP-67 Stage 2b — pipeline-path wiring (behind a flag, default off)

Builds on the merged Stage 1 (prompt-parts split) + Stage 2 (`SubagentTask.system` transport seam). Adds the machinery to actually deliver the untrusted reference block as a **separate user turn** from the trusted system prompt on the pipeline generation path — gated by a new flag, **inert by default**.

> **Not for auto-merge — please review.** This is the first slice that can change prompt shape at runtime; it's off by default and the transport is byte-identical when off, but the semantics warrant eyes. Full suite green (exit 0), ruff + mypy clean.

### What's wired
- **`settings.structural_role_isolation: bool = False`** — the gate.
- **Runners** (`competitor` / `analyst` / `architect`): `run(..., system="")` forwards into `SubagentTask.system`. Empty (default, every current call site) → single-prompt path, unchanged.
- **`build_role_handler`**: accepts a `system_map`, passes the per-role system turn.
- **`_run_via_pipeline` / `run_generation`**: accept an optional `PromptPartsBundle`; when the flag is on, build a `system_map` + user-turn `prompt_map` from the **`isolation_safe`** parts (competitor/analyst/architect). Architect's cadence-skip instruction stays in the system turn. **Coach** (enriched mid-flight with analyst output) and the **translator** stay flat.

### Why it's safe
Every new param defaults to off/None, so with the flag off — or `parts` not supplied — the maps are unchanged and behaviour is **byte-identical**. Verified: full suite green, mypy + ruff clean, plus 4 new unit tests (each runner forwards `system` as an isolated turn via `generate_multiturn`; competitor keeps tool-context in the user turn only; no-system → single-prompt).

### Deferred to 2b-2 (called out deliberately)
The last connector — capturing the `PromptPartsBundle` in `prepare_generation_prompts` and threading it via `ctx` into `run_generation` — is **not** in this PR, because `apply_harness_mutations_to_prompts` can rewrite the flat prompts after build (the same staleness concern Stage 1's hook-rewrite `isolation_safe` fallback solves). That connector, with its mutation-safety handling, deserves its own reviewed change. So the flag currently has the full transport machinery + tests but isn't fed parts end-to-end yet.

### Remaining after 2b-2
- Stage 3 — adversarial eval variants (role reassignment / fake system prompt / tool-call injection).
- Stage 4 — flip the default after a score-parity soak.
- Coach/translator isolation + the direct/RLM paths (currently flat).