### PR TITLE
AC-885 slice C2: evaluator-epoch promotion workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to this project will be documented in this file.
   candidate/active/disabled epochs; the first epoch a scenario sees auto-activates and a subsequent
   different epoch mints a candidate whose generation scores are marked `quarantined`. Promotion and
   enforcement follow in later sub-slices.
+- AC-885 Slice C2: evaluator-epoch promotion workflow. `promote_evaluator_epoch` decides via
+  calibration alignment tolerance and the autonomy dial whether to activate a candidate epoch,
+  records promotion and human-decision metadata, and retroactively clears the quarantine on the
+  promoted epoch's prior scores. The trigger (CLI/stage) and the promote.py generalization follow.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/ambient/policy.py
+++ b/autocontext/src/autocontext/ambient/policy.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from autocontext.ambient.charter import AutonomyLevel, Charter, CharterBudgets
 
-Action = Literal["train", "promote"]
+Action = Literal["train", "promote", "promote_epoch"]
 
 
 @dataclass(slots=True)

--- a/autocontext/src/autocontext/execution/evaluator_epoch_promotion.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_promotion.py
@@ -1,0 +1,137 @@
+"""Evaluator-epoch promotion operation (AC-885 Slice C2).
+
+Decide via calibration tolerance + the autonomy dial whether to activate a candidate epoch, record
+the promotion + human-decision metadata, and clear the quarantine on the promoted epoch's prior
+scores. Pure: the caller supplies the CalibrationReport (from run_judge_calibration). The trigger
+(CLI/stage) and the promote.py generalization are deferred. See docs/ac-885-slice-c2-promotion-design.md.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal, Protocol
+
+from autocontext.ambient.charter import Charter
+from autocontext.ambient.policy import decide
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRecord, EvaluatorEpochRegistry
+from autocontext.execution.rubric_calibration import AlignmentTolerance, CalibrationReport
+
+
+def _default_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewerDecision:
+    outcome: Literal["approved", "rejected"]
+    reviewed_by: str
+    reviewed_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionOutcome:
+    outcome: Literal["activated", "pending_review", "rejected", "blocked", "noop"]
+    reason: str
+    record: EvaluatorEpochRecord | None
+
+
+class _QuarantineClearer(Protocol):
+    def clear_quarantine_for_epoch(self, scenario: str, epoch_id: str) -> int: ...
+
+
+def _promotion_metadata(
+    report: CalibrationReport | None,
+    *,
+    requires_review: bool,
+    decision: ReviewerDecision | None,
+    previous_active: str,
+    now: str,
+) -> dict[str, Any]:
+    alignment = report.alignment if report is not None else None
+    variance = report.variance if report is not None else None
+    return {
+        "source_patch": None,
+        "calibration_anchors": report.num_anchors if report is not None else 0,
+        "alignment_delta": (
+            {
+                "mean_absolute_error": alignment.mean_absolute_error,
+                "bias": alignment.bias,
+                "correlation": alignment.correlation,
+            }
+            if alignment is not None
+            else None
+        ),
+        "variance_delta": ({"variance": variance.variance, "std_dev": variance.std_dev} if variance is not None else None),
+        "requires_review": requires_review,
+        "decision": (
+            {"reviewed_by": decision.reviewed_by, "reviewed_at": decision.reviewed_at, "outcome": decision.outcome}
+            if decision is not None
+            else None
+        ),
+        "promoted_at": now,
+        "previous_active": previous_active,
+    }
+
+
+def promote_evaluator_epoch(
+    registry: EvaluatorEpochRegistry,
+    scenario: str,
+    candidate_epoch_id: str,
+    *,
+    calibration_report: CalibrationReport | None,
+    tolerance: AlignmentTolerance,
+    charter: Charter,
+    reviewer_decision: ReviewerDecision | None = None,
+    sqlite: _QuarantineClearer | None = None,
+    now_fn: Callable[[], str] = _default_now,
+) -> PromotionOutcome:
+    candidate = registry.load(scenario, candidate_epoch_id)
+    if candidate is None or candidate.activation_state == "active":
+        return PromotionOutcome("noop", "candidate missing or already active", candidate)
+
+    now = now_fn()
+    calibration_passes = calibration_report is not None and bool(tolerance.check(calibration_report.alignment).get("passes"))
+    incumbent = registry.active_for(scenario)
+    previous_active = incumbent.epoch_id if incumbent is not None else ""
+    policy = decide(charter, "promote_epoch", scenario)
+
+    def _activate(decision: ReviewerDecision | None, requires_review: bool) -> PromotionOutcome:
+        meta = _promotion_metadata(
+            calibration_report,
+            requires_review=requires_review,
+            decision=decision,
+            previous_active=previous_active,
+            now=now,
+        )
+        registry.promote(scenario, candidate_epoch_id, promotion=meta)
+        if sqlite is not None:
+            sqlite.clear_quarantine_for_epoch(scenario, candidate_epoch_id)
+        return PromotionOutcome("activated", "promoted", registry.load(scenario, candidate_epoch_id))
+
+    if reviewer_decision is not None:
+        if reviewer_decision.outcome == "approved":
+            return _activate(reviewer_decision, requires_review=policy.requires_approval)
+        # rejected: record the decision, do not activate
+        candidate.promotion = _promotion_metadata(
+            calibration_report,
+            requires_review=policy.requires_approval,
+            decision=reviewer_decision,
+            previous_active=previous_active,
+            now=now,
+        )
+        registry.register(candidate)
+        return PromotionOutcome("rejected", "reviewer rejected", registry.load(scenario, candidate_epoch_id))
+
+    if policy.requires_approval:
+        candidate.promotion = _promotion_metadata(
+            calibration_report, requires_review=True, decision=None, previous_active=previous_active, now=now
+        )
+        registry.register(candidate)
+        return PromotionOutcome("pending_review", policy.reason, registry.load(scenario, candidate_epoch_id))
+
+    # autonomy full: decide on calibration
+    if calibration_passes:
+        return _activate(None, requires_review=False)
+    return PromotionOutcome("blocked", "calibration did not pass tolerance", candidate)

--- a/autocontext/src/autocontext/execution/evaluator_epoch_promotion.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_promotion.py
@@ -54,6 +54,7 @@ def _promotion_metadata(
     return {
         "source_patch": None,
         "calibration_anchors": report.num_anchors if report is not None else 0,
+        "calibration_anchor_ids": report.anchor_ids if report is not None else [],
         "alignment_delta": (
             {
                 "mean_absolute_error": alignment.mean_absolute_error,
@@ -80,6 +81,7 @@ def promote_evaluator_epoch(
     scenario: str,
     candidate_epoch_id: str,
     *,
+    target_name: str,
     calibration_report: CalibrationReport | None,
     tolerance: AlignmentTolerance,
     charter: Charter,
@@ -87,19 +89,41 @@ def promote_evaluator_epoch(
     sqlite: _QuarantineClearer | None = None,
     now_fn: Callable[[], str] = _default_now,
 ) -> PromotionOutcome:
+    # ``scenario`` keys the registry/sqlite; ``target_name`` names the charter target the autonomy
+    # policy is looked up by. They are deliberately separate: a valid charter forbids a target name
+    # colliding with a registered scenario, so passing ``scenario`` into ``decide`` would KeyError.
     candidate = registry.load(scenario, candidate_epoch_id)
-    if candidate is None or candidate.activation_state == "active":
-        return PromotionOutcome("noop", "candidate missing or already active", candidate)
+    if candidate is None:
+        return PromotionOutcome("noop", "candidate missing", candidate)
+    if candidate.activation_state == "active":
+        # Already active: a prior promotion may have activated the epoch but crashed before clearing
+        # its quarantine. Reconcile the clear so a retry is not a dead noop that strands rows.
+        if sqlite is not None:
+            sqlite.clear_quarantine_for_epoch(scenario, candidate_epoch_id)
+            return PromotionOutcome("activated", "already active; quarantine reconciled", candidate)
+        return PromotionOutcome("noop", "already active", candidate)
 
     now = now_fn()
-    calibration_passes = calibration_report is not None and bool(tolerance.check(calibration_report.alignment).get("passes"))
+    # Only trust a calibration report whose lineage matches THIS candidate: same evaluator epoch and
+    # same domain. A report tagged another epoch (or domain) must contribute no calibration evidence,
+    # so full autonomy cannot activate an uncalibrated evaluator off a passing but unrelated report.
+    valid_report = (
+        calibration_report
+        if (
+            calibration_report is not None
+            and calibration_report.evaluator_epoch == candidate_epoch_id
+            and calibration_report.domain == scenario
+        )
+        else None
+    )
+    calibration_passes = valid_report is not None and bool(tolerance.check(valid_report.alignment).get("passes"))
     incumbent = registry.active_for(scenario)
     previous_active = incumbent.epoch_id if incumbent is not None else ""
-    policy = decide(charter, "promote_epoch", scenario)
+    policy = decide(charter, "promote_epoch", target_name)
 
     def _activate(decision: ReviewerDecision | None, requires_review: bool) -> PromotionOutcome:
         meta = _promotion_metadata(
-            calibration_report,
+            valid_report,
             requires_review=requires_review,
             decision=decision,
             previous_active=previous_active,
@@ -114,21 +138,19 @@ def promote_evaluator_epoch(
         if reviewer_decision.outcome == "approved":
             return _activate(reviewer_decision, requires_review=policy.requires_approval)
         # rejected: record the decision, do not activate
-        candidate.promotion = _promotion_metadata(
-            calibration_report,
+        meta = _promotion_metadata(
+            valid_report,
             requires_review=policy.requires_approval,
             decision=reviewer_decision,
             previous_active=previous_active,
             now=now,
         )
-        registry.register(candidate)
+        registry.stamp_promotion(scenario, candidate_epoch_id, promotion=meta)
         return PromotionOutcome("rejected", "reviewer rejected", registry.load(scenario, candidate_epoch_id))
 
     if policy.requires_approval:
-        candidate.promotion = _promotion_metadata(
-            calibration_report, requires_review=True, decision=None, previous_active=previous_active, now=now
-        )
-        registry.register(candidate)
+        meta = _promotion_metadata(valid_report, requires_review=True, decision=None, previous_active=previous_active, now=now)
+        registry.stamp_promotion(scenario, candidate_epoch_id, promotion=meta)
         return PromotionOutcome("pending_review", policy.reason, registry.load(scenario, candidate_epoch_id))
 
     # autonomy full: decide on calibration

--- a/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
@@ -175,6 +175,25 @@ class EvaluatorEpochRegistry:
         with self._scenario_lock(scenario):
             return self._active_for_locked(scenario)
 
+    def _activate_locked(self, scenario: str, epoch_id: str, *, promotion: dict[str, Any] | None = None) -> None:
+        """Load-target-first activation under an already-held scenario lock (see activate/promote).
+
+        Shared critical section so activate and promote cannot diverge: load the target FIRST (no-op
+        if missing), demote any prior active to disabled, set the target active, and optionally stamp
+        its promotion metadata, all via atomic writes.
+        """
+        target = self.load(scenario, epoch_id)
+        if target is None:
+            return
+        current = self._active_for_locked(scenario)
+        if current is not None and current.epoch_id != epoch_id:
+            current.activation_state = "disabled"
+            self.register(current)
+        target.activation_state = "active"
+        if promotion is not None:
+            target.promotion = promotion
+        self.register(target)
+
     def activate(self, scenario: str, epoch_id: str) -> None:
         """Promote ``epoch_id`` to active, demoting any prior active to disabled.
 
@@ -182,15 +201,12 @@ class EvaluatorEpochRegistry:
         unchanged (no-op) so a bad id can never leave the scenario with zero active epochs.
         """
         with self._scenario_lock(scenario):
-            target = self.load(scenario, epoch_id)
-            if target is None:
-                return
-            current = self._active_for_locked(scenario)
-            if current is not None and current.epoch_id != epoch_id:
-                current.activation_state = "disabled"
-                self.register(current)
-            target.activation_state = "active"
-            self.register(target)
+            self._activate_locked(scenario, epoch_id)
+
+    def promote(self, scenario: str, epoch_id: str, *, promotion: dict[str, Any]) -> None:
+        """Activate ``epoch_id`` and stamp its promotion metadata, atomically under the scenario lock."""
+        with self._scenario_lock(scenario):
+            self._activate_locked(scenario, epoch_id, promotion=promotion)
 
     def observe(
         self,

--- a/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
@@ -208,6 +208,22 @@ class EvaluatorEpochRegistry:
         with self._scenario_lock(scenario):
             self._activate_locked(scenario, epoch_id, promotion=promotion)
 
+    def stamp_promotion(self, scenario: str, epoch_id: str, *, promotion: dict[str, Any]) -> None:
+        """Stamp ``promotion`` metadata on a record WITHOUT changing its activation_state.
+
+        Reloads the record fresh under the scenario lock (no-op if it vanished) and writes only the
+        promotion field, preserving whatever ``activation_state`` is on disk. Used by the pending-review
+        and rejected paths: those must not clobber a concurrent promotion that already activated the
+        candidate (a stale in-memory record would otherwise revert it to ``candidate``, leaving the
+        scenario with zero active epochs).
+        """
+        with self._scenario_lock(scenario):
+            record = self.load(scenario, epoch_id)
+            if record is None:
+                return
+            record.promotion = promotion
+            self.register(record)
+
     def observe(
         self,
         scenario: str,

--- a/autocontext/src/autocontext/execution/rubric_calibration.py
+++ b/autocontext/src/autocontext/execution/rubric_calibration.py
@@ -148,14 +148,16 @@ def compute_alignment(
     """Compute alignment between human and judge scores."""
     if not human_scores and not judge_scores:
         return AlignmentResult(
-            mean_absolute_error=0.0, bias=0.0, correlation=0.0,
-            num_pairs=0, per_anchor_errors=[],
+            mean_absolute_error=0.0,
+            bias=0.0,
+            correlation=0.0,
+            num_pairs=0,
+            per_anchor_errors=[],
         )
 
     if len(human_scores) != len(judge_scores):
         raise ValueError(
-            "human_scores and judge_scores must have the same length; "
-            f"got {len(human_scores)} and {len(judge_scores)}",
+            f"human_scores and judge_scores must have the same length; got {len(human_scores)} and {len(judge_scores)}",
         )
 
     hs = human_scores
@@ -218,19 +220,11 @@ class AlignmentTolerance(BaseModel):
         violations: list[str] = []
 
         if alignment.mean_absolute_error > self.max_mean_absolute_error:
-            violations.append(
-                f"mean_absolute_error {alignment.mean_absolute_error:.4f} "
-                f"> max {self.max_mean_absolute_error:.4f}"
-            )
+            violations.append(f"mean_absolute_error {alignment.mean_absolute_error:.4f} > max {self.max_mean_absolute_error:.4f}")
         if abs(alignment.bias) > self.max_bias:
-            violations.append(
-                f"bias {alignment.bias:.4f} > max {self.max_bias:.4f}"
-            )
+            violations.append(f"bias {alignment.bias:.4f} > max {self.max_bias:.4f}")
         if alignment.correlation < self.min_correlation and alignment.num_pairs >= 3:
-            violations.append(
-                f"correlation {alignment.correlation:.4f} "
-                f"< min {self.min_correlation:.4f}"
-            )
+            violations.append(f"correlation {alignment.correlation:.4f} < min {self.min_correlation:.4f}")
 
         return {
             "passes": len(violations) == 0,
@@ -249,6 +243,7 @@ class CalibrationReport(BaseModel):
     calibrated: bool
     metadata: dict[str, Any] = Field(default_factory=dict)
     evaluator_epoch: str | None = None
+    anchor_ids: list[str] = Field(default_factory=list)
 
     def summary(self) -> str:
         lines = [
@@ -363,11 +358,7 @@ def run_judge_calibration(
     calibration_epoch: str | None = None
 
     for anchor in calibration_set.anchors:
-        leave_one_out = [
-            example
-            for example in calibration_examples
-            if str(example.get("id")) != anchor.anchor_id
-        ]
+        leave_one_out = [example for example in calibration_examples if str(example.get("id")) != anchor.anchor_id]
         repeated_scores: list[float] = []
         for _ in range(max(1, repeat_judgments)):
             result = judge.evaluate(
@@ -405,4 +396,5 @@ def run_judge_calibration(
             "cross_domain_normalization": "explicit second phase",
         },
         evaluator_epoch=calibration_epoch,
+        anchor_ids=[anchor.anchor_id for anchor in calibration_set.anchors],
     )

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -177,7 +177,8 @@ class SQLiteStore(
         with self.connect() as conn:
             cur = conn.execute(
                 "UPDATE generations SET quarantined = NULL "
-                "WHERE evaluator_epoch = ? AND run_id IN (SELECT run_id FROM runs WHERE scenario = ?)",
+                "WHERE evaluator_epoch = ? AND quarantined IS NOT NULL "
+                "AND run_id IN (SELECT run_id FROM runs WHERE scenario = ?)",
                 (epoch_id, scenario),
             )
             return cur.rowcount

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -168,6 +168,20 @@ class SQLiteStore(
                 ),
             )
 
+    def clear_quarantine_for_epoch(self, scenario: str, epoch_id: str) -> int:
+        """Clear the quarantine marker on a scenario's generation rows scored under ``epoch_id``.
+
+        Scoped by scenario (via the runs table) so a content-hash epoch shared across scenarios only
+        clears the promoted scenario's rows. Returns the number of rows cleared.
+        """
+        with self.connect() as conn:
+            cur = conn.execute(
+                "UPDATE generations SET quarantined = NULL "
+                "WHERE evaluator_epoch = ? AND run_id IN (SELECT run_id FROM runs WHERE scenario = ?)",
+                (epoch_id, scenario),
+            )
+            return cur.rowcount
+
     def update_generation_duration(
         self,
         run_id: str,

--- a/autocontext/tests/test_clear_quarantine_for_epoch.py
+++ b/autocontext/tests/test_clear_quarantine_for_epoch.py
@@ -31,3 +31,6 @@ def test_clear_quarantine_scoped_by_scenario(tmp_path: Path) -> None:
     assert cleared == 1
     assert store.get_generation_metrics("run-a")[0]["quarantined"] is None
     assert store.get_generation_metrics("run-b")[0]["quarantined"] in (1, True)  # untouched
+    # FIX 6: the count reflects only rows ACTUALLY unquarantined. A second consecutive call finds
+    # nothing still quarantined for the epoch, so it clears (and counts) zero, not the matched row.
+    assert store.clear_quarantine_for_epoch("grid_ctf", "epoch-x") == 0

--- a/autocontext/tests/test_clear_quarantine_for_epoch.py
+++ b/autocontext/tests/test_clear_quarantine_for_epoch.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def test_clear_quarantine_scoped_by_scenario(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+    store.create_run("run-a", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.create_run("run-b", "othello", 1, "local", agent_provider="anthropic")
+    # same content-hash epoch used in two scenarios; only grid_ctf must be cleared
+    for rid in ("run-a", "run-b"):
+        store.upsert_generation(
+            rid,
+            1,
+            mean_score=0.9,
+            best_score=0.9,
+            elo=0.0,
+            wins=0,
+            losses=0,
+            gate_decision="completed",
+            status="completed",
+            evaluator_epoch="epoch-x",
+            quarantined=True,
+        )
+    cleared = store.clear_quarantine_for_epoch("grid_ctf", "epoch-x")
+    assert cleared == 1
+    assert store.get_generation_metrics("run-a")[0]["quarantined"] is None
+    assert store.get_generation_metrics("run-b")[0]["quarantined"] in (1, True)  # untouched

--- a/autocontext/tests/test_evaluator_epoch_promotion.py
+++ b/autocontext/tests/test_evaluator_epoch_promotion.py
@@ -16,18 +16,21 @@ from autocontext.storage.sqlite_store import SQLiteStore
 
 _MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
 
+# The registry/sqlite are keyed by the real scenario name ("grid_ctf"); the charter target the policy
+# is looked up by is a distinct name ("competitor-local"). A valid charter FORBIDS a target name that
+# collides with a registered scenario, so the two must never be conflated (see FIX 1 regression test).
+_SCENARIO = "grid_ctf"
+_TARGET = "competitor-local"
+
 
 def _charter(autonomy: str) -> Charter:
-    # A non-registered target name ("t1") is used consistently: a target name that collides with a
-    # registered scenario is rejected by Charter's collision validator, and decide() looks the target
-    # up by name == the scenario passed to promote_evaluator_epoch.
     return Charter(
         tier="oss",
         autonomy=autonomy,  # type: ignore[arg-type]
         sources=[CharterSource(name="native", kind="autocontext")],
         targets=[
             CharterTarget(
-                name="t1",
+                name=_TARGET,
                 kind="role",
                 selector="competitor@grid_ctf",
                 base_model="Qwen/Qwen2.5-3B-Instruct",
@@ -40,14 +43,15 @@ def _charter(autonomy: str) -> Charter:
     )
 
 
-def _report(mae: float, epoch_id: str) -> CalibrationReport:
+def _report(mae: float, epoch_id: str, *, domain: str = _SCENARIO) -> CalibrationReport:
     return CalibrationReport(
-        domain="t1",
+        domain=domain,
         num_anchors=3,
         alignment=AlignmentResult(mean_absolute_error=mae, bias=0.0, correlation=0.95, num_pairs=3, per_anchor_errors=[]),
         variance=JudgeVarianceResult(mean=0.5, variance=0.0, std_dev=0.0, range=0.0, num_samples=3),
         calibrated=True,
         evaluator_epoch=epoch_id,
+        anchor_ids=["a1", "a2", "a3"],
     )
 
 
@@ -55,68 +59,151 @@ def _reg(tmp_path: Path) -> tuple[EvaluatorEpochRegistry, object, object]:
     reg = EvaluatorEpochRegistry(tmp_path)
     e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
     e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
-    reg.observe("t1", e1, now_fn=lambda: "t0")  # active (bootstrap)
-    reg.observe("t1", e2, now_fn=lambda: "t1")  # candidate
+    reg.observe(_SCENARIO, e1, now_fn=lambda: "t0")  # active (bootstrap)
+    reg.observe(_SCENARIO, e2, now_fn=lambda: "t1")  # candidate
     return reg, e1, e2
 
 
-_TOL = AlignmentTolerance(domain="t1", max_mean_absolute_error=0.12, max_bias=0.08, min_correlation=0.7)
+_TOL = AlignmentTolerance(domain=_SCENARIO, max_mean_absolute_error=0.12, max_bias=0.08, min_correlation=0.7)
 
 
 def test_full_autonomy_passing_calibration_activates(tmp_path: Path) -> None:
     reg, e1, e2 = _reg(tmp_path)
     out = promote_evaluator_epoch(
         reg,
-        "t1",
+        _SCENARIO,
         e2.epoch_id,
+        target_name=_TARGET,
         calibration_report=_report(0.05, e2.epoch_id),
         tolerance=_TOL,
         charter=_charter("full"),
         now_fn=lambda: "t2",
     )
     assert out.outcome == "activated"
-    assert reg.active_for("t1").epoch_id == e2.epoch_id
-    assert reg.load("t1", e2.epoch_id).promotion["previous_active"] == e1.epoch_id
+    assert reg.active_for(_SCENARIO).epoch_id == e2.epoch_id
+    assert reg.load(_SCENARIO, e2.epoch_id).promotion["previous_active"] == e1.epoch_id
 
 
 def test_full_autonomy_failing_calibration_blocked(tmp_path: Path) -> None:
     reg, e1, e2 = _reg(tmp_path)
     out = promote_evaluator_epoch(
         reg,
-        "t1",
+        _SCENARIO,
         e2.epoch_id,
+        target_name=_TARGET,
         calibration_report=_report(0.5, e2.epoch_id),
         tolerance=_TOL,
         charter=_charter("full"),
         now_fn=lambda: "t2",
     )
     assert out.outcome == "blocked"
-    assert reg.active_for("t1").epoch_id == e1.epoch_id  # unchanged
+    assert reg.active_for(_SCENARIO).epoch_id == e1.epoch_id  # unchanged
+
+
+def test_scenario_differs_from_target_name_no_keyerror(tmp_path: Path) -> None:
+    # FIX 1 regression: the operation used to pass ``scenario`` ("grid_ctf") into decide(), which looks
+    # the charter target up by name. A valid charter cannot name a target "grid_ctf" (collides with a
+    # registered scenario), so the only target is "competitor-local" and the lookup raised
+    # ``KeyError: unknown charter target: grid_ctf``. With a separate target_name the promotion succeeds.
+    reg, _e1, e2 = _reg(tmp_path)
+    out = promote_evaluator_epoch(
+        reg,
+        _SCENARIO,
+        e2.epoch_id,
+        target_name=_TARGET,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("full"),
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "activated"  # no KeyError
+
+
+def test_full_autonomy_mismatched_epoch_report_blocked(tmp_path: Path) -> None:
+    # FIX 2 regression: a report that PASSES tolerance but is tagged a DIFFERENT epoch than the
+    # candidate must not license activation of the uncalibrated candidate.
+    reg, e1, e2 = _reg(tmp_path)
+    out = promote_evaluator_epoch(
+        reg,
+        _SCENARIO,
+        e2.epoch_id,
+        target_name=_TARGET,
+        calibration_report=_report(0.05, e1.epoch_id),  # lineage points at e1, not the candidate e2
+        tolerance=_TOL,
+        charter=_charter("full"),
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "blocked"
+    assert reg.active_for(_SCENARIO).epoch_id == e1.epoch_id  # candidate NOT activated
+
+
+def test_mismatched_report_carries_no_calibration_evidence(tmp_path: Path) -> None:
+    # FIX 2: a human reviewer can still override, but the recorded metadata must not carry the
+    # unrelated report's calibration deltas/anchors.
+    reg, e1, e2 = _reg(tmp_path)
+    decision = ReviewerDecision(outcome="approved", reviewed_by="jay", reviewed_at="t3")
+    out = promote_evaluator_epoch(
+        reg,
+        _SCENARIO,
+        e2.epoch_id,
+        target_name=_TARGET,
+        calibration_report=_report(0.05, e1.epoch_id, domain="other"),  # wrong epoch AND wrong domain
+        tolerance=_TOL,
+        charter=_charter("full"),
+        reviewer_decision=decision,
+        now_fn=lambda: "t3",
+    )
+    assert out.outcome == "activated"
+    promo = reg.load(_SCENARIO, e2.epoch_id).promotion
+    assert promo["alignment_delta"] is None
+    assert promo["calibration_anchors"] == 0
+    assert promo["calibration_anchor_ids"] == []
+
+
+def test_promotion_metadata_records_anchor_ids(tmp_path: Path) -> None:
+    # FIX 5: the metadata records the anchor identities, not only their count.
+    reg, _e1, e2 = _reg(tmp_path)
+    out = promote_evaluator_epoch(
+        reg,
+        _SCENARIO,
+        e2.epoch_id,
+        target_name=_TARGET,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("full"),
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "activated"
+    promo = reg.load(_SCENARIO, e2.epoch_id).promotion
+    assert promo["calibration_anchor_ids"] == ["a1", "a2", "a3"]
+    assert promo["calibration_anchors"] == 3
 
 
 def test_propose_requires_review(tmp_path: Path) -> None:
     reg, e1, e2 = _reg(tmp_path)
     out = promote_evaluator_epoch(
         reg,
-        "t1",
+        _SCENARIO,
         e2.epoch_id,
+        target_name=_TARGET,
         calibration_report=_report(0.05, e2.epoch_id),
         tolerance=_TOL,
         charter=_charter("propose"),
         now_fn=lambda: "t2",
     )
     assert out.outcome == "pending_review"
-    assert reg.active_for("t1").epoch_id == e1.epoch_id
-    assert reg.load("t1", e2.epoch_id).promotion["requires_review"] is True
+    assert reg.active_for(_SCENARIO).epoch_id == e1.epoch_id
+    assert reg.load(_SCENARIO, e2.epoch_id).promotion["requires_review"] is True
 
 
 def test_reviewer_approved_activates(tmp_path: Path) -> None:
-    reg, e1, e2 = _reg(tmp_path)
+    reg, _e1, e2 = _reg(tmp_path)
     decision = ReviewerDecision(outcome="approved", reviewed_by="jay", reviewed_at="t3")
     out = promote_evaluator_epoch(
         reg,
-        "t1",
+        _SCENARIO,
         e2.epoch_id,
+        target_name=_TARGET,
         calibration_report=_report(0.05, e2.epoch_id),
         tolerance=_TOL,
         charter=_charter("propose"),
@@ -124,7 +211,7 @@ def test_reviewer_approved_activates(tmp_path: Path) -> None:
         now_fn=lambda: "t3",
     )
     assert out.outcome == "activated"
-    assert reg.load("t1", e2.epoch_id).promotion["decision"]["reviewed_by"] == "jay"
+    assert reg.load(_SCENARIO, e2.epoch_id).promotion["decision"]["reviewed_by"] == "jay"
 
 
 def test_reviewer_rejected_stays(tmp_path: Path) -> None:
@@ -132,8 +219,9 @@ def test_reviewer_rejected_stays(tmp_path: Path) -> None:
     decision = ReviewerDecision(outcome="rejected", reviewed_by="jay", reviewed_at="t3")
     out = promote_evaluator_epoch(
         reg,
-        "t1",
+        _SCENARIO,
         e2.epoch_id,
+        target_name=_TARGET,
         calibration_report=_report(0.05, e2.epoch_id),
         tolerance=_TOL,
         charter=_charter("propose"),
@@ -141,15 +229,16 @@ def test_reviewer_rejected_stays(tmp_path: Path) -> None:
         now_fn=lambda: "t3",
     )
     assert out.outcome == "rejected"
-    assert reg.active_for("t1").epoch_id == e1.epoch_id
+    assert reg.active_for(_SCENARIO).epoch_id == e1.epoch_id
 
 
 def test_missing_candidate_noop(tmp_path: Path) -> None:
-    reg, e1, e2 = _reg(tmp_path)
+    reg, _e1, _e2 = _reg(tmp_path)
     out = promote_evaluator_epoch(
         reg,
-        "t1",
+        _SCENARIO,
         "f" * 64,
+        target_name=_TARGET,
         calibration_report=_report(0.05, "f" * 64),
         tolerance=_TOL,
         charter=_charter("full"),
@@ -159,10 +248,10 @@ def test_missing_candidate_noop(tmp_path: Path) -> None:
 
 
 def test_activation_clears_quarantine_when_sqlite_provided(tmp_path: Path) -> None:
-    reg, e1, e2 = _reg(tmp_path)
+    reg, _e1, e2 = _reg(tmp_path)
     store = SQLiteStore(tmp_path / "runs.sqlite3")
     store.migrate(_MIGRATIONS)
-    store.create_run("run-t1", "t1", 1, "local", agent_provider="anthropic")
+    store.create_run("run-t1", _SCENARIO, 1, "local", agent_provider="anthropic")
     store.upsert_generation(
         "run-t1",
         1,
@@ -178,8 +267,9 @@ def test_activation_clears_quarantine_when_sqlite_provided(tmp_path: Path) -> No
     )
     out = promote_evaluator_epoch(
         reg,
-        "t1",
+        _SCENARIO,
         e2.epoch_id,
+        target_name=_TARGET,
         calibration_report=_report(0.05, e2.epoch_id),
         tolerance=_TOL,
         charter=_charter("full"),
@@ -187,4 +277,41 @@ def test_activation_clears_quarantine_when_sqlite_provided(tmp_path: Path) -> No
         now_fn=lambda: "t2",
     )
     assert out.outcome == "activated"
+    assert store.get_generation_metrics("run-t1")[0]["quarantined"] is None
+
+
+def test_already_active_reconciles_quarantine_clear(tmp_path: Path) -> None:
+    # FIX 4 regression: registry.promote commits activation BEFORE the sqlite clear. If a prior clear
+    # raised, the epoch is active but its rows stay quarantined; a retry must reconcile the clear
+    # rather than dead-noop on the already-active guard.
+    reg, _e1, e2 = _reg(tmp_path)
+    reg.promote(_SCENARIO, e2.epoch_id, promotion={"promoted_at": "t2"})  # candidate already active
+    store = SQLiteStore(tmp_path / "runs.sqlite3")
+    store.migrate(_MIGRATIONS)
+    store.create_run("run-t1", _SCENARIO, 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-t1",
+        1,
+        mean_score=0.9,
+        best_score=0.9,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+        evaluator_epoch=e2.epoch_id,
+        quarantined=True,  # never cleared by the crashed prior promotion
+    )
+    out = promote_evaluator_epoch(
+        reg,
+        _SCENARIO,
+        e2.epoch_id,
+        target_name=_TARGET,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("full"),
+        sqlite=store,
+        now_fn=lambda: "t3",
+    )
+    assert out.outcome == "activated"  # reconciled, not a dead noop
     assert store.get_generation_metrics("run-t1")[0]["quarantined"] is None

--- a/autocontext/tests/test_evaluator_epoch_promotion.py
+++ b/autocontext/tests/test_evaluator_epoch_promotion.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_promotion import ReviewerDecision, promote_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+from autocontext.execution.rubric_calibration import (
+    AlignmentResult,
+    AlignmentTolerance,
+    CalibrationReport,
+    JudgeVarianceResult,
+)
+from autocontext.storage.sqlite_store import SQLiteStore
+
+_MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def _charter(autonomy: str) -> Charter:
+    # A non-registered target name ("t1") is used consistently: a target name that collides with a
+    # registered scenario is rejected by Charter's collision validator, and decide() looks the target
+    # up by name == the scenario passed to promote_evaluator_epoch.
+    return Charter(
+        tier="oss",
+        autonomy=autonomy,  # type: ignore[arg-type]
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="Qwen/Qwen2.5-3B-Instruct",
+                min_dataset_records=10,
+                eval_suite="grid_ctf_holdout",
+                autonomy=autonomy,  # type: ignore[arg-type]
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=8.0, window_hours=24, disk_quota_gb=10.0),
+    )
+
+
+def _report(mae: float, epoch_id: str) -> CalibrationReport:
+    return CalibrationReport(
+        domain="t1",
+        num_anchors=3,
+        alignment=AlignmentResult(mean_absolute_error=mae, bias=0.0, correlation=0.95, num_pairs=3, per_anchor_errors=[]),
+        variance=JudgeVarianceResult(mean=0.5, variance=0.0, std_dev=0.0, range=0.0, num_samples=3),
+        calibrated=True,
+        evaluator_epoch=epoch_id,
+    )
+
+
+def _reg(tmp_path: Path) -> tuple[EvaluatorEpochRegistry, object, object]:
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe("t1", e1, now_fn=lambda: "t0")  # active (bootstrap)
+    reg.observe("t1", e2, now_fn=lambda: "t1")  # candidate
+    return reg, e1, e2
+
+
+_TOL = AlignmentTolerance(domain="t1", max_mean_absolute_error=0.12, max_bias=0.08, min_correlation=0.7)
+
+
+def test_full_autonomy_passing_calibration_activates(tmp_path: Path) -> None:
+    reg, e1, e2 = _reg(tmp_path)
+    out = promote_evaluator_epoch(
+        reg,
+        "t1",
+        e2.epoch_id,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("full"),
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "activated"
+    assert reg.active_for("t1").epoch_id == e2.epoch_id
+    assert reg.load("t1", e2.epoch_id).promotion["previous_active"] == e1.epoch_id
+
+
+def test_full_autonomy_failing_calibration_blocked(tmp_path: Path) -> None:
+    reg, e1, e2 = _reg(tmp_path)
+    out = promote_evaluator_epoch(
+        reg,
+        "t1",
+        e2.epoch_id,
+        calibration_report=_report(0.5, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("full"),
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "blocked"
+    assert reg.active_for("t1").epoch_id == e1.epoch_id  # unchanged
+
+
+def test_propose_requires_review(tmp_path: Path) -> None:
+    reg, e1, e2 = _reg(tmp_path)
+    out = promote_evaluator_epoch(
+        reg,
+        "t1",
+        e2.epoch_id,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("propose"),
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "pending_review"
+    assert reg.active_for("t1").epoch_id == e1.epoch_id
+    assert reg.load("t1", e2.epoch_id).promotion["requires_review"] is True
+
+
+def test_reviewer_approved_activates(tmp_path: Path) -> None:
+    reg, e1, e2 = _reg(tmp_path)
+    decision = ReviewerDecision(outcome="approved", reviewed_by="jay", reviewed_at="t3")
+    out = promote_evaluator_epoch(
+        reg,
+        "t1",
+        e2.epoch_id,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("propose"),
+        reviewer_decision=decision,
+        now_fn=lambda: "t3",
+    )
+    assert out.outcome == "activated"
+    assert reg.load("t1", e2.epoch_id).promotion["decision"]["reviewed_by"] == "jay"
+
+
+def test_reviewer_rejected_stays(tmp_path: Path) -> None:
+    reg, e1, e2 = _reg(tmp_path)
+    decision = ReviewerDecision(outcome="rejected", reviewed_by="jay", reviewed_at="t3")
+    out = promote_evaluator_epoch(
+        reg,
+        "t1",
+        e2.epoch_id,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("propose"),
+        reviewer_decision=decision,
+        now_fn=lambda: "t3",
+    )
+    assert out.outcome == "rejected"
+    assert reg.active_for("t1").epoch_id == e1.epoch_id
+
+
+def test_missing_candidate_noop(tmp_path: Path) -> None:
+    reg, e1, e2 = _reg(tmp_path)
+    out = promote_evaluator_epoch(
+        reg,
+        "t1",
+        "f" * 64,
+        calibration_report=_report(0.05, "f" * 64),
+        tolerance=_TOL,
+        charter=_charter("full"),
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "noop"
+
+
+def test_activation_clears_quarantine_when_sqlite_provided(tmp_path: Path) -> None:
+    reg, e1, e2 = _reg(tmp_path)
+    store = SQLiteStore(tmp_path / "runs.sqlite3")
+    store.migrate(_MIGRATIONS)
+    store.create_run("run-t1", "t1", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-t1",
+        1,
+        mean_score=0.9,
+        best_score=0.9,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+        evaluator_epoch=e2.epoch_id,
+        quarantined=True,
+    )
+    out = promote_evaluator_epoch(
+        reg,
+        "t1",
+        e2.epoch_id,
+        calibration_report=_report(0.05, e2.epoch_id),
+        tolerance=_TOL,
+        charter=_charter("full"),
+        sqlite=store,
+        now_fn=lambda: "t2",
+    )
+    assert out.outcome == "activated"
+    assert store.get_generation_metrics("run-t1")[0]["quarantined"] is None

--- a/autocontext/tests/test_evaluator_epoch_registry.py
+++ b/autocontext/tests/test_evaluator_epoch_registry.py
@@ -207,6 +207,37 @@ def test_promote_missing_epoch_is_noop(tmp_path) -> None:
     assert reg.active_for("grid_ctf").epoch_id == e1.epoch_id  # unchanged
 
 
+def test_stamp_promotion_preserves_activation_state(tmp_path) -> None:
+    from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+    from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")  # active bootstrap
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")  # candidate
+    # Simulate a concurrent promotion that already activated e2 (demoting e1).
+    reg.promote("grid_ctf", e2.epoch_id, promotion={"promoted_at": "t2"})
+    # A stale pending/rejected write must stamp metadata WITHOUT reverting e2 to candidate.
+    reg.stamp_promotion("grid_ctf", e2.epoch_id, promotion={"requires_review": True})
+    rec = reg.load("grid_ctf", e2.epoch_id)
+    assert rec.activation_state == "active"  # preserved, not reverted to candidate
+    assert rec.promotion == {"requires_review": True}
+    active = reg.active_for("grid_ctf")
+    assert active is not None and active.epoch_id == e2.epoch_id  # scenario keeps an active epoch
+
+
+def test_stamp_promotion_missing_epoch_is_noop(tmp_path) -> None:
+    from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+    from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.stamp_promotion("grid_ctf", "f" * 64, promotion={"x": 1})  # nonexistent id
+    assert reg.active_for("grid_ctf").epoch_id == e1.epoch_id  # unchanged
+
+
 def test_concurrent_first_observe_yields_single_active(tmp_path) -> None:
     import concurrent.futures
 

--- a/autocontext/tests/test_evaluator_epoch_registry.py
+++ b/autocontext/tests/test_evaluator_epoch_registry.py
@@ -180,6 +180,33 @@ def test_active_for_self_heals_multiple_active(tmp_path) -> None:
     assert reg.load("grid_ctf", larger).activation_state == "disabled"
 
 
+def test_promote_activates_and_stamps_metadata(tmp_path) -> None:
+    from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+    from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")  # active bootstrap
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")  # candidate
+    meta = {"promoted_at": "t2", "previous_active": e1.epoch_id, "requires_review": False}
+    reg.promote("grid_ctf", e2.epoch_id, promotion=meta)
+    assert reg.active_for("grid_ctf").epoch_id == e2.epoch_id
+    assert reg.load("grid_ctf", e1.epoch_id).activation_state == "disabled"
+    assert reg.load("grid_ctf", e2.epoch_id).promotion == meta
+
+
+def test_promote_missing_epoch_is_noop(tmp_path) -> None:
+    from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+    from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+    reg = EvaluatorEpochRegistry(tmp_path)
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.promote("grid_ctf", "f" * 64, promotion={"x": 1})  # nonexistent id
+    assert reg.active_for("grid_ctf").epoch_id == e1.epoch_id  # unchanged
+
+
 def test_concurrent_first_observe_yields_single_active(tmp_path) -> None:
     import concurrent.futures
 

--- a/autocontext/tests/test_policy_promote_epoch.py
+++ b/autocontext/tests/test_policy_promote_epoch.py
@@ -1,0 +1,37 @@
+"""AC-885 Slice C2: the autonomy dial recognizes the ``promote_epoch`` action.
+
+``promote_epoch`` follows the same rules as ``promote``: propose and train
+autonomy require approval, full autonomy is autonomous. ``decide`` needs no
+logic change because its ``train`` branch already treats any non-``train``
+action as requiring approval.
+"""
+
+from __future__ import annotations
+
+from autocontext.ambient.charter import Charter, CharterBudgets, CharterSource, CharterTarget
+from autocontext.ambient.policy import decide
+
+
+def _charter(autonomy: str) -> Charter:
+    return Charter(
+        tier="oss",
+        autonomy=autonomy,  # type: ignore[arg-type]
+        sources=[CharterSource(name="native", kind="autocontext")],
+        targets=[
+            CharterTarget(
+                name="t1",
+                kind="role",
+                selector="competitor@grid_ctf",
+                base_model="Qwen/Qwen2.5-3B-Instruct",
+                min_dataset_records=10,
+                eval_suite="grid_ctf_holdout",
+            )
+        ],
+        budgets=CharterBudgets(gpu_hours_per_window=8.0, window_hours=24, disk_quota_gb=10.0),
+    )
+
+
+def test_promote_epoch_autonomy_matrix() -> None:
+    assert decide(_charter("propose"), "promote_epoch", "t1").requires_approval is True
+    assert decide(_charter("train"), "promote_epoch", "t1").requires_approval is True
+    assert decide(_charter("full"), "promote_epoch", "t1").requires_approval is False

--- a/autocontext/tests/test_rubric_calibration.py
+++ b/autocontext/tests/test_rubric_calibration.py
@@ -32,6 +32,7 @@ def _judge_response(score: float, reasoning: str = "aligned") -> str:
     }
     return f"<!-- JUDGE_RESULT_START -->\n{json.dumps(payload)}\n<!-- JUDGE_RESULT_END -->"
 
+
 # ===========================================================================
 # CalibrationAnchor
 # ===========================================================================
@@ -458,3 +459,5 @@ class TestRunJudgeCalibration:
         assert report.num_anchors == 2
         assert report.alignment.num_pairs == 2
         assert "per_anchor_variance" in report.metadata
+        # FIX 5: the report records the anchor identities used, matching the calibration inputs.
+        assert report.anchor_ids == ["1", "2"]

--- a/docs/ac-885-slice-c2-promotion-design.md
+++ b/docs/ac-885-slice-c2-promotion-design.md
@@ -73,11 +73,12 @@ tolerance.check(calibration_report.alignment)["passes"]`.
 candidate_epoch_id, promotion=metadata)`, then if `sqlite` is not None call
      `sqlite.clear_quarantine_for_epoch(scenario, candidate_epoch_id)`. Return `activated`.
 
-- Promotion metadata dict: `{ "source_patch": None, "calibration_anchors": [...],
+- Promotion metadata dict: `{ "source_patch": None, "calibration_anchors": <num_anchors count>,
 "alignment_delta": {"mean_absolute_error", "bias", "correlation"}, "variance_delta": {...},
 "requires_review": bool, "decision": {"reviewed_by", "reviewed_at", "outcome"} | None,
 "promoted_at": now, "previous_active": <prior active epoch_id or ""> }`. `calibration_anchors`
-  and the deltas come from the `CalibrationReport` (`alignment`, `variance`, `num_anchors`).
+  is the `CalibrationReport.num_anchors` count (0 when no report), and the deltas come from the
+  report's `alignment` and `variance`.
 
 ### Registry `promote`
 
@@ -122,7 +123,7 @@ candidate epoch (C1) + CalibrationReport (caller ran run_judge_calibration, epoc
 - **Missing / already-active candidate:** `noop`.
 - **No calibration report (None):** cannot auto-promote; under autonomy `full` returns `blocked`;
   under `propose`/`train` still returns `pending_review` (a human may approve without calibration,
-  but the metadata records `calibration_anchors: []`).
+  but the metadata records `calibration_anchors: 0`).
 - **Reviewer rejects:** the record stays candidate/disabled; the rejection decision is recorded so a
   later cycle does not re-prompt blindly (the caller/C3 decides re-review policy).
 - **Concurrency:** `registry.promote` holds the per-scenario lock; two concurrent promotions of the

--- a/docs/ac-885-slice-c2-promotion-design.md
+++ b/docs/ac-885-slice-c2-promotion-design.md
@@ -1,0 +1,170 @@
+# AC-885 Slice C2: evaluator-epoch promotion workflow
+
+Date: 2026-07-10
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: sub-slice C2 of Slice C. Slice 1, Slice B, and Slice C1 are merged (#1204, #1208, #1210).
+
+## Purpose
+
+Slice C1 stood up the per-scenario evaluator-epoch registry (candidate/active/disabled), the
+mechanical `observe` trigger, and the `quarantined` marker on scores produced under a non-active
+epoch, but nothing promotes a candidate. C2 adds the promotion workflow: given a candidate epoch and
+a calibration report (alignment/bias/variance vs human anchors, epoch-tagged since Slice B), decide
+via the autonomy dial whether to activate it, record the promotion metadata and the human decision,
+and retroactively clear the quarantine on the promoted epoch's prior scores.
+
+The operation is pure and takes the calibration report as input (the caller runs
+`run_judge_calibration`), so the whole decision matrix is unit-testable without an LLM. The trigger
+that calls it (a CLI approve/reject, an ambient stage) is deferred to C3.
+
+## Decisions of record
+
+1. **C2 is the evaluator-epoch promotion workflow; `promote.py` is deferred.** Generalizing the
+   ambient model-promotion `promote.py` cross-anchor refusal to `are_comparable(epoch)` needs the
+   ambient evaluate stage to stamp `evaluator_epoch` on `DistilledModelRecord` eval metadata, a
+   separate deeper change. C2 builds only the evaluator-epoch promotion operation.
+2. **Quarantine is cleared retroactively on promotion, scoped by scenario.**
+   `promote_evaluator_epoch` runs an UPDATE that clears `generations.quarantined` for the promoted
+   epoch's rows, scoped to the scenario's runs so a same-content epoch id in another scenario is
+   untouched. The stored column stays the source of truth for consumers. The TaskRunner task-queue
+   JSON quarantine snapshot is not retroactively cleared (a JSON blob, not a queryable column): a
+   documented limitation.
+3. **The operation takes the calibration report as input.** It does not run calibration itself,
+   keeping it pure and its decision matrix fully unit-testable.
+4. **Promotion mutations go through the C1 per-scenario lock + atomic writes.** The registry
+   `promote` method activates and stamps metadata inside the `fcntl` lock, carrying the C1
+   concurrency lesson forward (no unlocked check-then-write).
+5. **Python-only.** The promotion workflow is ambient/lifecycle with no TS mirror; the
+   quarantine-clear is a Python storage method, not a schema change. No parity surface.
+6. **The trigger is C3.** C2 is written-but-not-yet-triggered: the CLI approve/reject and any
+   ambient stage that runs calibration and calls the operation are C3. C2 delivers and thoroughly
+   tests the operation, the autonomy gate, and the quarantine-clear storage method.
+
+## Architecture
+
+### C1: autonomy gate for epoch promotion
+
+`ambient/policy.py`: extend `Action = Literal["train", "promote"]` to include `"promote_epoch"`.
+`decide()` already branches on the action string; `"promote_epoch"` follows the same rule as
+`"promote"` (autonomy `propose`/`train` require approval; `full` is autonomous). A one-line literal
+extension plus, if `decide` special-cases actions, the same branch as `promote`.
+
+### C2: the promotion operation
+
+New module `execution/evaluator_epoch_promotion.py`:
+
+- `PromotionOutcome` (pydantic or frozen dataclass): `outcome: Literal["activated", "pending_review",
+"rejected", "blocked", "noop"]`, `reason: str`, `record: EvaluatorEpochRecord | None`.
+- `ReviewerDecision` (value type): `outcome: Literal["approved", "rejected"]`, `reviewed_by: str`,
+  `reviewed_at: str`.
+- `promote_evaluator_epoch(registry, scenario, candidate_epoch_id, *, calibration_report,
+tolerance, charter, reviewer_decision=None, sqlite=None, now_fn=_default_now) -> PromotionOutcome`:
+  1. Load the candidate record. If missing or already active, return `noop`.
+  2. `calibration_passes = calibration_report is not None and
+tolerance.check(calibration_report.alignment)["passes"]`.
+  3. `policy = decide(charter, "promote_epoch", scenario)`.
+     - `policy.requires_approval` and `reviewer_decision is None`: stamp `requires_review=True` on the
+       candidate's `promotion` metadata (via `registry.register`), return `pending_review`.
+     - `reviewer_decision` present: `approved` -> activate; `rejected` -> stamp the rejection decision,
+       return `rejected` (record stays candidate/disabled).
+     - not `requires_approval` (autonomy `full`): activate iff `calibration_passes`, else `blocked`.
+  4. Activate path: build the promotion metadata, call `registry.promote(scenario,
+candidate_epoch_id, promotion=metadata)`, then if `sqlite` is not None call
+     `sqlite.clear_quarantine_for_epoch(scenario, candidate_epoch_id)`. Return `activated`.
+
+- Promotion metadata dict: `{ "source_patch": None, "calibration_anchors": [...],
+"alignment_delta": {"mean_absolute_error", "bias", "correlation"}, "variance_delta": {...},
+"requires_review": bool, "decision": {"reviewed_by", "reviewed_at", "outcome"} | None,
+"promoted_at": now, "previous_active": <prior active epoch_id or ""> }`. `calibration_anchors`
+  and the deltas come from the `CalibrationReport` (`alignment`, `variance`, `num_anchors`).
+
+### Registry `promote`
+
+`EvaluatorEpochRegistry.promote(scenario, epoch_id, *, promotion: dict[str, Any]) -> None`: inside
+the per-scenario `fcntl` lock, run the same demote-not-delete activation as `activate` (prior active
+-> disabled, target -> active) AND set `record.promotion = promotion` on the target, writing
+atomically. Do not duplicate the `activate` critical section; factor a `_locked` helper both call so
+they cannot diverge (addresses the C1 observe/observe_id duplication note by not repeating it here).
+
+### Quarantine-clear storage method
+
+`SQLiteStore.clear_quarantine_for_epoch(scenario: str, epoch_id: str) -> int`:
+
+```sql
+UPDATE generations SET quarantined = NULL
+WHERE evaluator_epoch = ?
+  AND run_id IN (SELECT run_id FROM runs WHERE scenario = ?)
+```
+
+Returns the number of rows cleared. Scenario-scoped so a content-hash epoch shared across scenarios
+only clears the promoted scenario's rows. (Confirm `runs` has a `scenario` column; it does per the
+schema.)
+
+## Data flow
+
+```
+candidate epoch (C1) + CalibrationReport (caller ran run_judge_calibration, epoch-tagged Slice B)
+   -> promote_evaluator_epoch(registry, scenario, candidate, calibration_report, tolerance, charter)
+        calibration_passes = tolerance.check(report.alignment).passes
+        decide(charter, "promote_epoch", scenario):
+            requires_approval + no decision  -> record requires_review, PENDING_REVIEW
+            decision approved                -> ACTIVATE
+            decision rejected                -> record rejection, REJECTED
+            autonomy full + passes           -> ACTIVATE
+            autonomy full + fails            -> BLOCKED
+        ACTIVATE: registry.promote (under lock: candidate->active, prior->disabled, stamp metadata)
+                  sqlite.clear_quarantine_for_epoch(scenario, epoch)  # prior scores now trusted
+```
+
+## Error handling and edge cases
+
+- **Missing / already-active candidate:** `noop`.
+- **No calibration report (None):** cannot auto-promote; under autonomy `full` returns `blocked`;
+  under `propose`/`train` still returns `pending_review` (a human may approve without calibration,
+  but the metadata records `calibration_anchors: []`).
+- **Reviewer rejects:** the record stays candidate/disabled; the rejection decision is recorded so a
+  later cycle does not re-prompt blindly (the caller/C3 decides re-review policy).
+- **Concurrency:** `registry.promote` holds the per-scenario lock; two concurrent promotions of the
+  same scenario serialize, and the demote-not-delete keeps a single active.
+- **Quarantine-clear when sqlite is None:** skipped (the operation still activates; clearing is a
+  best-effort side effect, not a correctness precondition for activation).
+
+## Testing
+
+- `decide(charter, "promote_epoch", target)` autonomy matrix (propose/train require approval; full
+  autonomous), mirroring the existing `promote` tests.
+- `registry.promote`: activates + stamps metadata under the lock; prior active demoted; a
+  self-heal / lock test in the C1 style.
+- `clear_quarantine_for_epoch`: clears only the (scenario, epoch) rows; a same-epoch row under a
+  different scenario is untouched; returns the count.
+- `promote_evaluator_epoch` decision matrix, the core: activated (full+passes, and approved),
+  pending_review (requires_approval + no decision), rejected (decision rejected), blocked
+  (full+fails, and None report under full), noop (missing/already-active). Assert the record state
+  transition, the stamped promotion metadata shape, and that quarantine was cleared on activation.
+- Existing gates: module-size, gate-taxonomy (no gate/guard/validator symbols), ruff/mypy, the
+  serde-convention test (run the FULL suite in the gate, per the C1 lesson), lockfiles unchanged.
+
+## Documentation
+
+Extend `docs/evaluator-epochs.md` with a "promotion (Slice C2)" subsection: the promotion operation,
+the calibration-tolerance + autonomy-dial decision matrix, the human-decision record, retroactive
+quarantine clearing (and the TaskRunner-JSON limitation), and that the trigger (CLI/stage) and the
+`promote.py` generalization are deferred. CHANGELOG entry.
+
+## Deferred / out of scope
+
+- The trigger: CLI `approve`/`reject` and any ambient stage running calibration then calling the
+  operation (C3).
+- The `promote.py` model-promotion generalization to `are_comparable(epoch)` (needs the ambient
+  evaluate stage to stamp evaluator_epoch on model eval metadata): a separate follow-on.
+- Clearing the TaskRunner task-queue-JSON quarantine snapshot (a JSON blob, not a column).
+- Running calibration inside the operation (the caller supplies the report).
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 promotion-metadata requirement (source patch, calibration anchors used, alignment/bias/
+  variance deltas, human-review requirement, decision): delivered by the promotion operation's
+  metadata and the autonomy-gated human decision.
+- AC-885 invalidation rules: an epoch's prior candidate-era scores are un-quarantined (trusted) only
+  on explicit promotion; before promotion they stay quarantined (C1).

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -181,6 +181,74 @@ refusal and progression exclusion of quarantined scores) and the promotion workf
 candidate into the active epoch (and so clears the quarantine going forward) arrive in Slices C2 and
 C3.
 
+## Promotion (Slice C2)
+
+Slice C1 left the registry able to record a candidate epoch but with no way to promote one. Slice C2
+adds the promotion decision itself: given a candidate epoch and the calibration evidence for it,
+decide whether to activate it, and if so record why and clean up after the activation. The operation
+is `promote_evaluator_epoch(...)` in
+`autocontext/src/autocontext/execution/evaluator_epoch_promotion.py`. It is pure with respect to
+scoring: the caller supplies the `CalibrationReport` (produced by `run_judge_calibration`), the
+`AlignmentTolerance`, and the scenario `Charter`, and the operation reads and writes only the registry
+(and, on activation, the quarantine).
+
+**The decision matrix.** Two inputs drive the outcome: whether the candidate's calibration alignment
+passes the supplied tolerance (`tolerance.check(report.alignment)["passes"]`), and the autonomy dial
+for the `promote_epoch` action (`decide(charter, "promote_epoch", scenario)`). The dial has the usual
+three positions: propose and train require human approval, full is autonomous. The operation returns
+one of five outcomes:
+
+1. `noop`: the candidate id is missing from the registry or is already the active epoch, so there is
+   nothing to promote.
+2. `pending_review`: the autonomy dial requires approval and no reviewer decision was supplied yet.
+   The candidate stays a candidate, its promotion metadata (with `requires_review` true and no
+   decision) is recorded so a reviewer can see the calibration evidence, and the active pointer is
+   untouched.
+3. `activated`: either the autonomy dial is full and the calibration passes tolerance, or a reviewer
+   approved the promotion. The candidate becomes the active epoch (the prior active one is demoted to
+   disabled by the registry, reversibly), the promotion metadata is stamped, and the quarantine on the
+   promoted epoch's prior scores is cleared (see below).
+4. `blocked`: the autonomy dial is full but the calibration did not pass tolerance, so the operation
+   refuses to activate. The candidate stays a candidate.
+5. `rejected`: a reviewer supplied a rejecting decision. The decision is recorded on the candidate but
+   it is not activated.
+
+**The recorded human decision.** When a reviewer weighs in, the operation records a `ReviewerDecision`
+(outcome `approved` or `rejected`, plus `reviewed_by` and `reviewed_at`) inside the promotion metadata
+alongside the calibration deltas (alignment mean-absolute-error, bias, correlation, and the variance
+delta), the anchor count, the `requires_review` flag, the promotion timestamp, and the previous active
+epoch id. So a promotion carries both the machine evidence (calibration) and the human evidence
+(who decided, when, and which way) in one record.
+
+Two behaviors surfaced in review are worth stating plainly:
+
+- **A reviewer-approved promotion overrides the calibration decision.** If a reviewer approves, the
+  candidate is activated even when the calibration did not pass tolerance: the human is the higher
+  authority. The calibration deltas are still recorded in the promotion metadata, so an override is
+  visible after the fact (you can see that a human promoted an epoch whose calibration was out of
+  tolerance), not silently discarded.
+- **A reviewer-rejected epoch stays a candidate, it is not disabled.** A rejection records the decision
+  and leaves the epoch in state `candidate`, so it remains re-promotable later (a better calibration
+  run, or a reviewer changing their mind, can promote it) and its scores stay quarantined in the
+  meantime. Rejection is "not now," not "never."
+
+**Retroactive quarantine clearing.** When an epoch is activated, its prior scores were stamped
+`quarantined` while it was a candidate (per Slice C1). Those markers are now stale: the epoch is the
+active one, so its scores are canonical. The operation clears them retroactively via
+`SQLiteStore.clear_quarantine_for_epoch(scenario, epoch_id)`, a scenario-scoped `UPDATE` that unmarks
+only the promoted epoch's rows under that scenario and leaves every other scenario's rows untouched.
+Clearing runs only on the `activated` outcome; `pending_review`, `blocked`, `rejected`, and `noop`
+leave the quarantine in place. The clear is a documented limitation in one respect: it clears the
+persisted `generations` rows in SQLite, but it does not retroactively rewrite the TaskRunner
+task-queue-JSON snapshot, so a score that was serialized into that snapshot as quarantined keeps its
+stale marker there. The SQLite row is the source of truth for enforcement; the JSON snapshot is a
+point-in-time artifact and is not reconciled.
+
+**What is deferred.** Slice C2 is the promotion decision as a pure operation. The trigger that calls
+it (a CLI subcommand or an ambient stage that runs a calibration and then promotes) is deferred to C3,
+as is generalizing `promote.py`'s cross-anchor refusal onto this path. Slice C2 makes promotion
+decidable and recordable; wiring it into an operator-facing entry point is the next sub-slice.
+
 ## Relationship to the ambient `eval_fingerprint` / `anchor_model`
 
 autocontext already had this mechanism, but only in the ambient trainer. `eval_fingerprint()`


### PR DESCRIPTION
Sub-slice C2 of AC-885 Slice C. Slice 1, B, and C1 are merged (#1204, #1208, #1210). C1 gave the registry candidate/active/disabled state + a quarantined marker; C2 promotes candidates.

## What this adds
- **`decide()` recognizes `promote_epoch`** (`ambient/policy.py`): a one-line `Action` extension; the autonomy dial gates epoch promotion (propose/train require approval, full autonomous) with no `decide()` logic change.
- **`EvaluatorEpochRegistry.promote(scenario, epoch_id, *, promotion)`**: activates the candidate and stamps promotion metadata atomically under the C1 per-scenario `fcntl` lock (factored `_activate_locked` shared with `activate`, so they cannot diverge).
- **`SQLiteStore.clear_quarantine_for_epoch(scenario, epoch_id)`**: a scenario-scoped UPDATE (via the `runs` join) so a content-hash epoch shared across scenarios only clears the promoted scenario's rows.
- **`promote_evaluator_epoch`** (`execution/evaluator_epoch_promotion.py`): the decision matrix (activated / pending_review / rejected / blocked / noop) driven by calibration `AlignmentTolerance` + the autonomy dial. On activation it promotes under the lock and clears quarantine; it records promotion metadata (calibration anchor count, alignment/bias/variance deltas, requires_review, human decision, promoted_at, previous_active). The operation takes the `CalibrationReport` as input (pure), so the whole matrix is unit-tested without an LLM.

## Design notes (surfaced in review)
- A reviewer-**approved** promotion overrides the calibration decision (human is higher authority); the calibration deltas are still recorded for audit.
- A reviewer-**rejected** epoch stays in state `candidate` (re-promotable; its scores stay quarantined), it is not disabled.
- Quarantine is cleared retroactively on the `generations` column; the TaskRunner task-queue-JSON quarantine snapshot is not (a JSON blob, not a queryable column) - documented limitation.

## Deliberately deferred
- The **trigger** (a CLI approve/reject, an ambient stage that runs calibration then calls the operation): **C3**. C2 is written-but-not-triggered (thoroughly unit-tested); nothing consumes the outcome yet.
- The **`promote.py` model-promotion generalization** to `are_comparable(epoch)` (needs the ambient evaluate stage to stamp evaluator_epoch on model eval metadata): a separate follow-on.

## Verification
Python-only (no TS parity surface). ruff + mypy clean, the C2 test files (policy / registry / clear-quarantine / promotion 6-case matrix + quarantine-clear integration) + serde-convention + module-size + gate-taxonomy green, `uv.lock` unchanged. Every active-pointer mutation goes through the C1 per-scenario lock (whole-branch review verified no zero/two-active states).

Left open for review; not merged.