### PR TITLE
feat(erp-67): structural isolation on the direct (default) path + coach (Stage 2c)

### DIFF
--- a/autocontext/src/autocontext/agents/agent_sdk_client.py
+++ b/autocontext/src/autocontext/agents/agent_sdk_client.py
@@ -49,6 +49,10 @@ class AgentSdkConfig:
 class AgentSdkClient(LanguageModelClient):
     """LLM client backed by claude_agent_sdk.query()."""
 
+    # generate_multiturn routes `system` through ClaudeAgentOptions.system_prompt,
+    # a genuine system/user separation → real message-role isolation (ERP-67).
+    supports_structural_isolation = True
+
     def __init__(self, config: AgentSdkConfig | None = None) -> None:
         self._config = config or AgentSdkConfig()
 

--- a/autocontext/src/autocontext/agents/coach.py
+++ b/autocontext/src/autocontext/agents/coach.py
@@ -27,7 +27,7 @@ class CoachRunner:
         self.runtime = runtime
         self.model = model
 
-    def run(self, prompt: str) -> RoleExecution:
+    def run(self, prompt: str, *, system: str = "") -> RoleExecution:
         return self.runtime.run_task(
             SubagentTask(
                 role="coach",
@@ -35,5 +35,6 @@ class CoachRunner:
                 prompt=prompt,
                 max_tokens=2000,
                 temperature=0.4,
+                system=system,
             )
         )

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -644,6 +644,7 @@ class AgentOrchestrator:
                 "competitor": parts.competitor,
                 "analyst": parts.analyst,
                 "architect": parts.architect,
+                "coach": parts.coach,
             }
             for role, rp in role_parts.items():
                 if not rp.isolation_safe:

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -560,6 +560,7 @@ class AgentOrchestrator:
             current_strategy,
             generation_deadline,
             _notify,
+            parts=parts,
         )
 
         strategy, translator_exec = _run_translator_phase(
@@ -572,9 +573,8 @@ class AgentOrchestrator:
             _notify,
         )
 
-        architect_prompt = prompts.architect
-        if generation_index % self.settings.architect_every_n_gens != 0:
-            architect_prompt += _ARCHITECT_CADENCE_SKIP
+        architect_cadence = _ARCHITECT_CADENCE_SKIP if generation_index % self.settings.architect_every_n_gens != 0 else ""
+        architect_prompt = prompts.architect + architect_cadence
 
         analyst_exec, coach_exec, architect_exec = _run_analyst_coach_architect(
             self,
@@ -587,6 +587,8 @@ class AgentOrchestrator:
             scenario_rules,
             generation_deadline,
             _notify,
+            parts=parts,
+            architect_cadence=architect_cadence,
         )
 
         return _assemble_agent_outputs(

--- a/autocontext/src/autocontext/agents/orchestrator_helpers.py
+++ b/autocontext/src/autocontext/agents/orchestrator_helpers.py
@@ -16,13 +16,36 @@ from typing import TYPE_CHECKING, Any
 from autocontext.agents.architect import parse_architect_harness_specs, parse_architect_tool_specs
 from autocontext.agents.coach import parse_coach_sections
 from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
+from autocontext.agents.role_isolation import resolve_role_turn
 from autocontext.agents.types import AgentOutputs, RoleExecution
 
 if TYPE_CHECKING:
     from autocontext.agents.orchestrator import AgentOrchestrator
-    from autocontext.prompts.templates import PromptBundle
+    from autocontext.prompts.templates import PromptBundle, PromptPartsBundle, RolePromptParts
 
 NotifyFn = Callable[[str, str], None]
+
+
+def _direct_turn(
+    orchestrator: AgentOrchestrator,
+    rp: RolePromptParts | None,
+    runner: object,
+    flat_prompt: str,
+    *,
+    suffix: str = "",
+) -> tuple[str, str]:
+    """Resolve (user_prompt, system) for a direct-path role.
+
+    Returns the legacy ``flat_prompt`` with no system turn unless structural
+    isolation is enabled and parts are available, in which case it defers to
+    ``resolve_role_turn`` (which itself falls back to flat for unsafe splits or
+    incapable clients). Must be called inside the role's ``_use_role_runtime``
+    scope so the resolved client's capability is what's checked.
+    """
+    if not orchestrator.settings.structural_role_isolation or rp is None:
+        return flat_prompt, ""
+    client = getattr(getattr(runner, "runtime", None), "client", None)
+    return resolve_role_turn(rp, client, suffix=suffix)
 
 
 def _run_competitor_phase(
@@ -37,6 +60,7 @@ def _run_competitor_phase(
     current_strategy: dict[str, Any] | None,
     generation_deadline: float | None,
     notify: NotifyFn,
+    parts: PromptPartsBundle | None = None,
 ) -> tuple[str, RoleExecution]:
     """Run the Competitor role, choosing RLM vs direct execution."""
     settings = orchestrator.settings
@@ -70,10 +94,12 @@ def _run_competitor_phase(
     else:
         notify("competitor", "started")
         competitor_prompt = prompts.competitor
+        code_suffix = ""
         if settings.code_strategies_enabled:
             from autocontext.prompts.templates import code_strategy_competitor_suffix
 
-            competitor_prompt += code_strategy_competitor_suffix(strategy_interface)
+            code_suffix = code_strategy_competitor_suffix(strategy_interface)
+            competitor_prompt += code_suffix
         with orchestrator._use_role_runtime(
             "competitor",
             orchestrator.competitor,
@@ -81,7 +107,17 @@ def _run_competitor_phase(
             scenario_name=scenario_name,
             generation_deadline=generation_deadline,
         ):
-            raw_text, competitor_exec = orchestrator.competitor.run(competitor_prompt, tool_context=tool_context)
+            user_prompt, system = _direct_turn(
+                orchestrator,
+                parts.competitor if parts else None,
+                orchestrator.competitor,
+                competitor_prompt,
+                suffix=code_suffix,
+            )
+            if system:
+                raw_text, competitor_exec = orchestrator.competitor.run(user_prompt, tool_context=tool_context, system=system)
+            else:
+                raw_text, competitor_exec = orchestrator.competitor.run(user_prompt, tool_context=tool_context)
         notify("competitor", "completed")
 
     return raw_text, competitor_exec
@@ -125,12 +161,21 @@ def _run_analyst_coach_architect(
     scenario_rules: str,
     generation_deadline: float | None,
     notify: NotifyFn,
+    parts: PromptPartsBundle | None = None,
+    architect_cadence: str = "",
 ) -> tuple[RoleExecution, RoleExecution, RoleExecution]:
     """Run Analyst, Coach, and Architect, choosing RLM vs threaded execution.
 
     Returns (analyst_exec, coach_exec, architect_exec).
     """
     settings = orchestrator.settings
+
+    def _coach_turn(base_prompt: str, analyst_content: str) -> tuple[str, str]:
+        # Resolve the coach turn, then enrich the (untrusted or flat) user base
+        # with the analyst's findings — enrichment always rides the user turn.
+        base, system = _direct_turn(orchestrator, parts.coach if parts else None, orchestrator.coach, base_prompt)
+        return orchestrator._enrich_coach_prompt(base, analyst_content), system
+
     if settings.rlm_enabled and orchestrator._rlm_loader is not None and settings.agent_provider != "agent_sdk":
         notify("analyst", "started")
         notify("architect", "started")
@@ -145,7 +190,6 @@ def _run_analyst_coach_architect(
         notify("analyst", "completed")
         notify("architect", "completed")
         notify("coach", "started")
-        enriched_coach_prompt = orchestrator._enrich_coach_prompt(prompts.coach, analyst_exec.content)
         with ThreadPoolExecutor(max_workers=1) as pool:
             with orchestrator._use_role_runtime(
                 "coach",
@@ -154,7 +198,9 @@ def _run_analyst_coach_architect(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
-                coach_future = pool.submit(orchestrator.coach.run, enriched_coach_prompt)
+                enriched_coach_prompt, coach_system = _coach_turn(prompts.coach, analyst_exec.content)
+                coach_kwargs = {"system": coach_system} if coach_system else {}
+                coach_future = pool.submit(orchestrator.coach.run, enriched_coach_prompt, **coach_kwargs)
                 coach_exec = coach_future.result()
         notify("coach", "completed")
     else:
@@ -167,9 +213,14 @@ def _run_analyst_coach_architect(
             scenario_name=scenario_name,
             generation_deadline=generation_deadline,
         ):
-            analyst_exec = orchestrator.analyst.run(prompts.analyst)
+            analyst_user, analyst_system = _direct_turn(
+                orchestrator, parts.analyst if parts else None, orchestrator.analyst, prompts.analyst
+            )
+            if analyst_system:
+                analyst_exec = orchestrator.analyst.run(analyst_user, system=analyst_system)
+            else:
+                analyst_exec = orchestrator.analyst.run(analyst_user)
         notify("analyst", "completed")
-        enriched_coach_prompt = orchestrator._enrich_coach_prompt(prompts.coach, analyst_exec.content)
         notify("coach", "started")
         notify("architect", "started")
         with (
@@ -188,9 +239,19 @@ def _run_analyst_coach_architect(
                 generation_deadline=generation_deadline,
             ),
         ):
+            enriched_coach_prompt, coach_system = _coach_turn(prompts.coach, analyst_exec.content)
+            architect_user, architect_system = _direct_turn(
+                orchestrator,
+                parts.architect if parts else None,
+                orchestrator.architect,
+                architect_prompt,
+                suffix=architect_cadence,
+            )
+            coach_kwargs = {"system": coach_system} if coach_system else {}
+            architect_kwargs = {"system": architect_system} if architect_system else {}
             with ThreadPoolExecutor(max_workers=2) as pool:
-                coach_future = pool.submit(orchestrator.coach.run, enriched_coach_prompt)
-                architect_future = pool.submit(orchestrator.architect.run, architect_prompt)
+                coach_future = pool.submit(orchestrator.coach.run, enriched_coach_prompt, **coach_kwargs)
+                architect_future = pool.submit(orchestrator.architect.run, architect_user, **architect_kwargs)
                 coach_exec = coach_future.result()
                 notify("coach", "completed")
                 architect_exec = architect_future.result()

--- a/autocontext/src/autocontext/agents/pipeline_adapter.py
+++ b/autocontext/src/autocontext/agents/pipeline_adapter.py
@@ -120,9 +120,6 @@ def build_role_handler(
                 return orch.architect.run(user_prompt)
         elif name == "coach":
             analyst_exec = completed.get("analyst")
-            enriched = prompt
-            if analyst_exec:
-                enriched = orch._enrich_coach_prompt(prompt, analyst_exec.content)
             with orch._use_role_runtime(
                 "coach",
                 orch.coach,
@@ -130,6 +127,14 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
+                # Resolve the coach base (untrusted user turn or flat) first, then
+                # append the analyst findings — enrichment rides the user turn.
+                user_base, system = _resolve_turn("coach", orch.coach, prompt)
+                enriched = user_base
+                if analyst_exec:
+                    enriched = orch._enrich_coach_prompt(user_base, analyst_exec.content)
+                if system:
+                    return orch.coach.run(enriched, system=system)
                 return orch.coach.run(enriched)
         else:
             raise ValueError(f"Unknown role: {name}")

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -139,35 +139,24 @@ class RuntimeSessionRecordingClient(LanguageModelClient):
         self.session = session
         self.role = role
         self.cwd = cwd
+        # Forward explicitly — __getattr__ never fires for this inherited base
+        # attribute, so without this a session-recorded capable client (the normal
+        # run path) reports False and ERP-67 isolation no-ops.
+        self.supports_structural_isolation = bool(getattr(inner, "supports_structural_isolation", False))
 
     def __getattr__(self, name: str) -> object:
         return getattr(self.inner, name)
 
-    def generate(
-        self,
-        *,
-        model: str,
-        prompt: str,
-        max_tokens: int,
-        temperature: float,
-        role: str = "",
-    ) -> ModelResponse:
+    def _record(self, *, prompt: str, model: str, resolved_role: str, call: Callable[[], ModelResponse]) -> ModelResponse:
         from autocontext.session.runtime_session import RuntimeSessionPromptHandlerOutput
 
         response: ModelResponse | None = None
         failure: Exception | None = None
-        resolved_role = role or self.role
 
         def handler(_input: object) -> RuntimeSessionPromptHandlerOutput:
             nonlocal response, failure
             try:
-                response = self.inner.generate(
-                    model=model,
-                    prompt=prompt,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    role=resolved_role,
-                )
+                response = call()
             except Exception as exc:
                 failure = exc
                 raise
@@ -181,12 +170,7 @@ class RuntimeSessionRecordingClient(LanguageModelClient):
                 ),
             )
 
-        result = self.session.submit_prompt(
-            prompt=prompt,
-            handler=handler,
-            role=resolved_role,
-            cwd=self.cwd,
-        )
+        result = self.session.submit_prompt(prompt=prompt, handler=handler, role=resolved_role, cwd=self.cwd)
         if result.is_error:
             raise failure or RuntimeError(result.error)
         if response is None:
@@ -203,6 +187,58 @@ class RuntimeSessionRecordingClient(LanguageModelClient):
         metadata = dict(response.metadata)
         metadata["runtimeSessionId"] = self.session.session_id
         return ModelResponse(text=response.text, usage=response.usage, metadata=metadata)
+
+    def generate(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        resolved_role = role or self.role
+        return self._record(
+            prompt=prompt,
+            model=model,
+            resolved_role=resolved_role,
+            call=lambda: self.inner.generate(
+                model=model,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                role=resolved_role,
+            ),
+        )
+
+    def generate_multiturn(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        # Record the flattened turns for the session log/replay, but call the
+        # inner client's real generate_multiturn so a capable backend keeps the
+        # untrusted content in a separate user turn (ERP-67 structural isolation).
+        resolved_role = role or self.role
+        recorded = system + "\n\n" + "\n\n".join(m["content"] for m in messages if m.get("role") == "user")
+        return self._record(
+            prompt=recorded,
+            model=model,
+            resolved_role=resolved_role,
+            call=lambda: self.inner.generate_multiturn(
+                model=model,
+                system=system,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                role=resolved_role,
+            ),
+        )
 
     def close(self) -> None:
         close = getattr(self.inner, "close", None)

--- a/autocontext/src/autocontext/agents/role_isolation.py
+++ b/autocontext/src/autocontext/agents/role_isolation.py
@@ -1,0 +1,34 @@
+"""Shared resolution for ERP-67 structural role isolation.
+
+Given a role's prompt-parts split and the resolved client, decide whether to
+deliver the untrusted reference as a separate user turn (capable backends) or
+fall back to the exact flat prompt (unsafe split, or single-prompt / runtime-
+bridge backends). Used by both the pipeline and direct execution paths so the
+capability gating and flat fallback stay identical.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autocontext.prompts.templates import RolePromptParts
+
+
+def resolve_role_turn(rp: RolePromptParts, client: object, *, suffix: str = "") -> tuple[str, str]:
+    """Return ``(user_prompt, system)`` for a role.
+
+    - Isolate (untrusted user turn + trusted system turn) only when the split is
+      ``isolation_safe`` AND ``client`` advertises real message roles.
+    - Otherwise return the exact flat prompt with an empty system turn —
+      byte-identical to legacy, so nothing is reordered and no runtime system
+      channel is silently dropped.
+
+    ``suffix`` is trusted operator text appended by the caller to the flat prompt
+    (e.g. the architect cadence-skip or the code-strategy instructions). It rides
+    with the system turn when isolating and with the flat prompt when falling
+    back, matching where it sits in the legacy prompt.
+    """
+    if rp.isolation_safe and getattr(client, "supports_structural_isolation", False):
+        return rp.untrusted_reference, rp.system + suffix
+    return rp.flat + suffix, ""

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -100,10 +100,13 @@ class AppSettings(BaseModel):
     structural_role_isolation: bool = Field(
         default=False,
         description=(
-            "ERP-67 Stage 2b: deliver the untrusted reference block (playbook / coach "
-            "hints / dead-ends) in a separate user turn from the trusted system prompt "
-            "for role-capable backends, instead of one flat prompt. Off = byte-identical "
-            "legacy behaviour. Pipeline path, competitor/analyst/architect only for now."
+            "ERP-67: deliver the untrusted reference block (playbook / coach hints / "
+            "dead-ends) in a separate user turn from the trusted system prompt for "
+            "role-capable backends (Anthropic, Agent SDK), instead of one flat prompt. "
+            "Applies to competitor/analyst/architect/coach on both the direct and "
+            "pipeline execution paths; single-prompt / runtime-bridge backends and "
+            "unsafe (hook-/mutation-rewritten) prompts fall back to the exact flat "
+            "prompt. Off = byte-identical legacy behaviour."
         ),
     )
     evidence_freshness_enabled: bool = Field(

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -16,6 +16,11 @@ class HookedLanguageModelClient(LanguageModelClient):
         self.inner = inner
         self.hook_bus = hook_bus
         self.provider_name = provider_name or inner.__class__.__name__
+        # Forward explicitly — __getattr__ can't (the base defines this as a real
+        # attribute, so lookup never misses). Without this, structural isolation
+        # (ERP-67) silently no-ops whenever a client is wrapped for hooks, which
+        # GenerationRunner always does.
+        self.supports_structural_isolation = bool(getattr(inner, "supports_structural_isolation", False))
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.inner, name)

--- a/autocontext/tests/test_role_isolation_resolve.py
+++ b/autocontext/tests/test_role_isolation_resolve.py
@@ -1,0 +1,57 @@
+"""ERP-67 — the shared capability-gated turn resolver used by both execution paths."""
+
+from __future__ import annotations
+
+from autocontext.agents.role_isolation import resolve_role_turn
+from autocontext.prompts.templates import RolePromptParts
+
+
+class _Capable:
+    supports_structural_isolation = True
+
+
+class _Incapable:
+    supports_structural_isolation = False
+
+
+def _parts(*, safe: bool = True) -> RolePromptParts:
+    return RolePromptParts(
+        system="SYS trusted",
+        untrusted_reference="UNTRUSTED ref",
+        flat="FLAT legacy",
+        isolation_safe=safe,
+    )
+
+
+def test_capable_client_gets_isolated_turns() -> None:
+    user, system = resolve_role_turn(_parts(), _Capable())
+    assert user == "UNTRUSTED ref"
+    assert system == "SYS trusted"
+
+
+def test_incapable_client_falls_back_to_flat() -> None:
+    user, system = resolve_role_turn(_parts(), _Incapable())
+    assert user == "FLAT legacy"
+    assert system == ""
+
+
+def test_unsafe_split_falls_back_to_flat_even_for_capable_clients() -> None:
+    user, system = resolve_role_turn(_parts(safe=False), _Capable())
+    assert user == "FLAT legacy"
+    assert system == ""
+
+
+def test_suffix_rides_system_when_isolating_and_flat_when_falling_back() -> None:
+    user, system = resolve_role_turn(_parts(), _Capable(), suffix=" +CADENCE")
+    assert user == "UNTRUSTED ref"
+    assert system == "SYS trusted +CADENCE"
+
+    user2, system2 = resolve_role_turn(_parts(), _Incapable(), suffix=" +CADENCE")
+    assert user2 == "FLAT legacy +CADENCE"
+    assert system2 == ""
+
+
+def test_missing_capability_attribute_is_treated_as_incapable() -> None:
+    user, system = resolve_role_turn(_parts(), object())
+    assert user == "FLAT legacy"
+    assert system == ""

--- a/autocontext/tests/test_role_isolation_wiring.py
+++ b/autocontext/tests/test_role_isolation_wiring.py
@@ -13,8 +13,11 @@ import contextlib
 
 from autocontext.agents.analyst import AnalystRunner
 from autocontext.agents.architect import ArchitectRunner
+from autocontext.agents.coach import CoachRunner
 from autocontext.agents.competitor import CompetitorRunner
 from autocontext.agents.subagent_runtime import SubagentRuntime
+from autocontext.extensions.hooks import HookBus
+from autocontext.extensions.llm import HookedLanguageModelClient
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleUsage
 
@@ -122,3 +125,35 @@ def test_handler_falls_back_to_flat_for_incapable_clients() -> None:
     # incapable backend → exact legacy flat prompt, no system turn, no reordering.
     assert client.generate_calls and not client.multiturn_calls
     assert client.generate_calls[0]["prompt"] == "FLAT legacy prompt"
+
+
+def test_coach_forwards_system_as_isolated_turn() -> None:
+    runtime, client = _runtime()
+    CoachRunner(runtime, "m").run("UNTRUSTED body", system="TRUSTED system")
+    call = client.multiturn_calls[0]
+    assert call["system"] == "TRUSTED system"
+    assert call["messages"] == [{"role": "user", "content": "UNTRUSTED body"}]
+    assert call["role"] == "coach"
+
+
+def test_coach_without_system_stays_flat() -> None:
+    runtime, client = _runtime()
+    CoachRunner(runtime, "m").run("flat coach prompt")
+    assert client.generate_calls and not client.multiturn_calls
+    assert client.generate_calls[0]["prompt"] == "flat coach prompt"
+
+
+def test_hook_wrapper_forwards_capability_so_production_isolates() -> None:
+    # GenerationRunner always wraps the client for hooks; the wrapper must expose
+    # the inner client's capability or every production role falls back to flat.
+    capable = HookedLanguageModelClient(_CapableClient(), HookBus())
+    assert capable.supports_structural_isolation is True
+    incapable = HookedLanguageModelClient(_RecordingClient(), HookBus())
+    assert incapable.supports_structural_isolation is False
+
+
+def test_agent_sdk_client_advertises_structural_isolation() -> None:
+    from autocontext.agents.agent_sdk_client import AgentSdkClient
+
+    # Routes system via ClaudeAgentOptions.system_prompt → genuinely role-capable.
+    assert AgentSdkClient.supports_structural_isolation is True


### PR DESCRIPTION
## ERP-67 Stage 2c — the default execution path + coach

Stage 2b (#1203) wired only the **opt-in pipeline** path. But `use_pipeline_engine` defaults **False**, so the **direct path** (`orchestrator_helpers`) is what runs by default and had no isolation. This wires it, and adds **coach** (both paths). Still behind `structural_role_isolation`, default off → byte-identical.

> Please review — this touches the default generation path. Full suite green (exit 0), ruff + mypy clean.

### What's new
- **Shared resolver** `agents/role_isolation.resolve_role_turn(rp, client, suffix="")` — one place for the capability gating + flat fallback: isolate (untrusted **user** turn + trusted **system** turn) only when the split is `isolation_safe` **and** the client supports real message roles; otherwise the **exact flat prompt** (+ trusted suffix), no system turn.
- **Direct path**: `_run_competitor_phase` and `_run_analyst_coach_architect` take `parts` (+ `architect_cadence`) and resolve each role's turn **inside its `_use_role_runtime` scope**, so the resolved (possibly role-routed) client's capability is what's checked. `system` is passed only when isolating. Competitor's code-strategy suffix and architect's cadence-skip ride the system turn when isolating, the flat prompt when falling back.
- **Coach**: the analyst enrichment now rides the **user** turn — the coach base is resolved first, then `_enrich_coach_prompt` appends the analyst findings to that (untrusted or flat) base; the system turn carries only trusted coach instructions. Wired in both branches.

### Safety
Every new param defaults off/None; with the flag off the resolver returns the legacy flat prompt with no system turn, so behaviour is **byte-identical**. Verified: full suite green, ruff + mypy clean. New unit tests: capable→isolated, incapable/unsafe→flat, suffix placement, missing-capability→flat.

### Remaining (tracked on ERP-67)
- The pipeline handler still uses its own inline resolution — a follow-up could dedupe it onto `resolve_role_turn`.
- Translator has no untrusted prompt to isolate; RLM analyst/architect keep their own `*_tpl` system separation.
- **Stage 3** — adversarial eval variants. **Stage 4** — flip the default after a score-parity soak.