### PR TITLE
AC-885 slice C1: evaluator-epoch lifecycle foundation (registry + trigger + quarantine marker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ All notable changes to this project will be documented in this file.
   rows carry `evaluator_epoch`; run facets, training exports, calibration reports, and rubric-drift
   snapshots read it through, with a `mixed_epoch` flag when an aggregate spans more than one
   evaluator. Tournament-scored and human-scored records are left unstamped.
+- AC-885 Slice C1: evaluator-epoch lifecycle foundation. A per-scenario registry records
+  candidate/active/disabled epochs; the first epoch a scenario sees auto-activates and a subsequent
+  different epoch mints a candidate whose generation scores are marked `quarantined`. Promotion and
+  enforcement follow in later sub-slices.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/migrations/017_generation_quarantined.sql
+++ b/autocontext/migrations/017_generation_quarantined.sql
@@ -1,0 +1,2 @@
+-- AC-885 Slice C1: quarantine marker for scores produced under a non-active evaluator epoch.
+ALTER TABLE generations ADD COLUMN quarantined INTEGER DEFAULT NULL;

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -50,6 +50,7 @@ from autocontext.execution.agent_task_completion import (
     build_evaluator_guardrail_payload,
     compute_effective_met_threshold,
 )
+from autocontext.execution.evaluator_epoch_registry import observe_epoch_quarantined
 from autocontext.execution.improvement_loop import ImprovementLoop
 from autocontext.extensions import active_hook_bus
 from autocontext.loop.generation_runner import GenerationRunner
@@ -353,6 +354,8 @@ def _run_agent_task(
         "max_rounds" if result.met_threshold and not effective_met_threshold else result.termination_reason
     )
 
+    epoch_id = getattr(result, "evaluator_epoch", None)
+    quarantined = observe_epoch_quarantined(settings.knowledge_root / "_evaluator_epochs", scenario_name, epoch_id)
     sqlite.append_agent_output(active_run_id, 1, "competitor", result.best_output)
     sqlite.upsert_generation(
         active_run_id,
@@ -365,7 +368,8 @@ def _run_agent_task(
         gate_decision=effective_termination_reason,
         status="completed",
         duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
-        evaluator_epoch=getattr(result, "evaluator_epoch", None),
+        evaluator_epoch=epoch_id,
+        quarantined=quarantined,
     )
 
     return AgentTaskRunSummary(

--- a/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
@@ -9,6 +9,7 @@ JSON store and its demote-not-delete rollback. See docs/ac-885-slice-c-epoch-lif
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -17,6 +18,8 @@ from typing import Any
 from pydantic import BaseModel
 
 from autocontext.execution.evaluator_epoch import EvaluatorEpoch
+
+logger = logging.getLogger(__name__)
 
 _VALID_STATES = frozenset({"candidate", "active", "disabled"})
 
@@ -33,12 +36,20 @@ def observe_epoch_quarantined(root: Path, scenario: str, epoch_id: str | None) -
     :meth:`EvaluatorEpochRegistry.observe_id` and returns ``True`` when the epoch is not the
     scenario's active one: a candidate or disabled epoch's scores are quarantined, the bootstrap or
     active epoch's are not.
+
+    Registry IO sits on the score-persist path, but the quarantine marker is non-critical lineage
+    metadata: any registry failure (unwritable root, a corrupt record) degrades to ``None`` (not
+    quarantined) rather than aborting persistence of an otherwise-complete run's score.
     """
     if epoch_id is None:
         return None
-    registry = EvaluatorEpochRegistry(root)
-    record = registry.observe_id(scenario, epoch_id)
-    return record.activation_state != "active"
+    try:
+        registry = EvaluatorEpochRegistry(root)
+        record = registry.observe_id(scenario, epoch_id)
+        return record.activation_state != "active"
+    except Exception:  # pragma: no cover - defensive; the marker must never break score persistence
+        logger.debug("evaluator_epoch_registry: observe failed for scenario %s", scenario, exc_info=True)
+        return None
 
 
 class EvaluatorEpochRecord(BaseModel):

--- a/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
@@ -25,6 +25,22 @@ def _default_now() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def observe_epoch_quarantined(root: Path, scenario: str, epoch_id: str | None) -> bool | None:
+    """Observe ``epoch_id`` for ``scenario`` and report whether its scores are quarantined.
+
+    Shared by the agent-task score write sites. Returns ``None`` when ``epoch_id`` is ``None``
+    (tournament/no-judge: there is nothing to observe). Otherwise it records/bootstraps the epoch via
+    :meth:`EvaluatorEpochRegistry.observe_id` and returns ``True`` when the epoch is not the
+    scenario's active one: a candidate or disabled epoch's scores are quarantined, the bootstrap or
+    active epoch's are not.
+    """
+    if epoch_id is None:
+        return None
+    registry = EvaluatorEpochRegistry(root)
+    record = registry.observe_id(scenario, epoch_id)
+    return record.activation_state != "active"
+
+
 class EvaluatorEpochRecord(BaseModel):
     scenario: str
     epoch_id: str
@@ -121,6 +137,37 @@ class EvaluatorEpochRegistry:
             rubric_hash=epoch.rubric_hash,
             judge_provider=epoch.judge_provider,
             judge_model=epoch.judge_model,
+            activation_state=state,
+            created_at=now_fn(),
+        )
+        self.register(record)
+        return record
+
+    def observe_id(
+        self,
+        scenario: str,
+        epoch_id: str,
+        *,
+        now_fn: Callable[[], str] = _default_now,
+    ) -> EvaluatorEpochRecord:
+        """Run the same mechanical trigger as :meth:`observe`, keyed only on ``epoch_id``.
+
+        Used at score write sites where only the epoch id string is authoritative (the judge
+        internals that produced it are not recomputed, since a BEFORE_JUDGE hook may have mutated
+        them). The rubric_hash/judge_provider/judge_model are stored empty and backfilled in Slice C2
+        when calibration runs. First id for a scenario auto-activates; a new id mints a candidate; a
+        known id is returned unchanged.
+        """
+        existing = self.load(scenario, epoch_id)
+        if existing is not None:
+            return existing
+        state = "active" if self.active_for(scenario) is None else "candidate"
+        record = EvaluatorEpochRecord(
+            scenario=scenario,
+            epoch_id=epoch_id,
+            rubric_hash="",
+            judge_provider="",
+            judge_model="",
             activation_state=state,
             created_at=now_fn(),
         )

--- a/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
@@ -1,0 +1,128 @@
+"""Per-scenario evaluator-epoch lifecycle registry (AC-885 Slice C).
+
+One ACTIVE evaluator epoch per scenario. observe() is the mechanical trigger: the first epoch a
+scenario ever sees auto-activates (bootstrap); a subsequent, different epoch is registered as a
+candidate (its scores are quarantined until promoted). Mirrors ModelRegistry's file-per-record
+JSON store and its demote-not-delete rollback. See docs/ac-885-slice-c-epoch-lifecycle-design.md.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from autocontext.execution.evaluator_epoch import EvaluatorEpoch
+
+_VALID_STATES = frozenset({"candidate", "active", "disabled"})
+
+
+def _default_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class EvaluatorEpochRecord(BaseModel):
+    scenario: str
+    epoch_id: str
+    rubric_hash: str
+    judge_provider: str
+    judge_model: str
+    activation_state: str
+    created_at: str
+    promotion: dict[str, Any] | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.activation_state not in _VALID_STATES:
+            raise ValueError(f"Invalid activation_state {self.activation_state!r}; expected {sorted(_VALID_STATES)}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvaluatorEpochRecord:
+        return cls(**data)
+
+
+def _safe(name: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+
+
+class EvaluatorEpochRegistry:
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _scenario_dir(self, scenario: str) -> Path:
+        return self.root / _safe(scenario)
+
+    def _path(self, scenario: str, epoch_id: str) -> Path:
+        return self._scenario_dir(scenario) / f"{epoch_id}.json"
+
+    def register(self, record: EvaluatorEpochRecord) -> Path:
+        path = self._path(record.scenario, record.epoch_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record.to_dict(), indent=2, ensure_ascii=False))
+        return path
+
+    def load(self, scenario: str, epoch_id: str) -> EvaluatorEpochRecord | None:
+        path = self._path(scenario, epoch_id)
+        if not path.exists():
+            return None
+        return EvaluatorEpochRecord.from_dict(json.loads(path.read_text()))
+
+    def list_for_scenario(self, scenario: str) -> list[EvaluatorEpochRecord]:
+        out: list[EvaluatorEpochRecord] = []
+        for path in self._scenario_dir(scenario).glob("*.json"):
+            out.append(EvaluatorEpochRecord.from_dict(json.loads(path.read_text())))
+        return out
+
+    def active_for(self, scenario: str) -> EvaluatorEpochRecord | None:
+        for rec in self.list_for_scenario(scenario):
+            if rec.activation_state == "active":
+                return rec
+        return None
+
+    def activate(self, scenario: str, epoch_id: str) -> None:
+        """Promote ``epoch_id`` to active, demoting any prior active to disabled.
+
+        Load the target FIRST: if the epoch does not exist for this scenario, leave all state
+        unchanged (no-op) so a bad id can never leave the scenario with zero active epochs.
+        """
+        target = self.load(scenario, epoch_id)
+        if target is None:
+            return
+        current = self.active_for(scenario)
+        if current is not None and current.epoch_id != epoch_id:
+            current.activation_state = "disabled"
+            self.register(current)
+        target.activation_state = "active"
+        self.register(target)
+
+    def observe(
+        self,
+        scenario: str,
+        epoch: EvaluatorEpoch,
+        *,
+        now_fn: Callable[[], str] = _default_now,
+    ) -> EvaluatorEpochRecord:
+        """Record an observed epoch. First epoch for a scenario auto-activates; a new epoch mints a
+        candidate; a known epoch is returned unchanged."""
+        existing = self.load(scenario, epoch.epoch_id)
+        if existing is not None:
+            return existing
+        state = "active" if self.active_for(scenario) is None else "candidate"
+        record = EvaluatorEpochRecord(
+            scenario=scenario,
+            epoch_id=epoch.epoch_id,
+            rubric_hash=epoch.rubric_hash,
+            judge_provider=epoch.judge_provider,
+            judge_model=epoch.judge_model,
+            activation_state=state,
+            created_at=now_fn(),
+        )
+        self.register(record)
+        return record

--- a/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
@@ -8,9 +8,14 @@ JSON store and its demote-not-delete rollback. See docs/ac-885-slice-c-epoch-lif
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
-from collections.abc import Callable
+import os
+import re
+import tempfile
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -22,6 +27,16 @@ from autocontext.execution.evaluator_epoch import EvaluatorEpoch
 logger = logging.getLogger(__name__)
 
 _VALID_STATES = frozenset({"candidate", "active", "disabled"})
+
+# Production epoch ids are sha256 hex digests (see execution/evaluator_epoch.py). Anything else at an
+# id-keyed write site (``observe_id``) is untrusted input and is refused: it could be a path-traversal
+# payload or a corrupt lineage value that must not silently mint a registry record.
+_EPOCH_ID_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _require_epoch_id(epoch_id: str) -> None:
+    if not _EPOCH_ID_PATTERN.match(epoch_id):
+        raise ValueError(f"Invalid epoch_id {epoch_id!r}; expected a 64-character sha256 hex digest")
 
 
 def _default_now() -> str:
@@ -37,9 +52,11 @@ def observe_epoch_quarantined(root: Path, scenario: str, epoch_id: str | None) -
     scenario's active one: a candidate or disabled epoch's scores are quarantined, the bootstrap or
     active epoch's are not.
 
-    Registry IO sits on the score-persist path, but the quarantine marker is non-critical lineage
-    metadata: any registry failure (unwritable root, a corrupt record) degrades to ``None`` (not
-    quarantined) rather than aborting persistence of an otherwise-complete run's score.
+    Registry IO sits on the score-persist path but never aborts persistence of an otherwise-complete
+    run's score. It fails CLOSED: when ``epoch_id`` is non-null but its lifecycle state cannot be
+    verified (unwritable root, a corrupt record, an invalid id), the score is conservatively
+    quarantined (returns ``True``) rather than trusted. Only ``epoch_id is None`` (tournament/no-judge:
+    genuinely nothing to observe) returns ``None``.
     """
     if epoch_id is None:
         return None
@@ -47,9 +64,9 @@ def observe_epoch_quarantined(root: Path, scenario: str, epoch_id: str | None) -
         registry = EvaluatorEpochRegistry(root)
         record = registry.observe_id(scenario, epoch_id)
         return record.activation_state != "active"
-    except Exception:  # pragma: no cover - defensive; the marker must never break score persistence
+    except Exception:
         logger.debug("evaluator_epoch_registry: observe failed for scenario %s", scenario, exc_info=True)
-        return None
+        return True
 
 
 class EvaluatorEpochRecord(BaseModel):
@@ -66,13 +83,6 @@ class EvaluatorEpochRecord(BaseModel):
         if self.activation_state not in _VALID_STATES:
             raise ValueError(f"Invalid activation_state {self.activation_state!r}; expected {sorted(_VALID_STATES)}")
 
-    def to_dict(self) -> dict[str, Any]:
-        return self.model_dump()
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> EvaluatorEpochRecord:
-        return cls(**data)
-
 
 def _safe(name: str) -> str:
     return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
@@ -87,31 +97,83 @@ class EvaluatorEpochRegistry:
         return self.root / _safe(scenario)
 
     def _path(self, scenario: str, epoch_id: str) -> Path:
-        return self._scenario_dir(scenario) / f"{epoch_id}.json"
+        """Resolve the record path, enforcing that it stays under the scenario directory.
+
+        Defense in depth against a traversal payload in ``epoch_id`` (``../../escaped``): the
+        resolved path must be contained by the scenario directory or this raises ``ValueError``.
+        """
+        scenario_dir = self._scenario_dir(scenario)
+        candidate = (scenario_dir / f"{epoch_id}.json").resolve()
+        base = scenario_dir.resolve()
+        if candidate != base and not candidate.is_relative_to(base):
+            raise ValueError(f"epoch_id {epoch_id!r} resolves outside the scenario directory")
+        return candidate
+
+    @contextmanager
+    def _scenario_lock(self, scenario: str) -> Iterator[None]:
+        """Hold an exclusive per-scenario process lock around a read-decide-write critical section.
+
+        Serializes concurrent bootstraps of the same scenario so two workers cannot both observe "no
+        active epoch" and each write an ``active`` record. Not re-entrant within a process: callers
+        already holding the lock must use the ``_locked`` helpers.
+        """
+        lock_path = self.root / f"{_safe(scenario)}.lock"
+        with open(lock_path, "w") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
     def register(self, record: EvaluatorEpochRecord) -> Path:
         path = self._path(record.scenario, record.epoch_id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(record.to_dict(), indent=2, ensure_ascii=False))
+        payload = json.dumps(record.model_dump(), indent=2, ensure_ascii=False)
+        fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".tmp-", suffix=".json")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+            os.replace(tmp_name, path)
+        except BaseException:
+            with suppress(OSError):
+                os.unlink(tmp_name)
+            raise
         return path
 
     def load(self, scenario: str, epoch_id: str) -> EvaluatorEpochRecord | None:
         path = self._path(scenario, epoch_id)
         if not path.exists():
             return None
-        return EvaluatorEpochRecord.from_dict(json.loads(path.read_text()))
+        return EvaluatorEpochRecord.model_validate(json.loads(path.read_text()))
 
     def list_for_scenario(self, scenario: str) -> list[EvaluatorEpochRecord]:
         out: list[EvaluatorEpochRecord] = []
         for path in self._scenario_dir(scenario).glob("*.json"):
-            out.append(EvaluatorEpochRecord.from_dict(json.loads(path.read_text())))
+            out.append(EvaluatorEpochRecord.model_validate(json.loads(path.read_text())))
         return out
 
+    def _active_for_locked(self, scenario: str) -> EvaluatorEpochRecord | None:
+        """Return the single active record, self-healing a multiple-active state.
+
+        If more than one active record exists (a legacy or raced write), deterministically keep the
+        lexicographically-smallest ``epoch_id`` active and demote the rest to disabled, then return
+        the kept one. Assumes the scenario lock is held.
+        """
+        actives = sorted(
+            (rec for rec in self.list_for_scenario(scenario) if rec.activation_state == "active"),
+            key=lambda rec: rec.epoch_id,
+        )
+        if not actives:
+            return None
+        kept = actives[0]
+        for extra in actives[1:]:
+            extra.activation_state = "disabled"
+            self.register(extra)
+        return kept
+
     def active_for(self, scenario: str) -> EvaluatorEpochRecord | None:
-        for rec in self.list_for_scenario(scenario):
-            if rec.activation_state == "active":
-                return rec
-        return None
+        with self._scenario_lock(scenario):
+            return self._active_for_locked(scenario)
 
     def activate(self, scenario: str, epoch_id: str) -> None:
         """Promote ``epoch_id`` to active, demoting any prior active to disabled.
@@ -119,15 +181,16 @@ class EvaluatorEpochRegistry:
         Load the target FIRST: if the epoch does not exist for this scenario, leave all state
         unchanged (no-op) so a bad id can never leave the scenario with zero active epochs.
         """
-        target = self.load(scenario, epoch_id)
-        if target is None:
-            return
-        current = self.active_for(scenario)
-        if current is not None and current.epoch_id != epoch_id:
-            current.activation_state = "disabled"
-            self.register(current)
-        target.activation_state = "active"
-        self.register(target)
+        with self._scenario_lock(scenario):
+            target = self.load(scenario, epoch_id)
+            if target is None:
+                return
+            current = self._active_for_locked(scenario)
+            if current is not None and current.epoch_id != epoch_id:
+                current.activation_state = "disabled"
+                self.register(current)
+            target.activation_state = "active"
+            self.register(target)
 
     def observe(
         self,
@@ -138,21 +201,22 @@ class EvaluatorEpochRegistry:
     ) -> EvaluatorEpochRecord:
         """Record an observed epoch. First epoch for a scenario auto-activates; a new epoch mints a
         candidate; a known epoch is returned unchanged."""
-        existing = self.load(scenario, epoch.epoch_id)
-        if existing is not None:
-            return existing
-        state = "active" if self.active_for(scenario) is None else "candidate"
-        record = EvaluatorEpochRecord(
-            scenario=scenario,
-            epoch_id=epoch.epoch_id,
-            rubric_hash=epoch.rubric_hash,
-            judge_provider=epoch.judge_provider,
-            judge_model=epoch.judge_model,
-            activation_state=state,
-            created_at=now_fn(),
-        )
-        self.register(record)
-        return record
+        with self._scenario_lock(scenario):
+            existing = self.load(scenario, epoch.epoch_id)
+            if existing is not None:
+                return existing
+            state = "active" if self._active_for_locked(scenario) is None else "candidate"
+            record = EvaluatorEpochRecord(
+                scenario=scenario,
+                epoch_id=epoch.epoch_id,
+                rubric_hash=epoch.rubric_hash,
+                judge_provider=epoch.judge_provider,
+                judge_model=epoch.judge_model,
+                activation_state=state,
+                created_at=now_fn(),
+            )
+            self.register(record)
+            return record
 
     def observe_id(
         self,
@@ -168,19 +232,25 @@ class EvaluatorEpochRegistry:
         them). The rubric_hash/judge_provider/judge_model are stored empty and backfilled in Slice C2
         when calibration runs. First id for a scenario auto-activates; a new id mints a candidate; a
         known id is returned unchanged.
+
+        ``epoch_id`` is untrusted here and must be a sha256 hex digest; anything else is rejected
+        (raising ``ValueError``) before any filesystem access, which the score-write helper degrades
+        to a quarantine.
         """
-        existing = self.load(scenario, epoch_id)
-        if existing is not None:
-            return existing
-        state = "active" if self.active_for(scenario) is None else "candidate"
-        record = EvaluatorEpochRecord(
-            scenario=scenario,
-            epoch_id=epoch_id,
-            rubric_hash="",
-            judge_provider="",
-            judge_model="",
-            activation_state=state,
-            created_at=now_fn(),
-        )
-        self.register(record)
-        return record
+        _require_epoch_id(epoch_id)
+        with self._scenario_lock(scenario):
+            existing = self.load(scenario, epoch_id)
+            if existing is not None:
+                return existing
+            state = "active" if self._active_for_locked(scenario) is None else "candidate"
+            record = EvaluatorEpochRecord(
+                scenario=scenario,
+                epoch_id=epoch_id,
+                rubric_hash="",
+                judge_provider="",
+                judge_model="",
+                activation_state=state,
+                created_at=now_fn(),
+            )
+            self.register(record)
+            return record

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -33,6 +33,7 @@ from autocontext.execution.agent_task_evolution import (
     AgentTaskGenerationEvaluation,
     AgentTaskTrajectory,
 )
+from autocontext.execution.evaluator_epoch_registry import observe_epoch_quarantined
 from autocontext.execution.evaluator_guardrail import evaluate_evaluator_guardrail
 from autocontext.execution.improvement_loop import ImprovementLoop, ImprovementResult
 from autocontext.execution.judge import LLMJudge
@@ -58,6 +59,7 @@ def _serialize_result(
     objective_guardrail: dict[str, Any] | None = None,
     evaluator_guardrail: dict[str, Any] | None = None,
     rubric_calibration: dict[str, Any] | None = None,
+    quarantined: bool | None = None,
 ) -> str:
     """Serialize an ImprovementResult to JSON."""
     rounds = []
@@ -79,6 +81,7 @@ def _serialize_result(
         "total_rounds": result.total_rounds,
         "met_threshold": result.met_threshold,
         "evaluator_epoch": result.evaluator_epoch,
+        "quarantined": quarantined,
     }
     if result.duration_ms is not None:
         data["duration_ms"] = result.duration_ms
@@ -109,6 +112,8 @@ def _serialize_evolution_result(
     evaluator_guardrail: dict[str, Any] | None = None,
     met_threshold: bool | None = None,
     rubric_calibration: dict[str, Any] | None = None,
+    evaluator_epoch: str | None = None,
+    quarantined: bool | None = None,
 ) -> str:
     """Serialize a multi-generation AgentTask evolution run to JSON."""
     final_rounds: list[dict[str, Any]] = []
@@ -149,6 +154,8 @@ def _serialize_evolution_result(
             met_threshold if met_threshold is not None else any(result.met_threshold for result in generation_results)
         ),
         "total_rounds": sum(result.total_rounds for result in generation_results),
+        "evaluator_epoch": evaluator_epoch,
+        "quarantined": quarantined,
     }
     if objective_verification is not None:
         data["objective_verification"] = objective_verification
@@ -302,6 +309,7 @@ class TaskRunner:
         notifier: Notifier | None = None,
         concurrency: int = 1,
         browser_context_service: QueuedTaskBrowserContextService | None = None,
+        settings: AppSettings | None = None,
     ) -> None:
         self.store = store
         self.provider = provider
@@ -311,8 +319,20 @@ class TaskRunner:
         self.notifier = notifier
         self.concurrency = max(1, concurrency)
         self.browser_context_service = browser_context_service
+        self.settings = settings
         self._shutdown = False
         self._tasks_processed = 0
+
+    def _observe_epoch_quarantine(self, scenario: str, epoch_id: str | None) -> bool | None:
+        """Observe the task's evaluator epoch and report whether its score is quarantined.
+
+        The queue result JSON is the always-on surface for TaskRunner (it does not write the
+        ``generations`` table); this is where its scores enter the epoch lifecycle. Requires
+        ``settings`` for the registry root; without it the marker is simply omitted.
+        """
+        if self.settings is None:
+            return None
+        return observe_epoch_quarantined(self.settings.knowledge_root / "_evaluator_epochs", scenario, epoch_id)
 
     def run(self) -> int:
         """Main loop. Returns the number of tasks processed.
@@ -480,6 +500,8 @@ class TaskRunner:
                 )
                 result.met_threshold = effective_met_threshold
 
+                epoch_id = getattr(result, "evaluator_epoch", None)
+                quarantined = self._observe_epoch_quarantine(spec_name, epoch_id)
                 self.store.complete_task(
                     task_id=task_id,
                     best_score=result.best_score,
@@ -492,6 +514,7 @@ class TaskRunner:
                         objective_guardrail,
                         evaluator_guardrail,
                         rubric_calibration,
+                        quarantined=quarantined,
                     ),
                 )
 
@@ -601,6 +624,15 @@ class TaskRunner:
             )
         )
 
+        best_generation = max(
+            ordered_results,
+            key=lambda result: result.best_score,
+        )
+        # The multi-generation aggregate persists best_generation's score; carry its epoch so the
+        # queue result JSON (and the returned result) keep the epoch + quarantine lineage.
+        epoch_id = best_generation.evaluator_epoch
+        quarantined = self._observe_epoch_quarantine(spec_name, epoch_id)
+
         self.store.complete_task(
             task_id=task_id,
             best_score=best_score,
@@ -615,13 +647,11 @@ class TaskRunner:
                 evaluator_guardrail,
                 effective_met_threshold,
                 rubric_calibration,
+                evaluator_epoch=epoch_id,
+                quarantined=quarantined,
             ),
         )
 
-        best_generation = max(
-            ordered_results,
-            key=lambda result: result.best_score,
-        )
         return ImprovementResult(
             rounds=best_generation.rounds,
             best_output=best_output,
@@ -635,6 +665,7 @@ class TaskRunner:
             duration_ms=sum(result.duration_ms or 0 for result in ordered_results),
             judge_calls=sum(result.judge_calls for result in ordered_results),
             dimension_trajectory={},
+            evaluator_epoch=epoch_id,
         )
 
     def _finalize_task_output(
@@ -777,6 +808,7 @@ def create_task_runner_from_settings(
         notifier=notifier,
         concurrency=concurrency,
         browser_context_service=browser_context_service,
+        settings=settings,
     )
 
 

--- a/autocontext/src/autocontext/knowledge/solve_task_execution.py
+++ b/autocontext/src/autocontext/knowledge/solve_task_execution.py
@@ -11,6 +11,7 @@ from typing import Any
 from autocontext.agents.provider_bridge import configured_role_provider
 from autocontext.agents.role_runtime_overrides import settings_for_budgeted_role_call
 from autocontext.config.settings import AppSettings
+from autocontext.execution.evaluator_epoch_registry import observe_epoch_quarantined
 from autocontext.execution.improvement_loop import ImprovementLoop
 from autocontext.extensions import HookBus, HookEvents, active_hook_bus
 from autocontext.loop.runner_hooks import (
@@ -306,6 +307,8 @@ def run_task_like_scenario(
             logger.debug("RUN_END hook failed after solve run failure", exc_info=True)
         raise
 
+    epoch_id = getattr(result, "evaluator_epoch", None)
+    quarantined = observe_epoch_quarantined(settings.knowledge_root / "_evaluator_epochs", scenario_name, epoch_id)
     sqlite.append_agent_output(active_run_id, 1, "competitor", result.best_output)
     sqlite.upsert_generation(
         active_run_id,
@@ -318,7 +321,8 @@ def run_task_like_scenario(
         gate_decision=result.termination_reason,
         status="completed",
         duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
-        evaluator_epoch=getattr(result, "evaluator_epoch", None),
+        evaluator_epoch=epoch_id,
+        quarantined=quarantined,
     )
     sqlite.mark_run_completed(active_run_id)
     if settings.cross_run_inheritance and not settings.ablation_no_feedback:

--- a/autocontext/src/autocontext/storage/bootstrap_schema.py
+++ b/autocontext/src/autocontext/storage/bootstrap_schema.py
@@ -23,6 +23,7 @@ _BOOTSTRAP_MIGRATIONS = (
     "014_scoring_backend_metadata.sql",
     "015_match_replay.sql",
     "016_generation_evaluator_epoch.sql",
+    "017_generation_quarantined.sql",
 )
 
 
@@ -76,6 +77,7 @@ def bootstrap_core_schema(conn: sqlite3.Connection) -> None:
             scoring_backend TEXT NOT NULL DEFAULT 'elo',
             rating_uncertainty REAL DEFAULT NULL,
             evaluator_epoch TEXT DEFAULT NULL,
+            quarantined INTEGER DEFAULT NULL,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now')),
             PRIMARY KEY (run_id, generation_index),

--- a/autocontext/src/autocontext/storage/migration_ledgers.py
+++ b/autocontext/src/autocontext/storage/migration_ledgers.py
@@ -15,6 +15,7 @@ TYPESCRIPT_TO_PYTHON_BASELINES: dict[str, tuple[str, ...]] = {
         "015_match_replay.sql",
     ),
     "014_generation_evaluator_epoch.sql": ("016_generation_evaluator_epoch.sql",),
+    "015_generation_quarantined.sql": ("017_generation_quarantined.sql",),
 }
 
 PYTHON_TO_TYPESCRIPT_BASELINES: dict[str, tuple[str, ...]] = {

--- a/autocontext/src/autocontext/storage/row_types.py
+++ b/autocontext/src/autocontext/storage/row_types.py
@@ -36,6 +36,7 @@ class GenerationMetricsRow(TypedDict):
     scoring_backend: str | None
     rating_uncertainty: float | None
     evaluator_epoch: str | None
+    quarantined: int | None
     dimension_summary_json: str | None
     created_at: str
     updated_at: str

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -122,6 +122,7 @@ class SQLiteStore(
         scoring_backend: str = "elo",
         rating_uncertainty: float | None = None,
         evaluator_epoch: str | None = None,
+        quarantined: bool | None = None,
     ) -> None:
         with self.connect() as conn:
             conn.execute(
@@ -129,9 +130,9 @@ class SQLiteStore(
                 INSERT INTO generations(
                     run_id, generation_index, mean_score, best_score, elo, wins, losses,
                     gate_decision, status, duration_seconds, dimension_summary_json,
-                    scoring_backend, rating_uncertainty, evaluator_epoch
+                    scoring_backend, rating_uncertainty, evaluator_epoch, quarantined
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(run_id, generation_index) DO UPDATE SET
                     mean_score = excluded.mean_score,
                     best_score = excluded.best_score,
@@ -145,6 +146,7 @@ class SQLiteStore(
                     scoring_backend = excluded.scoring_backend,
                     rating_uncertainty = excluded.rating_uncertainty,
                     evaluator_epoch = excluded.evaluator_epoch,
+                    quarantined = excluded.quarantined,
                     updated_at = datetime('now')
                 """,
                 (
@@ -162,6 +164,7 @@ class SQLiteStore(
                     scoring_backend,
                     rating_uncertainty,
                     evaluator_epoch,
+                    quarantined,
                 ),
             )
 

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -145,8 +145,8 @@ class SQLiteStore(
                     dimension_summary_json = excluded.dimension_summary_json,
                     scoring_backend = excluded.scoring_backend,
                     rating_uncertainty = excluded.rating_uncertainty,
-                    evaluator_epoch = excluded.evaluator_epoch,
-                    quarantined = excluded.quarantined,
+                    evaluator_epoch = COALESCE(excluded.evaluator_epoch, evaluator_epoch),
+                    quarantined = COALESCE(excluded.quarantined, quarantined),
                     updated_at = datetime('now')
                 """,
                 (

--- a/autocontext/tests/test_agent_task_generation_epoch.py
+++ b/autocontext/tests/test_agent_task_generation_epoch.py
@@ -82,6 +82,8 @@ def test_agent_task_run_persists_generation_epoch(tmp_path) -> None:
     settings.extensions = None
     settings.simplicity_mode = "off"
     settings.agent_provider = "anthropic"
+    # real path so the evaluator-epoch registry (observe wiring) writes under tmp, not a MagicMock dir
+    settings.knowledge_root = tmp_path / "knowledge"
 
     with (
         patch.object(store, "upsert_generation", _spy),

--- a/autocontext/tests/test_agent_task_quarantine.py
+++ b/autocontext/tests/test_agent_task_quarantine.py
@@ -16,6 +16,7 @@ a chosen ``evaluator_epoch``. The registry root is pointed at ``tmp_path`` via
 
 from __future__ import annotations
 
+import hashlib
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -26,6 +27,10 @@ from autocontext.execution.improvement_loop import ImprovementResult
 from autocontext.storage.sqlite_store import SQLiteStore
 
 MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+# Production epoch ids are sha256 hex digests; the id-keyed observe path rejects anything else.
+EPOCH_1 = hashlib.sha256(b"e-1").hexdigest()
+EPOCH_2 = hashlib.sha256(b"e-2").hexdigest()
 
 
 class _StubAgentTask:
@@ -95,16 +100,16 @@ def test_active_epoch_not_quarantined_new_epoch_quarantined(tmp_path) -> None:
     settings.agent_provider = "anthropic"
     settings.knowledge_root = tmp_path / "knowledge"
 
-    # First run: epoch e-1 bootstraps the scenario's active epoch.
-    _run_once(store, settings, epoch="e-1", run_id="run-e1")
+    # First run: EPOCH_1 bootstraps the scenario's active epoch.
+    _run_once(store, settings, epoch=EPOCH_1, run_id="run-e1")
     row1 = store.get_generation("run-e1", 1)
     assert row1 is not None
-    assert row1["evaluator_epoch"] == "e-1"
+    assert row1["evaluator_epoch"] == EPOCH_1
     assert not row1["quarantined"], "bootstrap/active epoch must not be quarantined"
 
-    # Second run: epoch e-2 is a candidate for the same scenario -> quarantined.
-    _run_once(store, settings, epoch="e-2", run_id="run-e2")
+    # Second run: EPOCH_2 is a candidate for the same scenario -> quarantined.
+    _run_once(store, settings, epoch=EPOCH_2, run_id="run-e2")
     row2 = store.get_generation("run-e2", 1)
     assert row2 is not None
-    assert row2["evaluator_epoch"] == "e-2"
+    assert row2["evaluator_epoch"] == EPOCH_2
     assert row2["quarantined"], "a non-active (candidate) epoch's score must be quarantined"

--- a/autocontext/tests/test_agent_task_quarantine.py
+++ b/autocontext/tests/test_agent_task_quarantine.py
@@ -1,0 +1,110 @@
+"""AC-885 Slice C1, Task 3: the agent-task write site must stamp ``quarantined``
+on the persisted generation row from the evaluator-epoch registry.
+
+Contract: when an agent-task run scores under an epoch that is NOT the scenario's
+active epoch, the persisted generation row is quarantined (truthy/1); when it
+scores under the active (or bootstrap) epoch, quarantined is null/false.
+
+This drives the real ``_run_agent_task`` code path (as
+``test_agent_task_generation_epoch.py`` does) against a stub scenario and a
+stubbed ``ImprovementLoop.run`` returning a *real* ``ImprovementResult`` carrying
+a chosen ``evaluator_epoch``. The registry root is pointed at ``tmp_path`` via
+``settings.knowledge_root``. The first run bootstraps epoch ``e-1`` to active
+(not quarantined); a second run of the same scenario under a different epoch
+``e-2`` mints a candidate (quarantined). Both persisted rows are asserted.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from autocontext.execution.improvement_loop import ImprovementResult
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+class _StubAgentTask:
+    """Minimal AgentTaskInterface stub for driving ``_run_agent_task``."""
+
+    def initial_state(self) -> dict[str, Any]:
+        return {}
+
+    def prepare_context(self, state: dict[str, Any]) -> dict[str, Any]:
+        return state
+
+    def validate_context(self, state: dict[str, Any]) -> list[str]:
+        return []
+
+    def get_task_prompt(self, state: dict[str, Any]) -> str:
+        return "do the task"
+
+
+@contextmanager
+def _noop_hook_bus(_hook_bus: Any):
+    yield
+
+
+def _real_result(epoch: str) -> ImprovementResult:
+    return ImprovementResult(
+        rounds=[],
+        best_output="final output",
+        best_score=0.75,
+        best_round=1,
+        total_rounds=1,
+        met_threshold=True,
+        termination_reason="threshold_met",
+        duration_ms=1234,
+        evaluator_epoch=epoch,
+    )
+
+
+def _run_once(store: SQLiteStore, settings: Any, *, epoch: str, run_id: str) -> None:
+    from autocontext import cli
+
+    fake_provider = SimpleNamespace(complete=lambda **_: SimpleNamespace(text="initial"))
+    fake_loop = MagicMock()
+    fake_loop.run.return_value = _real_result(epoch)
+
+    with (
+        patch.object(store, "upsert_generation", store.upsert_generation),
+        patch.dict(cli.SCENARIO_REGISTRY, {"stub_task": _StubAgentTask}, clear=False),
+        patch("autocontext.cli._sqlite_from_settings", return_value=store),
+        patch("autocontext.cli.initialize_hook_bus", return_value=(MagicMock(), [])),
+        patch("autocontext.cli.active_hook_bus", _noop_hook_bus),
+        patch("autocontext.cli._resolve_agent_task_runtime", return_value=(fake_provider, "m")),
+        patch("autocontext.cli.ImprovementLoop", return_value=fake_loop),
+        patch("autocontext.cli.build_evaluator_guardrail_payload", return_value=None),
+    ):
+        cli._run_agent_task("stub_task", settings, max_rounds=1, run_id=run_id)
+
+
+def test_active_epoch_not_quarantined_new_epoch_quarantined(tmp_path) -> None:
+    """First epoch bootstraps active (not quarantined); a second, different epoch
+    on the same scenario is a candidate (quarantined)."""
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+
+    settings = MagicMock()
+    settings.extensions = None
+    settings.simplicity_mode = "off"
+    settings.agent_provider = "anthropic"
+    settings.knowledge_root = tmp_path / "knowledge"
+
+    # First run: epoch e-1 bootstraps the scenario's active epoch.
+    _run_once(store, settings, epoch="e-1", run_id="run-e1")
+    row1 = store.get_generation("run-e1", 1)
+    assert row1 is not None
+    assert row1["evaluator_epoch"] == "e-1"
+    assert not row1["quarantined"], "bootstrap/active epoch must not be quarantined"
+
+    # Second run: epoch e-2 is a candidate for the same scenario -> quarantined.
+    _run_once(store, settings, epoch="e-2", run_id="run-e2")
+    row2 = store.get_generation("run-e2", 1)
+    assert row2 is not None
+    assert row2["evaluator_epoch"] == "e-2"
+    assert row2["quarantined"], "a non-active (candidate) epoch's score must be quarantined"

--- a/autocontext/tests/test_evaluator_epoch_registry.py
+++ b/autocontext/tests/test_evaluator_epoch_registry.py
@@ -103,3 +103,15 @@ def test_prefix_sharing_scenarios_do_not_leak(tmp_path) -> None:
     assert reg.active_for("grid_ctf_").epoch_id == e2.epoch_id
     # each scenario bootstrapped its own first epoch to active independently
     assert reg.observe("grid_ctf_", e2, now_fn=lambda: "t2").activation_state == "active"
+
+
+def test_observe_epoch_quarantined_degrades_on_registry_io_failure(tmp_path) -> None:
+    from autocontext.execution.evaluator_epoch_registry import observe_epoch_quarantined
+
+    # None epoch is never observed.
+    assert observe_epoch_quarantined(tmp_path / "reg", "grid_ctf", None) is None
+    # A root that is an existing FILE makes the registry mkdir fail; the marker must degrade to
+    # None (score persistence must never abort on a non-critical lineage failure), not raise.
+    bad_root = tmp_path / "afile"
+    bad_root.write_text("x")
+    assert observe_epoch_quarantined(bad_root, "grid_ctf", "e-1") is None

--- a/autocontext/tests/test_evaluator_epoch_registry.py
+++ b/autocontext/tests/test_evaluator_epoch_registry.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+
+def _epoch(rubric: str) -> object:
+    return compute_evaluator_epoch(rubric, "anthropic", "claude-sonnet-4-5")
+
+
+def test_first_epoch_bootstraps_active(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = _epoch("rubric one")
+    rec = reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    assert rec.activation_state == "active"
+    assert reg.active_for("grid_ctf").epoch_id == e1.epoch_id
+
+
+def test_same_epoch_is_noop(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = _epoch("rubric one")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    rec = reg.observe("grid_ctf", e1, now_fn=lambda: "t1")
+    assert rec.activation_state == "active"
+    assert len(reg.list_for_scenario("grid_ctf")) == 1
+
+
+def test_new_epoch_mints_candidate(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1, e2 = _epoch("rubric one"), _epoch("rubric two")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    rec = reg.observe("grid_ctf", e2, now_fn=lambda: "t1")
+    assert rec.activation_state == "candidate"
+    assert reg.active_for("grid_ctf").epoch_id == e1.epoch_id  # active unchanged
+
+
+def test_activate_demotes_prior(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1, e2 = _epoch("rubric one"), _epoch("rubric two")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")
+    reg.activate("grid_ctf", e2.epoch_id)
+    assert reg.active_for("grid_ctf").epoch_id == e2.epoch_id
+    assert reg.load("grid_ctf", e1.epoch_id).activation_state == "disabled"
+
+
+def test_reappearing_disabled_epoch_is_candidate_not_bootstrap(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1, e2 = _epoch("rubric one"), _epoch("rubric two")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")
+    reg.activate("grid_ctf", e2.epoch_id)  # e1 now disabled
+    rec = reg.observe("grid_ctf", e1, now_fn=lambda: "t2")  # e1 seen again
+    assert rec.activation_state == "disabled"  # known record, not re-bootstrapped
+
+
+def test_activate_missing_epoch_leaves_prior_active(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = _epoch("rubric one")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.activate("grid_ctf", "does-not-exist")  # bad id must not strand the scenario
+    active = reg.active_for("grid_ctf")
+    assert active is not None
+    assert active.epoch_id == e1.epoch_id
+    assert reg.load("grid_ctf", e1.epoch_id).activation_state == "active"
+
+
+def test_prefix_sharing_scenarios_do_not_leak(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1, e2 = _epoch("rubric one"), _epoch("rubric two")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.observe("grid_ctf_", e2, now_fn=lambda: "t1")
+    assert {r.epoch_id for r in reg.list_for_scenario("grid_ctf")} == {e1.epoch_id}
+    assert {r.epoch_id for r in reg.list_for_scenario("grid_ctf_")} == {e2.epoch_id}
+    assert reg.active_for("grid_ctf").epoch_id == e1.epoch_id
+    assert reg.active_for("grid_ctf_").epoch_id == e2.epoch_id
+    # each scenario bootstrapped its own first epoch to active independently
+    assert reg.observe("grid_ctf_", e2, now_fn=lambda: "t2").activation_state == "active"

--- a/autocontext/tests/test_evaluator_epoch_registry.py
+++ b/autocontext/tests/test_evaluator_epoch_registry.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import hashlib
+
 from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
-from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+from autocontext.execution.evaluator_epoch_registry import (
+    EvaluatorEpochRecord,
+    EvaluatorEpochRegistry,
+)
 
 
 def _epoch(rubric: str) -> object:
     return compute_evaluator_epoch(rubric, "anthropic", "claude-sonnet-4-5")
+
+
+def _hex_id(seed: str) -> str:
+    """A realistic 64-char sha256-hex epoch id (production ids are sha256 digests)."""
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
 
 
 def test_first_epoch_bootstraps_active(tmp_path) -> None:
@@ -44,14 +54,14 @@ def test_activate_demotes_prior(tmp_path) -> None:
     assert reg.load("grid_ctf", e1.epoch_id).activation_state == "disabled"
 
 
-def test_reappearing_disabled_epoch_is_candidate_not_bootstrap(tmp_path) -> None:
+def test_reappearing_disabled_epoch_stays_disabled(tmp_path) -> None:
     reg = EvaluatorEpochRegistry(tmp_path)
     e1, e2 = _epoch("rubric one"), _epoch("rubric two")
     reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
     reg.observe("grid_ctf", e2, now_fn=lambda: "t1")
     reg.activate("grid_ctf", e2.epoch_id)  # e1 now disabled
     rec = reg.observe("grid_ctf", e1, now_fn=lambda: "t2")  # e1 seen again
-    assert rec.activation_state == "disabled"  # known record, not re-bootstrapped
+    assert rec.activation_state == "disabled"  # known record returned unchanged, not re-bootstrapped
 
 
 def test_activate_missing_epoch_leaves_prior_active(tmp_path) -> None:
@@ -67,9 +77,10 @@ def test_activate_missing_epoch_leaves_prior_active(tmp_path) -> None:
 
 def test_observe_id_first_epoch_bootstraps_active(tmp_path) -> None:
     reg = EvaluatorEpochRegistry(tmp_path)
-    rec = reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t0")
+    id1 = _hex_id("e-1")
+    rec = reg.observe_id("grid_ctf", id1, now_fn=lambda: "t0")
     assert rec.activation_state == "active"
-    assert reg.active_for("grid_ctf").epoch_id == "e-1"
+    assert reg.active_for("grid_ctf").epoch_id == id1
     # only the id is known at this call site; components backfill in C2
     assert rec.rubric_hash == ""
     assert rec.judge_provider == ""
@@ -78,18 +89,41 @@ def test_observe_id_first_epoch_bootstraps_active(tmp_path) -> None:
 
 def test_observe_id_new_id_mints_candidate(tmp_path) -> None:
     reg = EvaluatorEpochRegistry(tmp_path)
-    reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t0")
-    rec = reg.observe_id("grid_ctf", "e-2", now_fn=lambda: "t1")
+    id1, id2 = _hex_id("e-1"), _hex_id("e-2")
+    reg.observe_id("grid_ctf", id1, now_fn=lambda: "t0")
+    rec = reg.observe_id("grid_ctf", id2, now_fn=lambda: "t1")
     assert rec.activation_state == "candidate"
-    assert reg.active_for("grid_ctf").epoch_id == "e-1"  # active unchanged
+    assert reg.active_for("grid_ctf").epoch_id == id1  # active unchanged
 
 
 def test_observe_id_same_id_is_noop(tmp_path) -> None:
     reg = EvaluatorEpochRegistry(tmp_path)
-    reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t0")
-    rec = reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t1")
+    id1 = _hex_id("e-1")
+    reg.observe_id("grid_ctf", id1, now_fn=lambda: "t0")
+    rec = reg.observe_id("grid_ctf", id1, now_fn=lambda: "t1")
     assert rec.activation_state == "active"
     assert len(reg.list_for_scenario("grid_ctf")) == 1
+
+
+def test_observe_id_rejects_non_hex_id(tmp_path) -> None:
+    import pytest
+
+    reg = EvaluatorEpochRegistry(tmp_path)
+    with pytest.raises(ValueError):
+        reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t0")
+
+
+def test_observe_id_path_traversal_is_rejected_and_writes_nothing(tmp_path) -> None:
+    import pytest
+
+    root = tmp_path / "reg"
+    reg = EvaluatorEpochRegistry(root)
+    with pytest.raises(ValueError):
+        reg.observe_id("grid_ctf", "../../escaped", now_fn=lambda: "t0")
+    # nothing escaped the registry root
+    assert not (tmp_path / "escaped.json").exists()
+    assert not (root.parent / "escaped.json").exists()
+    assert list(reg.list_for_scenario("grid_ctf")) == []
 
 
 def test_prefix_sharing_scenarios_do_not_leak(tmp_path) -> None:
@@ -105,13 +139,61 @@ def test_prefix_sharing_scenarios_do_not_leak(tmp_path) -> None:
     assert reg.observe("grid_ctf_", e2, now_fn=lambda: "t2").activation_state == "active"
 
 
-def test_observe_epoch_quarantined_degrades_on_registry_io_failure(tmp_path) -> None:
+def test_observe_epoch_quarantined_fails_closed_on_registry_io_failure(tmp_path) -> None:
     from autocontext.execution.evaluator_epoch_registry import observe_epoch_quarantined
 
-    # None epoch is never observed.
+    # None epoch is genuinely nothing to observe -> None (never quarantined).
     assert observe_epoch_quarantined(tmp_path / "reg", "grid_ctf", None) is None
-    # A root that is an existing FILE makes the registry mkdir fail; the marker must degrade to
-    # None (score persistence must never abort on a non-critical lineage failure), not raise.
+    # A root that is an existing FILE makes the registry mkdir fail. A non-null epoch whose lifecycle
+    # state cannot be verified must fail CLOSED (quarantined=True), never trusted, and never abort
+    # score persistence by raising.
     bad_root = tmp_path / "afile"
     bad_root.write_text("x")
-    assert observe_epoch_quarantined(bad_root, "grid_ctf", "e-1") is None
+    assert observe_epoch_quarantined(bad_root, "grid_ctf", _hex_id("e-1")) is True
+    # An invalid (non-hex) id is likewise unverifiable -> quarantined, not trusted.
+    assert observe_epoch_quarantined(tmp_path / "reg", "grid_ctf", "../../escaped") is True
+
+
+def test_active_for_self_heals_multiple_active(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    id_a, id_b = _hex_id("aaa"), _hex_id("bbb")
+    smaller, larger = sorted([id_a, id_b])
+    # Manually plant a corrupt two-active state (as a legacy/raced write would leave).
+    for epoch_id in (id_a, id_b):
+        reg.register(
+            EvaluatorEpochRecord(
+                scenario="grid_ctf",
+                epoch_id=epoch_id,
+                rubric_hash="",
+                judge_provider="",
+                judge_model="",
+                activation_state="active",
+                created_at="t0",
+            )
+        )
+    kept = reg.active_for("grid_ctf")
+    assert kept is not None
+    assert kept.epoch_id == smaller  # deterministically keep the lexicographically smallest
+    # exactly one active remains; the other is demoted to disabled (demote-not-delete)
+    actives = [r for r in reg.list_for_scenario("grid_ctf") if r.activation_state == "active"]
+    assert len(actives) == 1
+    assert reg.load("grid_ctf", larger).activation_state == "disabled"
+
+
+def test_concurrent_first_observe_yields_single_active(tmp_path) -> None:
+    import concurrent.futures
+
+    root = tmp_path / "reg"
+    EvaluatorEpochRegistry(root)  # create the root so the per-scenario lock file has a home
+    ids = [_hex_id(f"epoch-{i}") for i in range(8)]
+
+    def _first_observe(epoch_id: str) -> str:
+        reg = EvaluatorEpochRegistry(root)  # a fresh registry per worker (separate process-like)
+        return reg.observe_id("grid_ctf", epoch_id).activation_state
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(ids)) as pool:
+        list(pool.map(_first_observe, ids))
+
+    reg = EvaluatorEpochRegistry(root)
+    actives = [r for r in reg.list_for_scenario("grid_ctf") if r.activation_state == "active"]
+    assert len(actives) == 1  # exactly one bootstrap won under the per-scenario lock

--- a/autocontext/tests/test_evaluator_epoch_registry.py
+++ b/autocontext/tests/test_evaluator_epoch_registry.py
@@ -65,6 +65,33 @@ def test_activate_missing_epoch_leaves_prior_active(tmp_path) -> None:
     assert reg.load("grid_ctf", e1.epoch_id).activation_state == "active"
 
 
+def test_observe_id_first_epoch_bootstraps_active(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    rec = reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t0")
+    assert rec.activation_state == "active"
+    assert reg.active_for("grid_ctf").epoch_id == "e-1"
+    # only the id is known at this call site; components backfill in C2
+    assert rec.rubric_hash == ""
+    assert rec.judge_provider == ""
+    assert rec.judge_model == ""
+
+
+def test_observe_id_new_id_mints_candidate(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t0")
+    rec = reg.observe_id("grid_ctf", "e-2", now_fn=lambda: "t1")
+    assert rec.activation_state == "candidate"
+    assert reg.active_for("grid_ctf").epoch_id == "e-1"  # active unchanged
+
+
+def test_observe_id_same_id_is_noop(tmp_path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t0")
+    rec = reg.observe_id("grid_ctf", "e-1", now_fn=lambda: "t1")
+    assert rec.activation_state == "active"
+    assert len(reg.list_for_scenario("grid_ctf")) == 1
+
+
 def test_prefix_sharing_scenarios_do_not_leak(tmp_path) -> None:
     reg = EvaluatorEpochRegistry(tmp_path)
     e1, e2 = _epoch("rubric one"), _epoch("rubric two")

--- a/autocontext/tests/test_generation_quarantined_column.py
+++ b/autocontext/tests/test_generation_quarantined_column.py
@@ -27,6 +27,60 @@ def test_quarantined_roundtrips(tmp_path: Path) -> None:
     assert rows[0]["quarantined"] in (1, True)
 
 
+def test_later_upsert_omitting_quarantine_and_epoch_preserves_them(tmp_path: Path) -> None:
+    """A re-upsert that omits quarantined/evaluator_epoch (defaults NULL) must NOT erase an existing
+    marker or epoch lineage: ON CONFLICT COALESCEs the incoming NULL back to the stored value."""
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+    store.create_run("run-1", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-1",
+        1,
+        mean_score=0.9,
+        best_score=0.9,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+        evaluator_epoch="epoch-abc",
+        quarantined=True,
+    )
+    # Second upsert of the SAME row omits both -> they must survive.
+    store.upsert_generation(
+        "run-1",
+        1,
+        mean_score=0.95,
+        best_score=0.95,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+    )
+    row = store.get_generation("run-1", 1)
+    assert row is not None
+    assert row["quarantined"] in (1, True), "omitted upsert must not clear the quarantine marker"
+    assert row["evaluator_epoch"] == "epoch-abc", "omitted upsert must not erase the epoch lineage"
+
+    # An EXPLICIT falsy 0 is distinguishable from omitted-NULL and DOES overwrite (0 is not NULL).
+    store.upsert_generation(
+        "run-1",
+        1,
+        mean_score=0.95,
+        best_score=0.95,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+        quarantined=0,
+    )
+    row = store.get_generation("run-1", 1)
+    assert row is not None
+    assert row["quarantined"] in (0, False), "explicit 0 must overwrite (COALESCE keeps a non-NULL 0)"
+
+
 def test_quarantined_defaults_null(tmp_path: Path) -> None:
     store = SQLiteStore(tmp_path / "t2.sqlite3")
     store.migrate(MIGRATIONS)

--- a/autocontext/tests/test_generation_quarantined_column.py
+++ b/autocontext/tests/test_generation_quarantined_column.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def test_quarantined_roundtrips(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+    store.create_run("run-1", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-1",
+        1,
+        mean_score=0.9,
+        best_score=0.9,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+        quarantined=True,
+    )
+    rows = store.get_generation_metrics("run-1")
+    assert rows[0]["quarantined"] in (1, True)
+
+
+def test_quarantined_defaults_null(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "t2.sqlite3")
+    store.migrate(MIGRATIONS)
+    store.create_run("run-2", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-2",
+        1,
+        mean_score=0.5,
+        best_score=0.5,
+        elo=1000.0,
+        wins=1,
+        losses=0,
+        gate_decision="advance",
+        status="completed",
+    )
+    assert store.get_generation_metrics("run-2")[0]["quarantined"] is None

--- a/autocontext/tests/test_task_runner.py
+++ b/autocontext/tests/test_task_runner.py
@@ -898,10 +898,11 @@ class TestSerialization:
             met_threshold=True,
             evaluator_epoch="e2",
         )
-        serialized = _serialize_result(result)
+        serialized = _serialize_result(result, quarantined=True)
         data = json.loads(serialized)
         assert [r["evaluator_epoch"] for r in data["rounds"]] == ["e1", "e2"]
         assert data["evaluator_epoch"] == "e2"
+        assert data["quarantined"] is True
 
     def test_serialize_evolution_result_includes_optimizer_surface(self):
         from autocontext.execution.agent_task_evolution import AgentTaskTrajectory
@@ -939,12 +940,47 @@ class TestSerialization:
             ),
         ]
 
-        serialized = _serialize_evolution_result(trajectory, generation_results)
+        serialized = _serialize_evolution_result(trajectory, generation_results, evaluator_epoch="e-best", quarantined=True)
         data = json.loads(serialized)
 
         assert data["pareto_frontier"][0]["candidate_id"] == "round-2"
         assert data["actionable_side_info"][0]["example_id"] == "round-2-quality"
         assert data["generations"][0]["pareto_frontier"][0]["candidate_id"] == "round-1"
+        # AC-885 Slice C1 (Fix 5): the multi-generation queue JSON must carry epoch + quarantine.
+        assert data["evaluator_epoch"] == "e-best"
+        assert data["quarantined"] is True
+
+    def test_run_once_observes_epoch_and_stamps_quarantine_on_queue_json(self, store, tmp_path):
+        """Fix 5: the always-on TaskRunner queue surface must observe the evaluator epoch and carry
+        the resulting quarantine marker on the persisted result JSON (it does not write generations)."""
+        settings = AppSettings(knowledge_root=tmp_path / "knowledge")
+
+        # First task for the scenario bootstraps its active epoch -> not quarantined.
+        provider = _MockProvider(["candidate output", _judge_response(0.9)])
+        store.enqueue_task(
+            "t-epoch-1",
+            "epoch_scn",
+            config={"task_prompt": "do the thing", "rubric": "Rubric A", "max_rounds": 1},
+        )
+        result = TaskRunner(store=store, provider=provider, settings=settings).run_once()
+        assert result is not None
+        payload = json.loads(result["result_json"])
+        assert "quarantined" in payload
+        assert not payload["quarantined"], "bootstrap/active epoch score must not be quarantined"
+        assert payload["evaluator_epoch"], "the observed epoch id must ride on the queue JSON"
+        assert (settings.knowledge_root / "_evaluator_epochs").exists(), "registry must have recorded"
+
+        # Second task, SAME scenario, DIFFERENT rubric -> a new (candidate) epoch -> quarantined.
+        provider2 = _MockProvider(["candidate output 2", _judge_response(0.9)])
+        store.enqueue_task(
+            "t-epoch-2",
+            "epoch_scn",
+            config={"task_prompt": "do the thing", "rubric": "Rubric B is different", "max_rounds": 1},
+        )
+        result2 = TaskRunner(store=store, provider=provider2, settings=settings).run_once()
+        assert result2 is not None
+        payload2 = json.loads(result2["result_json"])
+        assert payload2["quarantined"] is True, "a non-active (candidate) epoch's score must be quarantined"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ac-885-slice-c-epoch-lifecycle-design.md
+++ b/docs/ac-885-slice-c-epoch-lifecycle-design.md
@@ -1,0 +1,167 @@
+# AC-885 Slice C: evaluator-epoch lifecycle (candidate to active promotion)
+
+Date: 2026-07-09
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: Slice C of four. Slice 1 (identity + comparability guard) and Slice B (persisted + derived
+lineage) are merged (#1204, #1208). Slice D (surfacing + lazy re-score) remains.
+
+## Purpose
+
+Slices 1 and B made the evaluator epoch a content-addressed identity carried by scores. Slice C
+adds the LIFECYCLE the AC-885 issue asks for ("evaluator changes should have explicit promotion and
+invalidation rules"): a rubric or judge change mints a CANDIDATE epoch whose scores are quarantined
+from the scenario's trusted progression until the epoch is PROMOTED (calibrated and, per the
+autonomy dial, human-reviewed) to ACTIVE. This generalizes the ambient trainer's existing
+model-promotion pattern (`promote.py`, which today refuses to compare scores across a mismatched
+scalar `anchor_model`) to the evaluator epoch itself.
+
+Today there is no "active vs candidate epoch" state anywhere: the epoch is purely a derived
+score-lineage value. Slice C introduces that state, the mechanical trigger that mints candidates,
+the quarantine enforcement, and the promotion workflow.
+
+## Decisions of record
+
+1. **Enforce via quarantine, not a hard block.** Scores produced under an epoch that is not the
+   scenario's ACTIVE epoch carry a `quarantined` marker and are excluded from cross-epoch/scenario
+   trust decisions (ambient model promotion, the scenario's canonical progression, reports). The
+   improve loop still iterates within a candidate epoch (Slice 1 re-baseline) so the calibration
+   data needed to promote that epoch is produced. Quarantine that hard-blocked the loop would be a
+   chicken-and-egg (you need candidate-epoch scores to calibrate the candidate for promotion).
+2. **Mechanical trigger; first epoch auto-activates.** The first time a score is produced under an
+   epoch that is not the scenario's active epoch, that epoch is auto-registered as a CANDIDATE. A
+   scenario's first-ever epoch (no incumbent) auto-activates, mirroring `promote.py`'s
+   "incumbent is None then promote". No dependency on the (unbuilt) rubric-patch apply path.
+3. **Keyed per scenario; registry mirrors ModelRegistry.** One ACTIVE epoch per scenario. A new
+   `EvaluatorEpochRegistry` stores one JSON file per `(scenario, epoch_id)` record, mirroring
+   `ModelRegistry`'s register/activate/list_all shape and its demote-not-delete rollback pattern.
+4. **Promotion via calibration deltas plus the autonomy dial; human decision recorded.**
+   `run_judge_calibration` yields alignment/bias/variance deltas (already epoch-tagged since Slice
+   B). Promotion criteria: calibration passes `AlignmentTolerance` and bias-probe drift is within
+   tolerance. The autonomy dial governs autonomy: `full` auto-promotes on pass; `propose`/`train`
+   require a persisted human decision (`reviewed_by`, `reviewed_at`, `outcome`).
+5. **Generalize `promote.py`'s cross-anchor refusal to epoch comparability.** Replace the scalar
+   `anchor_model` equality in `_beats_incumbent` with `are_comparable(candidate_epoch,
+incumbent_epoch)` (the Slice 1 primitive), and have the ambient promote flow consult the
+   evaluator-epoch registry so a model scored under a non-active evaluator epoch is refused
+   (`promote_epoch_not_active`).
+6. **Python-only except the quarantine marker.** The registry, trigger, promotion workflow, and
+   `promote.py` generalization are Python-only (the ambient/promote path has no TS mirror,
+   consistent with Slice 1's guard). The `quarantined` marker on persisted generation scores is the
+   only schema-parity touch (a `generations` column, like Slice B's).
+7. **Built as ordered sub-slices, each its own spec/plan/PR.** C1 (registry + trigger + marker),
+   then C2 (promotion workflow + metadata + generalize promote.py), then C3 (enforcement in
+   consumers + CLI to list/approve).
+
+## Architecture
+
+### C1: registry, record, mechanical trigger, quarantine marker
+
+- `EvaluatorEpochRecord` (`execution/evaluator_epoch_registry.py`, new): `scenario`, `epoch_id`,
+  `rubric_hash`, `judge_provider`, `judge_model`, `activation_state:
+Literal["candidate","active","disabled"]`, `created_at`, `promotion: dict | None`.
+- `EvaluatorEpochRegistry`: file-per-`(scenario, epoch_id)` JSON store under a registry root.
+  `observe(scenario, epoch) -> EvaluatorEpochRecord` implements the mechanical trigger: no active
+  for scenario -> register active (bootstrap); epoch == active -> return it; new epoch -> register
+  candidate. `active_for(scenario) -> EvaluatorEpochRecord | None`; `list_for_scenario`; `register`;
+  `activate(scenario, epoch_id)` (demote-not-delete). Pure, deterministic, no LLM.
+- `observe` is called at the scenario-aware layer (improve loop / task_runner / ambient evaluate)
+  where both the scenario and the score's epoch are known. A score whose epoch is not the active
+  one is stamped `quarantined = True`.
+- Persistence: a nullable `quarantined` marker rides the Slice B `generations` lineage (a
+  `generations.quarantined` boolean column, Python migration + TS parity column, always null on the
+  TS side per the Slice B asymmetry). In-memory results (`ImprovementResult`) carry a `quarantined`
+  flag too.
+
+### C2: promotion workflow, metadata, promote.py generalization
+
+- A `promote_evaluator_epoch(registry, scenario, candidate_epoch, calibration_report, charter)`
+  operation: checks the calibration deltas against tolerance, consults the autonomy dial via the
+  existing `decide()` (extended `Action` to include `"promote_epoch"`), and either activates the
+  candidate (autonomy `full` + calibration passes) or records a pending human-review requirement.
+  On activation: candidate -> active, prior active -> disabled, quarantine cleared for that epoch's
+  scores, `promotion` metadata stamped.
+- `promotion` metadata: `{ source_patch | None, calibration_anchors: list[str], alignment_delta,
+bias_delta, variance_delta, requires_review: bool, decision: { reviewed_by, reviewed_at, outcome:
+"approved"|"rejected"|None }, promoted_at, previous_active }`.
+- `promote.py`: `_beats_incumbent` uses `are_comparable(best_epoch, incumbent_epoch)` instead of
+  scalar `anchor_model` equality; a new refusal `promote_epoch_not_active` when a candidate model's
+  eval epoch is not the scenario's active evaluator epoch.
+
+### C3: enforcement in consumers, CLI
+
+- Ambient promote refuses non-active-epoch eval scores; the scenario canonical-progression /
+  reporting paths exclude `quarantined` scores.
+- A CLI surface (`autoctx epoch list|approve|reject <scenario>`) to view candidates and record a
+  human decision (writing the `promotion.decision` block).
+
+## Data flow
+
+```
+score produced (scenario known, epoch from Slice 1)
+   -> registry.observe(scenario, epoch)
+        first-ever epoch     -> register ACTIVE (bootstrap)
+        epoch == active      -> noop
+        new epoch            -> register CANDIDATE, stamp score quarantined=True
+   -> quarantined scores excluded from cross-epoch trust (ambient promote, canonical progression)
+   -> run_judge_calibration(candidate) -> alignment/bias/variance deltas (epoch-tagged, Slice B)
+   -> promote_evaluator_epoch: tolerance + autonomy dial
+        full + passes        -> activate candidate (prior active -> disabled), clear quarantine
+        propose/train        -> record requires_review; human approve/reject via CLI -> decision
+```
+
+## Error handling and edge cases
+
+- **Bootstrap (no active epoch):** the first observed epoch auto-activates; its scores are not
+  quarantined.
+- **Reappearing epoch:** an epoch that was previously active then superseded is still a known
+  record; if it is currently disabled and reappears, it is treated as a candidate again (its state
+  is looked up by `(scenario, epoch_id)`), not re-bootstrapped.
+- **Tournament / no-rubric scenarios:** produce no judge epoch (null); `observe` is a noop for a
+  null epoch, and such scores are never quarantined.
+- **Legacy scores (pre-Slice-C):** carry `quarantined = None`/false and are treated as trusted
+  (the active epoch is bootstrapped from the first observed epoch after upgrade).
+- **Calibration unavailable (< 2 anchors):** `run_judge_calibration` returns None; the candidate
+  cannot auto-promote and stays pending human review.
+
+## Testing
+
+- C1: `observe` state machine (bootstrap-active, noop-on-active, mint-candidate, reappearing-epoch);
+  registry register/activate/demote-not-delete; the `quarantined` marker persists on generation
+  rows (Python) with the TS parity column present-but-null; schema-parity stays green.
+- C2: `promote_evaluator_epoch` tolerance + autonomy branches (full-auto vs requires-review);
+  metadata shape; `promote.py` `_beats_incumbent` uses `are_comparable` (a candidate scored under a
+  non-comparable epoch is refused with `promote_epoch_not_active`); a regression test that the prior
+  anchor-mismatch behavior is preserved for same-epoch comparisons.
+- C3: ambient promote refuses a non-active-epoch model; canonical progression excludes quarantined
+  scores; CLI approve/reject writes the decision block. The required AC-885 regression: a record
+  scored under a candidate (non-active) epoch is excluded/flagged until the epoch is promoted, then
+  trusted.
+- No new gate/guard/validator-named symbols; module-size, ruff/mypy/lint, Python and TS suites,
+  lockfiles unchanged.
+
+## Documentation
+
+Extend `docs/evaluator-epochs.md` with a "lifecycle" section: candidate vs active state, the
+mechanical trigger and bootstrap, quarantine semantics (excluded from trust decisions, not a hard
+block), the promotion workflow (calibration deltas + autonomy dial + human decision), and the
+`promote.py` generalization. CHANGELOG per sub-slice.
+
+## Deferred / out of scope
+
+- The rubric-patch APPLY path (the `source_patch` promotion metadata is nullable until that path
+  exists; `propose_rubric_patches` is experimental and unwired today).
+- Drift-signal-triggered candidate minting (the mechanical per-score trigger is authoritative;
+  drift is a lagging aggregate).
+- Reconciling the ambient per-charter-anchor path and the main per-LLMJudge path beyond the shared
+  per-scenario registry key.
+- Slice D (CLI/API/dashboard stale-epoch surfacing and lazy re-score) beyond the C3 approve/reject
+  CLI.
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 #2 (changing an evaluator cannot silently overwrite the active baseline): promoted to an
+  explicit candidate/active lifecycle with quarantine, beyond Slice 1's re-baseline.
+- AC-885 promotion-metadata and invalidation-rules requirements (source patch, calibration anchors,
+  alignment/bias/variance deltas, human-review requirement, decision; mark/filter stale scores):
+  delivered by C2 and C3.

--- a/docs/ac-885-slice-c-epoch-lifecycle-design.md
+++ b/docs/ac-885-slice-c-epoch-lifecycle-design.md
@@ -65,13 +65,16 @@ Literal["candidate","active","disabled"]`, `created_at`, `promotion: dict | None
   for scenario -> register active (bootstrap); epoch == active -> return it; new epoch -> register
   candidate. `active_for(scenario) -> EvaluatorEpochRecord | None`; `list_for_scenario`; `register`;
   `activate(scenario, epoch_id)` (demote-not-delete). Pure, deterministic, no LLM.
-- `observe` is called at the scenario-aware layer (improve loop / task_runner / ambient evaluate)
-  where both the scenario and the score's epoch are known. A score whose epoch is not the active
-  one is stamped `quarantined = True`.
-- Persistence: a nullable `quarantined` marker rides the Slice B `generations` lineage (a
-  `generations.quarantined` boolean column, Python migration + TS parity column, always null on the
-  TS side per the Slice B asymmetry). In-memory results (`ImprovementResult`) carry a `quarantined`
-  flag too.
+- In C1, `observe` (via the shared id-keyed `observe_epoch_quarantined` helper) is called at the
+  three score-write surfaces where both the scenario and the score's epoch are known: the CLI direct
+  agent-task write site, the `solve` generation write site, and the always-on TaskRunner queue-result
+  path. A score whose epoch is not the active one is stamped `quarantined = True`.
+- Persistence: for the CLI and `solve` surfaces the marker rides the Slice B `generations` lineage (a
+  nullable `generations.quarantined` boolean column, Python migration + TS parity column, always null
+  on the TS side per the Slice B asymmetry). The TaskRunner surface does NOT write the `generations`
+  table; it writes task-queue result JSON, so C1 carries the `quarantined` marker (and the epoch) as a
+  top-level field of that JSON via `_serialize_result` / `_serialize_evolution_result`. C1 does NOT add
+  a `quarantined` flag to the in-memory `ImprovementResult`.
 
 ### C2: promotion workflow, metadata, promote.py generalization
 
@@ -115,8 +118,9 @@ score produced (scenario known, epoch from Slice 1)
 - **Bootstrap (no active epoch):** the first observed epoch auto-activates; its scores are not
   quarantined.
 - **Reappearing epoch:** an epoch that was previously active then superseded is still a known
-  record; if it is currently disabled and reappears, it is treated as a candidate again (its state
-  is looked up by `(scenario, epoch_id)`), not re-bootstrapped.
+  record; if it is currently disabled and reappears, `observe` returns that known record UNCHANGED
+  (still disabled), looked up by `(scenario, epoch_id)`, rather than re-bootstrapping it or
+  re-minting it as a candidate. Its scores stay quarantined because disabled is not the active epoch.
 - **Tournament / no-rubric scenarios:** produce no judge epoch (null); `observe` is a noop for a
   null epoch, and such scores are never quarantined.
 - **Legacy scores (pre-Slice-C):** carry `quarantined = None`/false and are treated as trusted

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -140,6 +140,47 @@ the flag is a lineage annotation, not a filter. Enforcement (refusing to aggrega
 partitioning by epoch before the math) is deferred to a later slice; Slice B's job is to make the
 mixing visible, not to act on it.
 
+## Epoch lifecycle (Slice C1)
+
+Slice B recorded which epoch produced a score. Slice C decides what to do about it: which epoch a
+scenario currently trusts, and which epochs are merely candidates awaiting promotion. Slice C1 lays
+the foundation for that decision. It builds the per-scenario registry, the mechanical trigger that
+populates it, and the marker on scores that a non-active epoch produces. The enforcement that
+consumes the marker and the promotion workflow that clears it arrive in later sub-slices (see below).
+
+**The per-scenario registry.** `EvaluatorEpochRegistry`
+(`autocontext/src/autocontext/execution/evaluator_epoch_registry.py`) holds one record per (scenario,
+epoch) pair, stored file-per-record under a per-scenario subdirectory, mirroring how the model
+registry keeps its records. Each `EvaluatorEpochRecord` carries the epoch identity (the `epoch_id`
+plus the rubric hash and judge provider and model that produced it) and an `activation_state` in
+`{candidate, active, disabled}`. The invariant is one active epoch per scenario: `active_for` returns
+it, and `activate` promotes a target epoch while demoting the prior active one to disabled. The
+demotion is a state change, not a delete, so a rollback is reversible, and `activate` loads the
+target first and no-ops on a missing id so a bad id can never leave a scenario with zero active
+epochs.
+
+**The mechanical observe trigger.** `observe` (and its id-only convenience `observe_id`, keyed on the
+`epoch_id` string alone) is the only way epochs enter the registry, and its rule is purely
+mechanical: the first epoch a scenario ever sees auto-activates (the bootstrap epoch becomes active
+with no ceremony), and any subsequent, different epoch is registered as a candidate. A known epoch is
+returned unchanged. The trigger is keyed per scenario, so two scenarios bootstrap independently. No
+score is compared and no judgment is made here; the registry simply records what it has seen and
+which epoch was first.
+
+**The `quarantined` marker.** A generation score produced under an epoch that is not the scenario's
+active one is stamped `quarantined` on its `generations` row (the nullable `quarantined` column added
+by migration 017 in Python and migration 015 in TypeScript, byte-identical across the two schemas per
+the parity constraint). The two agent-task write sites call the `observe_epoch_quarantined` helper,
+which observes the score's epoch and reports whether it is non-active: a candidate or disabled epoch's
+scores are marked quarantined, while the bootstrap or active epoch's scores are not. A score with no
+epoch (tournament or legacy, epoch `None`) has nothing to observe and is never quarantined.
+
+The marker is recorded here, not yet acted on. Slice C1 makes the fact visible on the row; it does
+not change any loop or aggregation behavior. The enforcement that consumes the marker (ambient-promote
+refusal and progression exclusion of quarantined scores) and the promotion workflow that turns a
+candidate into the active epoch (and so clears the quarantine going forward) arrive in Slices C2 and
+C3.
+
 ## Relationship to the ambient `eval_fingerprint` / `anchor_model`
 
 autocontext already had this mechanism, but only in the ambient trainer. `eval_fingerprint()`
@@ -165,6 +206,9 @@ The remaining slices are explicitly deferred, not dropped:
   unstamped by design.
 - **Slice C (epoch lifecycle):** candidate-to-active epoch promotion with promotion metadata
   (source patch, calibration anchors used, alignment / bias / variance deltas, human-review
-  requirement, decision); generalizes `promote.py`'s cross-anchor refusal.
+  requirement, decision); generalizes `promote.py`'s cross-anchor refusal. C1 (the per-scenario
+  registry, the mechanical observe trigger, and the `quarantined` marker) is shipped (see "Epoch
+  lifecycle (Slice C1)" above); the enforcement that consumes the marker and the promotion workflow
+  land in C2 and C3.
 - **Slice D (surfacing + lazy re-score):** stale-epoch warnings in CLI / status / replay, REST /
   API, and dashboard, plus lazy revalidation of raw artifacts when a stale scored record is touched.

--- a/ts/migrations/015_generation_quarantined.sql
+++ b/ts/migrations/015_generation_quarantined.sql
@@ -1,0 +1,2 @@
+-- AC-885 Slice C1: quarantine marker for scores produced under a non-active evaluator epoch.
+ALTER TABLE generations ADD COLUMN quarantined INTEGER DEFAULT NULL;

--- a/ts/src/storage/generation-record-contracts.ts
+++ b/ts/src/storage/generation-record-contracts.ts
@@ -11,6 +11,7 @@ export interface UpsertGenerationRecordOpts {
   scoringBackend?: string;
   ratingUncertainty?: number | null;
   evaluatorEpoch?: string | null;
+  quarantined?: number | null;
 }
 
 export interface RecordMatchRecordOpts {

--- a/ts/src/storage/generation-upsert-workflow.ts
+++ b/ts/src/storage/generation-upsert-workflow.ts
@@ -27,8 +27,8 @@ export function upsertGenerationRecord(
        dimension_summary_json = excluded.dimension_summary_json,
        scoring_backend = excluded.scoring_backend,
        rating_uncertainty = excluded.rating_uncertainty,
-       evaluator_epoch = excluded.evaluator_epoch,
-       quarantined = excluded.quarantined,
+       evaluator_epoch = COALESCE(excluded.evaluator_epoch, evaluator_epoch),
+       quarantined = COALESCE(excluded.quarantined, quarantined),
        updated_at = datetime('now')`,
   ).run(
     runId,

--- a/ts/src/storage/generation-upsert-workflow.ts
+++ b/ts/src/storage/generation-upsert-workflow.ts
@@ -12,9 +12,9 @@ export function upsertGenerationRecord(
     `INSERT INTO generations(
        run_id, generation_index, mean_score, best_score, elo, wins, losses,
        gate_decision, status, duration_seconds, dimension_summary_json,
-       scoring_backend, rating_uncertainty, evaluator_epoch
+       scoring_backend, rating_uncertainty, evaluator_epoch, quarantined
      )
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(run_id, generation_index) DO UPDATE SET
        mean_score = excluded.mean_score,
        best_score = excluded.best_score,
@@ -28,6 +28,7 @@ export function upsertGenerationRecord(
        scoring_backend = excluded.scoring_backend,
        rating_uncertainty = excluded.rating_uncertainty,
        evaluator_epoch = excluded.evaluator_epoch,
+       quarantined = excluded.quarantined,
        updated_at = datetime('now')`,
   ).run(
     runId,
@@ -44,6 +45,7 @@ export function upsertGenerationRecord(
     opts.scoringBackend ?? "elo",
     opts.ratingUncertainty ?? null,
     opts.evaluatorEpoch ?? null,
+    opts.quarantined ?? null,
   );
 }
 

--- a/ts/src/storage/storage-contracts.ts
+++ b/ts/src/storage/storage-contracts.ts
@@ -53,6 +53,7 @@ export interface GenerationRow {
   scoring_backend: string;
   rating_uncertainty: number | null;
   evaluator_epoch: string | null;
+  quarantined: number | null;
   created_at: string;
   updated_at: string;
 }

--- a/ts/src/storage/storage-migration-workflow.ts
+++ b/ts/src/storage/storage-migration-workflow.ts
@@ -21,6 +21,7 @@ export const TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES: Record<string, readonly s
   "012_consultation_log.sql": ["010_consultation_log.sql"],
   "012_research_hub.sql": ["012_research_hub.sql"],
   "014_generation_evaluator_epoch.sql": ["016_generation_evaluator_epoch.sql"],
+  "015_generation_quarantined.sql": ["017_generation_quarantined.sql"],
 };
 
 const TYPESCRIPT_BASELINE_SCHEMA_RECONCILIATION: Record<string, readonly string[]> = {

--- a/ts/tests/generation-record-store-workflow.test.ts
+++ b/ts/tests/generation-record-store-workflow.test.ts
@@ -84,6 +84,48 @@ describe("generation record store workflow", () => {
     });
   });
 
+  it("preserves quarantined and evaluator_epoch when a later upsert omits them", () => {
+    createRunRecord(db, "run-1", "grid_ctf", 3, "local");
+    upsertGenerationRecord(db, "run-1", 1, {
+      meanScore: 0.6,
+      bestScore: 0.7,
+      elo: 1050,
+      wins: 3,
+      losses: 2,
+      gateDecision: "advance",
+      status: "completed",
+      evaluatorEpoch: "epoch-abc",
+      quarantined: 1,
+    });
+    // Re-upsert the SAME row omitting quarantined + evaluatorEpoch (both default to null).
+    upsertGenerationRecord(db, "run-1", 1, {
+      meanScore: 0.8,
+      bestScore: 0.9,
+      elo: 1100,
+      wins: 4,
+      losses: 2,
+      gateDecision: "advance",
+      status: "completed",
+    });
+    let row = getGenerationRecords<GenerationRow>(db, "run-1")[0];
+    expect(row.quarantined).toBe(1); // COALESCE keeps the stored marker, not the incoming null
+    expect(row.evaluator_epoch).toBe("epoch-abc");
+
+    // An explicit falsy 0 IS distinguishable from omitted-null and overwrites.
+    upsertGenerationRecord(db, "run-1", 1, {
+      meanScore: 0.8,
+      bestScore: 0.9,
+      elo: 1100,
+      wins: 4,
+      losses: 2,
+      gateDecision: "advance",
+      status: "completed",
+      quarantined: 0,
+    });
+    row = getGenerationRecords<GenerationRow>(db, "run-1")[0];
+    expect(row.quarantined).toBe(0);
+  });
+
   it("records matches and agent outputs and returns best/generation-scoped lookups", () => {
     createRunRecord(db, "run-1", "grid_ctf", 3, "local");
     upsertGenerationRecord(db, "run-1", 1, {
@@ -116,7 +158,9 @@ describe("generation record store workflow", () => {
     expect(getAgentOutputRecords<AgentOutputRow>(db, "run-1", 1)[0]).toMatchObject({
       role: "competitor",
     });
-    expect(getBestGenerationForScenarioRecord<GenerationRow & { run_id: string }>(db, "grid_ctf")).toMatchObject({
+    expect(
+      getBestGenerationForScenarioRecord<GenerationRow & { run_id: string }>(db, "grid_ctf"),
+    ).toMatchObject({
       run_id: "run-1",
       best_score: 0.7,
     });

--- a/ts/tests/storage-migration-workflow.test.ts
+++ b/ts/tests/storage-migration-workflow.test.ts
@@ -111,6 +111,16 @@ describe("storage migration workflow", () => {
         .prepare("SELECT filename FROM schema_version WHERE filename = ?")
         .get("014_generation_evaluator_epoch.sql"),
     ).toEqual({ filename: "014_generation_evaluator_epoch.sql" });
+
+    const quarantinedColumns = (
+      db.prepare("PRAGMA table_info(generations)").all() as Array<{ name: string }>
+    ).filter((column) => column.name === "quarantined");
+    expect(quarantinedColumns).toHaveLength(1);
+    expect(
+      db
+        .prepare("SELECT filename FROM schema_version WHERE filename = ?")
+        .get("015_generation_quarantined.sql"),
+    ).toEqual({ filename: "015_generation_quarantined.sql" });
   });
 
   it("marks TypeScript migrations applied when Python already owns the equivalent schema", () => {


### PR DESCRIPTION
First sub-slice of AC-885 Slice C (the evaluator-epoch lifecycle). Slices 1 + B are merged (#1204, #1208). C1 lays the foundation; enforcement + promotion follow in C2/C3.

## What this adds
- **`EvaluatorEpochRegistry`** (`execution/evaluator_epoch_registry.py`): a per-scenario, file-per-record store with `candidate`/`active`/`disabled` state, mirroring `ModelRegistry`. `observe`/`observe_id` are the mechanical trigger: a scenario's first epoch auto-activates (bootstrap), a subsequent different epoch mints a candidate, a known epoch returns unchanged. `activate` demotes-not-deletes and no-ops on a missing target.
- **`generations.quarantined` column** (Python migration 017 + TS 015, byte-identical, schema-parity + migration-ledger pairing with a cross-package idempotency test).
- **Wiring**: `observe_epoch_quarantined` is called at the two agent-task generation write sites, stamping `quarantined` on a score produced under a non-active epoch. Registry IO on this hot path degrades to "not quarantined" rather than aborting score persistence.

## Design note (deliberate scope boundary)
This is a written-but-not-yet-consumed marker plus a sound registry state machine. The enforcement that CONSUMES `quarantined` (ambient-promote refusal, canonical-progression exclusion) and the promotion workflow (calibration deltas + autonomy dial + human decision, generalizing `promote.py`) are **Slice C2/C3**, so no half-built enforcement lands here. Python-only except the parity column.

## Review process
Design flagged the full lifecycle as speculative infra (no consumer yet); building it as ordered sub-slices keeps each PR reviewable. Per-task review caught and fixed two real registry bugs (an `activate` that demoted before checking the target existed; a filename-prefix scenario collision). The whole-branch review (Ready-to-merge: Yes) flagged the score-persist-path coupling, fixed here. Two remaining Minors (a theoretical `_safe` collision on controlled scenario names; a concurrent-bootstrap two-active race) are noted for C2.

## Verification
Python: ruff + mypy clean, C1 test files + cross-runtime migration ledger + module-size + gate-taxonomy green, `uv.lock` unchanged. TS: storage-schema-parity + storage-migration-workflow (incl. cross-package idempotency) + lint green. Rebased onto current main (erp-67 through #1207); no migration collision.

Left open for review; not merged.