### PR TITLE
AC-885 Slice C3: epoch CLI trigger + training-export quarantine enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
   calibration alignment tolerance and the autonomy dial whether to activate a candidate epoch,
   records promotion and human-decision metadata, and retroactively clears the quarantine on the
   promoted epoch's prior scores. The trigger (CLI/stage) and the promote.py generalization follow.
+- AC-885 Slice C3: evaluator-epoch promotion trigger and first enforcement. An `autoctx epoch`
+  CLI lists candidate epochs and approves/rejects them (a human-override trigger for the promotion
+  workflow), and `export_training_data` now excludes quarantined scores by default (pass
+  `include_quarantined=True` to keep them), so training data is not drawn from unpromoted evaluators.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -52,21 +52,23 @@ AUTOCONTEXT_AGENT_PROVIDER=codex AUTOCONTEXT_CODEX_MODEL=o4-mini uv run autoctx 
 
 ## Common commands
 
-| Command                                                                                | Purpose                                                |
-| -------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `uv run autoctx solve "..." --iterations 3`                                            | Generate and run a scenario from a plain-language goal |
-| `uv run autoctx run <scenario> --iterations 3`                                         | Improve an existing scenario                           |
-| `uv run autoctx simulate --description "..."`                                          | Create/replay/compare modeled-world simulations        |
-| `uv run autoctx investigate --description "..."`                                       | Run synthetic or iterative investigations              |
-| `uv run autoctx list` / `status <run_id>` / `show <run_id>`                            | Inspect runs                                           |
-| `uv run autoctx replay <run_id> --generation 1`                                        | Replay a generation before accepting knowledge         |
-| `uv run autoctx queue add --task-prompt "..." --rubric "..."`                          | Queue evaluation/improvement work                      |
-| `uv run autoctx serve --host 127.0.0.1 --port 8000`                                    | Start the local HTTP API                               |
-| `uv run autoctx worker --poll-interval 5 --concurrency 2`                              | Process queued tasks beside the API server             |
-| `uv run autoctx mcp-serve`                                                             | Expose the MCP tool surface                            |
-| `uv run autoctx export-training-data --scenario <name> --all-runs --output data.jsonl` | Build a training corpus                                |
-| `uv run autoctx train --scenario <name> --data data.jsonl --time-budget 300`           | Run the local training hook                            |
-| `uv run autoctx hermes inspect --json`                                                 | Inspect Hermes Curator state                           |
+| Command                                                                                | Purpose                                                                                                |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `uv run autoctx solve "..." --iterations 3`                                            | Generate and run a scenario from a plain-language goal                                                 |
+| `uv run autoctx run <scenario> --iterations 3`                                         | Improve an existing scenario                                                                           |
+| `uv run autoctx simulate --description "..."`                                          | Create/replay/compare modeled-world simulations                                                        |
+| `uv run autoctx investigate --description "..."`                                       | Run synthetic or iterative investigations                                                              |
+| `uv run autoctx list` / `status <run_id>` / `show <run_id>`                            | Inspect runs                                                                                           |
+| `uv run autoctx replay <run_id> --generation 1`                                        | Replay a generation before accepting knowledge                                                         |
+| `uv run autoctx queue add --task-prompt "..." --rubric "..."`                          | Queue evaluation/improvement work                                                                      |
+| `uv run autoctx serve --host 127.0.0.1 --port 8000`                                    | Start the local HTTP API                                                                               |
+| `uv run autoctx worker --poll-interval 5 --concurrency 2`                              | Process queued tasks beside the API server                                                             |
+| `uv run autoctx mcp-serve`                                                             | Expose the MCP tool surface                                                                            |
+| `uv run autoctx export-training-data --scenario <name> --all-runs --output data.jsonl` | Build a training corpus (quarantined scores excluded by default; `--include-quarantined` to keep them) |
+| `uv run autoctx train --scenario <name> --data data.jsonl --time-budget 300`           | Run the local training hook                                                                            |
+| `uv run autoctx epoch list [--scenario <name>]`                                        | List evaluator-epoch registry records (candidate/active)                                               |
+| `uv run autoctx epoch approve <scenario> <epoch_id> --charter ambient-charter.yaml`    | Approve a candidate evaluator epoch and clear its quarantine                                           |
+| `uv run autoctx hermes inspect --json`                                                 | Inspect Hermes Curator state                                                                           |
 
 Saved custom scenarios under `knowledge/_custom_scenarios/` can be rerun and benchmarked by name after their `spec.json` is persisted.
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -23,6 +23,7 @@ from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.cli_ambient import ambient_app
 from autocontext.cli_analytics import register_analytics_command
 from autocontext.cli_capabilities import register_capabilities_command
+from autocontext.cli_epoch import epoch_app
 from autocontext.cli_hermes import register_hermes_command
 from autocontext.cli_improve import register_improve_command
 from autocontext.cli_investigate import run_investigate_command
@@ -699,6 +700,7 @@ def _serve_mcp() -> None:
 
 app.add_typer(_serve_app, name="serve")
 app.add_typer(ambient_app, name="ambient")
+app.add_typer(epoch_app, name="epoch")
 
 
 @app.command()

--- a/autocontext/src/autocontext/cli_epoch.py
+++ b/autocontext/src/autocontext/cli_epoch.py
@@ -16,7 +16,7 @@ from typing import Annotated, Literal
 
 import typer
 
-from autocontext.ambient.charter import Charter
+from autocontext.ambient.charter import Charter, CharterTarget
 from autocontext.ambient.charter_io import load_charter
 from autocontext.ambient.eligibility import split_role_selector
 from autocontext.config import load_settings
@@ -39,18 +39,40 @@ def _all_scenarios(registry: EvaluatorEpochRegistry) -> list[str]:
     return sorted(p.name for p in root.iterdir() if p.is_dir()) if root.exists() else []
 
 
+def _target_binds_scenario(target: CharterTarget, scenario: str) -> bool:
+    """Whether a charter target's selector binds the given scenario.
+
+    Selector semantics differ by target kind (a role selector uses ``role@scenario`` notation, a
+    task-family selector is the scenario string itself), so parsing every selector as a role
+    selector wrongly drops valid ``task_family`` targets whose selector has no ``@``.
+    """
+    if target.kind == "task_family":
+        return target.selector == scenario
+    # role: a scoped ``role@scenario`` binds only its named scenario; a bare ``role`` binds every one.
+    _, target_scenario = split_role_selector(target.selector)
+    return target_scenario is None or target_scenario == scenario
+
+
 def _resolve_charter_target(charter: Charter, scenario: str) -> str:
     """Return the charter target NAME whose selector binds the given scenario.
 
     The promotion policy is looked up by charter target name, not by scenario; these are distinct
     keys. A valid charter forbids a target name that collides with a registered scenario, so passing
     the scenario in as the target name would raise inside ``decide``.
+
+    Exactly one target must bind the scenario: zero is unresolvable, and more than one is ambiguous
+    (silently promoting under the first target's autonomy would be a fail-open policy choice), so
+    both raise rather than guess.
     """
-    for target in charter.targets:
-        _, target_scenario = split_role_selector(target.selector)
-        if target_scenario == scenario:
-            return target.name
-    raise typer.BadParameter(f"no charter target selects scenario {scenario!r}")
+    matches = [t.name for t in charter.targets if _target_binds_scenario(t, scenario)]
+    if not matches:
+        raise typer.BadParameter(f"no charter target selects scenario {scenario!r}")
+    if len(matches) > 1:
+        raise typer.BadParameter(
+            f"charter is ambiguous for scenario {scenario!r}: targets {sorted(matches)!r} all bind it; "
+            "scope their selectors (role@scenario) so exactly one target selects the scenario"
+        )
+    return matches[0]
 
 
 @epoch_app.command("list")
@@ -60,7 +82,7 @@ def list_epochs(
     """List evaluator-epoch records (candidate/active/disabled) as JSON."""
     registry = _registry_for(load_settings())
     scenarios = [scenario] if scenario else _all_scenarios(registry)
-    records = [rec.model_dump(mode="json") for name in scenarios for rec in registry.list_for_scenario(name)]
+    records = [rec.model_dump(mode="json") for name in scenarios for rec in registry.snapshot_for_scenario(name)]
     typer.echo(json.dumps(records, indent=2))
 
 
@@ -82,8 +104,14 @@ def _decide(scenario: str, epoch_id: str, outcome: Literal["approved", "rejected
         reviewer_decision=decision,
         sqlite=store,
     )
+    # The outcome must match the requested action. Because C2 reconciles an already-active
+    # epoch as ``activated`` (to repair a crashed quarantine-clear), a bare "not noop" check would
+    # let ``epoch reject <active-id>`` exit 0 reporting ``activated``. Require approve -> activated
+    # and reject -> rejected; any other outcome (noop, activated-on-reject, pending_review, blocked)
+    # is a non-zero failure so an operator never reads a contradictory result as success.
+    expected = {"approved": "activated", "rejected": "rejected"}[outcome]
     typer.echo(json.dumps({"outcome": result.outcome, "reason": result.reason}, indent=2))
-    if result.outcome == "noop":
+    if result.outcome != expected:
         raise typer.Exit(code=1)
 
 

--- a/autocontext/src/autocontext/cli_epoch.py
+++ b/autocontext/src/autocontext/cli_epoch.py
@@ -1,0 +1,105 @@
+"""``autoctx epoch`` commands: list candidate epochs and approve/reject them (AC-885 Slice C3).
+
+The human trigger for the evaluator-epoch promotion workflow. approve/reject are pure human
+overrides (``calibration_report=None``; the human is the authority, and C2 records the decision on
+the epoch record). ``scenario`` keys the registry + sqlite; the charter target name is resolved
+separately by selector (never conflate the two -- a valid charter forbids a target name that
+collides with a registered scenario). See docs/ac-885-slice-c3-cli-enforcement-design.md.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated, Literal
+
+import typer
+
+from autocontext.ambient.charter import Charter
+from autocontext.ambient.charter_io import load_charter
+from autocontext.ambient.eligibility import split_role_selector
+from autocontext.config import load_settings
+from autocontext.config.settings import AppSettings
+from autocontext.execution.evaluator_epoch_promotion import ReviewerDecision, promote_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+from autocontext.execution.rubric_calibration import AlignmentTolerance
+from autocontext.storage.sqlite_store import SQLiteStore
+
+epoch_app = typer.Typer(help="Evaluator-epoch lifecycle: list candidates, approve or reject promotions.")
+
+
+def _registry_for(settings: AppSettings) -> EvaluatorEpochRegistry:
+    return EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
+
+
+def _all_scenarios(registry: EvaluatorEpochRegistry) -> list[str]:
+    # Records are stored in per-scenario subdirs under the registry root (Slice C1).
+    root = registry.root
+    return sorted(p.name for p in root.iterdir() if p.is_dir()) if root.exists() else []
+
+
+def _resolve_charter_target(charter: Charter, scenario: str) -> str:
+    """Return the charter target NAME whose selector binds the given scenario.
+
+    The promotion policy is looked up by charter target name, not by scenario; these are distinct
+    keys. A valid charter forbids a target name that collides with a registered scenario, so passing
+    the scenario in as the target name would raise inside ``decide``.
+    """
+    for target in charter.targets:
+        _, target_scenario = split_role_selector(target.selector)
+        if target_scenario == scenario:
+            return target.name
+    raise typer.BadParameter(f"no charter target selects scenario {scenario!r}")
+
+
+@epoch_app.command("list")
+def list_epochs(
+    scenario: Annotated[str, typer.Option("--scenario", help="Limit to one scenario")] = "",
+) -> None:
+    """List evaluator-epoch records (candidate/active/disabled) as JSON."""
+    registry = _registry_for(load_settings())
+    scenarios = [scenario] if scenario else _all_scenarios(registry)
+    records = [rec.model_dump(mode="json") for name in scenarios for rec in registry.list_for_scenario(name)]
+    typer.echo(json.dumps(records, indent=2))
+
+
+def _decide(scenario: str, epoch_id: str, outcome: Literal["approved", "rejected"], by: str, charter_path: Path) -> None:
+    settings = load_settings()
+    charter = load_charter(charter_path)
+    target_name = _resolve_charter_target(charter, scenario)
+    decision = ReviewerDecision(outcome=outcome, reviewed_by=by, reviewed_at=datetime.now(UTC).isoformat())
+    store = SQLiteStore(settings.db_path)
+    store.ensure_core_tables()
+    result = promote_evaluator_epoch(
+        _registry_for(settings),
+        scenario,
+        epoch_id,
+        target_name=target_name,
+        calibration_report=None,
+        tolerance=AlignmentTolerance.default_for_domain(scenario),
+        charter=charter,
+        reviewer_decision=decision,
+        sqlite=store,
+    )
+    typer.echo(json.dumps({"outcome": result.outcome, "reason": result.reason}, indent=2))
+    if result.outcome == "noop":
+        raise typer.Exit(code=1)
+
+
+_ScenarioArg = Annotated[str, typer.Argument(help="Registry scenario key, e.g. grid_ctf")]
+_EpochArg = Annotated[str, typer.Argument(help="Candidate evaluator-epoch id")]
+_ByOpt = Annotated[str, typer.Option("--by", help="Reviewer identity recorded on the decision")]
+_CharterOpt = Annotated[Path, typer.Option("--charter", help="Path to the ambient charter yaml")]
+
+
+@epoch_app.command("approve")
+def approve(scenario: _ScenarioArg, epoch_id: _EpochArg, charter: _CharterOpt, by: _ByOpt = "operator") -> None:
+    """Approve a candidate epoch (human override) and activate it."""
+    _decide(scenario, epoch_id, "approved", by, charter)
+
+
+@epoch_app.command("reject")
+def reject(scenario: _ScenarioArg, epoch_id: _EpochArg, charter: _CharterOpt, by: _ByOpt = "operator") -> None:
+    """Reject a candidate epoch; it stays a candidate and its scores stay quarantined."""
+    _decide(scenario, epoch_id, "rejected", by, charter)

--- a/autocontext/src/autocontext/cli_package_commands.py
+++ b/autocontext/src/autocontext/cli_package_commands.py
@@ -26,6 +26,7 @@ def _write_json_stderr(message: str) -> None:
 
 console = Console()
 
+
 def _resolve_export_artifact_roots(
     *,
     settings: AppSettings,
@@ -65,6 +66,7 @@ def _resolve_export_artifact_roots(
         Path(claude_skills_path) if claude_skills_path is not None else base_claude_skills_path,
     )
 
+
 def export_training_data_cmd(
     run_id: str | None = typer.Option(None, "--run-id", help="Export a specific run"),
     scenario: str | None = typer.Option(None, "--scenario", help="Export all runs for a scenario"),
@@ -72,6 +74,11 @@ def export_training_data_cmd(
     output: str = typer.Option("", "--output", help="Output JSONL file path"),
     include_matches: bool = typer.Option(False, "--include-matches", help="Include per-match records"),
     kept_only: bool = typer.Option(False, "--kept-only", help="Only export generations that advanced"),
+    include_quarantined: bool = typer.Option(
+        False,
+        "--include-quarantined",
+        help="Include generations scored under an unpromoted evaluator epoch (excluded by default)",
+    ),
     db_path: str | None = typer.Option(None, "--db-path", help="Override database path"),
     runs_root: str | None = typer.Option(None, "--runs-root", help="Override runs root for artifact lookup"),
     knowledge_root: str | None = typer.Option(None, "--knowledge-root", help="Override knowledge root for playbooks and hints"),
@@ -131,11 +138,13 @@ def export_training_data_cmd(
             scenario=scenario,
             include_matches=include_matches,
             kept_only=kept_only,
+            include_quarantined=include_quarantined,
         ):
             f.write(json.dumps(dataclasses.asdict(record)) + "\n")
             count += 1
 
     console.print(f"[green]Exported {count} record(s) to {output_path}[/green]")
+
 
 def export_cmd(
     run_id_text: str | None = typer.Argument(None, help="Run id to export"),
@@ -268,6 +277,7 @@ def export_cmd(
     else:
         console.print(f"[green]Exported {scenario_name} package to {output_path}[/green]")
         console.print(f"[dim]best_score={pkg.best_score:.4f} lessons={len(pkg.lessons)} harness={len(pkg.harness)}[/dim]")
+
 
 def import_package_cmd(
     package_file: str = typer.Argument(..., help="Path to the strategy package JSON file"),

--- a/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch_registry.py
@@ -152,6 +152,17 @@ class EvaluatorEpochRegistry:
             out.append(EvaluatorEpochRecord.model_validate(json.loads(path.read_text())))
         return out
 
+    def snapshot_for_scenario(self, scenario: str) -> list[EvaluatorEpochRecord]:
+        """Lock-held snapshot of a scenario's records for operator reads.
+
+        Promotion writes the demoted incumbent and the newly-active candidate as separate atomic
+        files, so an unlocked ``list_for_scenario`` mid-promotion can observe a transient zero-active
+        (or double-active) state. Taking the scenario lock returns a snapshot consistent with the
+        registry's read-decide-write critical section.
+        """
+        with self._scenario_lock(scenario):
+            return self.list_for_scenario(scenario)
+
     def _active_for_locked(self, scenario: str) -> EvaluatorEpochRecord | None:
         """Return the single active record, self-healing a multiple-active state.
 

--- a/autocontext/src/autocontext/training/export.py
+++ b/autocontext/src/autocontext/training/export.py
@@ -1,4 +1,5 @@
 """Strategy-level training data export iterator (AC-170, AC-171)."""
+
 from __future__ import annotations
 
 import json
@@ -57,6 +58,13 @@ def export_training_data(
         hints = artifacts.read_hints(run_scenario)
 
         generations = sqlite.get_generation_metrics(rid)
+        # Trajectory context must not embed scores from generations excluded as
+        # untrusted: a quarantined evaluator score would otherwise leak into every
+        # later trusted record via its `context.trajectory`. Filter the trajectory
+        # source with the same quarantine policy that gates the strategy records.
+        trajectory_generations = (
+            generations if include_quarantined else [g for g in generations if not bool(g.get("quarantined"))]
+        )
         # Build a lookup of competitor outputs for this run
         competitor_outputs = _get_competitor_outputs(sqlite, rid)
 
@@ -75,8 +83,8 @@ def export_training_data(
             if not skip_record:
                 strategy = competitor_outputs.get(gen_idx, "")
 
-                # Build trajectory up to this generation
-                trajectory = _build_trajectory_snippet(generations, gen_idx)
+                # Build trajectory up to this generation (from trusted gens only)
+                trajectory = _build_trajectory_snippet(trajectory_generations, gen_idx)
 
                 context: dict[str, Any] = {
                     "playbook": playbook,
@@ -203,7 +211,4 @@ def _extract_states(replay_json: str) -> list[dict[str, Any]]:
         return []
     if not isinstance(replay, list):
         return []
-    return [
-        entry["state"] for entry in replay
-        if isinstance(entry, dict) and "state" in entry
-    ]
+    return [entry["state"] for entry in replay if isinstance(entry, dict) and "state" in entry]

--- a/autocontext/src/autocontext/training/export.py
+++ b/autocontext/src/autocontext/training/export.py
@@ -17,6 +17,7 @@ def export_training_data(
     scenario: str | None = None,
     include_matches: bool = False,
     kept_only: bool = False,
+    include_quarantined: bool = False,
 ) -> Iterator[TrainingRecord | MatchRecord]:
     """Stream strategy-level training records from SQLite.
 
@@ -36,6 +37,9 @@ def export_training_data(
         generation's tournament matches.
     kept_only:
         When ``True``, only yield generations where ``gate_decision == 'advance'``.
+    include_quarantined:
+        When ``True``, also yield generations whose ``quarantined`` marker is set
+        (scored under an unpromoted evaluator epoch). Excluded by default.
 
     Yields
     ------
@@ -63,27 +67,33 @@ def export_training_data(
             if kept_only and gate != "advance":
                 continue
 
-            strategy = competitor_outputs.get(gen_idx, "")
+            # Quarantined generations are scored under an unpromoted evaluator epoch,
+            # so their strategy record is not trusted training data. Their tournament
+            # matches carry no evaluator epoch, so they are still emitted.
+            skip_record = (not include_quarantined) and bool(gen.get("quarantined"))
 
-            # Build trajectory up to this generation
-            trajectory = _build_trajectory_snippet(generations, gen_idx)
+            if not skip_record:
+                strategy = competitor_outputs.get(gen_idx, "")
 
-            context: dict[str, Any] = {
-                "playbook": playbook,
-                "hints": hints,
-                "trajectory": trajectory,
-            }
+                # Build trajectory up to this generation
+                trajectory = _build_trajectory_snippet(generations, gen_idx)
 
-            yield TrainingRecord(
-                run_id=rid,
-                scenario=run_scenario,
-                generation_index=gen_idx,
-                strategy=strategy,
-                score=gen["best_score"],
-                gate_decision=gate,
-                context=context,
-                evaluator_epoch=gen.get("evaluator_epoch"),
-            )
+                context: dict[str, Any] = {
+                    "playbook": playbook,
+                    "hints": hints,
+                    "trajectory": trajectory,
+                }
+
+                yield TrainingRecord(
+                    run_id=rid,
+                    scenario=run_scenario,
+                    generation_index=gen_idx,
+                    strategy=strategy,
+                    score=gen["best_score"],
+                    gate_decision=gate,
+                    context=context,
+                    evaluator_epoch=gen.get("evaluator_epoch"),
+                )
 
             if include_matches:
                 yield from _iter_matches(sqlite, rid, gen_idx)

--- a/autocontext/tests/test_cli_epoch.py
+++ b/autocontext/tests/test_cli_epoch.py
@@ -1,0 +1,118 @@
+"""CLI contract for ``autoctx epoch list|approve|reject`` (AC-885 Slice C3).
+
+scenario (``grid_ctf``) is the registry + sqlite key; the charter target NAME (``competitor-local``)
+is a deliberately distinct value resolved from the charter by selector (the C2 lesson: never pass the
+scenario as the charter target name). approve/reject are pure human overrides.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+runner = CliRunner()
+
+_SCENARIO = "grid_ctf"
+
+# Minimal valid charter ``load_charter`` accepts: a single autocontext source, one role target whose
+# selector maps to ``grid_ctf`` but whose NAME is NOT the scenario, and the three required budgets.
+_CHARTER_YAML = """\
+tier: oss
+sources:
+  - name: native
+    kind: autocontext
+targets:
+  - name: competitor-local
+    kind: role
+    selector: competitor@grid_ctf
+    base_model: Qwen/Qwen2.5-3B-Instruct
+    min_dataset_records: 10
+    eval_suite: grid_ctf_holdout
+budgets:
+  gpu_hours_per_window: 8.0
+  window_hours: 24
+  disk_quota_gb: 10.0
+"""
+
+
+def _charter_file(tmp_path: Path) -> Path:
+    path = tmp_path / "ambient-charter.yaml"
+    path.write_text(_CHARTER_YAML, encoding="utf-8")
+    return path
+
+
+def _seed(tmp_path: Path) -> tuple[EvaluatorEpochRegistry, str, str]:
+    """Point the CLI at tmp and seed one active + one candidate epoch for grid_ctf."""
+    kroot = tmp_path / "knowledge"
+    reg = EvaluatorEpochRegistry(kroot / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe(_SCENARIO, e1, now_fn=lambda: "t0")  # active (bootstrap)
+    reg.observe(_SCENARIO, e2, now_fn=lambda: "t1")  # candidate
+    return reg, e1.epoch_id, e2.epoch_id
+
+
+def _env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_KNOWLEDGE_ROOT", str(tmp_path / "knowledge"))
+    monkeypatch.setenv("AUTOCONTEXT_DB_PATH", str(tmp_path / "t.sqlite3"))
+
+
+def test_epoch_list_and_approve(tmp_path: Path, monkeypatch) -> None:
+    reg, _active, candidate = _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    charter = _charter_file(tmp_path)
+
+    listed = runner.invoke(app, ["epoch", "list", "--scenario", _SCENARIO])
+    assert listed.exit_code == 0, listed.output
+    assert candidate in listed.stdout
+
+    approved = runner.invoke(
+        app,
+        ["epoch", "approve", _SCENARIO, candidate, "--by", "jay", "--charter", str(charter)],
+    )
+    assert approved.exit_code == 0, approved.output
+    active = reg.active_for(_SCENARIO)
+    assert active is not None and active.epoch_id == candidate
+    assert "activated" in approved.stdout
+
+
+def test_epoch_reject_does_not_activate(tmp_path: Path, monkeypatch) -> None:
+    reg, prior_active, candidate = _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    charter = _charter_file(tmp_path)
+
+    rejected = runner.invoke(
+        app,
+        ["epoch", "reject", _SCENARIO, candidate, "--by", "jay", "--charter", str(charter)],
+    )
+    assert rejected.exit_code == 0, rejected.output
+    assert "rejected" in rejected.stdout
+    active = reg.active_for(_SCENARIO)
+    assert active is not None and active.epoch_id == prior_active
+
+
+def test_epoch_approve_missing_candidate_exits_nonzero(tmp_path: Path, monkeypatch) -> None:
+    _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    charter = _charter_file(tmp_path)
+
+    missing = "0" * 64
+    result = runner.invoke(
+        app,
+        ["epoch", "approve", _SCENARIO, missing, "--by", "jay", "--charter", str(charter)],
+    )
+    assert result.exit_code != 0
+
+def test_epoch_list_all_scenarios(tmp_path: Path, monkeypatch) -> None:
+    # bare `epoch list` (no --scenario) enumerates every scenario subdir under the registry root.
+    reg, _active, candidate = _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    listed = runner.invoke(app, ["epoch", "list"])
+    assert listed.exit_code == 0, listed.output
+    assert candidate in listed.stdout
+

--- a/autocontext/tests/test_cli_epoch.py
+++ b/autocontext/tests/test_cli_epoch.py
@@ -131,3 +131,94 @@ def test_epoch_approve_no_matching_target_errors(tmp_path: Path, monkeypatch) ->
     assert result.exit_code != 0
     # registry unchanged: the candidate is still a candidate, prior active preserved
     assert reg.active_for(_SCENARIO).epoch_id == active
+
+
+def test_epoch_reject_of_active_epoch_exits_nonzero(tmp_path: Path, monkeypatch) -> None:
+    # Rejecting the ALREADY-ACTIVE epoch is contradictory. C2 reconciles an already-active epoch as
+    # ``activated``, so a bare not-noop check would let reject exit 0 reporting ``activated``. The CLI
+    # must require the outcome to match the requested action and fail (non-zero) on the mismatch.
+    reg, active, _candidate = _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    charter = _charter_file(tmp_path)
+    result = runner.invoke(
+        app,
+        ["epoch", "reject", _SCENARIO, active, "--by", "jay", "--charter", str(charter)],
+    )
+    assert result.exit_code != 0
+    assert "activated" in result.stdout  # the contradictory outcome is surfaced, not hidden
+
+
+# --- charter target resolution by kind + ambiguity -------------------------------------------------
+
+_TASK_FAMILY_CHARTER = """\
+tier: oss
+sources:
+  - name: native
+    kind: autocontext
+targets:
+  - name: gridctf-family
+    kind: task_family
+    selector: grid_ctf
+    base_model: Qwen/Qwen2.5-3B-Instruct
+    min_dataset_records: 10
+    eval_suite: grid_ctf_holdout
+budgets:
+  gpu_hours_per_window: 8.0
+  window_hours: 24
+  disk_quota_gb: 10.0
+"""
+
+_AMBIGUOUS_CHARTER = """\
+tier: oss
+sources:
+  - name: native
+    kind: autocontext
+targets:
+  - name: competitor-local
+    kind: role
+    selector: competitor@grid_ctf
+    base_model: Qwen/Qwen2.5-3B-Instruct
+    min_dataset_records: 10
+    eval_suite: grid_ctf_holdout
+  - name: evaluator-local
+    kind: role
+    selector: evaluator@grid_ctf
+    base_model: Qwen/Qwen2.5-3B-Instruct
+    min_dataset_records: 10
+    eval_suite: grid_ctf_holdout
+budgets:
+  gpu_hours_per_window: 8.0
+  window_hours: 24
+  disk_quota_gb: 10.0
+"""
+
+
+def test_epoch_approve_resolves_task_family_target(tmp_path: Path, monkeypatch) -> None:
+    # A task_family target's selector IS the scenario string (no ``role@`` notation); it must resolve
+    # rather than be dropped by role-selector parsing.
+    reg, _active, candidate = _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    charter = tmp_path / "tf-charter.yaml"
+    charter.write_text(_TASK_FAMILY_CHARTER, encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["epoch", "approve", _SCENARIO, candidate, "--by", "jay", "--charter", str(charter)],
+    )
+    assert result.exit_code == 0, result.output
+    active = reg.active_for(_SCENARIO)
+    assert active is not None and active.epoch_id == candidate
+
+
+def test_epoch_approve_ambiguous_targets_exits_nonzero(tmp_path: Path, monkeypatch) -> None:
+    # Two role targets both bind grid_ctf. Silently promoting under the first target's autonomy would
+    # be fail-open; the CLI must refuse and leave the registry unchanged.
+    reg, active, candidate = _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    charter = tmp_path / "ambig-charter.yaml"
+    charter.write_text(_AMBIGUOUS_CHARTER, encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["epoch", "approve", _SCENARIO, candidate, "--by", "jay", "--charter", str(charter)],
+    )
+    assert result.exit_code != 0
+    assert reg.active_for(_SCENARIO).epoch_id == active  # unchanged

--- a/autocontext/tests/test_cli_epoch.py
+++ b/autocontext/tests/test_cli_epoch.py
@@ -29,7 +29,7 @@ sources:
 targets:
   - name: competitor-local
     kind: role
-    selector: competitor@grid_ctf
+    selector: competitor@{selector_scenario}
     base_model: Qwen/Qwen2.5-3B-Instruct
     min_dataset_records: 10
     eval_suite: grid_ctf_holdout
@@ -40,9 +40,9 @@ budgets:
 """
 
 
-def _charter_file(tmp_path: Path) -> Path:
+def _charter_file(tmp_path: Path, selector_scenario: str = "grid_ctf") -> Path:
     path = tmp_path / "ambient-charter.yaml"
-    path.write_text(_CHARTER_YAML, encoding="utf-8")
+    path.write_text(_CHARTER_YAML.format(selector_scenario=selector_scenario), encoding="utf-8")
     return path
 
 
@@ -108,6 +108,7 @@ def test_epoch_approve_missing_candidate_exits_nonzero(tmp_path: Path, monkeypat
     )
     assert result.exit_code != 0
 
+
 def test_epoch_list_all_scenarios(tmp_path: Path, monkeypatch) -> None:
     # bare `epoch list` (no --scenario) enumerates every scenario subdir under the registry root.
     reg, _active, candidate = _seed(tmp_path)
@@ -116,3 +117,17 @@ def test_epoch_list_all_scenarios(tmp_path: Path, monkeypatch) -> None:
     assert listed.exit_code == 0, listed.output
     assert candidate in listed.stdout
 
+
+def test_epoch_approve_no_matching_target_errors(tmp_path: Path, monkeypatch) -> None:
+    # a charter whose only target selects a DIFFERENT scenario cannot resolve target_name for _SCENARIO;
+    # approve must error clearly (non-zero) and not mutate the registry.
+    reg, active, candidate = _seed(tmp_path)
+    _env(monkeypatch, tmp_path)
+    charter = _charter_file(tmp_path, selector_scenario="othello")  # does not match _SCENARIO
+    result = runner.invoke(
+        app,
+        ["epoch", "approve", _SCENARIO, candidate, "--by", "jay", "--charter", str(charter)],
+    )
+    assert result.exit_code != 0
+    # registry unchanged: the candidate is still a candidate, prior active preserved
+    assert reg.active_for(_SCENARIO).epoch_id == active

--- a/autocontext/tests/test_training_export_quarantine.py
+++ b/autocontext/tests/test_training_export_quarantine.py
@@ -77,3 +77,27 @@ def test_quarantined_matches_survive_exclusion(tmp_path: Path) -> None:
 
     assert {r.generation_index for r in training} == {2}  # quarantined gen 1 record excluded
     assert any(m.generation_index == 1 and m.seed == 7 for m in matches)  # its match survives
+
+
+def _trajectory_indices(record: TrainingRecord) -> set[int]:
+    return {entry["generation_index"] for entry in record.context["trajectory"]}
+
+
+def test_quarantined_score_does_not_leak_into_trusted_trajectory(tmp_path: Path) -> None:
+    # Excluding the quarantined generation's own record is not enough: its score must also not
+    # ride along inside a later trusted record's trajectory context (the central enforcement leak).
+    store, artifacts = _setup(tmp_path)
+    recs = [r for r in export_training_data(store, artifacts, run_id="run-1") if isinstance(r, TrainingRecord)]
+    gen2 = next(r for r in recs if r.generation_index == 2)
+    assert _trajectory_indices(gen2) == {2}  # quarantined gen 1 absent from the trusted trajectory
+
+
+def test_include_quarantined_restores_trajectory(tmp_path: Path) -> None:
+    store, artifacts = _setup(tmp_path)
+    recs = [
+        r
+        for r in export_training_data(store, artifacts, run_id="run-1", include_quarantined=True)
+        if isinstance(r, TrainingRecord)
+    ]
+    gen2 = next(r for r in recs if r.generation_index == 2)
+    assert _trajectory_indices(gen2) == {1, 2}  # opt-in keeps the quarantined generation in context

--- a/autocontext/tests/test_training_export_quarantine.py
+++ b/autocontext/tests/test_training_export_quarantine.py
@@ -1,0 +1,79 @@
+"""Training-export excludes quarantined scores by default (AC-885 Slice C3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.storage.artifacts import ArtifactStore
+from autocontext.storage.sqlite_store import SQLiteStore
+from autocontext.training.export import export_training_data
+from autocontext.training.types import MatchRecord, TrainingRecord
+
+
+def _setup(tmp_path: Path) -> tuple[SQLiteStore, ArtifactStore]:
+    db = SQLiteStore(tmp_path / "t.sqlite3")
+    db.migrate(Path("migrations"))
+    artifacts = ArtifactStore(
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+    )
+    db.create_run("run-1", "grid_ctf", 2, "local")
+    db.upsert_generation(
+        "run-1",
+        1,
+        mean_score=0.9,
+        best_score=0.9,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="completed",
+        status="completed",
+        evaluator_epoch="e-2",
+        quarantined=True,
+    )
+    db.upsert_generation(
+        "run-1",
+        2,
+        mean_score=0.8,
+        best_score=0.8,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="advance",
+        status="completed",
+        evaluator_epoch="e-1",
+    )
+    return db, artifacts
+
+
+def test_quarantined_excluded_by_default(tmp_path: Path) -> None:
+    store, artifacts = _setup(tmp_path)
+    recs = [r for r in export_training_data(store, artifacts, run_id="run-1") if isinstance(r, TrainingRecord)]
+    idxs = {r.generation_index for r in recs}
+    assert 2 in idxs and 1 not in idxs  # quarantined gen 1 excluded, trusted gen 2 kept
+
+
+def test_include_quarantined_flag(tmp_path: Path) -> None:
+    store, artifacts = _setup(tmp_path)
+    recs = [
+        r
+        for r in export_training_data(store, artifacts, run_id="run-1", include_quarantined=True)
+        if isinstance(r, TrainingRecord)
+    ]
+    assert {r.generation_index for r in recs} == {1, 2}
+
+
+def test_quarantined_matches_survive_exclusion(tmp_path: Path) -> None:
+    # A quarantined generation's TrainingRecord is excluded by default, but its
+    # tournament matches (scored without an evaluator epoch) must still be exported.
+    store, artifacts = _setup(tmp_path)
+    store.insert_match("run-1", 1, seed=7, score=0.5, passed_validation=True, validation_errors="")
+
+    records = list(export_training_data(store, artifacts, run_id="run-1", include_matches=True))
+    training = [r for r in records if isinstance(r, TrainingRecord)]
+    matches = [r for r in records if isinstance(r, MatchRecord)]
+
+    assert {r.generation_index for r in training} == {2}  # quarantined gen 1 record excluded
+    assert any(m.generation_index == 1 and m.seed == 7 for m in matches)  # its match survives

--- a/docs/ac-885-slice-c3-cli-enforcement-design.md
+++ b/docs/ac-885-slice-c3-cli-enforcement-design.md
@@ -32,7 +32,7 @@ consumer that excludes quarantined scores from trusted training-data export.
 4. **The ambient-promote refusal stays deferred.** Refusing a model scored under a non-active
    evaluator epoch needs the `promote.py` generalization (the ambient evaluate stage stamping
    evaluator_epoch on model eval metadata), a separate follow-on. C3 does not touch `promote.py`.
-5. **Registry access via the C1/C2 lock-held API only.** The CLI reads via `list_for_scenario` /
+5. **Registry access via the C1/C2 lock-held API only.** The CLI reads via `snapshot_for_scenario` /
    `active_for` and mutates only via `promote_evaluator_epoch` (which uses `registry.promote` /
    `stamp_promotion` under the per-scenario lock). No direct unlocked writes.
 
@@ -55,12 +55,13 @@ include_matches=False, kept_only=False, include_quarantined=False)`: in the `Tra
 New module `autocontext/src/autocontext/cli_epoch.py`, registered on the main Typer `app`
 (`cli.py` is near the module-size cap, so the commands live in their own module):
 
-- `epoch list [--scenario S] [--charter PATH]`: enumerate registry records (scenario, epoch_id,
-  activation_state, and the promotion block when present) as JSON to stdout. Reads via
-  `EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs").list_for_scenario(...)` (or
-  all scenarios when `--scenario` is omitted, by scanning the registry root's scenario subdirs).
-- `epoch approve <scenario> <epoch_id> [--by USER] [--charter PATH]` and
-  `epoch reject <scenario> <epoch_id> [--by USER] [--charter PATH]`:
+- `epoch list [--scenario S]`: enumerate registry records (scenario, epoch_id,
+  activation_state, and the promotion block when present) as JSON to stdout. Reads via a lock-held
+  `EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs").snapshot_for_scenario(...)`
+  (or all scenarios when `--scenario` is omitted, by scanning the registry root's scenario subdirs).
+  `list` takes no `--charter` (it neither promotes nor resolves an autonomy target).
+- `epoch approve <scenario> <epoch_id> --charter PATH [--by USER]` and
+  `epoch reject <scenario> <epoch_id> --charter PATH [--by USER]` (`--charter` is required):
   1. Load the charter (the required `--charter` option) via `load_charter`.
   2. `target_name = _resolve_charter_target(charter, scenario)`; error clearly if no target's
      selector scenario matches.
@@ -78,9 +79,9 @@ charter=charter, reviewer_decision=decision, sqlite=SQLiteStore(settings.db_path
 
 ```
 operator: autoctx epoch list --scenario grid_ctf
-   -> EvaluatorEpochRegistry.list_for_scenario -> JSON of candidate/active/disabled records
+   -> EvaluatorEpochRegistry.snapshot_for_scenario -> JSON of candidate/active/disabled records
 
-operator: autoctx epoch approve grid_ctf <epoch> --by jay
+operator: autoctx epoch approve grid_ctf <epoch> --charter ambient-charter.yaml --by jay
    -> load_charter -> _resolve_charter_target(charter, "grid_ctf") -> "competitor-local"
    -> promote_evaluator_epoch(reg, scenario="grid_ctf", epoch, target_name="competitor-local",
         calibration_report=None, reviewer_decision=approved, sqlite=...)

--- a/docs/ac-885-slice-c3-cli-enforcement-design.md
+++ b/docs/ac-885-slice-c3-cli-enforcement-design.md
@@ -1,0 +1,140 @@
+# AC-885 Slice C3: promotion trigger (CLI) + quarantine enforcement
+
+Date: 2026-07-10
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: sub-slice C3 of Slice C. Slice 1, B, C1, C2 are merged (#1204, #1208, #1210, #1211).
+
+## Purpose
+
+Slice C1 stood up the evaluator-epoch registry and the `quarantined` marker; C2 built the
+`promote_evaluator_epoch` decision engine, but nothing triggers it and nothing consumes the
+quarantine marker. C3 gives the lifecycle end-to-end teeth: a human-facing CLI that lists candidate
+epochs and approves or rejects them (the trigger for C2's operation), and a first enforcement
+consumer that excludes quarantined scores from trusted training-data export.
+
+## Decisions of record
+
+1. **The CLI is a human-override trigger.** `autoctx epoch approve`/`reject` build a
+   `ReviewerDecision` and call `promote_evaluator_epoch` with `calibration_report=None` (the human
+   is the authority; C2 records the decision and, per the C2 fix, contributes no misleading
+   calibration evidence). The charter is loaded (from `--charter` or a settings default) to supply
+   the `decide()` autonomy read and to resolve the policy `target_name`.
+2. **Scenario and policy target_name are distinct (C2 lesson).** The CLI has the real scenario (the
+   registry/SQLite key); it resolves the charter `target_name` by matching each target's
+   `split_role_selector(selector)` scenario to the requested scenario. Never pass the scenario as the
+   charter target name.
+3. **Enforcement is training-export exclusion, scoped and opt-out-able.** `export_training_data`
+   excludes generation rows whose `quarantined` marker is truthy by default, with an
+   `include_quarantined` flag to opt in. A score produced under an unpromoted/candidate evaluator is
+   not trusted training data. The TS export mirror gets the same option for contract parity (its
+   `quarantined` is always null per the Slice B/C1 asymmetry, so the exclusion is a no-op there).
+4. **The ambient-promote refusal stays deferred.** Refusing a model scored under a non-active
+   evaluator epoch needs the `promote.py` generalization (the ambient evaluate stage stamping
+   evaluator_epoch on model eval metadata), a separate follow-on. C3 does not touch `promote.py`.
+5. **Registry access via the C1/C2 lock-held API only.** The CLI reads via `list_for_scenario` /
+   `active_for` and mutates only via `promote_evaluator_epoch` (which uses `registry.promote` /
+   `stamp_promotion` under the per-scenario lock). No direct unlocked writes.
+
+## Architecture
+
+### C3.1: training-export quarantine exclusion
+
+- Python `training/export.py` `export_training_data(sqlite, artifacts, run_id=None, scenario=None,
+include_matches=False, kept_only=False, include_quarantined=False)`: in the `TrainingRecord`
+  yield loop, skip a generation row when `bool(gen.get("quarantined"))` and not
+  `include_quarantined`. Match records are unaffected (tournament, never quarantined).
+- TS `ts/src/training/export-records-workflow.ts`: add an `includeQuarantined?: boolean` option and
+  the same skip on `generation.quarantined`. (TS never populates `quarantined`, so the branch is a
+  no-op, but the option exists for parity.)
+- Tests: a quarantined generation is excluded by default; `include_quarantined=True` includes it; a
+  non-quarantined generation is always exported.
+
+### C3.2: the epoch CLI
+
+New module `autocontext/src/autocontext/cli_epoch.py`, registered on the main Typer `app`
+(`cli.py` is near the module-size cap, so the commands live in their own module):
+
+- `epoch list [--scenario S] [--charter PATH]`: enumerate registry records (scenario, epoch_id,
+  activation_state, and the promotion block when present) as JSON to stdout. Reads via
+  `EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs").list_for_scenario(...)` (or
+  all scenarios when `--scenario` is omitted, by scanning the registry root's scenario subdirs).
+- `epoch approve <scenario> <epoch_id> [--by USER] [--charter PATH]` and
+  `epoch reject <scenario> <epoch_id> [--by USER] [--charter PATH]`:
+  1. Load the charter (`--charter` or settings default via `load_charter`).
+  2. `target_name = _resolve_charter_target(charter, scenario)`; error clearly if no target's
+     selector scenario matches.
+  3. Build `ReviewerDecision(outcome="approved"|"rejected", reviewed_by=USER, reviewed_at=now)`.
+  4. Call `promote_evaluator_epoch(registry, scenario, epoch_id, target_name=target_name,
+calibration_report=None, tolerance=AlignmentTolerance.default_for_domain(scenario),
+charter=charter, reviewer_decision=decision, sqlite=SQLiteStore(settings.db_path))`.
+  5. Print the `PromotionOutcome` (outcome, reason) as JSON; exit non-zero on `noop` for a missing
+     candidate so scripts can detect it.
+- Helper `_resolve_charter_target(charter, scenario) -> str`: iterate `charter.targets`, return the
+  first `t.name` whose `split_role_selector(t.selector)` scenario equals `scenario`; raise a
+  `typer.BadParameter`-style clear error if none.
+
+## Data flow
+
+```
+operator: autoctx epoch list --scenario grid_ctf
+   -> EvaluatorEpochRegistry.list_for_scenario -> JSON of candidate/active/disabled records
+
+operator: autoctx epoch approve grid_ctf <epoch> --by jay
+   -> load_charter -> _resolve_charter_target(charter, "grid_ctf") -> "competitor-local"
+   -> promote_evaluator_epoch(reg, scenario="grid_ctf", epoch, target_name="competitor-local",
+        calibration_report=None, reviewer_decision=approved, sqlite=...)
+        -> C2: activate under lock + clear quarantine
+   -> print PromotionOutcome
+
+training export: export_training_data(..., include_quarantined=False)
+   -> skip generation rows with quarantined truthy (unpromoted-evaluator scores excluded)
+```
+
+## Error handling and edge cases
+
+- **No matching charter target for the scenario:** `approve`/`reject` error clearly (cannot resolve
+  the autonomy target); no registry mutation.
+- **Missing candidate epoch:** `promote_evaluator_epoch` returns `noop`; the CLI prints it and exits
+  non-zero so a script sees the failure.
+- **No charter configured:** `approve`/`reject` require a charter (for `decide` + target
+  resolution); error if neither `--charter` nor a settings default is present. `list` does not need
+  a charter.
+- **Registry IO failure in the CLI:** surfaces as a CLI error (operator-facing, unlike the
+  score-persist hot path which fails closed); the operator retries.
+- **include_quarantined default is False:** existing export callers change behavior (quarantined
+  rows now excluded). This is the intended enforcement; documented in the CHANGELOG.
+
+## Testing
+
+- Training-export: quarantined generation excluded by default, included with the flag, non-quarantined
+  always exported (Python + a TS test asserting the option exists and excludes a quarantined row).
+- CLI: `epoch list` prints the registry records; `approve` on a candidate calls
+  `promote_evaluator_epoch` with a distinct scenario vs target_name (a realistic charter target like
+  `competitor-local` with selector `competitor@grid_ctf`, scenario `grid_ctf`), activates it, and the
+  outcome is printed; `reject` records the rejection and does not activate; `approve` of a missing
+  candidate exits non-zero; `_resolve_charter_target` matches by selector and errors on no match.
+- Existing gates: module-size (new `cli_epoch.py`), gate-taxonomy, ruff/mypy, the serde-convention
+  test (full-suite gate, C1 lesson), Python and TS export suites, lockfiles unchanged.
+
+## Documentation
+
+Extend `docs/evaluator-epochs.md` with a "trigger and enforcement (Slice C3)" subsection: the epoch
+CLI (list/approve/reject as the human trigger, charter-based target resolution), training-export
+quarantine exclusion (default-off include flag), and that the ambient-promote refusal remains
+deferred. CHANGELOG entry (noting the export behavior change).
+
+## Deferred / out of scope
+
+- The ambient-promote refusal (the `promote.py` generalization + model-eval-epoch stamping).
+- Other enforcement consumers (run facets, reports, canonical progression beyond training export).
+- Running calibration at CLI-approve time (the CLI approve is a pure human override).
+- Slice D (CLI/API/dashboard stale-epoch surfacing + lazy re-score) beyond this approve/reject CLI.
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 "surface stale evaluator lineage in CLI outputs so operators know when numbers are not
+  directly comparable": the `epoch list` CLI surfaces candidate/active state and promotion metadata.
+- AC-885 "mark or filter stale scores": training-export excludes quarantined scores.
+- AC-885 promotion decision + human-review requirement: the CLI is the human trigger that records the
+  approve/reject decision through C2's operation.

--- a/docs/ac-885-slice-c3-cli-enforcement-design.md
+++ b/docs/ac-885-slice-c3-cli-enforcement-design.md
@@ -18,7 +18,7 @@ consumer that excludes quarantined scores from trusted training-data export.
 1. **The CLI is a human-override trigger.** `autoctx epoch approve`/`reject` build a
    `ReviewerDecision` and call `promote_evaluator_epoch` with `calibration_report=None` (the human
    is the authority; C2 records the decision and, per the C2 fix, contributes no misleading
-   calibration evidence). The charter is loaded (from `--charter` or a settings default) to supply
+   calibration evidence). The charter is loaded (a required `--charter` option) to supply
    the `decide()` autonomy read and to resolve the policy `target_name`.
 2. **Scenario and policy target_name are distinct (C2 lesson).** The CLI has the real scenario (the
    registry/SQLite key); it resolves the charter `target_name` by matching each target's
@@ -61,7 +61,7 @@ New module `autocontext/src/autocontext/cli_epoch.py`, registered on the main Ty
   all scenarios when `--scenario` is omitted, by scanning the registry root's scenario subdirs).
 - `epoch approve <scenario> <epoch_id> [--by USER] [--charter PATH]` and
   `epoch reject <scenario> <epoch_id> [--by USER] [--charter PATH]`:
-  1. Load the charter (`--charter` or settings default via `load_charter`).
+  1. Load the charter (the required `--charter` option) via `load_charter`.
   2. `target_name = _resolve_charter_target(charter, scenario)`; error clearly if no target's
      selector scenario matches.
   3. Build `ReviewerDecision(outcome="approved"|"rejected", reviewed_by=USER, reviewed_at=now)`.
@@ -98,7 +98,7 @@ training export: export_training_data(..., include_quarantined=False)
 - **Missing candidate epoch:** `promote_evaluator_epoch` returns `noop`; the CLI prints it and exits
   non-zero so a script sees the failure.
 - **No charter configured:** `approve`/`reject` require a charter (for `decide` + target
-  resolution); error if neither `--charter` nor a settings default is present. `list` does not need
+  resolution); `--charter` is a required option for approve/reject, and the target selector must be scenario-scoped (`role@scenario`). `list` does not need
   a charter.
 - **Registry IO failure in the CLI:** surfaces as a CLI error (operator-facing, unlike the
   score-persist hot path which fails closed); the operator retries.

--- a/docs/cli-contract.json
+++ b/docs/cli-contract.json
@@ -370,6 +370,104 @@
       },
       "flags": [],
       "output_contract": "json"
+    },
+    {
+      "id": "epoch.list",
+      "path": ["epoch", "list"],
+      "summary": "List evaluator-epoch registry records (candidate/active/disabled) and their promotion metadata as JSON.",
+      "audience": "advanced",
+      "maturity": "experimental",
+      "domain_concept": null,
+      "aliases": [],
+      "runtime_support": {
+        "python": {
+          "status": "yes"
+        },
+        "typescript": {
+          "status": "intentional_gap",
+          "reason": "The evaluator-epoch promotion CLI is a Python-only operator surface in AC-885 Slice C3; the TS package has no epoch registry command yet."
+        }
+      },
+      "flags": [
+        {
+          "name": "scenario",
+          "type": "string",
+          "aliases": [],
+          "required": false,
+          "description": "Limit output to a single scenario; omit to list every scenario's records."
+        }
+      ],
+      "output_contract": "json"
+    },
+    {
+      "id": "epoch.approve",
+      "path": ["epoch", "approve"],
+      "summary": "Approve a candidate evaluator epoch (human override) and activate it, clearing quarantine on its scores.",
+      "audience": "advanced",
+      "maturity": "experimental",
+      "domain_concept": null,
+      "aliases": [],
+      "runtime_support": {
+        "python": {
+          "status": "yes"
+        },
+        "typescript": {
+          "status": "intentional_gap",
+          "reason": "The evaluator-epoch promotion CLI is a Python-only operator surface in AC-885 Slice C3; the TS package has no epoch registry command yet."
+        }
+      },
+      "flags": [
+        {
+          "name": "charter",
+          "type": "string",
+          "aliases": [],
+          "required": true,
+          "description": "Path to the ambient charter yaml; required to resolve the autonomy target for the scenario."
+        },
+        {
+          "name": "by",
+          "type": "string",
+          "aliases": [],
+          "required": false,
+          "description": "Reviewer identity recorded on the promotion decision."
+        }
+      ],
+      "output_contract": "json"
+    },
+    {
+      "id": "epoch.reject",
+      "path": ["epoch", "reject"],
+      "summary": "Reject a candidate evaluator epoch; it stays a candidate and its scores stay quarantined.",
+      "audience": "advanced",
+      "maturity": "experimental",
+      "domain_concept": null,
+      "aliases": [],
+      "runtime_support": {
+        "python": {
+          "status": "yes"
+        },
+        "typescript": {
+          "status": "intentional_gap",
+          "reason": "The evaluator-epoch promotion CLI is a Python-only operator surface in AC-885 Slice C3; the TS package has no epoch registry command yet."
+        }
+      },
+      "flags": [
+        {
+          "name": "charter",
+          "type": "string",
+          "aliases": [],
+          "required": true,
+          "description": "Path to the ambient charter yaml; required to resolve the autonomy target for the scenario."
+        },
+        {
+          "name": "by",
+          "type": "string",
+          "aliases": [],
+          "required": false,
+          "description": "Reviewer identity recorded on the promotion decision."
+        }
+      ],
+      "output_contract": "json"
     }
   ]
 }

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -249,6 +249,58 @@ it (a CLI subcommand or an ambient stage that runs a calibration and then promot
 as is generalizing `promote.py`'s cross-anchor refusal onto this path. Slice C2 makes promotion
 decidable and recordable; wiring it into an operator-facing entry point is the next sub-slice.
 
+## Trigger and enforcement (Slice C3)
+
+Slice C2 made promotion a pure, recordable operation but left it without an operator-facing entry
+point, and Slice C1's `quarantined` marker was still recorded but not acted on. Slice C3 supplies
+both: a human trigger for the promotion workflow, and the first enforcement that consumes the marker.
+
+**The `autoctx epoch` CLI (the human trigger).** `autocontext/src/autocontext/cli_epoch.py` adds an
+`autoctx epoch` command group with three subcommands:
+
+- `epoch list [--scenario NAME]` prints the evaluator-epoch records (candidate, active, disabled) as
+  JSON, over one scenario or all scenarios in the registry. It is read-only: it surfaces the
+  candidates awaiting a decision without changing anything.
+- `epoch approve SCENARIO EPOCH_ID --charter PATH [--by WHO]` approves a candidate and activates it.
+- `epoch reject SCENARIO EPOCH_ID --charter PATH [--by WHO]` rejects a candidate; it stays a
+  candidate and its scores stay quarantined (rejection is "not now," not "never," per Slice C2).
+
+Both approve and reject are **pure human overrides**. They call `promote_evaluator_epoch` with
+`calibration_report=None` and a `ReviewerDecision` carrying the outcome, the reviewer identity
+(`--by`, defaulting to `operator`), and the timestamp. Because the human is the higher authority
+(the C2 rule), an approval activates the candidate on the reviewer's word alone, with no calibration
+evidence supplied on this path, and the decision is recorded on the epoch record so the override is
+visible after the fact. This is the operator's manual trigger, distinct from an ambient stage that
+would run a calibration and promote autonomously.
+
+**Charter-based target_name resolution (distinct from the scenario key).** The `SCENARIO` argument is
+the registry and sqlite key (for example `grid_ctf`). The promotion policy, however, is looked up by
+the charter target NAME, and the two are deliberately distinct keys. The CLI resolves the target name
+from the scenario by scanning the charter's targets and matching each target's selector through
+`split_role_selector`: the target whose selector binds the given scenario supplies the target name
+passed into `promote_evaluator_epoch`. A valid charter forbids a target name that collides with a
+registered scenario, so passing the scenario in as the target name would raise inside the autonomy
+`decide` call; resolving through the selector keeps the two key spaces separate (the C2 lesson). If no
+charter target selects the scenario, the command fails with a clear error rather than guessing.
+
+**Training-export quarantine exclusion (the first enforcement).** `export_training_data` (Python) and
+its TypeScript mirror now exclude quarantined generation scores by default. The parameter is
+`include_quarantined`, defaulting to `False`: a generation whose Slice C1 `quarantined` marker is set
+(a score produced under a non-active, unpromoted evaluator epoch) is skipped, so training data is not
+drawn from an evaluator the scenario has not promoted. Passing `include_quarantined=True`
+(`includeQuarantined` in TypeScript) restores the old behavior and keeps the quarantined rows. This is
+the enforcement Slice C1 deferred: the marker recorded on the row now changes what the export yields.
+
+Matches are NOT affected by this exclusion. A tournament match carries no evaluator epoch (it is an
+Elo score, not a judge score, so it has no evaluator identity to quarantine), so `include_matches`
+emissions are unchanged; only judge-scored generations can carry a `quarantined` marker and only they
+are filtered.
+
+**What remains deferred.** The other enforcement consumer, the ambient-promote refusal (an ambient
+promote stage declining to act on a quarantined-only signal), is still deferred, as is generalizing
+`promote.py`'s cross-anchor refusal onto this path. Slice C3 lands the operator-facing trigger and the
+training-export enforcement; the autonomous ambient trigger and the remaining refusals follow later.
+
 ## Relationship to the ambient `eval_fingerprint` / `anchor_model`
 
 autocontext already had this mechanism, but only in the ambient trainer. `eval_fingerprint()`

--- a/ts/src/cli/commands/export.ts
+++ b/ts/src/cli/commands/export.ts
@@ -86,6 +86,7 @@ export async function cmdExportTrainingData(dbPath: string): Promise<void> {
       output: { type: "string", short: "o" },
       "include-matches": { type: "boolean" },
       "kept-only": { type: "boolean" },
+      "include-quarantined": { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },
   });

--- a/ts/src/cli/export-training-data-command-workflow.ts
+++ b/ts/src/cli/export-training-data-command-workflow.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 export const EXPORT_TRAINING_DATA_HELP_TEXT = [
-  "autoctx export-training-data --run-id <id> [--scenario <name> --all-runs] [--output <file>] [--include-matches] [--kept-only]",
+  "autoctx export-training-data --run-id <id> [--scenario <name> --all-runs] [--output <file>] [--include-matches] [--kept-only] [--include-quarantined]",
   "",
   "Exports training data as JSONL with Python-compatible snake_case fields.",
   "",
@@ -16,6 +16,7 @@ export interface ExportTrainingDataCommandValues {
   output?: string;
   "include-matches"?: boolean;
   "kept-only"?: boolean;
+  "include-quarantined"?: boolean;
 }
 
 export interface ExportTrainingDataCommandPlan {
@@ -25,6 +26,7 @@ export interface ExportTrainingDataCommandPlan {
   output?: string;
   includeMatches: boolean;
   keptOnly: boolean;
+  includeQuarantined: boolean;
 }
 
 export interface ExportTrainingDataProgress {
@@ -55,6 +57,7 @@ export function planExportTrainingDataCommand(
     output: values.output,
     includeMatches: !!values["include-matches"],
     keptOnly: !!values["kept-only"],
+    includeQuarantined: !!values["include-quarantined"],
   };
 }
 
@@ -75,11 +78,7 @@ function writeOutputFileWithParents(path: string, content: string): void {
   writeFileSync(path, content, "utf-8");
 }
 
-export function executeExportTrainingDataCommandWorkflow<
-  TStore,
-  TArtifacts,
-  TRecord,
->(opts: {
+export function executeExportTrainingDataCommandWorkflow<TStore, TArtifacts, TRecord>(opts: {
   plan: ExportTrainingDataCommandPlan;
   store: TStore;
   artifacts: TArtifacts;
@@ -91,6 +90,7 @@ export function executeExportTrainingDataCommandWorkflow<
       scenario?: string;
       includeMatches: boolean;
       keptOnly: boolean;
+      includeQuarantined: boolean;
       onProgress: (progress: ExportTrainingDataProgress) => void;
     },
   ) => TRecord[];
@@ -105,6 +105,7 @@ export function executeExportTrainingDataCommandWorkflow<
     scenario: opts.plan.scenario,
     includeMatches: opts.plan.includeMatches,
     keptOnly: opts.plan.keptOnly,
+    includeQuarantined: opts.plan.includeQuarantined,
     onProgress: (progress) => {
       const line = renderExportTrainingDataProgress(progress);
       if (line) {

--- a/ts/src/training/export-records-workflow.ts
+++ b/ts/src/training/export-records-workflow.ts
@@ -58,6 +58,13 @@ export function buildTrainingExportRecordsForRun(opts: {
   const hints = extractTrainingHints(playbook);
   const promptContext = resolveTrainingPromptContext(opts.artifacts, opts.run.scenario);
   const generations = opts.store.getGenerations(opts.run.run_id);
+  // Trajectory context must not embed scores from generations excluded as untrusted:
+  // a quarantined evaluator score would otherwise leak into every later trusted record
+  // via its context.trajectory. Filter the trajectory source with the same quarantine
+  // policy that gates the strategy records.
+  const trajectoryGenerations = opts.includeQuarantined
+    ? generations
+    : generations.filter((generation) => !generation.quarantined);
 
   for (const generation of generations) {
     if (opts.keptOnly && generation.gate_decision !== "advance") {
@@ -84,7 +91,7 @@ export function buildTrainingExportRecordsForRun(opts: {
           ...promptContext,
           playbook,
           hints,
-          trajectory: buildTrajectorySnippet(generations, generation.generation_index),
+          trajectory: buildTrajectorySnippet(trajectoryGenerations, generation.generation_index),
         },
         evaluator_epoch: generation.evaluator_epoch ?? null,
       };

--- a/ts/src/training/export-records-workflow.ts
+++ b/ts/src/training/export-records-workflow.ts
@@ -47,6 +47,7 @@ export function buildTrainingExportRecordsForRun(opts: {
   run: ExportRunRef;
   keptOnly?: boolean;
   includeMatches?: boolean;
+  includeQuarantined?: boolean;
   onGenerationRecords?: (
     generationIndex: number,
     generationRecords: TrainingExportRecord[],
@@ -63,24 +64,32 @@ export function buildTrainingExportRecordsForRun(opts: {
       continue;
     }
 
-    const outputs = opts.store.getAgentOutputs(opts.run.run_id, generation.generation_index);
-    const competitorOutput = outputs.find((output) => output.role === "competitor");
-    const record: TrainingRecord = {
-      run_id: opts.run.run_id,
-      scenario: opts.run.scenario,
-      generation_index: generation.generation_index,
-      strategy: competitorOutput?.content ?? "",
-      score: generation.best_score,
-      gate_decision: generation.gate_decision,
-      context: {
-        ...promptContext,
-        playbook,
-        hints,
-        trajectory: buildTrajectorySnippet(generations, generation.generation_index),
-      },
-      evaluator_epoch: generation.evaluator_epoch ?? null,
-    };
-    const generationRecords: TrainingExportRecord[] = [record];
+    // Quarantined generations are scored under an unpromoted evaluator epoch, so their
+    // strategy record is not trusted training data. Their tournament matches carry no
+    // evaluator epoch, so they are still emitted below.
+    const skipRecord = !opts.includeQuarantined && !!generation.quarantined;
+
+    const generationRecords: TrainingExportRecord[] = [];
+    if (!skipRecord) {
+      const outputs = opts.store.getAgentOutputs(opts.run.run_id, generation.generation_index);
+      const competitorOutput = outputs.find((output) => output.role === "competitor");
+      const record: TrainingRecord = {
+        run_id: opts.run.run_id,
+        scenario: opts.run.scenario,
+        generation_index: generation.generation_index,
+        strategy: competitorOutput?.content ?? "",
+        score: generation.best_score,
+        gate_decision: generation.gate_decision,
+        context: {
+          ...promptContext,
+          playbook,
+          hints,
+          trajectory: buildTrajectorySnippet(generations, generation.generation_index),
+        },
+        evaluator_epoch: generation.evaluator_epoch ?? null,
+      };
+      generationRecords.push(record);
+    }
 
     if (opts.includeMatches) {
       const matches = opts.store.getMatchesForGeneration(

--- a/ts/src/training/export-types.ts
+++ b/ts/src/training/export-types.ts
@@ -23,6 +23,7 @@ export interface ExportOpts {
   scenario?: string;
   keptOnly?: boolean;
   includeMatches?: boolean;
+  includeQuarantined?: boolean;
   onProgress?: (progress: ExportProgress) => void;
 }
 

--- a/ts/src/training/export.ts
+++ b/ts/src/training/export.ts
@@ -14,10 +14,7 @@ import {
   emitTrainingExportProgress,
   resolveTrainingExportRuns,
 } from "./export-records-workflow.js";
-import type {
-  ExportOpts,
-  TrainingExportRecord,
-} from "./export-types.js";
+import type { ExportOpts, TrainingExportRecord } from "./export-types.js";
 
 export type {
   ExportOpts,
@@ -60,6 +57,7 @@ export function exportTrainingData(
       run,
       keptOnly: opts.keptOnly,
       includeMatches: opts.includeMatches,
+      includeQuarantined: opts.includeQuarantined,
       onGenerationRecords: (generationIndex, generationRecords) => {
         records.push(...generationRecords);
         emitTrainingExportProgress(opts.onProgress, {

--- a/ts/tests/export-records-workflow.test.ts
+++ b/ts/tests/export-records-workflow.test.ts
@@ -24,19 +24,39 @@ describe("training export records workflow", () => {
       artifacts.writePlaybook("grid_ctf", "# Strategy\n");
       store.createRun("run-1", "grid_ctf", 2, "local");
       store.upsertGeneration("run-1", 1, {
-        meanScore: 0.65, bestScore: 0.7, elo: 1050,
-        wins: 3, losses: 2, gateDecision: "advance", status: "completed",
+        meanScore: 0.65,
+        bestScore: 0.7,
+        elo: 1050,
+        wins: 3,
+        losses: 2,
+        gateDecision: "advance",
+        status: "completed",
       });
       store.appendAgentOutput("run-1", 1, "competitor", '{"aggression":0.6}');
-      store.recordMatch("run-1", 1, { seed: 42, score: 0.7, passedValidation: true, validationErrors: "", winner: "challenger" });
+      store.recordMatch("run-1", 1, {
+        seed: 42,
+        score: 0.7,
+        passedValidation: true,
+        validationErrors: "",
+        winner: "challenger",
+      });
       store.upsertGeneration("run-1", 2, {
-        meanScore: 0.55, bestScore: 0.6, elo: 1020,
-        wins: 2, losses: 3, gateDecision: "rollback", status: "completed",
+        meanScore: 0.55,
+        bestScore: 0.6,
+        elo: 1020,
+        wins: 2,
+        losses: 3,
+        gateDecision: "rollback",
+        status: "completed",
       });
       store.appendAgentOutput("run-1", 2, "competitor", '{"aggression":0.9}');
 
-      expect(resolveTrainingExportRuns(store, { runId: "run-1" })).toEqual([{ run_id: "run-1", scenario: "grid_ctf" }]);
-      expect(resolveTrainingExportRuns(store, { scenario: "grid_ctf" })).toEqual([{ run_id: "run-1", scenario: "grid_ctf" }]);
+      expect(resolveTrainingExportRuns(store, { runId: "run-1" })).toEqual([
+        { run_id: "run-1", scenario: "grid_ctf" },
+      ]);
+      expect(resolveTrainingExportRuns(store, { scenario: "grid_ctf" })).toEqual([
+        { run_id: "run-1", scenario: "grid_ctf" },
+      ]);
       expect(resolveTrainingExportRuns(store, {})).toEqual([]);
 
       const generationEvents: Array<{ generationIndex: number; recordCount: number }> = [];
@@ -101,6 +121,111 @@ describe("training export records workflow", () => {
 
       expect(records).toHaveLength(1);
       expect(records[0]).toMatchObject({ evaluator_epoch: "e-1" });
+
+      store.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes quarantined generations by default and includes them with the flag", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-export-quarantine-"));
+    try {
+      const store = new SQLiteStore(join(dir, "test.db"));
+      store.migrate(join(process.cwd(), "migrations"));
+      const artifacts = new ArtifactStore({
+        runsRoot: join(dir, "runs"),
+        knowledgeRoot: join(dir, "knowledge"),
+      });
+
+      store.createRun("run-1", "grid_ctf", 2, "local");
+      store.upsertGeneration("run-1", 1, {
+        meanScore: 0.9,
+        bestScore: 0.9,
+        elo: 0,
+        wins: 0,
+        losses: 0,
+        gateDecision: "completed",
+        status: "completed",
+        evaluatorEpoch: "e-2",
+        quarantined: 1,
+      });
+      store.appendAgentOutput("run-1", 1, "competitor", '{"aggression":0.5}');
+      store.upsertGeneration("run-1", 2, {
+        meanScore: 0.8,
+        bestScore: 0.8,
+        elo: 0,
+        wins: 0,
+        losses: 0,
+        gateDecision: "advance",
+        status: "completed",
+        evaluatorEpoch: "e-1",
+      });
+      store.appendAgentOutput("run-1", 2, "competitor", '{"aggression":0.9}');
+
+      const run = { run_id: "run-1", scenario: "grid_ctf" };
+      const defaultRecords = buildTrainingExportRecordsForRun({ store, artifacts, run });
+      expect(
+        defaultRecords.map((r) => (r as { generation_index: number }).generation_index),
+      ).toEqual([2]);
+
+      const allRecords = buildTrainingExportRecordsForRun({
+        store,
+        artifacts,
+        run,
+        includeQuarantined: true,
+      });
+      expect(
+        allRecords.map((r) => (r as { generation_index: number }).generation_index).sort(),
+      ).toEqual([1, 2]);
+
+      store.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes a quarantined generation's training record but keeps its matches", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-export-quarantine-matches-"));
+    try {
+      const store = new SQLiteStore(join(dir, "test.db"));
+      store.migrate(join(process.cwd(), "migrations"));
+      const artifacts = new ArtifactStore({
+        runsRoot: join(dir, "runs"),
+        knowledgeRoot: join(dir, "knowledge"),
+      });
+
+      store.createRun("run-1", "grid_ctf", 1, "local");
+      store.upsertGeneration("run-1", 1, {
+        meanScore: 0.9,
+        bestScore: 0.9,
+        elo: 0,
+        wins: 0,
+        losses: 0,
+        gateDecision: "completed",
+        status: "completed",
+        quarantined: 1,
+      });
+      store.appendAgentOutput("run-1", 1, "competitor", '{"aggression":0.5}');
+      store.recordMatch("run-1", 1, {
+        seed: 7,
+        score: 0.5,
+        passedValidation: true,
+        validationErrors: "",
+      });
+
+      const records = buildTrainingExportRecordsForRun({
+        store,
+        artifacts,
+        run: { run_id: "run-1", scenario: "grid_ctf" },
+        includeMatches: true,
+      });
+
+      const training = records.filter((r) => "gate_decision" in r);
+      const matches = records.filter((r) => "seed" in r);
+      expect(training).toHaveLength(0); // quarantined generation's training record excluded
+      expect(matches).toHaveLength(1); // its tournament match survives
+      expect(matches[0]).toMatchObject({ generation_index: 1, seed: 7 });
 
       store.close();
     } finally {

--- a/ts/tests/export-records-workflow.test.ts
+++ b/ts/tests/export-records-workflow.test.ts
@@ -232,4 +232,64 @@ describe("training export records workflow", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("keeps a quarantined score out of a later trusted record's trajectory context", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-export-quarantine-trajectory-"));
+    try {
+      const store = new SQLiteStore(join(dir, "test.db"));
+      store.migrate(join(process.cwd(), "migrations"));
+      const artifacts = new ArtifactStore({
+        runsRoot: join(dir, "runs"),
+        knowledgeRoot: join(dir, "knowledge"),
+      });
+
+      store.createRun("run-1", "grid_ctf", 2, "local");
+      store.upsertGeneration("run-1", 1, {
+        meanScore: 0.9,
+        bestScore: 0.9,
+        elo: 0,
+        wins: 0,
+        losses: 0,
+        gateDecision: "completed",
+        status: "completed",
+        evaluatorEpoch: "e-2",
+        quarantined: 1,
+      });
+      store.appendAgentOutput("run-1", 1, "competitor", '{"aggression":0.5}');
+      store.upsertGeneration("run-1", 2, {
+        meanScore: 0.8,
+        bestScore: 0.8,
+        elo: 0,
+        wins: 0,
+        losses: 0,
+        gateDecision: "advance",
+        status: "completed",
+        evaluatorEpoch: "e-1",
+      });
+      store.appendAgentOutput("run-1", 2, "competitor", '{"aggression":0.9}');
+
+      const run = { run_id: "run-1", scenario: "grid_ctf" };
+      const trajectoryIndices = (records: ReturnType<typeof buildTrainingExportRecordsForRun>) => {
+        const gen2 = records.find(
+          (r) => (r as { generation_index: number }).generation_index === 2,
+        ) as { context: { trajectory: Array<{ generation_index: number }> } };
+        return gen2.context.trajectory.map((entry) => entry.generation_index).sort();
+      };
+
+      // Default: the quarantined generation 1 must be absent from the trusted generation 2 trajectory.
+      expect(
+        trajectoryIndices(buildTrainingExportRecordsForRun({ store, artifacts, run })),
+      ).toEqual([2]);
+      // Opt-in restores the quarantined generation to the trajectory context.
+      expect(
+        trajectoryIndices(
+          buildTrainingExportRecordsForRun({ store, artifacts, run, includeQuarantined: true }),
+        ),
+      ).toEqual([1, 2]);
+
+      store.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/ts/tests/export-training-data-command-workflow.test.ts
+++ b/ts/tests/export-training-data-command-workflow.test.ts
@@ -51,6 +51,7 @@ describe("export-training-data command workflow", () => {
         output: "/tmp/export.jsonl",
         "include-matches": true,
         "kept-only": true,
+        "include-quarantined": true,
       }),
     ).toEqual({
       runId: "run-123",
@@ -59,7 +60,12 @@ describe("export-training-data command workflow", () => {
       output: "/tmp/export.jsonl",
       includeMatches: true,
       keptOnly: true,
+      includeQuarantined: true,
     });
+  });
+
+  it("defaults include-quarantined to false when the flag is absent", () => {
+    expect(planExportTrainingDataCommand({ "run-id": "run-123" }).includeQuarantined).toBe(false);
   });
 
   it("renders progress updates for start and generation phases", () => {
@@ -120,6 +126,7 @@ describe("export-training-data command workflow", () => {
         output: undefined,
         includeMatches: true,
         keptOnly: false,
+        includeQuarantined: true,
       },
       store: { kind: "store" },
       artifacts: { kind: "artifacts" },
@@ -134,6 +141,7 @@ describe("export-training-data command workflow", () => {
         scenario: undefined,
         includeMatches: true,
         keptOnly: false,
+        includeQuarantined: true,
         onProgress: expect.any(Function),
       }),
     );
@@ -159,6 +167,7 @@ describe("export-training-data command workflow", () => {
         output: "/tmp/export.jsonl",
         includeMatches: false,
         keptOnly: true,
+        includeQuarantined: false,
       },
       store: { kind: "store" },
       artifacts: { kind: "artifacts" },


### PR DESCRIPTION
## AC-885 Slice C3: promotion trigger (CLI) + quarantine enforcement

Third sub-slice of Slice C. Slice 1/B/C1/C2 are merged (#1204, #1208, #1210, #1211). C1 stood up the evaluator-epoch registry and the `quarantined` marker; C2 built the `promote_evaluator_epoch` decision engine, but nothing triggered it and nothing consumed the quarantine marker. C3 gives the lifecycle end-to-end teeth.

### What this adds

**1. The epoch CLI (human-override trigger).** New `autocontext/src/autocontext/cli_epoch.py`, registered as `autoctx epoch`:
- `epoch list [--scenario S]` prints registry records (candidate/active/disabled + promotion metadata) as JSON.
- `epoch approve <scenario> <epoch_id> --charter PATH [--by USER]` and `epoch reject ...` build a `ReviewerDecision` and call `promote_evaluator_epoch(..., calibration_report=None)`: the human is the authority, and C2 records the decision. Exits non-zero on a `noop` (missing candidate) so scripts detect it.
- Scenario (the registry/SQLite key) and the charter `target_name` stay distinct (the C2 lesson): `_resolve_charter_target` resolves the policy target by matching each charter target's `split_role_selector(selector)` scenario to the requested scenario, never conflating the two. The `--charter` option is required for approve/reject, and the target selector must be scenario-scoped (`role@scenario`).
- Reads via the C1/C2 lock-held API only (`list_for_scenario`/`active_for`; mutation only through `promote_evaluator_epoch`).

**2. Training-export quarantine exclusion (first enforcement consumer).** `export_training_data` now excludes generation rows whose `quarantined` marker is truthy by default, with an `include_quarantined` opt-in flag. A score produced under an unpromoted/candidate evaluator is not trusted training data. The skip gates **only** the training-record yield; tournament match records are always emitted (they are never quarantined). The TS export mirror gets the same `includeQuarantined` option for contract parity (TS never populates `quarantined`, so it is a no-op there).

### Behavior change

`include_quarantined` defaults to `False`, so existing export callers now exclude quarantined rows. This is the intended enforcement; noted in the CHANGELOG.

### Deferred (out of scope)

- The ambient-promote refusal (needs the `promote.py` generalization + model-eval-epoch stamping).
- Other enforcement consumers (run facets, reports).
- Slice D (CLI/API/dashboard stale-epoch surfacing + lazy re-score) beyond this approve/reject CLI.

### Review

Built subagent-driven (fresh implementer per task, per-task reviews, opus whole-branch review). Per-task review caught a Critical (early quarantine `continue` dropped tournament matches too, fixed + regression tests Py+TS). Whole-branch review verdict "ready to merge" with three Minors, all folded in: design-doc charter language reconciled with the required-option reality, `_resolve_charter_target` no-match regression test added, scoped-selector requirement documented.

Tests: `tests/test_cli_epoch.py` (list/approve/reject/missing-candidate/all-scenarios/no-match), Python + TS export suites (quarantine excluded by default / included with flag / matches survive), module-size + serde-convention + schema-parity gates green. `uv.lock` unchanged.

Left open for review; do not merge without authorization.
