### PR TITLE
AC-885 Slice D1: stale-epoch surfacing in CLI + HTTP (read-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ All notable changes to this project will be documented in this file.
   CLI lists candidate epochs and approves/rejects them (a human-override trigger for the promotion
   workflow), and `export_training_data` now excludes quarantined scores by default (pass
   `include_quarantined=True` to keep them), so training data is not drawn from unpromoted evaluators.
+- AC-885 Slice D1: read-only stale-epoch surfacing. A four-state `classify_epoch_lineage` (`current`,
+  `stale`, `unknown`, `no_active_epoch`) and a registry-aware `annotate_status_rows` flag generation
+  scores against the scenario's active evaluator epoch; `show` and `status` (`--json` and the rich
+  table) gain per-generation `evaluator_epoch`, `evaluator_epoch_status`, and `quarantined` plus a
+  top-level `active_evaluator_epoch`, and the cockpit `GET /runs/{run_id}/status` adds the same
+  fields plus a `stale_epoch` warning per stale generation. TypeScript DTOs now carry the persisted
+  `evaluator_epoch`/`quarantined` fields but do not classify staleness (the registry stays
+  Python-only, a documented gap consistent with prior sub-slices). Lazy re-score of stale records
+  remains deferred to Slice D2.
 
 ## [0.11.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to this project will be documented in this file.
   `stale`, `unknown`, `no_active_epoch`) and a registry-aware `annotate_status_rows` flag generation
   scores against the scenario's active evaluator epoch; `show` and `status` (`--json` and the rich
   table) gain per-generation `evaluator_epoch`, `evaluator_epoch_status`, and `quarantined` plus a
-  top-level `active_evaluator_epoch`, and the cockpit `GET /runs/{run_id}/status` adds the same
+  top-level `active_evaluator_epoch`, and the cockpit `GET /api/cockpit/runs/{run_id}/status` adds the same
   fields plus a `stale_epoch` warning per stale generation. TypeScript DTOs now carry the persisted
   `evaluator_epoch`/`quarantined` fields but do not classify staleness (the registry stays
   Python-only, a documented gap consistent with prior sub-slices). Lazy re-score of stale records

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -33,7 +33,12 @@ from autocontext.cli_package_commands import register_package_commands
 from autocontext.cli_probes import register_probes_command
 from autocontext.cli_queue import register_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
-from autocontext.cli_run_inspect import register_run_inspect_commands
+from autocontext.cli_run_inspect import (
+    _lineage_cell,
+    _stale_warning_line,
+    annotate_run_status_rows,
+    register_run_inspect_commands,
+)
 from autocontext.cli_runtime_overrides import (
     apply_judge_runtime_overrides,
     format_runtime_provider_error,
@@ -572,6 +577,10 @@ def status(
     store = _sqlite_from_settings(settings)
     rows = store.run_status(run_id)
 
+    run = store.get_run(run_id)
+    scenario = run.get("scenario") if run else None
+    rows, active_epoch_id = annotate_run_status_rows(settings, scenario, rows)
+
     if json_output:
         generations = []
         for row in rows:
@@ -585,9 +594,21 @@ def status(
                     "losses": row["losses"],
                     "gate_decision": row["gate_decision"],
                     "status": row["status"],
+                    "evaluator_epoch": row.get("evaluator_epoch"),
+                    "evaluator_epoch_status": row["evaluator_epoch_status"],
+                    "quarantined": bool(row.get("quarantined")),
                 }
             )
-        sys.stdout.write(json.dumps({"run_id": run_id, "generations": generations}) + "\n")
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "active_evaluator_epoch": active_epoch_id,
+                    "generations": generations,
+                }
+            )
+            + "\n"
+        )
     else:
         table = Table(title=f"Run Status: {run_id}")
         table.add_column("Gen")
@@ -598,6 +619,7 @@ def status(
         table.add_column("L")
         table.add_column("Gate")
         table.add_column("Status")
+        table.add_column("Lineage")
         for row in rows:
             table.add_row(
                 str(row["generation_index"]),
@@ -608,8 +630,12 @@ def status(
                 str(row["losses"]),
                 row["gate_decision"],
                 row["status"],
+                _lineage_cell(row),
             )
         console.print(table)
+        warning = _stale_warning_line(rows, active_epoch_id)
+        if warning is not None:
+            console.print(warning)
 
 
 def _run_http_serve(host: str, port: int) -> None:

--- a/autocontext/src/autocontext/cli_run_inspect.py
+++ b/autocontext/src/autocontext/cli_run_inspect.py
@@ -28,10 +28,52 @@ from typing import TYPE_CHECKING, Any
 import typer
 from rich.table import Table
 
+from autocontext.execution.epoch_lineage import annotate_status_rows
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
 if TYPE_CHECKING:
     from rich.console import Console
 
+    from autocontext.config.settings import AppSettings
+
 _TERMINAL_STATUSES = frozenset({"completed", "failed", "succeeded", "errored"})
+
+# AC-885 Slice D1: map the four-state lineage classification to a compact rich "Lineage" cell.
+_LINEAGE_LABELS = {"current": "ok", "stale": "stale", "unknown": "legacy", "no_active_epoch": "-"}
+
+
+def annotate_run_status_rows(
+    settings: AppSettings,
+    scenario: str | None,
+    rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Annotate run_status rows with epoch lineage (AC-885 Slice D1).
+
+    Shared by ``show`` and ``status`` so the registry root is constructed in one place. Builds the
+    per-scenario epoch registry under ``settings.knowledge_root / "_evaluator_epochs"`` (same root as
+    ``cli_epoch``) and delegates to ``annotate_status_rows``. Read-only.
+    """
+    registry = EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
+    return annotate_status_rows(rows, scenario, registry)
+
+
+def _lineage_cell(row: dict[str, Any]) -> str:
+    """Render the ``Lineage`` column value, marking quarantined rows."""
+    label = _LINEAGE_LABELS.get(row.get("evaluator_epoch_status", ""), "-")
+    if row.get("quarantined"):
+        label = f"{label}+quarantined"
+    return label
+
+
+def _stale_warning_line(rows: list[dict[str, Any]], active_epoch_id: str | None) -> str | None:
+    """Return a single warning line if any row is stale or quarantined, else None."""
+    flagged = [r for r in rows if r.get("evaluator_epoch_status") == "stale" or r.get("quarantined")]
+    if not flagged:
+        return None
+    active8 = active_epoch_id[:8] if active_epoch_id else "none"
+    return (
+        f"[yellow]Warning: {len(flagged)} generation(s) scored under a stale evaluator epoch; active epoch {active8}...[/yellow]"
+    )
 
 
 def _cli_attr(dependency_module: str, name: str) -> Any:
@@ -89,11 +131,14 @@ def register_run_inspect_commands(
                     console.print(f"[red]{message}[/red]")
                 raise typer.Exit(code=1)
 
+        rows, active_epoch_id = annotate_run_status_rows(settings, run.get("scenario"), rows)
+
         if json_output:
             payload: dict[str, Any] = {
                 "run_id": run_id,
                 "scenario": run.get("scenario"),
                 "status": run.get("status"),
+                "active_evaluator_epoch": active_epoch_id,
                 "generations": [
                     {
                         "generation": r["generation_index"],
@@ -104,6 +149,9 @@ def register_run_inspect_commands(
                         "losses": r["losses"],
                         "gate_decision": r["gate_decision"],
                         "status": r["status"],
+                        "evaluator_epoch": r.get("evaluator_epoch"),
+                        "evaluator_epoch_status": r["evaluator_epoch_status"],
+                        "quarantined": bool(r.get("quarantined")),
                     }
                     for r in rows
                 ],
@@ -124,6 +172,7 @@ def register_run_inspect_commands(
         table.add_column("L")
         table.add_column("Gate")
         table.add_column("Status")
+        table.add_column("Lineage")
         for row in rows:
             table.add_row(
                 str(row["generation_index"]),
@@ -134,8 +183,12 @@ def register_run_inspect_commands(
                 str(row["losses"]),
                 row["gate_decision"],
                 row["status"],
+                _lineage_cell(row),
             )
         console.print(table)
+        warning = _stale_warning_line(rows, active_epoch_id)
+        if warning is not None:
+            console.print(warning)
 
     @app.command()
     def watch(

--- a/autocontext/src/autocontext/cli_run_inspect.py
+++ b/autocontext/src/autocontext/cli_run_inspect.py
@@ -66,14 +66,24 @@ def _lineage_cell(row: dict[str, Any]) -> str:
 
 
 def _stale_warning_line(rows: list[dict[str, Any]], active_epoch_id: str | None) -> str | None:
-    """Return a single warning line if any row is stale or quarantined, else None."""
-    flagged = [r for r in rows if r.get("evaluator_epoch_status") == "stale" or r.get("quarantined")]
-    if not flagged:
+    """Return a single warning line if any row is stale or quarantined, else None.
+
+    Stale and quarantined are distinct states and are reported separately: a stale row's epoch differs
+    from the active epoch, while a quarantined row was scored under an unpromoted epoch. A row can be
+    ``current`` yet quarantined (a promotion activated the epoch before quarantine cleanup ran), or
+    quarantined with no active epoch, so quarantine must not be folded into the "stale" wording.
+    """
+    stale = [r for r in rows if r.get("evaluator_epoch_status") == "stale"]
+    quarantined = [r for r in rows if r.get("quarantined")]
+    if not stale and not quarantined:
         return None
     active8 = active_epoch_id[:8] if active_epoch_id else "none"
-    return (
-        f"[yellow]Warning: {len(flagged)} generation(s) scored under a stale evaluator epoch; active epoch {active8}...[/yellow]"
-    )
+    parts: list[str] = []
+    if stale:
+        parts.append(f"{len(stale)} generation(s) scored under a stale evaluator epoch")
+    if quarantined:
+        parts.append(f"{len(quarantined)} generation(s) quarantined (scored under an unpromoted epoch)")
+    return f"[yellow]Warning: {'; '.join(parts)}; active epoch {active8}...[/yellow]"
 
 
 def _cli_attr(dependency_module: str, name: str) -> Any:

--- a/autocontext/src/autocontext/execution/epoch_lineage.py
+++ b/autocontext/src/autocontext/execution/epoch_lineage.py
@@ -1,0 +1,33 @@
+"""Registry-aware epoch-lineage annotation for operator read surfaces (AC-885 Slice D1).
+
+Separate from the leaf ``evaluator_epoch`` module because it depends on the registry (which imports
+the classifier), so co-locating would cycle. Read-only: reads the scenario's active epoch and
+classifies each status row.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.execution.evaluator_epoch import classify_epoch_lineage
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+
+def annotate_status_rows(
+    rows: list[dict[str, Any]],
+    scenario: str | None,
+    registry: EvaluatorEpochRegistry,
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Return (row copies each with an ``evaluator_epoch_status`` key, active_epoch_id).
+
+    The scenario's active epoch is read once. ``scenario is None`` yields ``no_active_epoch`` for every
+    row. Inputs are not mutated.
+    """
+    active = registry.active_for(scenario) if scenario else None
+    active_id = active.epoch_id if active is not None else None
+    annotated: list[dict[str, Any]] = []
+    for row in rows:
+        copy = dict(row)
+        copy["evaluator_epoch_status"] = classify_epoch_lineage(copy.get("evaluator_epoch"), active_id)
+        annotated.append(copy)
+    return annotated, active_id

--- a/autocontext/src/autocontext/execution/epoch_lineage.py
+++ b/autocontext/src/autocontext/execution/epoch_lineage.py
@@ -1,8 +1,9 @@
 """Registry-aware epoch-lineage annotation for operator read surfaces (AC-885 Slice D1).
 
 Separate from the leaf ``evaluator_epoch`` module because it depends on the registry (which imports
-the classifier), so co-locating would cycle. Read-only: reads the scenario's active epoch and
-classifies each status row.
+the classifier), so co-locating would cycle. Adds no score, judge call, or promotion: it reads the
+scenario's active epoch (via ``EvaluatorEpochRegistry.active_for``, whose own contract may lock and
+self-heal a multiple-active state) and classifies each status row.
 """
 
 from __future__ import annotations

--- a/autocontext/src/autocontext/execution/evaluator_epoch.py
+++ b/autocontext/src/autocontext/execution/evaluator_epoch.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from typing import Literal
 
 EVALUATOR_EPOCH_REBASELINE = "evaluator_epoch_rebaseline"
 
@@ -47,6 +48,23 @@ def compute_evaluator_epoch(rubric_text: str, judge_provider: str, judge_model: 
 def are_comparable(a: str | None, b: str | None) -> bool:
     """Two epoch ids are comparable only when equal; ``None`` (legacy/unknown) equals only ``None``."""
     return a == b
+
+
+EpochLineageStatus = Literal["current", "stale", "unknown", "no_active_epoch"]
+
+
+def classify_epoch_lineage(row_epoch: str | None, active_epoch: str | None) -> EpochLineageStatus:
+    """Classify a score row's epoch against the scenario's active epoch.
+
+    ``no_active_epoch``: the scenario has no promoted active epoch (nothing to compare against, e.g. a
+    game/no-judge run). ``unknown``: an active epoch exists but the row has no lineage (legacy/pre-slice
+    row); not asserted stale. ``current`` / ``stale``: both epochs known, equal vs different.
+    """
+    if active_epoch is None:
+        return "no_active_epoch"
+    if row_epoch is None:
+        return "unknown"
+    return "current" if are_comparable(row_epoch, active_epoch) else "stale"
 
 
 @dataclass(frozen=True, slots=True)

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -13,6 +13,8 @@ from autocontext.analytics.artifact_rendering import render_scenario_curation_ht
 from autocontext.consultation.runner import ConsultationRunner
 from autocontext.consultation.types import ConsultationRequest as ConsReq
 from autocontext.consultation.types import ConsultationTrigger
+from autocontext.execution.epoch_lineage import annotate_status_rows
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
 from autocontext.knowledge.context_selection_report import build_context_selection_report
 from autocontext.notebook.context_provider import NotebookContextProvider
 from autocontext.notebook.types import SessionNotebook
@@ -59,6 +61,13 @@ def _get_artifacts(request: Request) -> ArtifactStore:
     if settings is None:
         raise HTTPException(status_code=500, detail="Application settings are not configured")
     return artifact_store_from_settings(settings)
+
+
+def _get_epoch_registry(request: Request) -> EvaluatorEpochRegistry:
+    settings = getattr(request.app.state, "app_settings", None)
+    if settings is None:
+        raise HTTPException(status_code=500, detail="Application settings are not configured")
+    return EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
 
 
 def _build_effective_notebook_preview(
@@ -320,6 +329,7 @@ def get_run_runtime_session(run_id: str, request: Request) -> dict[str, Any]:
     finally:
         runtime_store.close()
 
+
 # ---------------------------------------------------------------------------
 # Run endpoints (read-only)
 # ---------------------------------------------------------------------------
@@ -403,7 +413,7 @@ def run_status(run_id: str, request: Request) -> dict[str, Any]:
     with store.connect() as conn:
         gen_rows = conn.execute(
             "SELECT generation_index, mean_score, best_score, elo, wins, losses, "
-            "gate_decision, status, duration_seconds "
+            "gate_decision, status, duration_seconds, evaluator_epoch, quarantined "
             "FROM generations WHERE run_id = ? ORDER BY generation_index ASC",
             (run_id,),
         ).fetchall()
@@ -422,8 +432,23 @@ def run_status(run_id: str, request: Request) -> dict[str, Any]:
                 "gate_decision": gd["gate_decision"],
                 "status": gd["status"],
                 "duration_seconds": gd["duration_seconds"],
+                "evaluator_epoch": gd["evaluator_epoch"],
+                "quarantined": bool(gd["quarantined"]),
             }
         )
+
+    generations, active_id = annotate_status_rows(generations, run_dict["scenario"], _get_epoch_registry(request))
+    warnings = [
+        {
+            "warning_type": "stale_epoch",
+            "generation": g["generation"],
+            "evaluator_epoch": g["evaluator_epoch"],
+            "active_evaluator_epoch": active_id,
+            "description": f"generation {g['generation']} scored under a stale evaluator epoch",
+        }
+        for g in generations
+        if g["evaluator_epoch_status"] == "stale"
+    ]
 
     runtime_store = _get_runtime_session_store(request)
     try:
@@ -438,6 +463,8 @@ def run_status(run_id: str, request: Request) -> dict[str, Any]:
         "status": run_dict["status"],
         "created_at": run_dict["created_at"],
         "generations": generations,
+        "active_evaluator_epoch": active_id,
+        "warnings": warnings,
         **runtime_session_discovery,
     }
 

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -13,8 +13,6 @@ from autocontext.analytics.artifact_rendering import render_scenario_curation_ht
 from autocontext.consultation.runner import ConsultationRunner
 from autocontext.consultation.types import ConsultationRequest as ConsReq
 from autocontext.consultation.types import ConsultationTrigger
-from autocontext.execution.epoch_lineage import annotate_status_rows
-from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
 from autocontext.knowledge.context_selection_report import build_context_selection_report
 from autocontext.notebook.context_provider import NotebookContextProvider
 from autocontext.notebook.types import SessionNotebook
@@ -23,6 +21,7 @@ from autocontext.providers.registry import create_provider
 from autocontext.providers.retry import RetryProvider
 from autocontext.server.background_session_api import background_session_router
 from autocontext.server.changelog import build_changelog
+from autocontext.server.run_status_lineage import build_run_status_generations
 from autocontext.server.trace_gate_review_api import InvalidHarnessChangeProposalError, build_run_trace_gate_review
 from autocontext.server.writeup import generate_writeup, generate_writeup_html
 from autocontext.session.runtime_events import RuntimeSessionEventStore
@@ -61,13 +60,6 @@ def _get_artifacts(request: Request) -> ArtifactStore:
     if settings is None:
         raise HTTPException(status_code=500, detail="Application settings are not configured")
     return artifact_store_from_settings(settings)
-
-
-def _get_epoch_registry(request: Request) -> EvaluatorEpochRegistry:
-    settings = getattr(request.app.state, "app_settings", None)
-    if settings is None:
-        raise HTTPException(status_code=500, detail="Application settings are not configured")
-    return EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
 
 
 def _build_effective_notebook_preview(
@@ -418,37 +410,7 @@ def run_status(run_id: str, request: Request) -> dict[str, Any]:
             (run_id,),
         ).fetchall()
 
-    generations = []
-    for g in gen_rows:
-        gd = dict(g)
-        generations.append(
-            {
-                "generation": gd["generation_index"],
-                "mean_score": gd["mean_score"],
-                "best_score": gd["best_score"],
-                "elo": gd["elo"],
-                "wins": gd["wins"],
-                "losses": gd["losses"],
-                "gate_decision": gd["gate_decision"],
-                "status": gd["status"],
-                "duration_seconds": gd["duration_seconds"],
-                "evaluator_epoch": gd["evaluator_epoch"],
-                "quarantined": bool(gd["quarantined"]),
-            }
-        )
-
-    generations, active_id = annotate_status_rows(generations, run_dict["scenario"], _get_epoch_registry(request))
-    warnings = [
-        {
-            "warning_type": "stale_epoch",
-            "generation": g["generation"],
-            "evaluator_epoch": g["evaluator_epoch"],
-            "active_evaluator_epoch": active_id,
-            "description": f"generation {g['generation']} scored under a stale evaluator epoch",
-        }
-        for g in generations
-        if g["evaluator_epoch_status"] == "stale"
-    ]
+    generations, active_id, warnings = build_run_status_generations(gen_rows, run_dict["scenario"], request)
 
     runtime_store = _get_runtime_session_store(request)
     try:

--- a/autocontext/src/autocontext/server/run_status_lineage.py
+++ b/autocontext/src/autocontext/server/run_status_lineage.py
@@ -1,0 +1,68 @@
+"""HTTP run-status generation view with evaluator-epoch lineage (AC-885 Slice D1).
+
+Extracted from ``cockpit_api`` so that module stays under its size limit: this holds the
+generation-dict construction plus the read-only epoch-lineage annotation and stale-epoch warnings for
+``GET /runs/{run_id}/status``. Adds no score, judge call, or promotion; it reads the scenario's active
+epoch via ``EvaluatorEpochRegistry.active_for`` (whose own contract may lock and self-heal) and renders.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from autocontext.execution.epoch_lineage import annotate_status_rows
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+
+def _epoch_registry_from_request(request: Request) -> EvaluatorEpochRegistry:
+    settings = getattr(request.app.state, "app_settings", None)
+    if settings is None:
+        raise HTTPException(status_code=500, detail="Application settings are not configured")
+    return EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
+
+
+def build_run_status_generations(
+    gen_rows: list[Any],
+    scenario: str | None,
+    request: Request,
+) -> tuple[list[dict[str, Any]], str | None, list[dict[str, Any]]]:
+    """Return (generation dicts with lineage, active epoch id, stale-epoch warnings).
+
+    Each generation dict carries the existing status fields plus ``evaluator_epoch``,
+    ``quarantined`` (bool), and ``evaluator_epoch_status`` (one of current/stale/unknown/no_active_epoch).
+    A ``stale_epoch`` warning is emitted only for generations classified ``stale``.
+    """
+    generations: list[dict[str, Any]] = []
+    for row in gen_rows:
+        gd = dict(row)
+        generations.append(
+            {
+                "generation": gd["generation_index"],
+                "mean_score": gd["mean_score"],
+                "best_score": gd["best_score"],
+                "elo": gd["elo"],
+                "wins": gd["wins"],
+                "losses": gd["losses"],
+                "gate_decision": gd["gate_decision"],
+                "status": gd["status"],
+                "duration_seconds": gd["duration_seconds"],
+                "evaluator_epoch": gd["evaluator_epoch"],
+                "quarantined": bool(gd["quarantined"]),
+            }
+        )
+
+    generations, active_id = annotate_status_rows(generations, scenario, _epoch_registry_from_request(request))
+    warnings = [
+        {
+            "warning_type": "stale_epoch",
+            "generation": g["generation"],
+            "evaluator_epoch": g.get("evaluator_epoch"),
+            "active_evaluator_epoch": active_id,
+            "description": f"generation {g['generation']} scored under a stale evaluator epoch",
+        }
+        for g in generations
+        if g.get("evaluator_epoch_status") == "stale"
+    ]
+    return generations, active_id, warnings

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -762,7 +762,8 @@ class SQLiteStore(
         with self.connect() as conn:
             rows = conn.execute(
                 """
-                SELECT generation_index, mean_score, best_score, elo, wins, losses, gate_decision, status
+                SELECT generation_index, mean_score, best_score, elo, wins, losses, gate_decision, status,
+                       evaluator_epoch, quarantined
                 FROM generations
                 WHERE run_id = ?
                 ORDER BY generation_index

--- a/autocontext/tests/test_cli_json.py
+++ b/autocontext/tests/test_cli_json.py
@@ -280,7 +280,7 @@ class TestStatusJson:
 
         assert result.exit_code == 0, result.output
         data = json.loads(result.output.strip())
-        assert data == {"run_id": "missing-run", "generations": []}
+        assert data == {"run_id": "missing-run", "generations": [], "active_evaluator_epoch": None}
 
     def test_status_json_is_valid_json(self, tmp_path: Path) -> None:
         """status --json output should be parseable as JSON without error."""

--- a/autocontext/tests/test_cli_stale_epoch_surfacing.py
+++ b/autocontext/tests/test_cli_stale_epoch_surfacing.py
@@ -129,3 +129,36 @@ def test_status_rich_no_active_epoch(tmp_path: Path, monkeypatch) -> None:
     assert result.exit_code == 0, result.output
     assert "Run Status: run-bare" in result.output
     assert "Warning" not in result.output
+
+
+def test_current_but_quarantined_warns_quarantined_not_stale(tmp_path: Path, monkeypatch) -> None:
+    """A generation whose epoch IS the active one but is still quarantined (a promotion activated the
+    epoch before quarantine cleanup ran) must warn as quarantined, never as scored under a stale epoch."""
+    _env(monkeypatch, tmp_path)
+    _e1, e2 = _seed_epochs(tmp_path)  # e2 is the active epoch
+    store = _store(tmp_path)
+    store.create_run("run-q", _SCENARIO, 1, "local")
+    store.upsert_generation(
+        "run-q",
+        1,
+        mean_score=0.5,
+        best_score=0.6,
+        elo=1000.0,
+        wins=1,
+        losses=0,
+        gate_decision="pass",
+        status="completed",
+        evaluator_epoch=e2,  # same as active -> classifies current
+        quarantined=True,
+    )
+
+    result = runner.invoke(app, ["show", "run-q"])
+    assert result.exit_code == 0, result.output
+    normalized = " ".join(result.output.split())
+    assert "quarantined" in normalized
+    assert "stale evaluator epoch" not in normalized  # a current row must not be described as stale
+
+    payload = json.loads(runner.invoke(app, ["show", "run-q", "--json"]).output)
+    gen = payload["generations"][0]
+    assert gen["evaluator_epoch_status"] == "current"
+    assert gen["quarantined"] is True

--- a/autocontext/tests/test_cli_stale_epoch_surfacing.py
+++ b/autocontext/tests/test_cli_stale_epoch_surfacing.py
@@ -74,7 +74,7 @@ def test_show_json_flags_stale_generation(tmp_path: Path, monkeypatch) -> None:
     gen = payload["generations"][0]
     assert gen["evaluator_epoch"] == e1
     assert gen["evaluator_epoch_status"] == "stale"
-    assert gen["quarantined"] in (False, True)
+    assert gen["quarantined"] is False
 
 
 def test_status_json_flags_stale_generation(tmp_path: Path, monkeypatch) -> None:
@@ -89,7 +89,7 @@ def test_status_json_flags_stale_generation(tmp_path: Path, monkeypatch) -> None
     gen = payload["generations"][0]
     assert gen["evaluator_epoch"] == e1
     assert gen["evaluator_epoch_status"] == "stale"
-    assert gen["quarantined"] in (False, True)
+    assert gen["quarantined"] is False
 
 
 def test_show_json_no_active_epoch(tmp_path: Path, monkeypatch) -> None:
@@ -103,3 +103,29 @@ def test_show_json_no_active_epoch(tmp_path: Path, monkeypatch) -> None:
     assert payload["active_evaluator_epoch"] is None
     gen = payload["generations"][0]
     assert gen["evaluator_epoch_status"] == "no_active_epoch"
+
+
+def test_show_rich_flags_stale_generation(tmp_path: Path, monkeypatch) -> None:
+    """Non-JSON ``show`` prints the stale warning line and a ``stale`` Lineage cell."""
+    _env(monkeypatch, tmp_path)
+    e1, e2 = _seed_epochs(tmp_path)
+    _seed_run(tmp_path, "run-stale", e1)
+
+    result = runner.invoke(app, ["show", "run-stale"])
+    assert result.exit_code == 0, result.output
+    normalized = " ".join(result.output.split())
+    assert "stale" in normalized
+    assert "Warning" in normalized
+    assert f"active epoch {e2[:8]}" in normalized
+
+
+def test_status_rich_no_active_epoch(tmp_path: Path, monkeypatch) -> None:
+    """Non-JSON ``status`` on a scenario with no registered active epoch prints no stale warning."""
+    _env(monkeypatch, tmp_path)
+    # No epochs registered for the scenario -> nothing to compare against.
+    _seed_run(tmp_path, "run-bare", "e1")
+
+    result = runner.invoke(app, ["status", "run-bare"])
+    assert result.exit_code == 0, result.output
+    assert "Run Status: run-bare" in result.output
+    assert "Warning" not in result.output

--- a/autocontext/tests/test_cli_stale_epoch_surfacing.py
+++ b/autocontext/tests/test_cli_stale_epoch_surfacing.py
@@ -1,0 +1,105 @@
+"""CLI stale-epoch lineage surfacing for ``show`` + ``status`` (AC-885 Slice D1).
+
+A generation scored under a superseded evaluator epoch must render as ``stale`` once a newer epoch is
+promoted active, without any re-score (read-only surfacing). Rows with no lineage under an active epoch
+are ``unknown``; a scenario with no active epoch yields ``no_active_epoch`` for every row.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+runner = CliRunner()
+
+_SCENARIO = "grid_ctf"
+_MIGRATIONS = Path(__file__).resolve().parents[1] / "migrations"
+
+
+def _env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_KNOWLEDGE_ROOT", str(tmp_path / "knowledge"))
+    monkeypatch.setenv("AUTOCONTEXT_DB_PATH", str(tmp_path / "t.sqlite3"))
+
+
+def _store(tmp_path: Path):
+    from autocontext.storage.sqlite_store import SQLiteStore
+
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(_MIGRATIONS)
+    return store
+
+
+def _seed_epochs(tmp_path: Path) -> tuple[str, str]:
+    reg = EvaluatorEpochRegistry(tmp_path / "knowledge" / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe(_SCENARIO, e1, now_fn=lambda: "t0")  # active (bootstrap)
+    reg.observe(_SCENARIO, e2, now_fn=lambda: "t1")  # candidate
+    reg.activate(_SCENARIO, e2.epoch_id)  # promote e2 -> e1-scored rows now stale
+    return e1.epoch_id, e2.epoch_id
+
+
+def _seed_run(tmp_path: Path, run_id: str, epoch_id: str | None) -> None:
+    store = _store(tmp_path)
+    store.create_run(run_id, _SCENARIO, 1, "local")
+    store.upsert_generation(
+        run_id,
+        1,
+        mean_score=0.5,
+        best_score=0.6,
+        elo=1000.0,
+        wins=1,
+        losses=0,
+        gate_decision="pass",
+        status="completed",
+        evaluator_epoch=epoch_id,
+    )
+
+
+def test_show_json_flags_stale_generation(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    e1, e2 = _seed_epochs(tmp_path)
+    _seed_run(tmp_path, "run-stale", e1)
+
+    result = runner.invoke(app, ["show", "run-stale", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["active_evaluator_epoch"] == e2
+    gen = payload["generations"][0]
+    assert gen["evaluator_epoch"] == e1
+    assert gen["evaluator_epoch_status"] == "stale"
+    assert gen["quarantined"] in (False, True)
+
+
+def test_status_json_flags_stale_generation(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    e1, e2 = _seed_epochs(tmp_path)
+    _seed_run(tmp_path, "run-stale", e1)
+
+    result = runner.invoke(app, ["status", "run-stale", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["active_evaluator_epoch"] == e2
+    gen = payload["generations"][0]
+    assert gen["evaluator_epoch"] == e1
+    assert gen["evaluator_epoch_status"] == "stale"
+    assert gen["quarantined"] in (False, True)
+
+
+def test_show_json_no_active_epoch(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    # No epochs registered for the scenario -> nothing to compare against.
+    _seed_run(tmp_path, "run-bare", "e1")
+
+    result = runner.invoke(app, ["show", "run-bare", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["active_evaluator_epoch"] is None
+    gen = payload["generations"][0]
+    assert gen["evaluator_epoch_status"] == "no_active_epoch"

--- a/autocontext/tests/test_cockpit_stale_epoch.py
+++ b/autocontext/tests/test_cockpit_stale_epoch.py
@@ -1,0 +1,81 @@
+"""Stale-epoch surfacing in the HTTP cockpit run_status (AC-885 Slice D1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from autocontext.config.settings import AppSettings
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+from autocontext.server.cockpit_api import cockpit_router
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations"
+
+
+def _client(tmp_path: Path, store: SQLiteStore) -> TestClient:
+    settings = AppSettings(
+        db_path=tmp_path / "test.db",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+    )
+    app = FastAPI()
+    app.state.store = store
+    app.state.app_settings = settings
+    app.include_router(cockpit_router)
+    return TestClient(app)
+
+
+def test_run_status_surfaces_stale_epoch(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "test.db")
+    store.migrate(MIGRATIONS_DIR)
+
+    reg = EvaluatorEpochRegistry(tmp_path / "knowledge" / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")
+    reg.activate("grid_ctf", e2.epoch_id)
+
+    store.create_run("run1", "grid_ctf", 1, "local")
+    store.upsert_generation("run1", 1, 0.40, 0.50, 1000.0, 2, 1, "advance", "completed", 30.0, evaluator_epoch=e1.epoch_id)
+    store.mark_run_completed("run1")
+
+    client = _client(tmp_path, store)
+    resp = client.get("/api/cockpit/runs/run1/status")
+    assert resp.status_code == 200
+    payload = resp.json()
+
+    assert payload["active_evaluator_epoch"] == e2.epoch_id
+    gen = payload["generations"][0]
+    assert gen["evaluator_epoch"] == e1.epoch_id
+    assert gen["evaluator_epoch_status"] == "stale"
+    assert gen["quarantined"] in (False, True)
+
+    warnings = payload["warnings"]
+    stale = [w for w in warnings if w["warning_type"] == "stale_epoch"]
+    assert len(stale) == 1
+    assert stale[0]["generation"] == 1
+    assert stale[0]["evaluator_epoch"] == e1.epoch_id
+    assert stale[0]["active_evaluator_epoch"] == e2.epoch_id
+
+
+def test_run_status_no_active_epoch(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "test.db")
+    store.migrate(MIGRATIONS_DIR)
+
+    store.create_run("run1", "grid_ctf", 1, "local")
+    store.upsert_generation("run1", 1, 0.40, 0.50, 1000.0, 2, 1, "advance", "completed", 30.0)
+    store.mark_run_completed("run1")
+
+    client = _client(tmp_path, store)
+    payload = client.get("/api/cockpit/runs/run1/status").json()
+
+    assert payload["active_evaluator_epoch"] is None
+    assert payload["generations"][0]["evaluator_epoch_status"] == "no_active_epoch"
+    assert payload["warnings"] == []

--- a/autocontext/tests/test_epoch_lineage.py
+++ b/autocontext/tests/test_epoch_lineage.py
@@ -1,0 +1,56 @@
+"""Stale-epoch lineage classification + annotation (AC-885 Slice D1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.execution.epoch_lineage import annotate_status_rows
+from autocontext.execution.evaluator_epoch import classify_epoch_lineage, compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+
+def test_classify_four_states() -> None:
+    assert classify_epoch_lineage("e1", None) == "no_active_epoch"
+    assert classify_epoch_lineage(None, None) == "no_active_epoch"
+    assert classify_epoch_lineage(None, "e2") == "unknown"
+    assert classify_epoch_lineage("e2", "e2") == "current"
+    assert classify_epoch_lineage("e1", "e2") == "stale"
+
+
+def test_annotate_reads_active_and_classifies(tmp_path: Path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")  # active (bootstrap)
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")  # candidate
+    rows = [
+        {"generation_index": 1, "evaluator_epoch": e1.epoch_id},
+        {"generation_index": 2, "evaluator_epoch": None},
+    ]
+    out, active = annotate_status_rows(rows, "grid_ctf", reg)
+    assert active == e1.epoch_id
+    assert out[0]["evaluator_epoch_status"] == "current"
+    assert out[1]["evaluator_epoch_status"] == "unknown"
+    # inputs not mutated
+    assert "evaluator_epoch_status" not in rows[0]
+
+
+def test_annotate_stale_after_promotion(tmp_path: Path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")
+    reg.activate("grid_ctf", e2.epoch_id)  # promote e2 -> e1 rows now stale
+    rows = [{"generation_index": 1, "evaluator_epoch": e1.epoch_id}]
+    out, active = annotate_status_rows(rows, "grid_ctf", reg)
+    assert active == e2.epoch_id
+    assert out[0]["evaluator_epoch_status"] == "stale"
+
+
+def test_annotate_no_scenario(tmp_path: Path) -> None:
+    reg = EvaluatorEpochRegistry(tmp_path / "_evaluator_epochs")
+    rows = [{"generation_index": 1, "evaluator_epoch": "e1"}]
+    out, active = annotate_status_rows(rows, None, reg)
+    assert active is None
+    assert out[0]["evaluator_epoch_status"] == "no_active_epoch"

--- a/autocontext/tests/test_service_layer.py
+++ b/autocontext/tests/test_service_layer.py
@@ -62,6 +62,8 @@ class TestRunStatus:
                 "losses": 1,
                 "gate_decision": "advance",
                 "status": "completed",
+                "evaluator_epoch": None,
+                "quarantined": None,
             },
             {
                 "generation_index": 2,
@@ -72,6 +74,8 @@ class TestRunStatus:
                 "losses": 2,
                 "gate_decision": "retry",
                 "status": "running",
+                "evaluator_epoch": None,
+                "quarantined": None,
             },
         ]
 

--- a/docs/ac-885-slice-d1-stale-surfacing-design.md
+++ b/docs/ac-885-slice-d1-stale-surfacing-design.md
@@ -71,7 +71,7 @@ artifacts is deferred to D2.
   ```
   Rows lacking an `evaluator_epoch` key (e.g. a legacy caller) are treated as `evaluator_epoch = None`.
 
-### D1.2: plumbing — carry the epoch through reads
+### D1.2: plumbing (carry the epoch through reads)
 
 - `SQLiteStore.run_status()` (`storage/sqlite_store.py`): add `evaluator_epoch, quarantined` to the
   SELECT column list. The returned dicts gain both keys. This is additive; existing consumers ignore

--- a/docs/ac-885-slice-d1-stale-surfacing-design.md
+++ b/docs/ac-885-slice-d1-stale-surfacing-design.md
@@ -38,7 +38,12 @@ artifacts is deferred to D2.
    `active_for`. The HTTP warning mirrors the existing `stale_score` notebook-warning shape
    (`{warning_type, description, ...}`). The classification names sit alongside the analytics
    `mixed_epoch` concept rather than replacing it.
-5. **Read-only.** No write path, no judge call, no re-score. D1 only reads the registry and renders.
+5. **No score write, no re-score.** D1 adds no scoring, judge call, promotion, or score mutation; it
+   reads the active epoch and renders. Note that "read" here goes through `EvaluatorEpochRegistry`
+   construction and `active_for`, which per that class's own pre-existing contract may create the
+   `_evaluator_epochs` directory, open a per-scenario lock file, take an exclusive `flock` for the
+   duration of the read, and self-heal a multiple-active state by demoting duplicates. D1 newly routes
+   `show`/`status`/`GET /runs/{id}/status` through that path; it does not itself write scores or epochs.
 
 ## Architecture
 

--- a/docs/ac-885-slice-d1-stale-surfacing-design.md
+++ b/docs/ac-885-slice-d1-stale-surfacing-design.md
@@ -43,7 +43,7 @@ artifacts is deferred to D2.
    construction and `active_for`, which per that class's own pre-existing contract may create the
    `_evaluator_epochs` directory, open a per-scenario lock file, take an exclusive `flock` for the
    duration of the read, and self-heal a multiple-active state by demoting duplicates. D1 newly routes
-   `show`/`status`/`GET /runs/{id}/status` through that path; it does not itself write scores or epochs.
+   `show`/`status`/`GET /api/cockpit/runs/{id}/status` through that path; it does not itself write scores or epochs.
 
 ## Architecture
 
@@ -95,7 +95,7 @@ hand); `status` must additionally call `store.get_run(run_id)` to obtain the sce
   quarantined, print a single yellow warning line after the table naming the active epoch (short
   8-char prefix) so the operator knows the numbers are not directly comparable.
 
-### D1.4: Python HTTP render (`GET /runs/{run_id}/status`)
+### D1.4: Python HTTP render (`GET /api/cockpit/runs/{run_id}/status`)
 
 `server/cockpit_api.py` already has the run's scenario. Add `_get_epoch_registry(request)` (mirrors
 `_get_artifacts`, builds the registry from `app.state.app_settings.knowledge_root`). Extend the inline
@@ -123,7 +123,7 @@ operator: autoctx show <run_id> --json
        -> active = registry.active_for(scenario); each row.evaluator_epoch_status = classify(...)
   -> JSON: generations[].{evaluator_epoch, evaluator_epoch_status, quarantined}, active_evaluator_epoch
 
-GET /runs/{id}/status
+GET /api/cockpit/runs/{id}/status
   -> same annotate -> generations[] + active_evaluator_epoch + warnings[stale_epoch...]
 ```
 
@@ -135,8 +135,11 @@ GET /runs/{id}/status
   not counted as stale, no warning.
 - **Registry read failure** in the CLI/HTTP: surfaces as the normal command/endpoint error; this is an
   operator read path, not the score-persist hot path, so it does not need to fail closed.
-- **`status` without a run** / unknown scenario: `get_run` returns None -> existing not-found handling;
-  when scenario is None, annotation yields `no_active_epoch` for all rows.
+- **`show` on a missing run:** returns the existing not-found error (prints the message, exits 1).
+- **`status` on a missing run:** preserves the pre-D1 behavior of exiting 0 with an empty `generations`
+  list. `get_run` returns None so `scenario` is None, `active_evaluator_epoch` is null, and there are no
+  rows to classify. `status` deliberately does NOT raise not-found (a fresh-workspace bootstrap must not
+  crash); `show` is the not-found surface.
 
 ## Testing
 
@@ -147,7 +150,7 @@ GET /runs/{id}/status
 - **Regression (AC requirement):** seed a generation under epoch e1 (active in the registry), promote
   e2 active, assert `show`/`status` (and the HTTP handler) flag the e1 generation `stale` and report
   `active_evaluator_epoch == e2`.
-- HTTP: `GET /runs/{id}/status` includes the fields, `active_evaluator_epoch`, and a `stale_epoch`
+- HTTP: `GET /api/cockpit/runs/{id}/status` includes the fields, `active_evaluator_epoch`, and a `stale_epoch`
   warning when a generation is stale.
 - TS: `RunInspectionGeneration` / `formatGenerationStatus` now carry `evaluator_epoch` + `quarantined`.
 - Existing gates: module-size, gate-taxonomy, ruff/mypy, tsc/lint, cli-contract parity (unchanged: no

--- a/docs/ac-885-slice-d1-stale-surfacing-design.md
+++ b/docs/ac-885-slice-d1-stale-surfacing-design.md
@@ -1,0 +1,172 @@
+# AC-885 Slice D1: stale-epoch surfacing (read-only)
+
+Date: 2026-07-10
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: sub-slice D1 of Slice D. Slice 1, B, C1, C2, C3 are merged (#1204, #1208, #1210, #1211, #1212).
+
+## Purpose
+
+Slices 1 through C3 built evaluator-epoch identity, persisted lineage, the per-scenario registry, the
+promotion workflow, and training-export enforcement. What remains from the AC-885 acceptance criteria
+("Reports and exports distinguish active-epoch scores from stale-epoch scores"; "surface stale
+evaluator lineage in CLI/API/dashboard outputs") is that an operator reading a finished run cannot see
+whether a generation's score is still comparable to the scenario's active evaluator epoch. The score
+row already persists `evaluator_epoch` and `quarantined`, but every read/render surface drops them.
+
+D1 surfaces that lineage read-only. It does not re-score anything: lazy re-score / revalidation of raw
+artifacts is deferred to D2.
+
+## Decisions of record
+
+1. **Staleness is a four-state classification, not a boolean.** A pure `classify_epoch_lineage`
+   returns `current` / `stale` / `unknown` / `no_active_epoch`. Only `stale` (both row and active
+   epoch non-null and different, per `are_comparable`) is warning-worthy. A `None` row epoch is
+   `unknown` (legacy / pre-slice, or a game/no-judge run), never `stale`, so old runs and tournament
+   scores are not flooded with false warnings. When the scenario has no promoted active epoch the
+   state is `no_active_epoch` and nothing is asserted. This honors the documented null-legacy rule.
+2. **Fix the epoch-drop at the plumbing layer once.** `SQLiteStore.run_status()` currently SELECTs an
+   explicit column list that omits the epoch; extend it to carry `evaluator_epoch` + the already-
+   persisted `quarantined` bit. That single fix feeds CLI `show`/`status`/`watch` together. The HTTP
+   handler has its own inline SQL and is extended in parallel.
+3. **Python surfaces are full; TS surfaces carry the field only.** The evaluator-epoch registry is
+   Python-only (C1/C2/C3 all marked TS `intentional_gap`), so TS has no active epoch to classify
+   against. D1 fixes the TS DTO mappers to stop dropping the persisted `evaluator_epoch` / `quarantined`
+   fields (parity of shape), but the stale-vs-active classification and warnings stay Python-only, a
+   documented intentional gap consistent with the prior slices. No registry is ported to TS.
+4. **Reuse existing vocabulary, do not invent.** The comparison reuses `are_comparable` +
+   `active_for`. The HTTP warning mirrors the existing `stale_score` notebook-warning shape
+   (`{warning_type, description, ...}`). The classification names sit alongside the analytics
+   `mixed_epoch` concept rather than replacing it.
+5. **Read-only.** No write path, no judge call, no re-score. D1 only reads the registry and renders.
+
+## Architecture
+
+### D1.1: staleness classifier + registry-aware annotator
+
+- Pure classifier in `execution/evaluator_epoch.py` (co-located with `are_comparable`, a leaf module):
+  ```python
+  EpochLineageStatus = Literal["current", "stale", "unknown", "no_active_epoch"]
+
+  def classify_epoch_lineage(row_epoch: str | None, active_epoch: str | None) -> EpochLineageStatus:
+      if active_epoch is None:
+          return "no_active_epoch"
+      if row_epoch is None:
+          return "unknown"
+      return "current" if are_comparable(row_epoch, active_epoch) else "stale"
+  ```
+- Registry-aware annotator in a NEW module `execution/epoch_lineage.py` (imports both the classifier
+  and the registry, so it cannot live in the leaf `evaluator_epoch.py` without a cycle):
+  ```python
+  def annotate_status_rows(
+      rows: list[dict[str, Any]],
+      scenario: str | None,
+      registry: EvaluatorEpochRegistry,
+  ) -> tuple[list[dict[str, Any]], str | None]:
+      """Return (rows each with an added ``evaluator_epoch_status`` key, active_epoch_id).
+
+      Reads the scenario's active epoch ONCE, then classifies each row. Returns copies; does not
+      mutate the inputs. ``scenario is None`` -> active_epoch None -> every row ``no_active_epoch``.
+      """
+  ```
+  Rows lacking an `evaluator_epoch` key (e.g. a legacy caller) are treated as `evaluator_epoch = None`.
+
+### D1.2: plumbing — carry the epoch through reads
+
+- `SQLiteStore.run_status()` (`storage/sqlite_store.py`): add `evaluator_epoch, quarantined` to the
+  SELECT column list. The returned dicts gain both keys. This is additive; existing consumers ignore
+  the extra keys.
+
+### D1.3: Python CLI render (`show`, `status`)
+
+Both build a registry from settings (`EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")`)
+and call `annotate_status_rows` with the run's scenario. `show` already loads `run` (scenario in
+hand); `status` must additionally call `store.get_run(run_id)` to obtain the scenario.
+
+- `--json`: each generation dict gains `evaluator_epoch`, `evaluator_epoch_status`, `quarantined`
+  (as a bool); top-level payload gains `active_evaluator_epoch`.
+- rich table: add one compact `Lineage` column rendering `ok` (current) / `stale` / `legacy`
+  (unknown) / `-` (no_active_epoch), and mark quarantined rows. When any row is `stale` or
+  quarantined, print a single yellow warning line after the table naming the active epoch (short
+  8-char prefix) so the operator knows the numbers are not directly comparable.
+
+### D1.4: Python HTTP render (`GET /runs/{run_id}/status`)
+
+`server/cockpit_api.py` already has the run's scenario. Add `_get_epoch_registry(request)` (mirrors
+`_get_artifacts`, builds the registry from `app.state.app_settings.knowledge_root`). Extend the inline
+generation SQL to select `evaluator_epoch, quarantined`; each generation dict gains
+`evaluator_epoch`, `evaluator_epoch_status`, `quarantined`. The response gains `active_evaluator_epoch`
+and a `warnings` list with one `{warning_type: "stale_epoch", generation, evaluator_epoch,
+active_evaluator_epoch, description}` entry per stale generation (mirrors the `stale_score` shape).
+
+### D1.5: TS DTO carry (no classification)
+
+- `ts/src/cli/run-inspection-command-workflow.ts`: add `evaluator_epoch: string | null` and
+  `quarantined: number | null` to the `RunInspectionGeneration` interface and carry them from the
+  source `GenerationRow` in the mapper (the row already supplies them via `SELECT *`). JSON output
+  then includes the persisted lineage instead of silently dropping it.
+- `ts/src/server/cockpit-api.ts`: `formatGenerationStatus` carries `evaluator_epoch` + `quarantined`.
+- No active-epoch classification, no warnings on TS (registry is Python-only; documented gap).
+
+## Data flow
+
+```
+operator: autoctx show <run_id> --json
+  -> store.get_run -> scenario
+  -> store.run_status -> rows carrying evaluator_epoch + quarantined
+  -> annotate_status_rows(rows, scenario, EvaluatorEpochRegistry(...))
+       -> active = registry.active_for(scenario); each row.evaluator_epoch_status = classify(...)
+  -> JSON: generations[].{evaluator_epoch, evaluator_epoch_status, quarantined}, active_evaluator_epoch
+
+GET /runs/{id}/status
+  -> same annotate -> generations[] + active_evaluator_epoch + warnings[stale_epoch...]
+```
+
+## Error handling and edge cases
+
+- **No active epoch for the scenario** (registry empty, or a game/no-judge run): every row classifies
+  `no_active_epoch`; no warning banner; `active_evaluator_epoch` is null.
+- **Legacy rows** (`evaluator_epoch` null) with an active epoch present: `unknown`, rendered `legacy`,
+  not counted as stale, no warning.
+- **Registry read failure** in the CLI/HTTP: surfaces as the normal command/endpoint error; this is an
+  operator read path, not the score-persist hot path, so it does not need to fail closed.
+- **`status` without a run** / unknown scenario: `get_run` returns None -> existing not-found handling;
+  when scenario is None, annotation yields `no_active_epoch` for all rows.
+
+## Testing
+
+- Unit (`classify_epoch_lineage`): the four states, including legacy-None -> `unknown`, both-None or
+  no-active -> `no_active_epoch`, equal -> `current`, differ -> `stale`.
+- Unit (`annotate_status_rows`): reads active once, annotates each row, returns copies, handles
+  `scenario=None`.
+- **Regression (AC requirement):** seed a generation under epoch e1 (active in the registry), promote
+  e2 active, assert `show`/`status` (and the HTTP handler) flag the e1 generation `stale` and report
+  `active_evaluator_epoch == e2`.
+- HTTP: `GET /runs/{id}/status` includes the fields, `active_evaluator_epoch`, and a `stale_epoch`
+  warning when a generation is stale.
+- TS: `RunInspectionGeneration` / `formatGenerationStatus` now carry `evaluator_epoch` + `quarantined`.
+- Existing gates: module-size, gate-taxonomy, ruff/mypy, tsc/lint, cli-contract parity (unchanged: no
+  new commands), schema-parity (unchanged: no new columns), lockfiles unchanged.
+
+## Documentation
+
+Extend `docs/evaluator-epochs.md` with a "Slice D1: stale surfacing" subsection: the four-state
+classification, the Python-full / TS-field-only asymmetry, the `stale_epoch` HTTP warning, and that
+lazy re-score is D2. CHANGELOG entry (additive output fields on `show`/`status`/`run_status`).
+
+## Deferred / out of scope (D2 and beyond)
+
+- Lazy re-score / revalidation of raw artifacts when a stale scored record is touched (D2).
+- Porting the evaluator-epoch registry to TypeScript (classification stays Python-only).
+- A separate web dashboard frontend (the cockpit HTTP API is the dashboard backend and is covered).
+- Surfacing epoch lineage on `list` (run-level; epoch is per-generation) or `replay` (raw replay JSON).
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 "surface stale evaluator lineage in CLI/API/dashboard outputs so operators know when numbers
+  are not directly comparable": `show`/`status`/`run_status` render the four-state lineage + active
+  epoch + stale warnings.
+- AC-885 "Reports and exports distinguish active-epoch scores from stale-epoch scores": the CLI/API
+  render distinguishes `current` from `stale` (exports were handled in C3).
+- AC-885 "At least one regression test demonstrates that a record scored under an old evaluator is
+  flagged after a new evaluator epoch is promoted": the promote-then-flag regression test.

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -301,6 +301,61 @@ promote stage declining to act on a quarantined-only signal), is still deferred,
 `promote.py`'s cross-anchor refusal onto this path. Slice C3 lands the operator-facing trigger and the
 training-export enforcement; the autonomous ambient trigger and the remaining refusals follow later.
 
+## Slice D1: stale surfacing
+
+Slices 1 through C3 built the epoch identity, the persisted lineage, the per-scenario registry, and
+the promotion workflow, but every read surface still dropped `evaluator_epoch` and `quarantined`
+before it reached an operator. Slice D1 closes that gap, read-only: an operator looking at a
+finished run can now see whether a generation's score is still comparable to the scenario's active
+evaluator epoch. It does not re-score or revalidate anything; that lazy re-score of raw artifacts is
+deferred to D2 (see "Deferred slices" below).
+
+**The four-state classification.** `classify_epoch_lineage(row_epoch, active_epoch)`
+(`execution/evaluator_epoch.py`) is a pure function returning one of `current`, `stale`, `unknown`,
+`no_active_epoch`:
+
+- `no_active_epoch`: the scenario has no promoted active epoch (nothing to compare against, for
+  example a game or no-judge run). Nothing is asserted.
+- `unknown`: an active epoch exists, but the row carries no epoch of its own. This is a legacy or
+  pre-slice row, not a stale one, and it is deliberately not flagged: a `None` row epoch is `unknown`,
+  never `stale`, so old runs and tournament scores are not flooded with false warnings.
+- `current`: both epochs are known and equal (per `are_comparable`).
+- `stale`: both epochs are known and different. This is the only warning-worthy state.
+
+A registry-aware `annotate_status_rows(rows, scenario, registry)` (new module
+`execution/epoch_lineage.py`, kept separate from the leaf `evaluator_epoch.py` because it depends on
+`EvaluatorEpochRegistry` and co-locating would cycle) reads the scenario's active epoch once, then
+classifies each row and returns annotated copies without mutating the input.
+
+**Fields added to the read surfaces.** `SQLiteStore.run_status()` now carries `evaluator_epoch` and
+`quarantined` in every generation row it returns, which is the single plumbing fix that feeds the CLI
+`show` and `status` commands. Both commands' `--json` output gains, per generation,
+`evaluator_epoch`, `evaluator_epoch_status`, and `quarantined` (as a bool), plus a top-level
+`active_evaluator_epoch`. The rich table gains a compact `Lineage` column rendering `ok` (current),
+`stale`, `legacy` (unknown), or `-` (no active epoch), with quarantined rows marked; when any row is
+stale or quarantined, a single yellow warning line prints after the table naming the active epoch's
+short prefix.
+
+**The HTTP `stale_epoch` warning.** `GET /runs/{run_id}/status` (the cockpit API) carries the same
+per-generation fields plus `active_evaluator_epoch`, and adds a `warnings` list with one entry per
+stale generation, shaped like the existing `stale_score` warning:
+
+```
+{"warning_type": "stale_epoch", "generation": ..., "evaluator_epoch": ..., "active_evaluator_epoch": ..., "description": "..."}
+```
+
+**Python-full, TS-field-only.** The evaluator-epoch registry is Python-only (the C1/C2/C3 sections
+above each mark the TS side an intentional gap), so TS has no active epoch to classify against. Slice
+D1 fixes the TS DTO mappers (`RunInspectionGeneration` in `run-inspection-command-workflow.ts`, and
+`formatGenerationStatus` in `cockpit-api.ts`) to stop dropping the persisted `evaluator_epoch` and
+`quarantined` fields, so the shape is at parity. The stale-vs-active classification and the
+`stale_epoch` warning stay Python-only: this is a documented, intentional gap consistent with the
+prior slices, not an oversight.
+
+**What remains deferred.** Slice D1 is read-only surfacing. Lazy re-score, that is, revalidating a
+raw artifact and recomputing its score when a stale scored record is actually touched, is Slice D2
+and is not implemented here.
+
 ## Relationship to the ambient `eval_fingerprint` / `anchor_model`
 
 autocontext already had this mechanism, but only in the ambient trainer. `eval_fingerprint()`
@@ -332,3 +387,6 @@ The remaining slices are explicitly deferred, not dropped:
   land in C2 and C3.
 - **Slice D (surfacing + lazy re-score):** stale-epoch warnings in CLI / status / replay, REST /
   API, and dashboard, plus lazy revalidation of raw artifacts when a stale scored record is touched.
+  D1 (read-only surfacing: the four-state classification, the `show` / `status` / `run_status`
+  fields, and the `stale_epoch` HTTP warning) is shipped, see "Slice D1: stale surfacing" above. D2
+  (lazy re-score / revalidation of raw artifacts) remains.

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -336,7 +336,7 @@ classifies each row and returns annotated copies without mutating the input.
 stale or quarantined, a single yellow warning line prints after the table naming the active epoch's
 short prefix.
 
-**The HTTP `stale_epoch` warning.** `GET /runs/{run_id}/status` (the cockpit API) carries the same
+**The HTTP `stale_epoch` warning.** `GET /api/cockpit/runs/{run_id}/status` (the cockpit API) carries the same
 per-generation fields plus `active_evaluator_epoch`, and adds a `warnings` list with one entry per
 stale generation, shaped like the existing `stale_score` warning:
 

--- a/ts/src/cli/run-inspection-command-workflow.ts
+++ b/ts/src/cli/run-inspection-command-workflow.ts
@@ -54,6 +54,8 @@ export interface RunInspectionGeneration {
   gate_decision: string;
   status: string;
   duration_seconds: number | null;
+  evaluator_epoch: string | null;
+  quarantined: number | null;
   created_at: string;
   updated_at: string;
 }

--- a/ts/src/server/cockpit-api.ts
+++ b/ts/src/server/cockpit-api.ts
@@ -305,6 +305,8 @@ function formatGenerationStatus(generation: GenerationRow): Record<string, unkno
     gate_decision: generation.gate_decision,
     status: generation.status,
     duration_seconds: generation.duration_seconds,
+    evaluator_epoch: generation.evaluator_epoch ?? null,
+    quarantined: generation.quarantined ?? null,
   };
 }
 

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -963,10 +963,41 @@ describe("HTTP API — cockpit", () => {
           generation: 1,
           best_score: 0.7,
           elo: 1050,
+          evaluator_epoch: null,
+          quarantined: null,
         }),
       ],
     });
     expectTestRunRuntimeSessionDiscovery(body);
+  });
+
+  it("GET /api/cockpit/runs/:run_id/status carries evaluator_epoch and quarantined lineage", async () => {
+    const { SQLiteStore } = await import("../src/storage/index.js");
+    const store = new SQLiteStore(join(dir, "test.db"));
+    store.upsertGeneration("test-run-1", 1, {
+      meanScore: 0.65,
+      bestScore: 0.7,
+      elo: 1050,
+      wins: 3,
+      losses: 2,
+      gateDecision: "advance",
+      status: "completed",
+      evaluatorEpoch: "epoch-abc",
+      quarantined: 1,
+    });
+
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/status`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      generations: [
+        expect.objectContaining({
+          generation: 1,
+          evaluator_epoch: "epoch-abc",
+          quarantined: 1,
+        }),
+      ],
+    });
   });
 
   it("GET /api/cockpit/runs/:run_id/context-selection returns telemetry cards", async () => {

--- a/ts/tests/run-inspection-command-workflow.test.ts
+++ b/ts/tests/run-inspection-command-workflow.test.ts
@@ -28,6 +28,8 @@ const generations = [
     gate_decision: "advance",
     status: "completed",
     duration_seconds: 1,
+    evaluator_epoch: null,
+    quarantined: null,
     created_at: "2026-04-30T00:00:10Z",
     updated_at: "2026-04-30T00:00:20Z",
   },
@@ -39,6 +41,8 @@ const generations = [
     gate_decision: "advance",
     status: "completed",
     duration_seconds: 1,
+    evaluator_epoch: "epoch-2",
+    quarantined: 1,
     created_at: "2026-04-30T00:00:30Z",
     updated_at: "2026-04-30T00:00:40Z",
   },
@@ -104,6 +108,24 @@ describe("run inspection command workflow", () => {
     );
 
     expect(payload.runtime_session.session_id).toBe("run:run-123:runtime");
+  });
+
+  it("carries evaluator_epoch and quarantined lineage fields in show JSON", () => {
+    const payload = JSON.parse(
+      renderRunShow(run, generations, { best: true, json: true }, runtimeSession),
+    );
+
+    expect(payload.generation.evaluator_epoch).toBe("epoch-2");
+    expect(payload.generation.quarantined).toBe(1);
+  });
+
+  it("carries null lineage fields through show JSON", () => {
+    const payload = JSON.parse(
+      renderRunShow(run, generations, { generation: "1", json: true }, runtimeSession),
+    );
+
+    expect(payload.generation.evaluator_epoch).toBeNull();
+    expect(payload.generation.quarantined).toBeNull();
   });
 
   it("validates watch intervals", () => {


### PR DESCRIPTION
## AC-885 Slice D1: stale-epoch surfacing (read-only)

First sub-slice of Slice D. Slices 1/B/C1/C2/C3 are merged (#1204, #1208, #1210, #1211, #1212). Score rows already persist `evaluator_epoch` + `quarantined`, but every read/render surface dropped them, so an operator reading a finished run could not see whether a generation's score is still comparable to its scenario's active evaluator epoch. D1 surfaces that lineage read-only. It re-scores nothing; lazy re-score / revalidation is deferred to D2.

### What this adds

**1. A four-state staleness classifier (not a boolean).** `classify_epoch_lineage(row_epoch, active_epoch)` in `execution/evaluator_epoch.py` returns `current` / `stale` / `unknown` / `no_active_epoch`. Only `stale` (both epochs non-null and different, per `are_comparable`) is warning-worthy. A `None` row epoch is `unknown` (legacy/pre-slice, or game/no-judge runs), never `stale`, so old runs and tournament scores are not flooded with false warnings; `no_active_epoch` when the scenario has no promoted epoch. A registry-aware `annotate_status_rows` (new `execution/epoch_lineage.py`) reads the scenario's active epoch once and classifies each row.

**2. Plumbing.** `SQLiteStore.run_status()` now carries `evaluator_epoch` + `quarantined` (was dropped by an explicit-column SELECT). This single fix feeds CLI `show`/`status` together.

**3. Python CLI (`show`, `status`).** `--json` gains per-generation `evaluator_epoch`, `evaluator_epoch_status`, `quarantined` (bool) and top-level `active_evaluator_epoch`; the rich table gains a `Lineage` column (`ok`/`stale`/`legacy`/`-`) plus a one-line warning when any stale/quarantined generation is present. A shared helper builds the registry and annotates, reused by both commands.

**4. HTTP cockpit (`GET /runs/{run_id}/status`, the dashboard backend).** Same per-generation fields + `active_evaluator_epoch` + a `warnings` list with `{"warning_type": "stale_epoch", ...}` per stale generation (mirrors the existing `stale_score` warning shape). The lineage view was extracted to `server/run_status_lineage.py` to keep `cockpit_api.py` under its module-size limit.

**5. TS parity (deliberately asymmetric, consistent with C1-C3).** The evaluator-epoch registry is Python-only, so TS has no active epoch to classify against. TS stops dropping the persisted `evaluator_epoch` / `quarantined` fields in its generation DTOs (`RunInspectionGeneration`, `formatGenerationStatus`), but the stale-vs-active classification and warnings stay Python-only, a documented intentional gap. No registry ported.

### Behavior

Additive only: existing JSON keys and rich columns are preserved; new fields/columns are added. Read-only: no scoring, judge call, promotion, or score mutation (reads go through `active_for`, whose own contract may lock and self-heal a multiple-active state; documented in the design doc).

### Acceptance criteria advanced

- "surface stale evaluator lineage in CLI/API/dashboard outputs": `show`/`status`/`run_status` render the four-state lineage + active epoch + stale warnings.
- "Reports and exports distinguish active-epoch scores from stale-epoch scores": CLI/API distinguish `current` from `stale` (exports were C3).
- "at least one regression test demonstrates a record scored under an old evaluator is flagged after a new epoch is promoted": `test_cli_stale_epoch_surfacing.py` + `test_cockpit_stale_epoch.py` (seed under e1, promote e2, assert `stale`).

### Deferred (D2)

Lazy re-score / revalidation of raw artifacts when a stale record is touched.

### Review

Built subagent-driven (fresh opus implementer per task; per-task reviews sized to each diff; opus whole-branch review). Reviews caught and fixed: a full-dict-equality break in `test_service_layer.py` from the added `run_status` keys; two per-task Minors; and the whole-branch reviewer's note that decision #5's "read-only" wording overstated `active_for` (fixed in doc + docstring). The FULL Python suite (run before opening this PR, not just touched-area gates) then caught two more: `cockpit_api.py` crossing the 800-line module-size limit (fixed by the `run_status_lineage.py` extraction, now 789) and the status-json full-dict-equality test needing the additive `active_evaluator_epoch` key.

Local gates green: full Python suite, full TS suite (tsc + vitest + lint), module-size, serde-convention, cli-contract parity (unchanged: no new commands), schema-parity (unchanged: no new columns). `uv.lock` untouched, no em dashes in added lines.

Left open for review; do not merge without authorization.
