### PR TITLE
AC-885 slice B: persisted and derived evaluator-epoch lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
   `evaluator_epoch` (rubric plus judge provider and model), and the improvement loop re-baselines
   instead of comparing a round against a baseline scored under a different evaluator, emitting an
   `evaluator_epoch_rebaseline` event. Python and TypeScript share a parity-pinned epoch hash.
+- AC-885 Slice B: evaluator-epoch lineage on persisted and derived records. Judge-scored generation
+  rows carry `evaluator_epoch`; run facets, training exports, calibration reports, and rubric-drift
+  snapshots read it through, with a `mixed_epoch` flag when an aggregate spans more than one
+  evaluator. Tournament-scored and human-scored records are left unstamped.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/migrations/016_generation_evaluator_epoch.sql
+++ b/autocontext/migrations/016_generation_evaluator_epoch.sql
@@ -1,0 +1,3 @@
+-- AC-885 Slice B: evaluator-epoch lineage on judge-scored generation rows.
+-- Null for tournament-scored rows and legacy rows.
+ALTER TABLE generations ADD COLUMN evaluator_epoch TEXT DEFAULT NULL;

--- a/autocontext/src/autocontext/analytics/calibration.py
+++ b/autocontext/src/autocontext/analytics/calibration.py
@@ -90,9 +90,13 @@ class CalibrationRound(BaseModel):
 
 
 def compute_round_mixed_epoch(samples: list[CalibrationSample]) -> bool:
-    """True when the samples span more than one distinct non-null evaluator epoch."""
-    epochs = {s.evaluator_epoch for s in samples if s.evaluator_epoch is not None}
-    return len(epochs) > 1
+    """True when the samples span more than one evaluator class.
+
+    None (unknown/legacy) is its own class comparable only with None, so it is
+    NOT filtered out: a known epoch mixed with None spans two classes and is
+    flagged, while an all-None or empty aggregate is not.
+    """
+    return len({s.evaluator_epoch for s in samples}) > 1
 
 
 class SpotCheckSampler:

--- a/autocontext/src/autocontext/analytics/calibration.py
+++ b/autocontext/src/autocontext/analytics/calibration.py
@@ -35,6 +35,7 @@ class CalibrationSample(BaseModel):
     best_score: float = 0.0
     score_delta: float = 0.0
     playbook_mutation_size: int = 0
+    evaluator_epoch: str | None = None
     created_at: str = ""
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -77,6 +78,7 @@ class CalibrationRound(BaseModel):
     outcomes: list[CalibrationOutcome] = Field(default_factory=list)
     status: str = "pending"  # pending, in_progress, completed
     summary: str = ""
+    mixed_epoch: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -85,6 +87,12 @@ class CalibrationRound(BaseModel):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CalibrationRound:
         return cls.model_validate(data)
+
+
+def compute_round_mixed_epoch(samples: list[CalibrationSample]) -> bool:
+    """True when the samples span more than one distinct non-null evaluator epoch."""
+    epochs = {s.evaluator_epoch for s in samples if s.evaluator_epoch is not None}
+    return len(epochs) > 1
 
 
 class SpotCheckSampler:
@@ -168,6 +176,7 @@ class SpotCheckSampler:
                 best_score=facet.best_score,
                 score_delta=round(score_delta, 4),
                 playbook_mutation_size=0,
+                evaluator_epoch=facet.evaluator_epoch,
                 created_at=now,
             )
             scored.append((risk_score, sample))

--- a/autocontext/src/autocontext/analytics/extractor.py
+++ b/autocontext/src/autocontext/analytics/extractor.py
@@ -41,6 +41,12 @@ class FacetExtractor:
         best_score = max((g.get("best_score") or 0.0 for g in generations), default=0.0)
         best_elo = max((g.get("elo") or 0.0 for g in generations), default=0.0)
 
+        # Epoch of the best-scoring generation row (null if no rows or no epoch)
+        best_gen = max(
+            generations, key=lambda g: g.get("best_score") or 0.0, default=None
+        )
+        best_epoch = best_gen.get("evaluator_epoch") if best_gen is not None else None
+
         # Duration
         total_duration = sum(g.get("duration_seconds") or 0.0 for g in generations)
 
@@ -91,6 +97,7 @@ class FacetExtractor:
             delight_signals=delight_signals,
             events=[],
             metadata=run.get("metadata", {}),
+            evaluator_epoch=best_epoch,
             created_at=datetime.now(UTC).isoformat(),
         )
 

--- a/autocontext/src/autocontext/analytics/facets.py
+++ b/autocontext/src/autocontext/analytics/facets.py
@@ -109,6 +109,7 @@ class RunFacet(BaseModel):
     delight_signals: list[DelightSignal]
     events: list[RunEvent]
     metadata: dict[str, Any] = Field(default_factory=dict)
+    evaluator_epoch: str | None = None
     created_at: str = ""
 
     def to_dict(self) -> dict[str, Any]:

--- a/autocontext/src/autocontext/analytics/rubric_drift.py
+++ b/autocontext/src/autocontext/analytics/rubric_drift.py
@@ -46,6 +46,8 @@ class RubricSnapshot(BaseModel):
     release: str
     scenario_family: str
     agent_provider: str
+    evaluator_epochs: list[str] = Field(default_factory=list)
+    mixed_epoch: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -107,6 +109,7 @@ class DriftWarning(BaseModel):
     affected_scenarios: list[str]
     affected_providers: list[str]
     affected_releases: list[str]
+    mixed_epoch: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -157,6 +160,8 @@ class RubricDriftMonitor:
             )
 
         scores = [f.best_score for f in facets]
+        epochs = sorted({f.evaluator_epoch for f in facets if f.evaluator_epoch is not None})
+        mixed_epoch = len(epochs) > 1
         timestamps = sorted(f.created_at for f in facets if f.created_at)
         window_start = timestamps[0] if timestamps else ""
         window_end = timestamps[-1] if timestamps else ""
@@ -213,6 +218,8 @@ class RubricDriftMonitor:
             release=release,
             scenario_family=scenario_family,
             agent_provider=agent_provider,
+            evaluator_epochs=epochs,
+            mixed_epoch=mixed_epoch,
             metadata={"scenarios": scenarios},
         )
 
@@ -354,6 +361,9 @@ class RubricDriftMonitor:
                 thresholds.max_rollback_rate,
                 scenarios, providers, releases,
             ))
+
+        for warning in warnings:
+            warning.mixed_epoch = current.mixed_epoch
 
         return warnings
 

--- a/autocontext/src/autocontext/analytics/rubric_drift.py
+++ b/autocontext/src/autocontext/analytics/rubric_drift.py
@@ -48,6 +48,7 @@ class RubricSnapshot(BaseModel):
     agent_provider: str
     evaluator_epochs: list[str] = Field(default_factory=list)
     mixed_epoch: bool = False
+    has_unknown_epoch: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -56,6 +57,17 @@ class RubricSnapshot(BaseModel):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RubricSnapshot:
         return cls.model_validate(data)
+
+
+def _combined_mixed(a: RubricSnapshot, b: RubricSnapshot) -> bool:
+    """True when two snapshots together span more than one evaluator class.
+
+    Known epochs come from the union of each snapshot's evaluator_epochs; the
+    unknown (None) class is counted once if either snapshot carries a null epoch.
+    """
+    return len(set(a.evaluator_epochs) | set(b.evaluator_epochs)) + (
+        1 if (a.has_unknown_epoch or b.has_unknown_epoch) else 0
+    ) > 1
 
 
 class DimensionDriftSnapshot(BaseModel):
@@ -161,7 +173,8 @@ class RubricDriftMonitor:
 
         scores = [f.best_score for f in facets]
         epochs = sorted({f.evaluator_epoch for f in facets if f.evaluator_epoch is not None})
-        mixed_epoch = len(epochs) > 1
+        has_unknown_epoch = any(f.evaluator_epoch is None for f in facets)
+        mixed_epoch = len(epochs) + (1 if has_unknown_epoch else 0) > 1
         timestamps = sorted(f.created_at for f in facets if f.created_at)
         window_start = timestamps[0] if timestamps else ""
         window_end = timestamps[-1] if timestamps else ""
@@ -220,6 +233,7 @@ class RubricDriftMonitor:
             agent_provider=agent_provider,
             evaluator_epochs=epochs,
             mixed_epoch=mixed_epoch,
+            has_unknown_epoch=has_unknown_epoch,
             metadata={"scenarios": scenarios},
         )
 
@@ -289,10 +303,11 @@ class RubricDriftMonitor:
             ))
 
         # Score inflation — baseline comparison
+        inflation_warning: DriftWarning | None = None
         if baseline is not None:
             delta = current.mean_score - baseline.mean_score
             if delta > thresholds.max_score_inflation:
-                warnings.append(self._make_warning(
+                inflation_warning = self._make_warning(
                     now, "score_inflation", "high",
                     f"Mean score increased by {delta:.2f} from baseline "
                     f"({baseline.mean_score:.2f} → {current.mean_score:.2f})",
@@ -300,7 +315,8 @@ class RubricDriftMonitor:
                     "mean_score_delta", delta,
                     thresholds.max_score_inflation,
                     scenarios, providers, releases,
-                ))
+                )
+                warnings.append(inflation_warning)
 
         # Perfect rate
         if current.perfect_score_rate > thresholds.max_perfect_rate:
@@ -364,6 +380,11 @@ class RubricDriftMonitor:
 
         for warning in warnings:
             warning.mixed_epoch = current.mixed_epoch
+
+        # The baseline-derived inflation warning is a cross-snapshot comparison,
+        # so it must reflect the epochs of BOTH snapshots, not current alone.
+        if baseline is not None and inflation_warning is not None:
+            inflation_warning.mixed_epoch = _combined_mixed(current, baseline)
 
         return warnings
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -365,6 +365,7 @@ def _run_agent_task(
         gate_decision=effective_termination_reason,
         status="completed",
         duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
+        evaluator_epoch=result.evaluator_epoch,
     )
 
     return AgentTaskRunSummary(

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -365,7 +365,7 @@ def _run_agent_task(
         gate_decision=effective_termination_reason,
         status="completed",
         duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
-        evaluator_epoch=result.evaluator_epoch,
+        evaluator_epoch=getattr(result, "evaluator_epoch", None),
     )
 
     return AgentTaskRunSummary(

--- a/autocontext/src/autocontext/execution/rubric_calibration.py
+++ b/autocontext/src/autocontext/execution/rubric_calibration.py
@@ -248,6 +248,7 @@ class CalibrationReport(BaseModel):
     variance: JudgeVarianceResult
     calibrated: bool
     metadata: dict[str, Any] = Field(default_factory=dict)
+    evaluator_epoch: str | None = None
 
     def summary(self) -> str:
         lines = [
@@ -359,6 +360,7 @@ def run_judge_calibration(
     human_scores: list[float] = []
     judge_means: list[float] = []
     per_anchor_variance: dict[str, dict[str, Any]] = {}
+    calibration_epoch: str | None = None
 
     for anchor in calibration_set.anchors:
         leave_one_out = [
@@ -376,6 +378,8 @@ def run_judge_calibration(
                 calibration_examples=leave_one_out if leave_one_out else None,
             )
             repeated_scores.append(result.score)
+            if calibration_epoch is None:
+                calibration_epoch = result.evaluator_epoch
 
         variance = measure_judge_variance(repeated_scores)
         per_anchor_variance[anchor.anchor_id] = variance.to_dict()
@@ -400,4 +404,5 @@ def run_judge_calibration(
             "per_anchor_variance": per_anchor_variance,
             "cross_domain_normalization": "explicit second phase",
         },
+        evaluator_epoch=calibration_epoch,
     )

--- a/autocontext/src/autocontext/knowledge/solve_task_execution.py
+++ b/autocontext/src/autocontext/knowledge/solve_task_execution.py
@@ -318,6 +318,7 @@ def run_task_like_scenario(
         gate_decision=result.termination_reason,
         status="completed",
         duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
+        evaluator_epoch=result.evaluator_epoch,
     )
     sqlite.mark_run_completed(active_run_id)
     if settings.cross_run_inheritance and not settings.ablation_no_feedback:

--- a/autocontext/src/autocontext/knowledge/solve_task_execution.py
+++ b/autocontext/src/autocontext/knowledge/solve_task_execution.py
@@ -318,7 +318,7 @@ def run_task_like_scenario(
         gate_decision=result.termination_reason,
         status="completed",
         duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
-        evaluator_epoch=result.evaluator_epoch,
+        evaluator_epoch=getattr(result, "evaluator_epoch", None),
     )
     sqlite.mark_run_completed(active_run_id)
     if settings.cross_run_inheritance and not settings.ablation_no_feedback:

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -18,6 +18,7 @@ from autocontext.analytics.calibration import (
     CalibrationRound,
     CalibrationStore,
     SpotCheckSampler,
+    compute_round_mixed_epoch,
 )
 from autocontext.analytics.clustering import PatternClusterer
 from autocontext.analytics.correlation import CorrelationStore
@@ -489,6 +490,7 @@ class GenerationRunner:
                 samples=samples,
                 outcomes=[],
                 status="pending",
+                mixed_epoch=compute_round_mixed_epoch(samples),
                 summary=(
                     f"{len(samples)} high-risk sample(s) selected from "
                     f"{len(relevant_facets)} run(s); warnings: {', '.join(warning_types)}"

--- a/autocontext/src/autocontext/storage/bootstrap_schema.py
+++ b/autocontext/src/autocontext/storage/bootstrap_schema.py
@@ -22,6 +22,7 @@ _BOOTSTRAP_MIGRATIONS = (
     "013_generation_dimension_summary.sql",
     "014_scoring_backend_metadata.sql",
     "015_match_replay.sql",
+    "016_generation_evaluator_epoch.sql",
 )
 
 
@@ -74,6 +75,7 @@ def bootstrap_core_schema(conn: sqlite3.Connection) -> None:
             dimension_summary_json TEXT DEFAULT NULL,
             scoring_backend TEXT NOT NULL DEFAULT 'elo',
             rating_uncertainty REAL DEFAULT NULL,
+            evaluator_epoch TEXT DEFAULT NULL,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now')),
             PRIMARY KEY (run_id, generation_index),

--- a/autocontext/src/autocontext/storage/migration_ledgers.py
+++ b/autocontext/src/autocontext/storage/migration_ledgers.py
@@ -14,6 +14,7 @@ TYPESCRIPT_TO_PYTHON_BASELINES: dict[str, tuple[str, ...]] = {
         "014_scoring_backend_metadata.sql",
         "015_match_replay.sql",
     ),
+    "014_generation_evaluator_epoch.sql": ("016_generation_evaluator_epoch.sql",),
 }
 
 PYTHON_TO_TYPESCRIPT_BASELINES: dict[str, tuple[str, ...]] = {

--- a/autocontext/src/autocontext/storage/row_types.py
+++ b/autocontext/src/autocontext/storage/row_types.py
@@ -35,6 +35,7 @@ class GenerationMetricsRow(TypedDict):
     duration_seconds: float | None
     scoring_backend: str | None
     rating_uncertainty: float | None
+    evaluator_epoch: str | None
     dimension_summary_json: str | None
     created_at: str
     updated_at: str

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -121,6 +121,7 @@ class SQLiteStore(
         dimension_summary_json: str | None = None,
         scoring_backend: str = "elo",
         rating_uncertainty: float | None = None,
+        evaluator_epoch: str | None = None,
     ) -> None:
         with self.connect() as conn:
             conn.execute(
@@ -128,9 +129,9 @@ class SQLiteStore(
                 INSERT INTO generations(
                     run_id, generation_index, mean_score, best_score, elo, wins, losses,
                     gate_decision, status, duration_seconds, dimension_summary_json,
-                    scoring_backend, rating_uncertainty
+                    scoring_backend, rating_uncertainty, evaluator_epoch
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(run_id, generation_index) DO UPDATE SET
                     mean_score = excluded.mean_score,
                     best_score = excluded.best_score,
@@ -143,6 +144,7 @@ class SQLiteStore(
                     dimension_summary_json = excluded.dimension_summary_json,
                     scoring_backend = excluded.scoring_backend,
                     rating_uncertainty = excluded.rating_uncertainty,
+                    evaluator_epoch = excluded.evaluator_epoch,
                     updated_at = datetime('now')
                 """,
                 (
@@ -159,6 +161,7 @@ class SQLiteStore(
                     dimension_summary_json,
                     scoring_backend,
                     rating_uncertainty,
+                    evaluator_epoch,
                 ),
             )
 

--- a/autocontext/src/autocontext/training/export.py
+++ b/autocontext/src/autocontext/training/export.py
@@ -82,6 +82,7 @@ def export_training_data(
                 score=gen["best_score"],
                 gate_decision=gate,
                 context=context,
+                evaluator_epoch=gen.get("evaluator_epoch"),
             )
 
             if include_matches:

--- a/autocontext/src/autocontext/training/types.py
+++ b/autocontext/src/autocontext/training/types.py
@@ -1,4 +1,5 @@
 """Training data types for strategy-level export."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -16,6 +17,7 @@ class TrainingRecord:
     score: float
     gate_decision: str
     context: dict[str, Any] = field(default_factory=dict)
+    evaluator_epoch: str | None = None
 
 
 @dataclass(slots=True)

--- a/autocontext/tests/test_agent_task_generation_epoch.py
+++ b/autocontext/tests/test_agent_task_generation_epoch.py
@@ -1,0 +1,132 @@
+"""AC-885 Slice B, Task 2: the agent-task generation write sites must stamp
+``evaluator_epoch`` from the ``ImprovementResult`` onto the persisted row.
+
+The positive test drives the real ``_run_agent_task`` code path against a stub
+scenario and a stubbed ``ImprovementLoop.run`` that returns a *real*
+``ImprovementResult`` carrying ``evaluator_epoch="e-1"``. Everything from that
+result through to the real ``SQLiteStore.upsert_generation`` call and back out of
+the persisted row is exercised (no mock stands in for the call site). The
+negative test pins the contract boundary: the tournament write site
+(``loop/stages.py``, deliberately untouched by this task) omits the kwarg, so a
+generation upserted the way that site upserts stays ``evaluator_epoch = NULL``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from autocontext.execution.improvement_loop import ImprovementResult
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+class _StubAgentTask:
+    """Minimal AgentTaskInterface stub for driving ``_run_agent_task``."""
+
+    def initial_state(self) -> dict[str, Any]:
+        return {}
+
+    def prepare_context(self, state: dict[str, Any]) -> dict[str, Any]:
+        return state
+
+    def validate_context(self, state: dict[str, Any]) -> list[str]:
+        return []
+
+    def get_task_prompt(self, state: dict[str, Any]) -> str:
+        return "do the task"
+
+
+@contextmanager
+def _noop_hook_bus(_hook_bus: Any):
+    yield
+
+
+def _real_result() -> ImprovementResult:
+    return ImprovementResult(
+        rounds=[],
+        best_output="final output",
+        best_score=0.75,
+        best_round=1,
+        total_rounds=1,
+        met_threshold=True,
+        termination_reason="threshold_met",
+        duration_ms=1234,
+        evaluator_epoch="e-1",
+    )
+
+
+def test_agent_task_run_persists_generation_epoch(tmp_path) -> None:
+    """The agent-task write site forwards ImprovementResult.evaluator_epoch."""
+    from autocontext import cli
+
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+
+    calls: list[dict[str, Any]] = []
+    orig = store.upsert_generation
+
+    def _spy(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return orig(*args, **kwargs)
+
+    fake_provider = SimpleNamespace(complete=lambda **_: SimpleNamespace(text="initial"))
+    fake_loop = MagicMock()
+    fake_loop.run.return_value = _real_result()
+
+    settings = MagicMock()
+    settings.extensions = None
+    settings.simplicity_mode = "off"
+    settings.agent_provider = "anthropic"
+
+    with (
+        patch.object(store, "upsert_generation", _spy),
+        patch.dict(cli.SCENARIO_REGISTRY, {"stub_task": _StubAgentTask}, clear=False),
+        patch("autocontext.cli._sqlite_from_settings", return_value=store),
+        patch("autocontext.cli.initialize_hook_bus", return_value=(MagicMock(), [])),
+        patch("autocontext.cli.active_hook_bus", _noop_hook_bus),
+        patch("autocontext.cli._resolve_agent_task_runtime", return_value=(fake_provider, "m")),
+        patch("autocontext.cli.ImprovementLoop", return_value=fake_loop),
+        patch("autocontext.cli.build_evaluator_guardrail_payload", return_value=None),
+    ):
+        summary = cli._run_agent_task("stub_task", settings, max_rounds=1, run_id="run-epoch")
+
+    # The persisted "completed" upsert forwarded the result's epoch...
+    completed = [c for c in calls if c.get("status") == "completed"]
+    assert completed, "expected a completed upsert_generation call"
+    assert completed[-1].get("evaluator_epoch") == "e-1"
+
+    # ...and it round-trips through the real row.
+    row = store.get_generation("run-epoch", 1)
+    assert row is not None
+    assert row["evaluator_epoch"] == "e-1"
+    assert summary.run_id == "run-epoch"
+
+
+def test_tournament_generation_epoch_stays_null(tmp_path) -> None:
+    """The tournament write site (loop/stages.py) omits the kwarg, so its rows
+    stay null. Mirrors the exact kwargs of stages.py::upsert_generation."""
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+    store.create_run("run-tourney", "some_scenario", 1, "tournament")
+
+    # Faithful mirror of loop/stages.py:1092 (no evaluator_epoch kwarg).
+    store.upsert_generation(
+        "run-tourney",
+        1,
+        mean_score=0.5,
+        best_score=0.6,
+        elo=1500.0,
+        wins=1,
+        losses=0,
+        gate_decision="promoted",
+        status="completed",
+    )
+
+    row = store.get_generation("run-tourney", 1)
+    assert row is not None
+    assert row["evaluator_epoch"] is None

--- a/autocontext/tests/test_calibration_sample_epoch.py
+++ b/autocontext/tests/test_calibration_sample_epoch.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from autocontext.analytics.calibration import (
+    CalibrationRound,
+    CalibrationSample,
+    compute_round_mixed_epoch,
+)
+
+
+def test_round_mixed_epoch_flag() -> None:
+    s1 = CalibrationSample(sample_id="a", run_id="r1", scenario="s", evaluator_epoch="e1")
+    s2 = CalibrationSample(sample_id="b", run_id="r2", scenario="s", evaluator_epoch="e1")
+    s3 = CalibrationSample(sample_id="c", run_id="r3", scenario="s", evaluator_epoch="e2")
+    assert compute_round_mixed_epoch([s1, s2]) is False
+    assert compute_round_mixed_epoch([s1, s2, s3]) is True
+    # nulls do not count as a distinct evaluator
+    s4 = CalibrationSample(sample_id="d", run_id="r4", scenario="s", evaluator_epoch=None)
+    assert compute_round_mixed_epoch([s1, s2, s4]) is False
+
+
+def test_round_default_mixed_epoch_false() -> None:
+    rnd = CalibrationRound(round_id="rnd", created_at="2026-07-08T00:00:00Z")
+    assert rnd.mixed_epoch is False

--- a/autocontext/tests/test_calibration_sample_epoch.py
+++ b/autocontext/tests/test_calibration_sample_epoch.py
@@ -13,9 +13,13 @@ def test_round_mixed_epoch_flag() -> None:
     s3 = CalibrationSample(sample_id="c", run_id="r3", scenario="s", evaluator_epoch="e2")
     assert compute_round_mixed_epoch([s1, s2]) is False
     assert compute_round_mixed_epoch([s1, s2, s3]) is True
-    # nulls do not count as a distinct evaluator
+    # None is its own evaluator class: known + unknown spans two classes.
     s4 = CalibrationSample(sample_id="d", run_id="r4", scenario="s", evaluator_epoch=None)
-    assert compute_round_mixed_epoch([s1, s2, s4]) is False
+    s5 = CalibrationSample(sample_id="e", run_id="r5", scenario="s", evaluator_epoch=None)
+    assert compute_round_mixed_epoch([s1, s2, s4]) is True
+    # All-None is a single (unknown) class; empty aggregate is not mixed.
+    assert compute_round_mixed_epoch([s4, s5]) is False
+    assert compute_round_mixed_epoch([]) is False
 
 
 def test_round_default_mixed_epoch_false() -> None:

--- a/autocontext/tests/test_generation_epoch_column.py
+++ b/autocontext/tests/test_generation_epoch_column.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def test_generation_epoch_roundtrips(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+    store.create_run("run-1", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-1",
+        1,
+        mean_score=0.9,
+        best_score=0.9,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+        evaluator_epoch="epoch-abc",
+    )
+    rows = store.get_generation_metrics("run-1")
+    assert rows[0]["evaluator_epoch"] == "epoch-abc"
+
+
+def test_generation_epoch_defaults_null(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "t2.sqlite3")
+    store.migrate(MIGRATIONS)
+    store.create_run("run-2", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-2",
+        1,
+        mean_score=0.5,
+        best_score=0.5,
+        elo=1000.0,
+        wins=1,
+        losses=0,
+        gate_decision="advance",
+        status="completed",
+    )
+    assert store.get_generation_metrics("run-2")[0]["evaluator_epoch"] is None

--- a/autocontext/tests/test_rubric_calibration_epoch.py
+++ b/autocontext/tests/test_rubric_calibration_epoch.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.rubric_calibration import run_judge_calibration
+from autocontext.providers.callable_wrapper import CallableProvider
+
+
+def test_calibration_report_carries_evaluator_epoch() -> None:
+    provider = CallableProvider(lambda system, user: '{"score": 0.7, "reasoning": "ok"}', model_name="m")
+    report = run_judge_calibration(
+        domain="d",
+        task_prompt="t",
+        rubric="score correctness 0-1",
+        provider=provider,
+        model="m",
+        calibration_examples=[
+            {"id": "a", "agent_output": "a", "human_score": 0.7, "human_notes": "n"},
+            {"id": "b", "agent_output": "b", "human_score": 0.3, "human_notes": "n"},
+        ],
+        repeat_judgments=1,
+    )
+    assert report is not None
+    expected = compute_evaluator_epoch("score correctness 0-1", provider.name, "m").epoch_id
+    assert report.evaluator_epoch == expected

--- a/autocontext/tests/test_rubric_drift_epoch.py
+++ b/autocontext/tests/test_rubric_drift_epoch.py
@@ -4,7 +4,7 @@ from autocontext.analytics.facets import RunFacet
 from autocontext.analytics.rubric_drift import RubricDriftMonitor
 
 
-def _facet(run_id: str, best: float, epoch: str) -> RunFacet:
+def _facet(run_id: str, best: float, epoch: str | None) -> RunFacet:
     return RunFacet(
         run_id=run_id,
         scenario="s",
@@ -39,3 +39,37 @@ def test_snapshot_flags_mixed_epoch() -> None:
     assert mixed.mixed_epoch is True and mixed.evaluator_epochs == ["e1", "e2"]
     # math unchanged: mean over the same scores regardless of epoch
     assert mixed.mean_score == single.mean_score  # both means of {0.9, 0.8}
+
+
+def test_snapshot_known_plus_unknown_epoch_is_mixed() -> None:
+    mon = RubricDriftMonitor()
+    # None is its own class: a known epoch mixed with a null spans two classes.
+    known_unknown = mon.compute_snapshot([_facet("a", 0.9, "e1"), _facet("b", 0.8, None)])
+    assert known_unknown.mixed_epoch is True
+    assert known_unknown.has_unknown_epoch is True
+    assert known_unknown.evaluator_epochs == ["e1"]  # only KNOWN epochs displayed
+    # All-null is a single unknown class -> not mixed.
+    all_unknown = mon.compute_snapshot([_facet("a", 0.9, None), _facet("b", 0.8, None)])
+    assert all_unknown.mixed_epoch is False
+    assert all_unknown.has_unknown_epoch is True
+    assert all_unknown.evaluator_epochs == []
+
+
+def test_baseline_inflation_warning_reflects_both_epochs() -> None:
+    mon = RubricDriftMonitor()
+    # Homogeneous e1 baseline vs homogeneous e2 current: the mean-score delta is a
+    # cross-evaluator comparison, so the inflation warning must be flagged mixed.
+    baseline = mon.compute_snapshot([_facet("a", 0.5, "e1"), _facet("b", 0.5, "e1")])
+    current_e2 = mon.compute_snapshot([_facet("c", 0.9, "e2"), _facet("d", 0.9, "e2")])
+    warnings = mon.detect_drift(current_e2, baseline)
+    inflation = [w for w in warnings if w.metric_name == "mean_score_delta"]
+    assert len(inflation) == 1
+    assert current_e2.mixed_epoch is False  # current alone is single-epoch
+    assert inflation[0].mixed_epoch is True  # but the comparison spans e1 + e2
+
+    # Same-epoch baseline/current: the inflation warning is not cross-evaluator.
+    current_e1 = mon.compute_snapshot([_facet("c", 0.9, "e1"), _facet("d", 0.9, "e1")])
+    warnings_same = mon.detect_drift(current_e1, baseline)
+    inflation_same = [w for w in warnings_same if w.metric_name == "mean_score_delta"]
+    assert len(inflation_same) == 1
+    assert inflation_same[0].mixed_epoch is False

--- a/autocontext/tests/test_rubric_drift_epoch.py
+++ b/autocontext/tests/test_rubric_drift_epoch.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from autocontext.analytics.facets import RunFacet
+from autocontext.analytics.rubric_drift import RubricDriftMonitor
+
+
+def _facet(run_id: str, best: float, epoch: str) -> RunFacet:
+    return RunFacet(
+        run_id=run_id,
+        scenario="s",
+        scenario_family="f",
+        agent_provider="anthropic",
+        executor_mode="local",
+        total_generations=1,
+        advances=1,
+        retries=0,
+        rollbacks=0,
+        best_score=best,
+        best_elo=0.0,
+        total_duration_seconds=0.0,
+        total_tokens=0,
+        total_cost_usd=0.0,
+        tool_invocations=0,
+        validation_failures=0,
+        consultation_count=0,
+        consultation_cost_usd=0.0,
+        friction_signals=[],
+        delight_signals=[],
+        events=[],
+        evaluator_epoch=epoch,
+    )
+
+
+def test_snapshot_flags_mixed_epoch() -> None:
+    mon = RubricDriftMonitor()
+    single = mon.compute_snapshot([_facet("a", 0.9, "e1"), _facet("b", 0.8, "e1")])
+    assert single.mixed_epoch is False and single.evaluator_epochs == ["e1"]
+    mixed = mon.compute_snapshot([_facet("a", 0.9, "e1"), _facet("b", 0.8, "e2")])
+    assert mixed.mixed_epoch is True and mixed.evaluator_epochs == ["e1", "e2"]
+    # math unchanged: mean over the same scores regardless of epoch
+    assert mixed.mean_score == single.mean_score  # both means of {0.9, 0.8}

--- a/autocontext/tests/test_run_facet_epoch.py
+++ b/autocontext/tests/test_run_facet_epoch.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from autocontext.analytics.extractor import FacetExtractor
+
+
+def _gen(idx: int, best: float, epoch: str | None) -> dict[str, object]:
+    return {
+        "generation_index": idx,
+        "best_score": best,
+        "elo": 0.0,
+        "gate_decision": "advance",
+        "duration_seconds": 0.0,
+        "evaluator_epoch": epoch,
+    }
+
+
+def test_facet_epoch_is_best_scoring_rows_epoch() -> None:
+    data = {
+        "run": {"run_id": "r", "scenario": "s"},
+        "generations": [
+            _gen(1, 0.4, "e-lo"),
+            _gen(2, 0.9, "e-hi"),
+            _gen(3, 0.5, "e-mid"),
+        ],
+    }
+    facet = FacetExtractor().extract(data)
+    assert facet.evaluator_epoch == "e-hi"
+
+
+def test_facet_epoch_null_when_tournament() -> None:
+    data = {
+        "run": {"run_id": "r", "scenario": "s"},
+        "generations": [_gen(1, 0.4, None), _gen(2, 0.9, None)],
+    }
+    facet = FacetExtractor().extract(data)
+    assert facet.evaluator_epoch is None

--- a/autocontext/tests/test_training_export_epoch.py
+++ b/autocontext/tests/test_training_export_epoch.py
@@ -1,0 +1,44 @@
+"""Training-export records carry evaluator_epoch (AC-885 Slice B)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.storage.artifacts import ArtifactStore
+from autocontext.storage.sqlite_store import SQLiteStore
+from autocontext.training.export import export_training_data
+from autocontext.training.types import TrainingRecord
+
+
+def _make_stores(tmp_path: Path) -> tuple[SQLiteStore, ArtifactStore]:
+    db = SQLiteStore(tmp_path / "t.sqlite3")
+    db.migrate(Path("migrations"))
+    artifacts = ArtifactStore(
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+    )
+    return db, artifacts
+
+
+def test_training_record_carries_epoch(tmp_path: Path) -> None:
+    db, artifacts = _make_stores(tmp_path)
+    db.create_run("run-1", "grid_ctf", 1, "local")
+    db.upsert_generation(
+        "run-1",
+        1,
+        mean_score=0.9,
+        best_score=0.9,
+        elo=1000.0,
+        wins=1,
+        losses=0,
+        gate_decision="advance",
+        status="completed",
+        evaluator_epoch="e-1",
+    )
+    db.append_agent_output("run-1", 1, "competitor", '{"aggression": 0.5}')
+
+    recs = [r for r in export_training_data(db, artifacts, run_id="run-1") if isinstance(r, TrainingRecord)]
+    assert recs
+    assert recs[0].evaluator_epoch == "e-1"

--- a/docs/ac-885-slice-b-row-lineage-design.md
+++ b/docs/ac-885-slice-b-row-lineage-design.md
@@ -1,0 +1,177 @@
+# AC-885 Slice B: persisted and derived evaluator-epoch lineage
+
+Date: 2026-07-09
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: Slice B of four. Slice 1 (identity + comparability guard) is merged (PR #1204). Slice C
+(promotion lifecycle) and Slice D (surfacing + lazy re-score) remain.
+
+## Purpose
+
+Slice 1 gave the LLM-judge path an evaluator epoch (`JudgeResult.evaluator_epoch`), propagated it
+through `AgentTaskResult` into `ImprovementResult`, guarded the improve loop against cross-epoch
+comparison, and serialized it into the task-queue result JSON. Slice B extends that lineage to the
+records that persist or derive from judge scores, so a stored generation, an exported training
+example, a calibration report, and a rubric-drift snapshot each record which evaluator produced the
+numbers they carry.
+
+Lineage is attached only where a judge or rubric evaluator produced the score. The main run loop is
+tournament and Elo based (game scenarios) and carries no rubric or judge, so tournament-scored rows
+(`matches`, the tournament `generations` write) and human-scored rows (`human_feedback`) are left
+unstamped: an epoch column there would always be null. This slice stamps the judge-scored write
+sites and the derived analytics that consume them.
+
+## Decisions of record
+
+1. **generations gets an `evaluator_epoch` column, stamped only at the judge-scored write sites.**
+   The two agent-task write sites (`cli.py` `_run_agent_task`, `knowledge/solve_task_execution.py`)
+   write from an `ImprovementResult` that Slice 1 already stamped, so `result.evaluator_epoch` is
+   in scope. The tournament write site (`loop/stages.py`) and the `matches` table stay null and
+   untouched.
+2. **TypeScript gets the parity column but never populates it.** `generations` is a schema-parity
+   shared table, so the identical column is added on the TS side, but TS has no agent-task-direct
+   generations write path, so the TS column is always null. This is a documented asymmetry, not a
+   blocker.
+3. **`rubric_calibration.run_judge_calibration` threads its already-computed epoch.** It makes a
+   live judge call whose `JudgeResult.evaluator_epoch` is currently discarded; this is the cheapest
+   win and needs no migration.
+4. **`RunFacet.evaluator_epoch` is sourced from the run's best-scoring generation row.** The facet's
+   `best_score` comes from a specific generation; its epoch is that generation's epoch (null for
+   tournament or absent). This ties the facet's score to the evaluator that produced it and is the
+   source the second-order consumers read.
+5. **Analytics and drift record the epoch and flag mixed-epoch aggregates; the math is unchanged.**
+   `CalibrationSample`/`CalibrationOutcome` (AC-260) and `RubricSnapshot`/`DriftWarning` (AC-259)
+   carry the epoch(s) they cover, and set a `mixed_epoch` marker when an aggregate spans more than
+   one epoch. The drift and calibration statistics are not re-grouped in this slice; enforcement
+   (grouping or refusing cross-epoch aggregates) is a deferred follow-on.
+6. **Training-export reads the new column through.** `TrainingRecord` gains a nullable
+   `evaluator_epoch`; `export_training_data` copies `gen["evaluator_epoch"]`. This delivers the
+   AC-885-named "exported training examples that depend on evaluator scores." Match export stays
+   unstamped (tournament).
+
+## Architecture
+
+### Component 1: the `generations.evaluator_epoch` column (the anchor)
+
+- Python migration `016_generation_evaluator_epoch.sql`: `ALTER TABLE generations ADD COLUMN
+evaluator_epoch TEXT`. TS migration with the next TS number, adding the identical column. The
+  `migration_ledgers.py` cross-map (Python <-> TS migration numbers) gets the new pairing.
+- `bootstrap_schema.py` adds the column to the generations create statement; the TS bootstrap
+  mirrors it. `GenerationMetricsRow` (`storage/row_types.py`) and the TS
+  `UpsertGenerationRecordOpts` gain `evaluator_epoch: str | None` / `string | null`.
+- `upsert_generation()` (`storage/sqlite_store.py`) accepts and writes the column; the TS
+  `upsertGenerationRecord` mirrors the parameter (always null on the TS side).
+- `storage-schema-parity.test.ts` continues to pass: both migration sets produce the identical
+  `generations` columns.
+
+### Component 2: stamp the two agent-task write sites
+
+At `cli.py` `_run_agent_task` and `knowledge/solve_task_execution.py`
+`run_task_like_scenario`, the guarded `upsert_generation(...)` calls pass
+`evaluator_epoch=result.evaluator_epoch` from the `ImprovementResult` in scope. No other write site
+is touched. The tournament path passes nothing (defaults to null).
+
+### Component 3: `rubric_calibration` epoch
+
+`run_judge_calibration` builds an `LLMJudge` and calls `judge.evaluate(...)`, discarding the
+result's epoch. It threads the epoch onto the returned `CalibrationReport` as a new nullable field
+`evaluator_epoch`. Because all samples in one calibration run use the same rubric, provider, and
+model, they share one epoch. No migration (the calibration report is an in-memory/JSON artifact).
+
+### Component 4: `RunFacet.evaluator_epoch`
+
+`RunFacet` (`analytics/facets.py`) gains `evaluator_epoch: str | None`. When the facet is built from
+a run's generation rows, it records the epoch of the row that produced `best_score`. If that row has
+no epoch (tournament) or no rows exist, the facet epoch is null.
+
+### Component 5: analytics/calibration lineage + mixed-epoch flag
+
+`CalibrationSample` (`analytics/calibration.py`) carries `evaluator_epoch` from its source
+`RunFacet`. A `CalibrationRound`/`CalibrationOutcome` that aggregates samples across more than one
+distinct non-null epoch sets `mixed_epoch: bool = True`. The existing sampling and calibration
+computation is unchanged; the flag is a lineage signal only.
+
+### Component 6: rubric-drift lineage + mixed-epoch flag
+
+`RubricSnapshot` (`analytics/rubric_drift.py`) records the set (or the single value) of evaluator
+epochs among the facets it aggregates, plus a `mixed_epoch` marker when that set has more than one
+non-null value. `DriftWarning` carries the marker through so an operator sees when a drift signal is
+computed across differing evaluators. `compute_snapshot` and the drift comparison math are unchanged.
+
+### Component 7: training-export read-through
+
+`TrainingRecord` (`training/types.py`) gains `evaluator_epoch: str | None = None`.
+`export_training_data` (`training/export.py`) sets it from `gen["evaluator_epoch"]` (present once
+Component 1 lands; null for tournament rows). `MatchRecord` is not changed (matches are tournament).
+The TS `export-records-workflow.ts` mirror gets the field for contract parity, noting the TS
+generations column is always null so TS-exported records carry null there today.
+
+## Data flow
+
+```
+ImprovementResult.evaluator_epoch (Slice 1)
+   -> upsert_generation(evaluator_epoch=...) at the 2 agent-task write sites   [Component 1/2]
+        -> generations.evaluator_epoch column
+             -> RunFacet.evaluator_epoch (epoch of the best-scoring row)        [Component 4]
+                  -> CalibrationSample.evaluator_epoch + mixed_epoch flag       [Component 5]
+                  -> RubricSnapshot epochs + mixed_epoch flag                    [Component 6]
+             -> export_training_data -> TrainingRecord.evaluator_epoch          [Component 7]
+
+LLMJudge.evaluate (in run_judge_calibration) -> JudgeResult.evaluator_epoch
+   -> CalibrationReport.evaluator_epoch                                         [Component 3]
+```
+
+## Error handling and edge cases
+
+- **Legacy rows / null epoch:** existing generation rows predate the column and read as null; a
+  facet or export over them carries null, consistent with the Slice 1 null-legacy semantics.
+- **Mid-run evaluator change (rebaseline):** a run can contain generation rows under different
+  epochs. `RunFacet` uses the best-scoring row's epoch, so it is well-defined. Analytics that
+  aggregate multiple facets/rows with differing epochs set `mixed_epoch`.
+- **Tournament runs:** every generations/matches row epoch is null; facets and exports over them are
+  null; `mixed_epoch` stays false (a set of nulls is not "mixed").
+- **TS always-null column:** documented; TS parity tests assert the column exists, not that it is
+  populated.
+
+## Testing
+
+- **Migration + parity:** Python and TS migrations add the identical `generations.evaluator_epoch`
+  column; `storage-schema-parity.test.ts` passes; a migration-idempotency/rollback check per the
+  repo's migration test pattern.
+- **Write-site stamping:** a test that an agent-task run persists `generations.evaluator_epoch` equal
+  to the `ImprovementResult` epoch, and that a tournament run leaves it null.
+- **rubric_calibration:** `run_judge_calibration` returns a `CalibrationReport` whose
+  `evaluator_epoch` equals `compute_evaluator_epoch(rubric, provider, model).epoch_id`.
+- **RunFacet:** facet built from generation rows records the best-scoring row's epoch; null when
+  tournament.
+- **Analytics/drift mixed-epoch:** an aggregate over one epoch sets `mixed_epoch=False`; an aggregate
+  over two distinct epochs sets `mixed_epoch=True`; the computed statistics are byte-identical to
+  before the field was added (regression pin).
+- **Training-export:** an exported record from a judge-scored generation carries the epoch; from a
+  tournament generation carries null.
+- Existing gates: module-size, gate-taxonomy (no new gate/guard/validator symbols), ruff/mypy/lint,
+  Python and TS suites, lockfiles unchanged.
+
+## Documentation
+
+Extend `docs/evaluator-epochs.md` with a "persisted and derived lineage" section: which records
+carry the epoch and which deliberately do not (tournament, human), the always-null TS generations
+column, the `mixed_epoch` flag semantics on analytics/drift, and how training-export carries
+lineage. CHANGELOG entry.
+
+## Deferred to later slices
+
+- Enforcement of cross-epoch refusal or grouping in drift and calibration (this slice records and
+  flags only).
+- `matches` and `human_feedback` epochs (never: not judge-scored).
+- AC-881 `CalibrationReport` (pure noise-floor statistics, no rubric concept to attach to).
+- Package export/import epoch (`knowledge/package.py`), not currently reachable.
+- CLI, API, and dashboard stale-epoch surfacing and lazy re-score (Slice D).
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 #1 (score-bearing records carry lineage): extends from the judge path to persisted
+  generations (judge-scored), calibration reports, run facets, and analytics/drift snapshots.
+- AC-885 #3 (reports and exports distinguish evaluator lineage): training-export and the analytics
+  `mixed_epoch` flag are the first concrete delivery; full active-vs-stale reporting is Slice D.
+- AC-885 #6 (documentation): the persisted-lineage section.

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -92,6 +92,49 @@ There is no SQLite migration in this slice. The epoch rides in memory on the loo
 and on the records the loop already persists. Stamping the `generations` / `matches` /
 `human_feedback` rows with a migration is deferred to Slice B.
 
+## Persisted and derived lineage (Slice B)
+
+Slice 1 kept the epoch in memory on the loop's round baseline. Slice B writes it down: the epoch
+that produced a score now rides on the persisted rows and on the records derived from them, so
+lineage survives a process restart and travels with exports. The stamping rule is uniform
+throughout: only a genuine LLM-judge score carries an epoch. Tournament-scored and human-scored
+records stay `None`, exactly as the null-legacy fallback prescribes (a game score has no rubric and
+no judge, so it has no evaluator identity to record).
+
+**The `generations` column.** Migration 016 (Python) and migration 014 (TypeScript) add a nullable
+`evaluator_epoch` column to `generations`, byte-identical across the two schemas per the parity
+constraint. Python stamps it only at the two agent-task write sites (`cli._run_agent_task` and
+`solve_task_execution`), reading `ImprovementResult.evaluator_epoch`. The tournament write site and
+the `matches` rows are deliberately left null: those are Elo scores, not judge scores. The
+TypeScript `generations` column is always null in practice, because the TypeScript package has no
+agent-task-direct write path that produces a judge score. The column exists in the TypeScript schema
+for parity (so the two migrations stay in lockstep and a future TypeScript writer has the slot), but
+nothing populates it today. That asymmetry is intentional and load-bearing: it keeps the schemas
+equal without inventing a TypeScript write site that does not exist.
+
+**`rubric_calibration`.** `run_judge_calibration` threads the judge's own epoch onto
+`CalibrationReport.evaluator_epoch`, taken from the judge result it already computed. The calibration
+report is a judge score by construction, so it always has an epoch to record.
+
+**`RunFacet`.** A run facet sources its `evaluator_epoch` from the best-scoring generation row's
+epoch, the same row whose score the facet already surfaces. If that row is a tournament or legacy
+row, the facet epoch is `None`, consistent with the row it points at.
+
+**Training-export read-through.** `TrainingRecord.evaluator_epoch` (Python and TypeScript) is a
+read-through of the stamped `generations` value, so an exported training example carries the lineage
+of the score it was selected on. `MatchRecord` is left unstamped, matching the tournament decision.
+
+**The `mixed_epoch` flag.** Two derived records aggregate across many samples, and an aggregate can
+span more than one evaluator. `CalibrationSample.evaluator_epoch` records each sample's epoch, and
+`CalibrationRound.mixed_epoch` is set when the round's samples do not all share one epoch. The same
+shape carries to rubric drift: `RubricSnapshot.evaluator_epochs` lists the epochs present in the
+snapshot and `RubricSnapshot.mixed_epoch` (with `DriftWarning.mixed_epoch`) flags the mixed case.
+These fields record lineage only. They do not change any arithmetic: the calibration means and the
+drift statistics are computed exactly as before (pinned by a byte-identical-mean regression), and
+the flag is a lineage annotation, not a filter. Enforcement (refusing to aggregate across epochs, or
+partitioning by epoch before the math) is deferred to a later slice; Slice B's job is to make the
+mixing visible, not to act on it.
+
 ## Relationship to the ambient `eval_fingerprint` / `anchor_model`
 
 autocontext already had this mechanism, but only in the ambient trainer. `eval_fingerprint()`
@@ -108,11 +151,13 @@ within-epoch variance rather than deciding cross-epoch comparability.
 
 ## Deferred slices
 
-This slice is the first of four. The rest are explicitly deferred, not dropped:
+This slice is the first of four. Slice B is now shipped (see "Persisted and derived lineage" above).
+The remaining slices are explicitly deferred, not dropped:
 
-- **Slice B (stamp the rest):** matches, `human_feedback`, calibration reports, rubric-drift
-  snapshots, and training-export examples carry the epoch, with the broader migration and parity
-  surface that implies.
+- **Slice B (stamp the rest, shipped):** the `generations` column, calibration reports, rubric-drift
+  snapshots, and training-export examples carry the epoch, with the migration and parity surface
+  that implies. Tournament-scored `matches` and human-scored `human_feedback` records are left
+  unstamped by design.
 - **Slice C (epoch lifecycle):** candidate-to-active epoch promotion with promotion metadata
   (source patch, calibration anchors used, alignment / bias / variance deltas, human-review
   requirement, decision); generalizes `promote.py`'s cross-anchor refusal.

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -125,10 +125,15 @@ read-through of the stamped `generations` value, so an exported training example
 of the score it was selected on. `MatchRecord` is left unstamped, matching the tournament decision.
 
 **The `mixed_epoch` flag.** Two derived records aggregate across many samples, and an aggregate can
-span more than one evaluator. `CalibrationSample.evaluator_epoch` records each sample's epoch, and
-`CalibrationRound.mixed_epoch` is set when the round's samples do not all share one epoch. The same
-shape carries to rubric drift: `RubricSnapshot.evaluator_epochs` lists the epochs present in the
-snapshot and `RubricSnapshot.mixed_epoch` (with `DriftWarning.mixed_epoch`) flags the mixed case.
+span more than one evaluator class. Following the comparability rule above, `None` (unknown / legacy)
+is its own class, comparable only with `None`: `mixed_epoch` is set whenever an aggregate spans more
+than one class, so a known epoch mixed with a null is flagged, while an all-null or empty aggregate is
+not. `CalibrationSample.evaluator_epoch` records each sample's epoch, and
+`CalibrationRound.mixed_epoch` is set when the round's samples span more than one class. The same
+shape carries to rubric drift: `RubricSnapshot.evaluator_epochs` lists the known epochs present in the
+snapshot, `RubricSnapshot.has_unknown_epoch` records whether any null-epoch facet is present, and
+`RubricSnapshot.mixed_epoch` (with `DriftWarning.mixed_epoch`) flags the mixed case. A baseline
+comparison warning reflects the classes of both snapshots, not the current snapshot alone.
 These fields record lineage only. They do not change any arithmetic: the calibration means and the
 drift statistics are computed exactly as before (pinned by a byte-identical-mean regression), and
 the flag is a lineage annotation, not a filter. Enforcement (refusing to aggregate across epochs, or

--- a/ts/migrations/014_generation_evaluator_epoch.sql
+++ b/ts/migrations/014_generation_evaluator_epoch.sql
@@ -1,0 +1,3 @@
+-- AC-885 Slice B: evaluator-epoch lineage on judge-scored generation rows.
+-- Null for tournament-scored rows and legacy rows.
+ALTER TABLE generations ADD COLUMN evaluator_epoch TEXT DEFAULT NULL;

--- a/ts/src/analytics/rubric-drift-statistics.ts
+++ b/ts/src/analytics/rubric-drift-statistics.ts
@@ -67,11 +67,15 @@ export function computeRubricSnapshot(
       release: opts.release ?? "",
       scenarioFamily: opts.scenarioFamily ?? "",
       agentProvider: opts.agentProvider ?? "",
+      evaluatorEpochs: [],
+      mixedEpoch: false,
       metadata: { scenarios },
     };
   }
 
   const scores = facets.map((facet) => facet.bestScore);
+  const epochs = [...new Set(facets.map((facet) => facet.evaluatorEpoch).filter((epoch): epoch is string => epoch != null))].sort();
+  const mixedEpoch = epochs.length > 1;
   const timestamps = facets
     .map((facet) => facet.createdAt ?? "")
     .filter((timestamp) => timestamp.length > 0)
@@ -115,6 +119,8 @@ export function computeRubricSnapshot(
     release: opts.release ?? "",
     scenarioFamily: opts.scenarioFamily ?? "",
     agentProvider: opts.agentProvider ?? "",
+    evaluatorEpochs: epochs,
+    mixedEpoch,
     metadata: { scenarios },
   };
 }

--- a/ts/src/analytics/rubric-drift-statistics.ts
+++ b/ts/src/analytics/rubric-drift-statistics.ts
@@ -69,13 +69,15 @@ export function computeRubricSnapshot(
       agentProvider: opts.agentProvider ?? "",
       evaluatorEpochs: [],
       mixedEpoch: false,
+      hasUnknownEpoch: false,
       metadata: { scenarios },
     };
   }
 
   const scores = facets.map((facet) => facet.bestScore);
   const epochs = [...new Set(facets.map((facet) => facet.evaluatorEpoch).filter((epoch): epoch is string => epoch != null))].sort();
-  const mixedEpoch = epochs.length > 1;
+  const hasUnknownEpoch = facets.some((facet) => facet.evaluatorEpoch == null);
+  const mixedEpoch = epochs.length + (hasUnknownEpoch ? 1 : 0) > 1;
   const timestamps = facets
     .map((facet) => facet.createdAt ?? "")
     .filter((timestamp) => timestamp.length > 0)
@@ -121,6 +123,7 @@ export function computeRubricSnapshot(
     agentProvider: opts.agentProvider ?? "",
     evaluatorEpochs: epochs,
     mixedEpoch,
+    hasUnknownEpoch,
     metadata: { scenarios },
   };
 }

--- a/ts/src/analytics/rubric-drift-types.ts
+++ b/ts/src/analytics/rubric-drift-types.ts
@@ -10,6 +10,7 @@ export interface RunFacetLike {
   delightSignals?: DelightSignalLike[];
   retries?: number;
   rollbacks?: number;
+  evaluatorEpoch?: string | null;
 }
 
 export interface RubricSnapshot {
@@ -31,6 +32,8 @@ export interface RubricSnapshot {
   release: string;
   scenarioFamily: string;
   agentProvider: string;
+  evaluatorEpochs: string[];
+  mixedEpoch: boolean;
   metadata: Record<string, unknown>;
 }
 
@@ -56,6 +59,7 @@ export interface DriftWarning {
   affectedScenarios: string[];
   affectedProviders: string[];
   affectedReleases: string[];
+  mixedEpoch: boolean;
   metadata: Record<string, unknown>;
 }
 

--- a/ts/src/analytics/rubric-drift-types.ts
+++ b/ts/src/analytics/rubric-drift-types.ts
@@ -34,6 +34,7 @@ export interface RubricSnapshot {
   agentProvider: string;
   evaluatorEpochs: string[];
   mixedEpoch: boolean;
+  hasUnknownEpoch: boolean;
   metadata: Record<string, unknown>;
 }
 

--- a/ts/src/analytics/rubric-drift-warnings.ts
+++ b/ts/src/analytics/rubric-drift-warnings.ts
@@ -43,6 +43,7 @@ export function makeWarning(
     affectedScenarios,
     affectedProviders,
     affectedReleases,
+    mixedEpoch: snapshot.mixedEpoch,
     metadata: {},
   };
 }

--- a/ts/src/analytics/rubric-drift-warnings.ts
+++ b/ts/src/analytics/rubric-drift-warnings.ts
@@ -48,6 +48,17 @@ export function makeWarning(
   };
 }
 
+/**
+ * True when two snapshots together span more than one evaluator class. Known
+ * epochs come from the union of each snapshot's evaluatorEpochs; the unknown
+ * (null) class is counted once if either snapshot carries a null epoch.
+ */
+export function combinedMixed(a: RubricSnapshot, b: RubricSnapshot): boolean {
+  const knownEpochs = new Set([...a.evaluatorEpochs, ...b.evaluatorEpochs]);
+  const unknownClass = a.hasUnknownEpoch || b.hasUnknownEpoch ? 1 : 0;
+  return knownEpochs.size + unknownClass > 1;
+}
+
 export function detectRubricDrift(
   current: RubricSnapshot,
   thresholds: DriftThresholds,
@@ -76,7 +87,7 @@ export function detectRubricDrift(
   if (baseline) {
     const delta = current.meanScore - baseline.meanScore;
     if (delta > thresholds.maxScoreInflation) {
-      warnings.push(makeWarning(
+      const inflationWarning = makeWarning(
         now,
         "score_inflation",
         "high",
@@ -85,7 +96,11 @@ export function detectRubricDrift(
         "mean_score_delta",
         delta,
         thresholds.maxScoreInflation,
-      ));
+      );
+      // The baseline-derived inflation warning is a cross-snapshot comparison,
+      // so it must reflect the epochs of BOTH snapshots, not current alone.
+      inflationWarning.mixedEpoch = combinedMixed(current, baseline);
+      warnings.push(inflationWarning);
     }
   }
 

--- a/ts/src/storage/generation-record-contracts.ts
+++ b/ts/src/storage/generation-record-contracts.ts
@@ -10,6 +10,7 @@ export interface UpsertGenerationRecordOpts {
   dimensionSummaryJson?: string | null;
   scoringBackend?: string;
   ratingUncertainty?: number | null;
+  evaluatorEpoch?: string | null;
 }
 
 export interface RecordMatchRecordOpts {

--- a/ts/src/storage/generation-upsert-workflow.ts
+++ b/ts/src/storage/generation-upsert-workflow.ts
@@ -12,9 +12,9 @@ export function upsertGenerationRecord(
     `INSERT INTO generations(
        run_id, generation_index, mean_score, best_score, elo, wins, losses,
        gate_decision, status, duration_seconds, dimension_summary_json,
-       scoring_backend, rating_uncertainty
+       scoring_backend, rating_uncertainty, evaluator_epoch
      )
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(run_id, generation_index) DO UPDATE SET
        mean_score = excluded.mean_score,
        best_score = excluded.best_score,
@@ -27,6 +27,7 @@ export function upsertGenerationRecord(
        dimension_summary_json = excluded.dimension_summary_json,
        scoring_backend = excluded.scoring_backend,
        rating_uncertainty = excluded.rating_uncertainty,
+       evaluator_epoch = excluded.evaluator_epoch,
        updated_at = datetime('now')`,
   ).run(
     runId,
@@ -42,21 +43,24 @@ export function upsertGenerationRecord(
     opts.dimensionSummaryJson ?? null,
     opts.scoringBackend ?? "elo",
     opts.ratingUncertainty ?? null,
+    opts.evaluatorEpoch ?? null,
   );
 }
 
 export function getGenerationRecords<T>(db: Database.Database, runId: string): T[] {
-  return db.prepare(
-    `SELECT * FROM generations WHERE run_id = ? ORDER BY generation_index`,
-  ).all(runId) as T[];
+  return db
+    .prepare(`SELECT * FROM generations WHERE run_id = ? ORDER BY generation_index`)
+    .all(runId) as T[];
 }
 
 export function getBestGenerationForScenarioRecord<T>(
   db: Database.Database,
   scenario: string,
 ): T | null {
-  return ((db.prepare(
-    `SELECT g.*
+  return (
+    (db
+      .prepare(
+        `SELECT g.*
      FROM generations g
      JOIN runs r ON r.run_id = g.run_id
      WHERE r.scenario = ?
@@ -64,5 +68,7 @@ export function getBestGenerationForScenarioRecord<T>(
        AND g.status = 'completed'
      ORDER BY g.best_score DESC, g.elo DESC, g.updated_at DESC
      LIMIT 1`,
-  ).get(scenario) as T | undefined) ?? null);
+      )
+      .get(scenario) as T | undefined) ?? null
+  );
 }

--- a/ts/src/storage/storage-contracts.ts
+++ b/ts/src/storage/storage-contracts.ts
@@ -52,6 +52,7 @@ export interface GenerationRow {
   dimension_summary_json: string | null;
   scoring_backend: string;
   rating_uncertainty: number | null;
+  evaluator_epoch: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/ts/src/storage/storage-migration-workflow.ts
+++ b/ts/src/storage/storage-migration-workflow.ts
@@ -20,6 +20,7 @@ export const TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES: Record<string, readonly s
   "011_monitors.sql": ["011_monitors.sql"],
   "012_consultation_log.sql": ["010_consultation_log.sql"],
   "012_research_hub.sql": ["012_research_hub.sql"],
+  "014_generation_evaluator_epoch.sql": ["016_generation_evaluator_epoch.sql"],
 };
 
 const TYPESCRIPT_BASELINE_SCHEMA_RECONCILIATION: Record<string, readonly string[]> = {
@@ -50,15 +51,15 @@ function readAppliedSet(
   column: "filename" | "version",
 ): Set<string> {
   return new Set(
-    (db.prepare(sql).all() as Array<Record<typeof column, string>>).map(
-      (row) => row[column],
-    ),
+    (db.prepare(sql).all() as Array<Record<typeof column, string>>).map((row) => row[column]),
   );
 }
 
 function isCoveredByPythonLedger(file: string, appliedPython: Set<string>): boolean {
   const pythonBaselines = TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES[file] ?? [];
-  return pythonBaselines.length > 0 && pythonBaselines.every((migration) => appliedPython.has(migration));
+  return (
+    pythonBaselines.length > 0 && pythonBaselines.every((migration) => appliedPython.has(migration))
+  );
 }
 
 function isDuplicateColumnError(error: unknown): boolean {
@@ -77,10 +78,7 @@ function reconcilePythonBaselineSchema(db: Database.Database, file: string): voi
   }
 }
 
-export function migrateDatabase(
-  db: Database.Database,
-  migrationsDir: string,
-): void {
+export function migrateDatabase(db: Database.Database, migrationsDir: string): void {
   db.exec(
     `CREATE TABLE IF NOT EXISTS schema_version (
        filename TEXT PRIMARY KEY,
@@ -116,7 +114,9 @@ export function migrateDatabase(
     db.prepare("INSERT INTO schema_version(filename) VALUES (?)").run(file);
     appliedTypescript.add(file);
     for (const pythonMigration of TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES[file] ?? []) {
-      db.prepare("INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)").run(pythonMigration);
+      db.prepare("INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)").run(
+        pythonMigration,
+      );
       appliedPython.add(pythonMigration);
     }
   }

--- a/ts/src/training/export-records-workflow.ts
+++ b/ts/src/training/export-records-workflow.ts
@@ -78,6 +78,7 @@ export function buildTrainingExportRecordsForRun(opts: {
         hints,
         trajectory: buildTrajectorySnippet(generations, generation.generation_index),
       },
+      evaluator_epoch: generation.evaluator_epoch ?? null,
     };
     const generationRecords: TrainingExportRecord[] = [record];
 

--- a/ts/src/training/export-types.ts
+++ b/ts/src/training/export-types.ts
@@ -6,6 +6,7 @@ export interface TrainingRecord {
   score: number;
   gate_decision: string;
   context: Record<string, unknown>;
+  evaluator_epoch: string | null;
 }
 
 export interface MatchRecord {

--- a/ts/tests/export-records-workflow.test.ts
+++ b/ts/tests/export-records-workflow.test.ts
@@ -69,4 +69,42 @@ describe("training export records workflow", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("carries evaluator_epoch from the generation row onto the exported record", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-export-epoch-"));
+    try {
+      const store = new SQLiteStore(join(dir, "test.db"));
+      store.migrate(join(process.cwd(), "migrations"));
+      const artifacts = new ArtifactStore({
+        runsRoot: join(dir, "runs"),
+        knowledgeRoot: join(dir, "knowledge"),
+      });
+
+      store.createRun("run-1", "grid_ctf", 1, "local");
+      store.upsertGeneration("run-1", 1, {
+        meanScore: 0.9,
+        bestScore: 0.9,
+        elo: 1000,
+        wins: 1,
+        losses: 0,
+        gateDecision: "advance",
+        status: "completed",
+        evaluatorEpoch: "e-1",
+      });
+      store.appendAgentOutput("run-1", 1, "competitor", '{"aggression":0.5}');
+
+      const records = buildTrainingExportRecordsForRun({
+        store,
+        artifacts,
+        run: { run_id: "run-1", scenario: "grid_ctf" },
+      });
+
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({ evaluator_epoch: "e-1" });
+
+      store.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/ts/tests/rubric-drift-epoch.test.ts
+++ b/ts/tests/rubric-drift-epoch.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { computeRubricSnapshot } from "../src/analytics/rubric-drift-statistics.js";
+import { DEFAULT_THRESHOLDS, detectRubricDrift } from "../src/analytics/rubric-drift-warnings.js";
 import type { RunFacetLike } from "../src/analytics/rubric-drift-types.js";
 
-function facet(bestScore: number, evaluatorEpoch: string): RunFacetLike {
+function facet(bestScore: number, evaluatorEpoch: string | null): RunFacetLike {
   return {
     scenario: "s",
     bestScore,
@@ -27,5 +28,33 @@ describe("rubric drift epoch lineage", () => {
 
     // math unchanged: mean over the same scores regardless of epoch
     expect(mixed.meanScore).toBe(single.meanScore);
+  });
+
+  it("treats a known epoch mixed with null as mixed (None is its own class)", () => {
+    const knownUnknown = computeRubricSnapshot([facet(0.9, "e1"), facet(0.8, null)]);
+    expect(knownUnknown.mixedEpoch).toBe(true);
+    expect(knownUnknown.hasUnknownEpoch).toBe(true);
+    expect(knownUnknown.evaluatorEpochs).toEqual(["e1"]); // only KNOWN epochs displayed
+
+    const allUnknown = computeRubricSnapshot([facet(0.9, null), facet(0.8, null)]);
+    expect(allUnknown.mixedEpoch).toBe(false);
+    expect(allUnknown.hasUnknownEpoch).toBe(true);
+    expect(allUnknown.evaluatorEpochs).toEqual([]);
+  });
+
+  it("flags the baseline inflation warning when the two snapshots span different epochs", () => {
+    const baseline = computeRubricSnapshot([facet(0.5, "e1"), facet(0.5, "e1")]);
+    const currentE2 = computeRubricSnapshot([facet(0.9, "e2"), facet(0.9, "e2")]);
+    const warnings = detectRubricDrift(currentE2, DEFAULT_THRESHOLDS, baseline);
+    const inflation = warnings.filter((w) => w.metricName === "mean_score_delta");
+    expect(inflation).toHaveLength(1);
+    expect(currentE2.mixedEpoch).toBe(false); // current alone is single-epoch
+    expect(inflation[0].mixedEpoch).toBe(true); // but the comparison spans e1 + e2
+
+    const currentE1 = computeRubricSnapshot([facet(0.9, "e1"), facet(0.9, "e1")]);
+    const warningsSame = detectRubricDrift(currentE1, DEFAULT_THRESHOLDS, baseline);
+    const inflationSame = warningsSame.filter((w) => w.metricName === "mean_score_delta");
+    expect(inflationSame).toHaveLength(1);
+    expect(inflationSame[0].mixedEpoch).toBe(false);
   });
 });

--- a/ts/tests/rubric-drift-epoch.test.ts
+++ b/ts/tests/rubric-drift-epoch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { computeRubricSnapshot } from "../src/analytics/rubric-drift-statistics.js";
+import type { RunFacetLike } from "../src/analytics/rubric-drift-types.js";
+
+function facet(bestScore: number, evaluatorEpoch: string): RunFacetLike {
+  return {
+    scenario: "s",
+    bestScore,
+    totalGenerations: 1,
+    delightSignals: [],
+    retries: 0,
+    rollbacks: 0,
+    evaluatorEpoch,
+  };
+}
+
+describe("rubric drift epoch lineage", () => {
+  it("flags mixed epoch and carries evaluator epochs without changing the math", () => {
+    const single = computeRubricSnapshot([facet(0.9, "e1"), facet(0.8, "e1")]);
+    expect(single.mixedEpoch).toBe(false);
+    expect(single.evaluatorEpochs).toEqual(["e1"]);
+
+    const mixed = computeRubricSnapshot([facet(0.9, "e1"), facet(0.8, "e2")]);
+    expect(mixed.mixedEpoch).toBe(true);
+    expect(mixed.evaluatorEpochs).toEqual(["e1", "e2"]);
+
+    // math unchanged: mean over the same scores regardless of epoch
+    expect(mixed.meanScore).toBe(single.meanScore);
+  });
+});

--- a/ts/tests/storage-migration-workflow.test.ts
+++ b/ts/tests/storage-migration-workflow.test.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -55,7 +55,9 @@ describe("storage migration workflow", () => {
     migrateDatabase(db, MIGRATIONS_DIR);
     migrateDatabase(db, MIGRATIONS_DIR);
 
-    const versions = db.prepare("SELECT filename FROM schema_version ORDER BY filename").all() as Array<{ filename: string }>;
+    const versions = db
+      .prepare("SELECT filename FROM schema_version ORDER BY filename")
+      .all() as Array<{ filename: string }>;
     expect(versions.length).toBeGreaterThan(0);
     expect(new Set(versions.map((row) => row.filename)).size).toBe(versions.length);
   });
@@ -73,6 +75,44 @@ describe("storage migration workflow", () => {
     }
   });
 
+  function applyEveryPythonMigration(target: Database.Database): void {
+    target.exec(
+      `CREATE TABLE schema_migrations (
+         version TEXT PRIMARY KEY,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`,
+    );
+    const insert = target.prepare("INSERT INTO schema_migrations(version) VALUES (?)");
+    const pythonFiles = readdirSync(PYTHON_MIGRATIONS_DIR)
+      .filter((file) => file.endsWith(".sql"))
+      .sort();
+    for (const pythonMigration of pythonFiles) {
+      target.exec(readFileSync(join(PYTHON_MIGRATIONS_DIR, pythonMigration), "utf8"));
+      insert.run(pythonMigration);
+    }
+  }
+
+  it("migrates a fully Python-owned database without duplicating the evaluator epoch column", () => {
+    applyEveryPythonMigration(db);
+    expect(
+      db
+        .prepare("SELECT version FROM schema_migrations WHERE version = ?")
+        .get("016_generation_evaluator_epoch.sql"),
+    ).toEqual({ version: "016_generation_evaluator_epoch.sql" });
+
+    expect(() => migrateDatabase(db, MIGRATIONS_DIR)).not.toThrow();
+
+    const evaluatorEpochColumns = (
+      db.prepare("PRAGMA table_info(generations)").all() as Array<{ name: string }>
+    ).filter((column) => column.name === "evaluator_epoch");
+    expect(evaluatorEpochColumns).toHaveLength(1);
+    expect(
+      db
+        .prepare("SELECT filename FROM schema_version WHERE filename = ?")
+        .get("014_generation_evaluator_epoch.sql"),
+    ).toEqual({ filename: "014_generation_evaluator_epoch.sql" });
+  });
+
   it("marks TypeScript migrations applied when Python already owns the equivalent schema", () => {
     db.exec(
       `CREATE TABLE schema_migrations (
@@ -80,8 +120,9 @@ describe("storage migration workflow", () => {
          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
        )`,
     );
-    const pythonMigrations = [...new Set(Object.values(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES).flat())]
-      .sort();
+    const pythonMigrations = [
+      ...new Set(Object.values(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES).flat()),
+    ].sort();
     const insert = db.prepare("INSERT INTO schema_migrations(version) VALUES (?)");
     for (const pythonMigration of pythonMigrations) {
       db.exec(readFileSync(join(PYTHON_MIGRATIONS_DIR, pythonMigration), "utf8"));
@@ -138,7 +179,9 @@ describe("storage migration workflow", () => {
         (row) => row.version,
       ),
     );
-    for (const pythonMigration of TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES["009_generation_loop.sql"]) {
+    for (const pythonMigration of TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES[
+      "009_generation_loop.sql"
+    ]) {
       expect(appliedPython.has(pythonMigration)).toBe(true);
     }
   });
@@ -175,6 +218,9 @@ describe("storage migration workflow", () => {
          '2026-04-25T00:00:00.000Z',
          '2026-04-25T00:00:01.000Z'
        );
+       CREATE TABLE generations (
+         generation_id TEXT PRIMARY KEY
+       );
        CREATE TABLE schema_version (
          filename TEXT PRIMARY KEY,
          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -192,7 +238,8 @@ describe("storage migration workflow", () => {
       status: "queued",
     });
     expect(
-      db.prepare("SELECT filename FROM schema_version WHERE filename = ?")
+      db
+        .prepare("SELECT filename FROM schema_version WHERE filename = ?")
         .get("013_runs_status_default_parity.sql"),
     ).toEqual({ filename: "013_runs_status_default_parity.sql" });
   });


### PR DESCRIPTION
Slice B of AC-885 (Slice 1 merged in #1204). Extends the judge-path evaluator epoch to the records that persist or derive from judge scores, where lineage is meaningful. Built via subagent-driven development (8 tasks + a whole-branch-review fix), each task spec+quality reviewed.

## What this adds

- **`generations.evaluator_epoch` column** (Python migration 016 + TS migration 014, schema-parity), stamped **only at the two agent-task write sites** (`cli._run_agent_task`, `solve_task_execution`) from the `ImprovementResult` epoch. The tournament write site and the `matches` table stay null and untouched.
- **`rubric_calibration`**: `CalibrationReport.evaluator_epoch` threaded from the judge result (previously discarded).
- **`RunFacet.evaluator_epoch`**: the epoch of the run's best-scoring generation row.
- **Training-export**: `TrainingRecord.evaluator_epoch` read-through (Python + TS). Delivers the AC-885-named "exported training examples that depend on evaluator scores." `MatchRecord` left unstamped.
- **Analytics/calibration + rubric-drift**: `CalibrationSample.evaluator_epoch` / `RubricSnapshot.evaluator_epochs` carry lineage, and `mixed_epoch` flags an aggregate that spans more than one evaluator. **The drift/calibration math is unchanged** (records + flags; enforcement deferred), pinned by a byte-identical-statistic regression assertion.

## Deliberately not stamped

`matches` and `human_feedback` (tournament/human-scored, no rubric/judge). The AC-881 `CalibrationReport` (pure statistics). Package export. These would be all-null or have no evaluator concept.

## Documented asymmetry

The TS `generations.evaluator_epoch` column exists for schema-parity but is always null: TS has no agent-task-direct generations write path. The migration ledgers pair TS 014 <-> Python 016 so a DB migrated by one package does not double-apply the column under the other (a cross-package idempotency test covers the Python-DB-then-TS-migrator path).

## Acceptance criteria advanced

AC-885 #1 (lineage on persisted/derived records), #3 (reports/exports distinguish lineage: training-export + the `mixed_epoch` flag), #6 (docs). Deferred: enforcement of cross-epoch refusal in drift, `matches`/`human_feedback`, package export, and Slice D (CLI/API/dashboard surfacing + lazy re-score).

## Verification

Python: ruff + mypy clean, all Slice B test files + cross-runtime migration ledger + module-size + gate-taxonomy green, `uv.lock` unchanged. TS: storage-schema-parity + migration-workflow (incl. the new cross-package test) + lint green, `bun.lock` unchanged. Rebased onto current main (erp-67 Stages 2b/2c/3); no migration-number collision.

Left open for review; not merged.