### PR TITLE
AC-885 Slice D2a: on-demand re-score / revalidation (report-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ All notable changes to this project will be documented in this file.
   `evaluator_epoch`/`quarantined` fields but do not classify staleness (the registry stays
   Python-only, a documented gap consistent with prior sub-slices). Lazy re-score of stale records
   remains deferred to Slice D2.
+- AC-885 Slice D2a: on-demand re-score (report-only). A new `autoctx rescore <run_id> [--generation N]`
+  command re-runs the current evaluator against a stale generation's original stored competitor
+  artifact and reports the old-vs-new score and epoch, including whether the fresh epoch matches the
+  scenario's active one. It writes nothing (no `upsert_generation`, no registry write, no quarantine
+  clear) and degrades every failure mode (no artifact, no active epoch, no evaluator, a scorer error)
+  to a per-generation skip status rather than crashing. Persisting a re-score is deferred to Slice D2b.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -32,6 +32,7 @@ from autocontext.cli_new_scenario import register_new_scenario_command
 from autocontext.cli_package_commands import register_package_commands
 from autocontext.cli_probes import register_probes_command
 from autocontext.cli_queue import register_queue_command
+from autocontext.cli_rescore import rescore_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_run_inspect import (
     _lineage_cell,
@@ -1228,6 +1229,7 @@ register_self_improve_command(app, console)
 register_share_command(app, console=console)
 register_train_command(app, console)
 register_worker_command(app, console=console)
+app.command("rescore")(rescore_command)
 
 
 if __name__ == "__main__":

--- a/autocontext/src/autocontext/cli_rescore.py
+++ b/autocontext/src/autocontext/cli_rescore.py
@@ -31,6 +31,20 @@ _console = Console()
 ScoreFn = Callable[[str], tuple[float | None, str | None]]
 
 
+def _emit_error(message: str, json_output: bool) -> None:
+    """Report a not-found error via the CLI's JSON-or-Rich convention.
+
+    Under ``--json`` this writes ``{"error": message}`` to stderr (matching ``_write_json_stderr`` in
+    ``cli``, replicated here to avoid importing ``cli`` at module load, which would cycle).
+    """
+    if json_output:
+        import sys
+
+        sys.stderr.write(json.dumps({"error": message}) + "\n")
+    else:
+        _console.print(f"[red]{message}[/red]")
+
+
 def _store(settings: AppSettings) -> SQLiteStore:
     from pathlib import Path
 
@@ -124,11 +138,7 @@ def rescore_command(
     store = _store(settings)
     run = store.get_run(run_id)
     if run is None:
-        message = f"run {run_id!r} not found"
-        if json_output:
-            typer.echo(message, err=True)
-        else:
-            _console.print(f"[red]{message}[/red]")
+        _emit_error(f"run {run_id!r} not found", json_output)
         raise typer.Exit(code=1)
 
     scenario = run.get("scenario")
@@ -137,14 +147,12 @@ def rescore_command(
 
     rows = store.run_status(run_id)
     if generation is not None and not any(r["generation_index"] == generation for r in rows):
-        message = f"run {run_id!r} has no generation {generation}"
-        if json_output:
-            typer.echo(message, err=True)
-        else:
-            _console.print(f"[red]{message}[/red]")
+        _emit_error(f"run {run_id!r} has no generation {generation}", json_output)
         raise typer.Exit(code=1)
 
     targets = _select_rows(rows, generation, active_epoch)
+    # One competitor output per generation on the solve path. If a generation has more than one
+    # (a tournament re-append), keep the last by rowid, matching training-export's _get_competitor_outputs.
     artifacts = {o["generation_index"]: o["content"] for o in store.get_agent_outputs_by_role(run_id, "competitor")}
 
     reports = [

--- a/autocontext/src/autocontext/cli_rescore.py
+++ b/autocontext/src/autocontext/cli_rescore.py
@@ -1,0 +1,172 @@
+"""``autoctx rescore <run_id> [--generation N] [--json]`` (AC-885 Slice D2a).
+
+Re-score a stale generation's ORIGINAL competitor artifact under the CURRENT evaluator and report the
+old-vs-new score + epoch. Report-only: this command writes nothing (no upsert_generation, no registry
+write, no quarantine clear). Re-scoring goes through the scenario task's own ``evaluate_output`` (the
+production path), so the score is faithful; the whole thing is fail-safe via ``revalidate_one``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from autocontext.config import load_settings
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+from autocontext.execution.rescore import GenerationRevalidation, revalidate_one
+from autocontext.scenarios import SCENARIO_REGISTRY
+
+if TYPE_CHECKING:
+    from autocontext.config.settings import AppSettings
+    from autocontext.storage.sqlite_store import SQLiteStore
+
+_console = Console()
+
+ScoreFn = Callable[[str], tuple[float | None, str | None]]
+
+
+def _store(settings: AppSettings) -> SQLiteStore:
+    from pathlib import Path
+
+    from autocontext.storage.sqlite_store import SQLiteStore
+
+    store = SQLiteStore(settings.db_path)
+    store.migrate(Path(__file__).resolve().parents[2] / "migrations")
+    return store
+
+
+def _active_epoch(settings: AppSettings, scenario: str | None) -> str | None:
+    """Return the active evaluator epoch id for ``scenario`` (registry read-only), or None."""
+    if not scenario:
+        return None
+    registry = EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
+    record = registry.active_for(scenario)
+    return record.epoch_id if record is not None else None
+
+
+def _build_score_fn(scenario: str, settings: AppSettings) -> ScoreFn | None:
+    """Build a re-scoring closure over the scenario task's own ``evaluate_output``.
+
+    Returns None when the scenario is not an agent-task (no reconstructable rubric judge). Imports
+    ``_is_agent_task`` lazily from ``cli`` to avoid a circular import (``cli`` imports this module to
+    register the command).
+    """
+    from autocontext.cli import _is_agent_task
+
+    if not _is_agent_task(scenario):
+        return None
+    task = SCENARIO_REGISTRY[scenario]()
+    state = task.prepare_context(task.initial_state())
+
+    def score_fn(artifact: str) -> tuple[float | None, str | None]:
+        result = task.evaluate_output(artifact, state)
+        return result.score, result.evaluator_epoch
+
+    return score_fn
+
+
+def _is_stale(row: dict[str, Any], active_epoch: str | None) -> bool:
+    epoch = row.get("evaluator_epoch")
+    return epoch is not None and active_epoch is not None and epoch != active_epoch
+
+
+def _select_rows(
+    rows: list[dict[str, Any]],
+    generation: int | None,
+    active_epoch: str | None,
+) -> list[dict[str, Any]]:
+    """Choose the generations to report on.
+
+    ``--generation N`` targets that single row. Otherwise: with no active epoch, report every row (each
+    surfaces ``skipped_no_active_epoch``); with an active epoch, report only the stale rows.
+    """
+    if generation is not None:
+        return [r for r in rows if r["generation_index"] == generation]
+    if active_epoch is None:
+        return rows
+    return [r for r in rows if _is_stale(r, active_epoch)]
+
+
+def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None) -> None:
+    active8 = active_epoch[:8] if active_epoch else "none"
+    table = Table(title=f"Re-score (active epoch {active8}...)")
+    table.add_column("Gen", justify="right")
+    table.add_column("Status")
+    table.add_column("Old score", justify="right")
+    table.add_column("New score", justify="right")
+    table.add_column("Delta", justify="right")
+    table.add_column("Stale")
+    for rep in reports:
+        old = "-" if rep.original_score is None else f"{rep.original_score:.3f}"
+        new = "-" if rep.new_score is None else f"{rep.new_score:.3f}"
+        delta = "-" if rep.score_delta is None else f"{rep.score_delta:+.3f}"
+        table.add_row(str(rep.generation_index), rep.status, old, new, delta, "yes" if rep.was_stale else "no")
+    _console.print(table)
+    revalidated = sum(1 for r in reports if r.status == "revalidated")
+    _console.print(f"[dim]{revalidated} of {len(reports)} generation(s) re-scored; nothing was written.[/dim]")
+
+
+def rescore_command(
+    run_id: str = typer.Argument(..., help="Run to re-score"),
+    generation: int | None = typer.Option(
+        None, "--generation", min=1, help="Re-score a single generation by index (default: all stale rows)"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
+) -> None:
+    """Re-score stale generations under the current evaluator and report drift (read-only)."""
+    settings = load_settings()
+    store = _store(settings)
+    run = store.get_run(run_id)
+    if run is None:
+        message = f"run {run_id!r} not found"
+        if json_output:
+            typer.echo(message, err=True)
+        else:
+            _console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+
+    scenario = run.get("scenario")
+    active_epoch = _active_epoch(settings, scenario)
+    score_fn = _build_score_fn(scenario, settings) if scenario else None
+
+    rows = store.run_status(run_id)
+    if generation is not None and not any(r["generation_index"] == generation for r in rows):
+        message = f"run {run_id!r} has no generation {generation}"
+        if json_output:
+            typer.echo(message, err=True)
+        else:
+            _console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+
+    targets = _select_rows(rows, generation, active_epoch)
+    artifacts = {o["generation_index"]: o["content"] for o in store.get_agent_outputs_by_role(run_id, "competitor")}
+
+    reports = [
+        revalidate_one(
+            r["generation_index"],
+            original_score=r.get("best_score"),
+            original_epoch=r.get("evaluator_epoch"),
+            active_epoch=active_epoch,
+            artifact=artifacts.get(r["generation_index"]),
+            score_fn=score_fn,
+        )
+        for r in targets
+    ]
+
+    if json_output:
+        payload = {
+            "run_id": run_id,
+            "scenario": scenario,
+            "active_evaluator_epoch": active_epoch,
+            "generations": [asdict(rep) for rep in reports],
+        }
+        typer.echo(json.dumps(payload))
+        return
+
+    _print_table(reports, active_epoch)

--- a/autocontext/src/autocontext/cli_rescore.py
+++ b/autocontext/src/autocontext/cli_rescore.py
@@ -1,9 +1,12 @@
 """``autoctx rescore <run_id> [--generation N] [--json]`` (AC-885 Slice D2a).
 
 Re-score a stale generation's ORIGINAL competitor artifact under the CURRENT evaluator and report the
-old-vs-new score + epoch. Report-only: this command writes nothing (no upsert_generation, no registry
-write, no quarantine clear). Re-scoring goes through the scenario task's own ``evaluate_output`` (the
-production path), so the score is faithful; the whole thing is fail-safe via ``revalidate_one``.
+old-vs-new score + epoch. This command writes no score, generation, or evaluator-epoch lineage data: it
+performs no ``upsert_generation``, no registry activation/promotion, and no quarantine clear. (Like every
+other inspect command it opens the existing sqlite store, and it runs the configured evaluator hooks so
+the re-score reproduces the production evaluator; it does not create a database for a missing run.)
+Re-scoring goes through the scenario task's own ``evaluate_output`` (the production path) inside the
+configured hook bus, so the score is faithful; the whole thing is fail-safe via ``revalidate_one``.
 """
 
 from __future__ import annotations
@@ -45,18 +48,26 @@ def _emit_error(message: str, json_output: bool) -> None:
         _console.print(f"[red]{message}[/red]")
 
 
-def _store(settings: AppSettings) -> SQLiteStore:
+def _open_store(settings: AppSettings) -> SQLiteStore | None:
+    """Open the existing sqlite store read side, or None when the database does not exist.
+
+    Report-only: a missing-run invocation must not CREATE a database. Returning None lets the caller
+    surface not-found without materializing an empty store (migrate is applied only to a database that
+    already exists, where it is idempotent and writes nothing new).
+    """
     from pathlib import Path
 
     from autocontext.storage.sqlite_store import SQLiteStore
 
+    if not settings.db_path.exists():
+        return None
     store = SQLiteStore(settings.db_path)
     store.migrate(Path(__file__).resolve().parents[2] / "migrations")
     return store
 
 
 def _active_epoch(settings: AppSettings, scenario: str | None) -> str | None:
-    """Return the active evaluator epoch id for ``scenario`` (registry read-only), or None."""
+    """Return the active evaluator epoch id for ``scenario`` (registry read), or None."""
     if not scenario:
         return None
     registry = EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
@@ -67,22 +78,51 @@ def _active_epoch(settings: AppSettings, scenario: str | None) -> str | None:
 def _build_score_fn(scenario: str, settings: AppSettings) -> ScoreFn | None:
     """Build a re-scoring closure over the scenario task's own ``evaluate_output``.
 
-    Returns None when the scenario is not an agent-task (no reconstructable rubric judge). Imports
-    ``_is_agent_task`` lazily from ``cli`` to avoid a circular import (``cli`` imports this module to
-    register the command).
+    Returns None when the scenario is not an agent-task (no reconstructable rubric judge). Custom agent
+    tasks are loaded from the CONFIGURED ``settings.knowledge_root`` first (the import-time registry only
+    scans a relative ``knowledge/``, so a non-default root would otherwise miss them). The closure
+    evaluates inside the configured hook bus so BEFORE_JUDGE / AFTER_JUDGE hooks reproduce the production
+    evaluator (a hook can change the effective model, and therefore the stamped epoch, or the response).
+    Imports ``_is_agent_task`` lazily from ``cli`` to avoid a circular import.
     """
     from autocontext.cli import _is_agent_task
+    from autocontext.extensions import active_hook_bus
+    from autocontext.loop.runner_hooks import initialize_hook_bus
+    from autocontext.scenarios.custom.registry import load_all_custom_scenarios
 
+    SCENARIO_REGISTRY.update(load_all_custom_scenarios(settings.knowledge_root))
     if not _is_agent_task(scenario):
         return None
     task = SCENARIO_REGISTRY[scenario]()
     state = task.prepare_context(task.initial_state())
+    hook_bus, _loaded_extensions = initialize_hook_bus(settings)
 
     def score_fn(artifact: str) -> tuple[float | None, str | None]:
-        result = task.evaluate_output(artifact, state)
+        with active_hook_bus(hook_bus):
+            result = task.evaluate_output(artifact, state)
         return result.score, result.evaluator_epoch
 
     return score_fn
+
+
+def _resolve_score_fn(scenario: str | None, settings: AppSettings) -> ScoreFn | None:
+    """Build the score fn, converting any construction failure into a per-generation ``error``.
+
+    ``_build_score_fn`` can raise while loading a custom scenario or preparing its context. Rather than
+    letting that escape as an uncaught exit, return a closure that raises inside ``revalidate_one`` so the
+    failure is reported per generation (fail-safe boundary) instead of crashing the command.
+    """
+    if not scenario:
+        return None
+    try:
+        return _build_score_fn(scenario, settings)
+    except Exception as exc:  # noqa: BLE001 - convert setup failure into a per-generation error status
+        message = f"evaluator construction failed: {exc}"
+
+        def failing(artifact: str) -> tuple[float | None, str | None]:
+            raise RuntimeError(message)
+
+        return failing
 
 
 def _is_stale(row: dict[str, Any], active_epoch: str | None) -> bool:
@@ -107,6 +147,10 @@ def _select_rows(
     return [r for r in rows if _is_stale(r, active_epoch)]
 
 
+def _epoch8(epoch: str | None) -> str:
+    return epoch[:8] if epoch else "-"
+
+
 def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None) -> None:
     active8 = active_epoch[:8] if active_epoch else "none"
     table = Table(title=f"Re-score (active epoch {active8}...)")
@@ -116,14 +160,37 @@ def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None
     table.add_column("New score", justify="right")
     table.add_column("Delta", justify="right")
     table.add_column("Stale")
+    table.add_column("Old epoch")
+    table.add_column("New epoch")
+    table.add_column("Matches active")
     for rep in reports:
         old = "-" if rep.original_score is None else f"{rep.original_score:.3f}"
         new = "-" if rep.new_score is None else f"{rep.new_score:.3f}"
         delta = "-" if rep.score_delta is None else f"{rep.score_delta:+.3f}"
-        table.add_row(str(rep.generation_index), rep.status, old, new, delta, "yes" if rep.was_stale else "no")
+        matches = "yes" if rep.new_matches_active else ("no" if rep.new_epoch is not None else "-")
+        table.add_row(
+            str(rep.generation_index),
+            rep.status,
+            old,
+            new,
+            delta,
+            "yes" if rep.was_stale else "no",
+            _epoch8(rep.original_epoch),
+            _epoch8(rep.new_epoch),
+            matches,
+        )
     _console.print(table)
     revalidated = sum(1 for r in reports if r.status == "revalidated")
-    _console.print(f"[dim]{revalidated} of {len(reports)} generation(s) re-scored; nothing was written.[/dim]")
+    _console.print(
+        f"[dim]{revalidated} of {len(reports)} generation(s) re-scored; no score, generation, or lineage data was written.[/dim]"
+    )
+    drifted = [r for r in reports if r.status == "revalidated" and not r.new_matches_active]
+    if drifted:
+        _console.print(
+            f"[yellow]Warning: {len(drifted)} re-scored generation(s) produced an epoch that does NOT "
+            f"match the active epoch {active8}...; the current scenario spec has drifted from the active "
+            "evaluator, so these fresh scores are not under the active epoch.[/yellow]"
+        )
 
 
 def rescore_command(
@@ -135,22 +202,24 @@ def rescore_command(
 ) -> None:
     """Re-score stale generations under the current evaluator and report drift (read-only)."""
     settings = load_settings()
-    store = _store(settings)
-    run = store.get_run(run_id)
-    if run is None:
+    store = _open_store(settings)
+    if store is None or store.get_run(run_id) is None:
         _emit_error(f"run {run_id!r} not found", json_output)
         raise typer.Exit(code=1)
 
-    scenario = run.get("scenario")
-    active_epoch = _active_epoch(settings, scenario)
-    score_fn = _build_score_fn(scenario, settings) if scenario else None
-
+    run = store.get_run(run_id)
+    scenario = run.get("scenario") if run else None
     rows = store.run_status(run_id)
     if generation is not None and not any(r["generation_index"] == generation for r in rows):
         _emit_error(f"run {run_id!r} has no generation {generation}", json_output)
         raise typer.Exit(code=1)
 
+    active_epoch = _active_epoch(settings, scenario)
     targets = _select_rows(rows, generation, active_epoch)
+    # Reconstruct the evaluator only when it can actually be used (an active epoch exists and there are
+    # targets), and after the generation check, so construction cost and failures stay inside the
+    # fail-safe boundary. Setup failures become per-generation ``error`` reports (see _resolve_score_fn).
+    score_fn = _resolve_score_fn(scenario, settings) if (active_epoch is not None and targets) else None
     # One competitor output per generation on the solve path. If a generation has more than one
     # (a tournament re-append), keep the last by rowid, matching training-export's _get_competitor_outputs.
     artifacts = {o["generation_index"]: o["content"] for o in store.get_agent_outputs_by_role(run_id, "competitor")}

--- a/autocontext/src/autocontext/execution/rescore.py
+++ b/autocontext/src/autocontext/execution/rescore.py
@@ -1,0 +1,113 @@
+"""Pure revalidation core for on-demand re-score (AC-885 Slice D2a).
+
+Report-only: computes a comparison of a generation's original score/epoch against a fresh re-score, via
+an injected ``score_fn`` so this module has no provider/network/DB dependency. Writes nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+
+RescoreStatus = Literal["revalidated", "skipped_no_artifact", "skipped_no_active_epoch", "skipped_no_evaluator", "error"]
+
+
+class _Common(TypedDict):
+    original_score: float | None
+    original_epoch: str | None
+    active_epoch: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationRevalidation:
+    generation_index: int
+    status: RescoreStatus
+    reason: str
+    original_score: float | None
+    original_epoch: str | None
+    new_score: float | None
+    new_epoch: str | None
+    active_epoch: str | None
+    was_stale: bool
+    new_matches_active: bool
+    score_delta: float | None
+
+
+def _was_stale(original_epoch: str | None, active_epoch: str | None) -> bool:
+    return original_epoch is not None and active_epoch is not None and original_epoch != active_epoch
+
+
+def _matches_active(new_epoch: str | None, active_epoch: str | None) -> bool:
+    return new_epoch is not None and active_epoch is not None and new_epoch == active_epoch
+
+
+def _delta(new_score: float | None, original_score: float | None) -> float | None:
+    if new_score is None or original_score is None:
+        return None
+    return new_score - original_score
+
+
+def _result(
+    generation_index: int,
+    status: RescoreStatus,
+    reason: str,
+    original_score: float | None,
+    original_epoch: str | None,
+    active_epoch: str | None,
+    new_score: float | None = None,
+    new_epoch: str | None = None,
+) -> GenerationRevalidation:
+    return GenerationRevalidation(
+        generation_index=generation_index,
+        status=status,
+        reason=reason,
+        original_score=original_score,
+        original_epoch=original_epoch,
+        new_score=new_score,
+        new_epoch=new_epoch,
+        active_epoch=active_epoch,
+        was_stale=_was_stale(original_epoch, active_epoch),
+        new_matches_active=_matches_active(new_epoch, active_epoch),
+        score_delta=_delta(new_score, original_score),
+    )
+
+
+def revalidate_one(
+    generation_index: int,
+    original_score: float | None,
+    original_epoch: str | None,
+    active_epoch: str | None,
+    artifact: str | None,
+    score_fn: Callable[[str], tuple[float | None, str | None]] | None,
+) -> GenerationRevalidation:
+    """Re-score one generation's artifact via ``score_fn`` and report the comparison. Writes nothing.
+
+    Skip precedence: no active epoch, then no evaluator (``score_fn`` None), then no artifact. A
+    ``score_fn`` that raises yields ``error``; one that returns a None epoch yields ``skipped_no_evaluator``.
+    """
+    common: _Common = {
+        "original_score": original_score,
+        "original_epoch": original_epoch,
+        "active_epoch": active_epoch,
+    }
+    if active_epoch is None:
+        return _result(generation_index, "skipped_no_active_epoch", "scenario has no active evaluator epoch", **common)
+    if score_fn is None:
+        return _result(generation_index, "skipped_no_evaluator", "scenario has no reconstructable rubric judge", **common)
+    if not artifact:
+        return _result(generation_index, "skipped_no_artifact", "no stored competitor output for this generation", **common)
+    try:
+        new_score, new_epoch = score_fn(artifact)
+    except Exception as exc:  # noqa: BLE001 - report any scorer failure, never crash the command
+        return _result(generation_index, "error", f"re-score failed: {exc}", **common)
+    if new_epoch is None:
+        return _result(generation_index, "skipped_no_evaluator", "scenario evaluator produced no epoch", **common)
+    return _result(
+        generation_index,
+        "revalidated",
+        "re-scored under the current evaluator",
+        new_score=new_score,
+        new_epoch=new_epoch,
+        **common,
+    )

--- a/autocontext/src/autocontext/execution/rescore.py
+++ b/autocontext/src/autocontext/execution/rescore.py
@@ -95,7 +95,7 @@ def revalidate_one(
         return _result(generation_index, "skipped_no_active_epoch", "scenario has no active evaluator epoch", **common)
     if score_fn is None:
         return _result(generation_index, "skipped_no_evaluator", "scenario has no reconstructable rubric judge", **common)
-    if not artifact:
+    if artifact is None:
         return _result(generation_index, "skipped_no_artifact", "no stored competitor output for this generation", **common)
     try:
         new_score, new_epoch = score_fn(artifact)

--- a/autocontext/tests/test_cli_rescore.py
+++ b/autocontext/tests/test_cli_rescore.py
@@ -125,6 +125,9 @@ def test_rescore_missing_run(tmp_path: Path, monkeypatch) -> None:
     _env(monkeypatch, tmp_path)
     result = runner.invoke(app, ["rescore", "does-not-exist", "--json"])
     assert result.exit_code == 1
+    # --json errors emit a JSON object, not a bare string (matches sibling --json commands).
+    assert '"error"' in result.output
+    assert json.loads(result.output.strip()) == {"error": "run 'does-not-exist' not found"}
 
 
 def test_rescore_non_agent_task_no_evaluator(tmp_path: Path, monkeypatch) -> None:

--- a/autocontext/tests/test_cli_rescore.py
+++ b/autocontext/tests/test_cli_rescore.py
@@ -1,0 +1,140 @@
+"""CLI integration for ``autoctx rescore`` (AC-885 Slice D2a).
+
+The scoring seam (``_build_score_fn``) is patched to inject a deterministic ``score_fn`` so no
+provider/network/paid-LLM call is made. The command is report-only: it re-scores stale generations
+under the current evaluator and prints old-vs-new score + epoch, writing nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+runner = CliRunner()
+
+_SCENARIO = "grid_ctf"
+_MIGRATIONS = Path(__file__).resolve().parents[1] / "migrations"
+
+
+def _env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_KNOWLEDGE_ROOT", str(tmp_path / "knowledge"))
+    monkeypatch.setenv("AUTOCONTEXT_DB_PATH", str(tmp_path / "t.sqlite3"))
+
+
+def _store(tmp_path: Path):
+    from autocontext.storage.sqlite_store import SQLiteStore
+
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(_MIGRATIONS)
+    return store
+
+
+def _seed_epochs_active_e2(tmp_path: Path) -> tuple[str, str]:
+    """Seed e1 (bootstrap active) + e2 (candidate), then promote e2 so e1-scored rows are stale."""
+    reg = EvaluatorEpochRegistry(tmp_path / "knowledge" / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe(_SCENARIO, e1, now_fn=lambda: "t0")
+    reg.observe(_SCENARIO, e2, now_fn=lambda: "t1")
+    reg.activate(_SCENARIO, e2.epoch_id)
+    return e1.epoch_id, e2.epoch_id
+
+
+def _seed_generation(tmp_path: Path, run_id: str, epoch_id: str | None, *, with_output: bool) -> None:
+    store = _store(tmp_path)
+    store.create_run(run_id, _SCENARIO, 1, "local")
+    store.upsert_generation(
+        run_id,
+        1,
+        mean_score=0.5,
+        best_score=0.6,
+        elo=1000.0,
+        wins=1,
+        losses=0,
+        gate_decision="pass",
+        status="completed",
+        evaluator_epoch=epoch_id,
+    )
+    if with_output:
+        store.append_agent_output(run_id, 1, "competitor", "strategy text")
+
+
+def _fixed_build(score: float, epoch: str | None):
+    def build(scenario: str, settings):  # noqa: ANN001, ANN202 - test seam signature parity
+        def fn(artifact: str) -> tuple[float | None, str | None]:
+            return score, epoch
+
+        return fn
+
+    return build
+
+
+def test_rescore_revalidated_json(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-stale", e1, with_output=True)
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.55, e2))
+
+    result = runner.invoke(app, ["rescore", "run-stale", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["active_evaluator_epoch"] == e2
+    gen = payload["generations"][0]
+    assert gen["status"] == "revalidated"
+    assert gen["original_epoch"] == e1
+    assert gen["new_epoch"] == e2
+    assert gen["was_stale"] is True
+    assert gen["new_matches_active"] is True
+    assert gen["new_score"] == 0.55
+
+
+def test_rescore_no_active_epoch(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    # No epochs registered for the scenario -> nothing to re-score against.
+    _seed_generation(tmp_path, "run-bare", "e1", with_output=True)
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.55, "e2"))
+
+    result = runner.invoke(app, ["rescore", "run-bare", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["active_evaluator_epoch"] is None
+    gen = payload["generations"][0]
+    assert gen["status"] == "skipped_no_active_epoch"
+    assert gen["was_stale"] is False
+
+
+def test_rescore_stale_no_artifact(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    _e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-noart", _e1, with_output=False)
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.55, e2))
+
+    result = runner.invoke(app, ["rescore", "run-noart", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["status"] == "skipped_no_artifact"
+
+
+def test_rescore_missing_run(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    result = runner.invoke(app, ["rescore", "does-not-exist", "--json"])
+    assert result.exit_code == 1
+
+
+def test_rescore_non_agent_task_no_evaluator(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    _e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-nonagent", _e1, with_output=True)
+    # _build_score_fn returns None for a non-agent-task scenario.
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", lambda scenario, settings: None)
+
+    result = runner.invoke(app, ["rescore", "run-nonagent", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["status"] == "skipped_no_evaluator"

--- a/autocontext/tests/test_cli_rescore.py
+++ b/autocontext/tests/test_cli_rescore.py
@@ -141,3 +141,126 @@ def test_rescore_non_agent_task_no_evaluator(tmp_path: Path, monkeypatch) -> Non
     assert result.exit_code == 0, result.output
     gen = json.loads(result.stdout)["generations"][0]
     assert gen["status"] == "skipped_no_evaluator"
+
+
+def test_rescore_missing_run_does_not_create_db(tmp_path: Path, monkeypatch) -> None:
+    # Report-only: a missing-run invocation against a nonexistent database must NOT materialize one.
+    _env(monkeypatch, tmp_path)
+    db_path = tmp_path / "t.sqlite3"
+    assert not db_path.exists()
+    result = runner.invoke(app, ["rescore", "does-not-exist"])
+    assert result.exit_code == 1
+    assert not db_path.exists()  # no database was created
+
+
+def test_rescore_build_failure_is_per_generation_error(tmp_path: Path, monkeypatch) -> None:
+    # A _build_score_fn failure (custom-task load / prepare_context) must become a per-generation
+    # `error` report, not an uncaught exit, and other flow stays fail-safe (exit 0).
+    _env(monkeypatch, tmp_path)
+    _e1, _e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-buildfail", _e1, with_output=True)
+
+    def boom(scenario, settings):  # noqa: ANN001, ANN202
+        raise RuntimeError("spec load blew up")
+
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", boom)
+    result = runner.invoke(app, ["rescore", "run-buildfail", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["status"] == "error"
+    assert "spec load blew up" in gen["reason"]
+
+
+def test_rescore_rich_surfaces_epoch_drift_warning(tmp_path: Path, monkeypatch) -> None:
+    # When the current evaluator produces an epoch that does NOT match the active epoch, the rich
+    # (non-JSON) output must surface the drift, not silently show `revalidated`.
+    _env(monkeypatch, tmp_path)
+    _e1, _e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-drift", _e1, with_output=True)
+    # Fresh score under a DIFFERENT epoch than active (spec has drifted).
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.5, "e_drifted_epoch"))
+
+    result = runner.invoke(app, ["rescore", "run-drift"])
+    assert result.exit_code == 0, result.output
+    normalized = " ".join(result.output.split())
+    assert "Warning" in normalized
+    assert "does NOT match the active epoch" in normalized
+
+
+def test_rescore_loads_custom_scenarios_from_configured_root(tmp_path: Path, monkeypatch) -> None:
+    # _build_score_fn must load custom agent tasks from settings.knowledge_root (not the import-time
+    # relative knowledge/), so a non-default-root deployment resolves its own scenarios.
+    _env(monkeypatch, tmp_path)
+    _e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-custom", _e1, with_output=True)
+
+    seen_roots: list[Path] = []
+
+    def spy_loader(knowledge_root: Path):
+        seen_roots.append(knowledge_root)
+        return {}
+
+    # Let the REAL _build_score_fn run; patch only its inner dependencies.
+    monkeypatch.setattr("autocontext.scenarios.custom.registry.load_all_custom_scenarios", spy_loader)
+    monkeypatch.setattr("autocontext.cli._is_agent_task", lambda name: False)
+
+    result = runner.invoke(app, ["rescore", "run-custom", "--json"])
+    assert result.exit_code == 0, result.output
+    assert seen_roots == [tmp_path / "knowledge"]  # loaded from the CONFIGURED root
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["status"] == "skipped_no_evaluator"
+
+
+class _FakeAgentTask:
+    """Minimal agent-task double whose evaluate_output records the active hook bus at call time."""
+
+    hook_active_during_eval = False
+    eval_epoch = "e2-fake"
+
+    def initial_state(self, seed=None):  # noqa: ANN001, ANN201
+        return {}
+
+    def prepare_context(self, state):  # noqa: ANN001, ANN201
+        return state
+
+    def get_task_prompt(self, state):  # noqa: ANN001, ANN201
+        return "task"
+
+    def get_rubric(self):  # noqa: ANN201
+        return "rubric"
+
+    def describe_task(self):  # noqa: ANN201
+        return "fake"
+
+    def evaluate_output(self, output, state, **kwargs):  # noqa: ANN001, ANN003, ANN201
+        from autocontext.extensions import get_current_hook_bus
+        from autocontext.scenarios.agent_task import AgentTaskResult
+
+        type(self).hook_active_during_eval = get_current_hook_bus() is not None
+        return AgentTaskResult(score=0.42, reasoning="r", evaluator_epoch=type(self).eval_epoch)
+
+
+def test_rescore_evaluates_inside_hook_bus(tmp_path: Path, monkeypatch) -> None:
+    # The re-score must run inside the configured hook bus so BEFORE/AFTER_JUDGE hooks reproduce the
+    # production evaluator. Assert evaluate_output sees an active hook bus.
+    _env(monkeypatch, tmp_path)
+    _e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _FakeAgentTask.eval_epoch = e2
+    _FakeAgentTask.hook_active_during_eval = False
+    _seed_generation(tmp_path, "run-hooks", _e1, with_output=True)
+
+    from autocontext.scenarios import SCENARIO_REGISTRY
+
+    monkeypatch.setitem(SCENARIO_REGISTRY, _SCENARIO, _FakeAgentTask)
+    monkeypatch.setattr("autocontext.cli._is_agent_task", lambda name: True)
+    monkeypatch.setattr("autocontext.scenarios.custom.registry.load_all_custom_scenarios", lambda root: {})
+    # A real (empty) hook bus so get_current_hook_bus() is not None inside active_hook_bus.
+    from autocontext.extensions import HookBus
+
+    monkeypatch.setattr("autocontext.loop.runner_hooks.initialize_hook_bus", lambda settings: (HookBus(), []))
+
+    result = runner.invoke(app, ["rescore", "run-hooks", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["status"] == "revalidated"
+    assert _FakeAgentTask.hook_active_during_eval is True

--- a/autocontext/tests/test_rescore_core.py
+++ b/autocontext/tests/test_rescore_core.py
@@ -1,0 +1,72 @@
+"""Pure revalidation core for on-demand re-score (AC-885 Slice D2a)."""
+
+from __future__ import annotations
+
+from pytest import approx
+
+from autocontext.execution.rescore import revalidate_one
+
+
+def _score_fn_ok(score: float, epoch: str | None):
+    def fn(artifact: str) -> tuple[float | None, str | None]:
+        return score, epoch
+
+    return fn
+
+
+def test_revalidated_stale_generation() -> None:
+    r = revalidate_one(
+        1, original_score=0.8, original_epoch="e1", active_epoch="e2", artifact="strategy text", score_fn=_score_fn_ok(0.6, "e2")
+    )
+    assert r.status == "revalidated"
+    assert r.new_score == 0.6 and r.new_epoch == "e2"
+    assert r.was_stale is True  # e1 != e2
+    assert r.new_matches_active is True  # e2 == e2
+    assert r.score_delta == approx(-0.2)
+
+
+def test_no_active_epoch_skips() -> None:
+    r = revalidate_one(1, 0.8, "e1", None, "art", _score_fn_ok(0.6, "e2"))
+    assert r.status == "skipped_no_active_epoch"
+    assert r.was_stale is False
+
+
+def test_no_evaluator_when_score_fn_none() -> None:
+    r = revalidate_one(1, 0.8, "e1", "e2", "art", None)
+    assert r.status == "skipped_no_evaluator"
+
+
+def test_no_evaluator_when_new_epoch_none() -> None:
+    r = revalidate_one(1, 0.8, "e1", "e2", "art", _score_fn_ok(0.6, None))
+    assert r.status == "skipped_no_evaluator"
+
+
+def test_no_artifact_skips() -> None:
+    r = revalidate_one(1, 0.8, "e1", "e2", "", _score_fn_ok(0.6, "e2"))
+    assert r.status == "skipped_no_artifact"
+    r2 = revalidate_one(1, 0.8, "e1", "e2", None, _score_fn_ok(0.6, "e2"))
+    assert r2.status == "skipped_no_artifact"
+
+
+def test_scorer_error_captured() -> None:
+    def boom(artifact: str) -> tuple[float | None, str | None]:
+        raise RuntimeError("provider down")
+
+    r = revalidate_one(1, 0.8, "e1", "e2", "art", boom)
+    assert r.status == "error"
+    assert "provider down" in r.reason
+
+
+def test_not_stale_when_epochs_match() -> None:
+    r = revalidate_one(1, 0.8, "e2", "e2", "art", _score_fn_ok(0.7, "e2"))
+    assert r.status == "revalidated"
+    assert r.was_stale is False
+    assert r.new_matches_active is True
+
+
+def test_derived_fields_none_safe() -> None:
+    # legacy original epoch/score None: not stale, delta None
+    r = revalidate_one(1, None, None, "e2", "art", _score_fn_ok(0.5, "e2"))
+    assert r.was_stale is False
+    assert r.score_delta is None
+    assert r.new_matches_active is True

--- a/autocontext/tests/test_rescore_core.py
+++ b/autocontext/tests/test_rescore_core.py
@@ -41,11 +41,16 @@ def test_no_evaluator_when_new_epoch_none() -> None:
     assert r.status == "skipped_no_evaluator"
 
 
-def test_no_artifact_skips() -> None:
-    r = revalidate_one(1, 0.8, "e1", "e2", "", _score_fn_ok(0.6, "e2"))
+def test_no_artifact_skips_only_when_none() -> None:
+    # Only a MISSING artifact (None) skips; an empty-string output is a real artifact that was judged.
+    r = revalidate_one(1, 0.8, "e1", "e2", None, _score_fn_ok(0.6, "e2"))
     assert r.status == "skipped_no_artifact"
-    r2 = revalidate_one(1, 0.8, "e1", "e2", None, _score_fn_ok(0.6, "e2"))
-    assert r2.status == "skipped_no_artifact"
+
+
+def test_empty_string_artifact_is_revalidated() -> None:
+    r = revalidate_one(1, 0.8, "e1", "e2", "", _score_fn_ok(0.6, "e2"))
+    assert r.status == "revalidated"
+    assert r.new_score == 0.6
 
 
 def test_scorer_error_captured() -> None:

--- a/docs/ac-885-slice-d2a-rescore-report-design.md
+++ b/docs/ac-885-slice-d2a-rescore-report-design.md
@@ -1,0 +1,178 @@
+# AC-885 Slice D2a: on-demand re-score (report-only)
+
+Date: 2026-07-11
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: sub-slice D2a of Slice D. Slice 1, B, C1, C2, C3, D1 are merged (#1204, #1208, #1210, #1211, #1212, #1213).
+
+## Purpose
+
+D1 surfaced whether a generation's score is stale relative to its scenario's active evaluator epoch.
+The last AC-885 thread is a re-score / revalidation path: re-run the current evaluator against a stale
+generation's ORIGINAL artifact and report what it scores today. D2a delivers that path report-only: it
+performs no database writes and does not overwrite any score. Persisting a re-score (which needs
+net-new schema to avoid clobbering the original score's lineage) is deferred to D2b.
+
+## Constraints that shaped the design (from the code map)
+
+1. **The registry stores only the active `epoch_id`,** not the rubric text / provider / model (the
+   score-write path uses `observe_id`, which leaves those empty). So D2a cannot reconstruct a
+   historical active rubric. It re-scores under the CURRENT evaluator (the scenario's current
+   `spec.judge_rubric` + settings judge) and reports whether the freshly computed epoch matches the
+   registry's active epoch. This is the operator-meaningful question and fails safe when the current
+   spec has drifted from the active epoch.
+2. **Persistence would destroy lineage.** One row per `(run_id, generation_index)`, `upsert_generation`
+   COALESCE-overwrites in place, and there is no score-history table. Report-only sidesteps this
+   entirely; D2b adds the schema.
+
+## Decisions of record
+
+1. **Explicit trigger, not auto-on-read.** A new `autoctx rescore <run_id> [--generation N]` command.
+   Auto-re-scoring on every `show`/`status` would fire paid LLM calls on reads and make them slow and
+   nondeterministic. The operator "touches" a stale record by invoking `rescore`.
+2. **Read-only.** No `upsert_generation`, no registry write, no quarantine clear. D2a fetches, re-scores
+   in memory, and prints. (`evaluate_output` itself performs no DB write.)
+3. **Faithful re-score via the scenario's own evaluator.** The re-score reuses the scenario task's
+   `evaluate_output`, the same path a fresh run scores through (it builds the `LLMJudge` from
+   `spec.judge_rubric` + `settings.judge_model` + provider and stamps the epoch). D2a does not
+   re-implement scoring.
+4. **Default target is the run's stale generations;** `--generation N` targets one specific generation
+   regardless of staleness. This bounds LLM cost (re-scoring only what is stale) unless the operator
+   asks for a specific generation.
+5. **Fail-safe, never crash.** Every failure mode degrades to a per-generation skip with a reason and
+   exit 0. Only a missing run is a not-found error (exit 1), matching `show`.
+
+## Architecture
+
+### D2a.1: the pure revalidation core (`execution/rescore.py`)
+
+```python
+RescoreStatus = Literal[
+    "revalidated", "skipped_no_artifact", "skipped_no_active_epoch", "skipped_no_evaluator", "error"
+]
+
+@dataclass(frozen=True, slots=True)
+class GenerationRevalidation:
+    generation_index: int
+    status: RescoreStatus
+    reason: str
+    original_score: float | None
+    original_epoch: str | None
+    new_score: float | None
+    new_epoch: str | None
+    active_epoch: str | None
+    was_stale: bool           # original and active both non-null and different
+    new_matches_active: bool  # new_epoch and active_epoch both non-null and equal
+    score_delta: float | None # new_score - original_score when both present
+
+def revalidate_one(
+    generation_index: int,
+    original_score: float | None,
+    original_epoch: str | None,
+    active_epoch: str | None,
+    artifact: str | None,
+    score_fn: Callable[[str], tuple[float | None, str | None]] | None,
+) -> GenerationRevalidation: ...
+```
+
+`revalidate_one` skip precedence: `active_epoch is None` -> `skipped_no_active_epoch`; `score_fn is None`
+(scenario has no reconstructable rubric judge) -> `skipped_no_evaluator`; falsy `artifact` ->
+`skipped_no_artifact`; `score_fn` raises -> `error` (message carries the exception); `score_fn` returns
+a `None` epoch -> `skipped_no_evaluator`; otherwise -> `revalidated`. The derived fields (`was_stale`,
+`new_matches_active`, `score_delta`) are computed once from the inputs. `score_fn` is injected so the
+core is pure and fully unit-testable with a fake scorer (no providers, no network, no paid calls).
+
+### D2a.2: the CLI command (`cli_rescore.py`, registered on the main app)
+
+`autoctx rescore <run_id> [--generation N] [--json]`:
+
+1. Load settings + store; `store.get_run(run_id)` -> scenario (None -> not-found, exit 1).
+2. `active_epoch = EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs").active_for(scenario)`
+   `.epoch_id` (or None).
+3. `rows = store.run_status(run_id)` (carries `evaluator_epoch` since D1). Select targets: the row for
+   `--generation N` if given, else rows that are stale (`evaluator_epoch != active_epoch`, both
+   non-null).
+4. Build the score function: `score_fn = _build_score_fn(scenario, settings)`, which returns `None`
+   when the scenario is not an agent-task (game scenario, unregistered), else a closure over the
+   scenario task:
+   ```python
+   cls = SCENARIO_REGISTRY[scenario]; task = cls()
+   state = task.prepare_context(task.initial_state())
+   def score(artifact: str) -> tuple[float | None, str | None]:
+       result = task.evaluate_output(artifact, state)
+       return result.score, result.evaluator_epoch
+   ```
+   (`_is_agent_task` is the existing `cli.py` predicate; reuse it.)
+5. Fetch artifacts: `{gen_idx: content}` from `store.get_agent_outputs_by_role(run_id, "competitor")`.
+6. Per target row, call `revalidate_one(...)`; collect `GenerationRevalidation`s.
+7. `--json`: `{run_id, scenario, active_evaluator_epoch, generations: [<revalidation dicts>]}`. Rich
+   table otherwise (gen, original score/epoch8, new score/epoch8, delta, stale?, matches-active?,
+   status), with a one-line summary.
+
+### D2a.3: contract + registration
+
+`rescore` is a new top-level command, so add it to `docs/cli-contract.json` (`python: yes`,
+`typescript: intentional_gap` with a reason: the re-score path depends on the Python-only judge +
+evaluator-epoch registry, matching the epoch CLI). Register `app.command("rescore")` in `cli.py`.
+
+## Data flow
+
+```
+operator: autoctx rescore <run_id>
+  -> get_run -> scenario ; registry.active_for(scenario) -> active_epoch
+  -> run_status(run_id) -> rows (evaluator_epoch each) ; select stale rows
+  -> score_fn = task.evaluate_output(...) closure (or None for game scenarios)
+  -> artifacts = get_agent_outputs_by_role(run_id, "competitor")
+  -> per row: revalidate_one(gi, orig_score, orig_epoch, active_epoch, artifact, score_fn)
+  -> report old vs new score + epoch, was_stale, new_matches_active, delta, status  (NO writes)
+```
+
+## Error handling and edge cases
+
+- **Missing run:** not-found, exit 1 (like `show`).
+- **Scenario has no active epoch:** every target row -> `skipped_no_active_epoch` (nothing is stale to
+  revalidate).
+- **Game / non-agent-task scenario** (score_fn None): `skipped_no_evaluator` (no rubric judge).
+- **No stored competitor output** for a generation: `skipped_no_artifact`.
+- **Evaluator raises** (provider error, malformed rubric): `error` with the message; other generations
+  still report. Exit 0.
+- **Current spec no longer reproduces the active epoch:** the re-score still runs under the current
+  evaluator; `new_matches_active` is False and the report shows the new epoch differs from active, so
+  the operator sees the drift explicitly.
+- **`--generation N` not present in the run:** not-found for that generation, exit 1.
+
+## Testing
+
+- Unit (`revalidate_one` + derived fields): every status branch (revalidated, no_artifact,
+  no_active_epoch, no_evaluator via None score_fn and via None epoch, error via raising score_fn), plus
+  `was_stale` / `new_matches_active` / `score_delta` truth values, all with a fake in-memory `score_fn`
+  (no providers).
+- Integration (CLI): seed a run with a stale generation and a stored competitor output, patch
+  `get_provider` with a deterministic fake provider (existing test pattern, no network) so
+  `evaluate_output` returns a fixed score, invoke `rescore --json`, and assert the report shows the
+  original vs new score, the new epoch, and `was_stale` true. Plus fail-safe cases: no active epoch,
+  no competitor artifact, missing run (exit 1).
+- Gates: module-size, gate-taxonomy, ruff/mypy, the serde-convention test, cli-contract parity (the new
+  `rescore` entry), schema-parity (unchanged: no new columns), lockfiles unchanged.
+
+## Documentation
+
+Extend `docs/evaluator-epochs.md` with a "Slice D2a: on-demand re-score (report-only)" subsection: the
+`rescore` command, that it re-scores under the current evaluator and reports drift vs the active epoch,
+the fail-safe skip statuses, that it writes nothing, and that persisting a re-score is D2b. CHANGELOG
+entry (new `rescore` command).
+
+## Deferred / out of scope (D2b and beyond)
+
+- Persisting a re-score: the `generation_score_revisions` table, an `--apply` flag, clearing quarantine
+  after a successful active-epoch re-score, and TS parity for the new table.
+- Auto-on-read re-score (rejected: paid LLM calls on reads).
+- Reconstructing a historical active rubric when the current spec has drifted (needs registry backfill
+  of rubric text; a separate piece).
+- TS parity for the `rescore` command (Python-only, documented intentional gap).
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 "Add a lazy re-score or revalidation path for raw artifacts when stale scored records are
+  touched": `autoctx rescore` re-runs the current evaluator against a stale generation's raw artifact
+  and reports the fresh score and epoch, on operator demand.

--- a/docs/ac-885-slice-d2a-rescore-report-design.md
+++ b/docs/ac-885-slice-d2a-rescore-report-design.md
@@ -10,7 +10,9 @@ Scope: sub-slice D2a of Slice D. Slice 1, B, C1, C2, C3, D1 are merged (#1204, #
 D1 surfaced whether a generation's score is stale relative to its scenario's active evaluator epoch.
 The last AC-885 thread is a re-score / revalidation path: re-run the current evaluator against a stale
 generation's ORIGINAL artifact and report what it scores today. D2a delivers that path report-only: it
-performs no database writes and does not overwrite any score. Persisting a re-score (which needs
+writes no score, generation, or evaluator-epoch lineage data, and does not create a database for a
+missing run. (Like every inspect command it opens the existing store, and it runs the configured
+evaluator hooks so the re-score is faithful; it persists no score.) Persisting a re-score (which needs
 net-new schema to avoid clobbering the original score's lineage) is deferred to D2b.
 
 ## Constraints that shaped the design (from the code map)
@@ -30,17 +32,25 @@ net-new schema to avoid clobbering the original score's lineage) is deferred to 
 1. **Explicit trigger, not auto-on-read.** A new `autoctx rescore <run_id> [--generation N]` command.
    Auto-re-scoring on every `show`/`status` would fire paid LLM calls on reads and make them slow and
    nondeterministic. The operator "touches" a stale record by invoking `rescore`.
-2. **Read-only.** No `upsert_generation`, no registry write, no quarantine clear. D2a fetches, re-scores
-   in memory, and prints. (`evaluate_output` itself performs no DB write.)
-3. **Faithful re-score via the scenario's own evaluator.** The re-score reuses the scenario task's
-   `evaluate_output`, the same path a fresh run scores through (it builds the `LLMJudge` from
-   `spec.judge_rubric` + `settings.judge_model` + provider and stamps the epoch). D2a does not
-   re-implement scoring.
+2. **Writes no score or lineage.** No `upsert_generation`, no registry activation/promotion, no
+   quarantine clear. D2a fetches, re-scores in memory, and prints. It opens only an EXISTING store
+   (a missing database is reported as not-found, never created), matching the migrate-on-read
+   convention of the other inspect commands; the registry `active_for` read may self-heal a corrupt
+   multiple-active state (its own contract), and running the evaluator hooks (below) can have their
+   configured side effects. No score, generation, or evaluator-epoch lineage is persisted by D2a.
+3. **Faithful re-score via the scenario's own evaluator, hooks and all.** The re-score reuses the
+   scenario task's `evaluate_output`, the same path a fresh run scores through (it builds the
+   `LLMJudge` from `spec.judge_rubric` + `settings.judge_model` + provider and stamps the epoch), run
+   inside the configured hook bus (`initialize_hook_bus` + `active_hook_bus`) so BEFORE_JUDGE /
+   AFTER_JUDGE hooks reproduce the production evaluator. Custom agent tasks are loaded from the
+   configured `settings.knowledge_root` first (the import-time registry only scans a relative
+   `knowledge/`). D2a does not re-implement scoring.
 4. **Default target is the run's stale generations;** `--generation N` targets one specific generation
    regardless of staleness. This bounds LLM cost (re-scoring only what is stale) unless the operator
    asks for a specific generation.
-5. **Fail-safe, never crash.** Every failure mode degrades to a per-generation skip with a reason and
-   exit 0. Only a missing run is a not-found error (exit 1), matching `show`.
+5. **Fail-safe, never crash.** Every failure mode (no artifact, no active epoch, no evaluator, a scorer
+   or evaluator-construction exception) degrades to a per-generation skip/`error` with a reason and
+   exit 0. Only a missing run or a missing `--generation N` is a not-found error (exit 1), matching `show`.
 
 ## Architecture
 
@@ -76,8 +86,8 @@ def revalidate_one(
 ```
 
 `revalidate_one` skip precedence: `active_epoch is None` -> `skipped_no_active_epoch`; `score_fn is None`
-(scenario has no reconstructable rubric judge) -> `skipped_no_evaluator`; falsy `artifact` ->
-`skipped_no_artifact`; `score_fn` raises -> `error` (message carries the exception); `score_fn` returns
+(scenario has no reconstructable rubric judge) -> `skipped_no_evaluator`; a `None` `artifact` (no stored
+competitor output; an empty string is still a real artifact and is re-scored) -> `skipped_no_artifact`; `score_fn` raises -> `error` (message carries the exception); `score_fn` returns
 a `None` epoch -> `skipped_no_evaluator`; otherwise -> `revalidated`. The derived fields (`was_stale`,
 `new_matches_active`, `score_delta`) are computed once from the inputs. `score_fn` is injected so the
 core is pure and fully unit-testable with a fake scorer (no providers, no network, no paid calls).
@@ -92,9 +102,11 @@ core is pure and fully unit-testable with a fake scorer (no providers, no networ
 3. `rows = store.run_status(run_id)` (carries `evaluator_epoch` since D1). Select targets: the row for
    `--generation N` if given, else rows that are stale (`evaluator_epoch != active_epoch`, both
    non-null).
-4. Build the score function: `score_fn = _build_score_fn(scenario, settings)`, which returns `None`
-   when the scenario is not an agent-task (game scenario, unregistered), else a closure over the
-   scenario task:
+4. Build the score function (only when an active epoch and targets exist, and after the generation
+   check, so setup cost and failures stay inside the fail-safe boundary; a construction failure becomes
+   a per-generation `error`): `score_fn = _build_score_fn(scenario, settings)` loads custom scenarios
+   from `settings.knowledge_root`, returns `None` when the scenario is not an agent-task (game scenario,
+   unregistered), else a closure that runs `task.evaluate_output` inside the configured hook bus:
    ```python
    cls = SCENARIO_REGISTRY[scenario]; task = cls()
    state = task.prepare_context(task.initial_state())

--- a/docs/cli-contract.json
+++ b/docs/cli-contract.json
@@ -468,6 +468,34 @@
         }
       ],
       "output_contract": "json"
+    },
+    {
+      "id": "rescore",
+      "path": ["rescore"],
+      "summary": "Re-score a run's stale generations under the current evaluator and report drift, read-only.",
+      "audience": "advanced",
+      "maturity": "experimental",
+      "domain_concept": null,
+      "aliases": [],
+      "runtime_support": {
+        "python": {
+          "status": "yes"
+        },
+        "typescript": {
+          "status": "intentional_gap",
+          "reason": "on-demand re-score depends on the Python-only LLM-judge and evaluator-epoch registry path; no TypeScript equivalent (matches the epoch CLI)."
+        }
+      },
+      "flags": [
+        {
+          "name": "generation",
+          "type": "int",
+          "aliases": [],
+          "required": false,
+          "description": "Re-score a single generation by index (default: all stale generations)."
+        }
+      ],
+      "output_contract": "json"
     }
   ]
 }

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -394,8 +394,11 @@ next to the new score/epoch, plus `was_stale`, `new_matches_active`, and `score_
 Only a missing run is a hard failure (exit 1, matching `show`); every other failure mode degrades to
 a per-generation skip and the command still exits 0.
 
-**It writes nothing.** No `upsert_generation`, no registry write, no quarantine clear, anywhere in
-this path. The command fetches, re-scores in memory, and prints, either a Rich table or a `--json`
+**It writes no score or lineage.** No `upsert_generation`, no registry activation/promotion, no
+quarantine clear, anywhere in this path. It opens only an existing store (a missing database is
+reported as not-found, never created) and runs the configured evaluator hooks so the re-score matches
+production. The command fetches, re-scores in memory, and prints, either a Rich table (which surfaces
+the old / new epoch and a warning when the fresh epoch does not match the active one) or a `--json`
 payload of `{run_id, scenario, active_evaluator_epoch, generations: [...]}`.
 
 **Python-only.** Like the `epoch` CLI, `rescore` depends on the Python-only LLM-judge and

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -356,6 +356,58 @@ prior slices, not an oversight.
 raw artifact and recomputing its score when a stale scored record is actually touched, is Slice D2
 and is not implemented here.
 
+## On-demand re-score (Slice D2a)
+
+Slice D1 surfaced whether a generation's score is stale relative to its scenario's active evaluator
+epoch, but stopped at surfacing: it did not re-score anything. Slice D2a adds the re-score /
+revalidation path itself, report-only: `autoctx rescore <run_id> [--generation N] [--json]`
+(`autocontext/src/autocontext/cli_rescore.py`) re-runs the CURRENT evaluator against a stale
+generation's ORIGINAL stored competitor artifact and reports what it scores today, without touching
+the database.
+
+**Why the current evaluator, not the historical one.** The registry stores only the active
+`epoch_id`, not the rubric text, provider, or model behind it, so a historical active rubric cannot
+be reconstructed. Re-score therefore always runs under the scenario's CURRENT evaluator (its current
+`spec.judge_rubric` plus the configured judge provider and model) and reports whether the freshly
+computed epoch matches the registry's active epoch (`new_matches_active`). That is the
+operator-meaningful question, and it fails safe even when the current spec has drifted from the
+active epoch: the re-score still runs, and the report shows the mismatch explicitly rather than
+hiding it.
+
+**What it does.** By default the command targets every stale generation in the run (its own epoch
+known and different from the scenario's active epoch); `--generation N` targets one specific
+generation regardless of staleness, bounding LLM cost to what the operator actually asks for. For
+each target it re-scores the ORIGINAL stored competitor artifact through the scenario task's own
+`evaluate_output`, the same path a fresh run scores through, and reports the original score/epoch
+next to the new score/epoch, plus `was_stale`, `new_matches_active`, and `score_delta`.
+
+**The five fail-safe statuses.** Every generation report carries exactly one of:
+
+- `revalidated`: re-scored successfully under the current evaluator.
+- `skipped_no_artifact`: no stored competitor output for this generation.
+- `skipped_no_active_epoch`: the scenario has no promoted active evaluator epoch to compare against.
+- `skipped_no_evaluator`: the scenario has no reconstructable rubric judge (a game or non-agent-task
+  scenario), or the evaluator produced no epoch.
+- `error`: the evaluator raised (for example a provider error); the message is carried in the
+  report, and other generations still report normally.
+
+Only a missing run is a hard failure (exit 1, matching `show`); every other failure mode degrades to
+a per-generation skip and the command still exits 0.
+
+**It writes nothing.** No `upsert_generation`, no registry write, no quarantine clear, anywhere in
+this path. The command fetches, re-scores in memory, and prints, either a Rich table or a `--json`
+payload of `{run_id, scenario, active_evaluator_epoch, generations: [...]}`.
+
+**Python-only.** Like the `epoch` CLI, `rescore` depends on the Python-only LLM-judge and
+evaluator-epoch registry path, so it has no TypeScript equivalent; this is a documented intentional
+gap in `docs/cli-contract.json`, not an oversight.
+
+**What remains deferred.** Persisting a re-score (an `--apply` flag that writes the fresh score
+somewhere durable, backed by a net-new `generation_score_revisions`-style table so the original
+score's lineage is not clobbered) is Slice D2b. Auto-re-scoring on every read (`show`/`status`) was
+considered and rejected: it would fire paid LLM calls on reads and make them slow and
+nondeterministic, which is why `rescore` is an explicit operator-triggered command instead.
+
 ## Relationship to the ambient `eval_fingerprint` / `anchor_model`
 
 autocontext already had this mechanism, but only in the ambient trainer. `eval_fingerprint()`
@@ -386,7 +438,9 @@ The remaining slices are explicitly deferred, not dropped:
   lifecycle (Slice C1)" above); the enforcement that consumes the marker and the promotion workflow
   land in C2 and C3.
 - **Slice D (surfacing + lazy re-score):** stale-epoch warnings in CLI / status / replay, REST /
-  API, and dashboard, plus lazy revalidation of raw artifacts when a stale scored record is touched.
+  API, and dashboard, plus revalidation of raw artifacts when a stale scored record is touched.
   D1 (read-only surfacing: the four-state classification, the `show` / `status` / `run_status`
-  fields, and the `stale_epoch` HTTP warning) is shipped, see "Slice D1: stale surfacing" above. D2
-  (lazy re-score / revalidation of raw artifacts) remains.
+  fields, and the `stale_epoch` HTTP warning) is shipped, see "Slice D1: stale surfacing" above. D2a
+  (the on-demand, report-only `autoctx rescore` command) is shipped, see "On-demand re-score (Slice
+  D2a)" above. D2b (persisting a re-score behind an `--apply` flag and a score-revisions table)
+  remains.


### PR DESCRIPTION
## AC-885 Slice D2a: on-demand re-score (report-only)

First sub-slice of Slice D2. Slices 1/B/C1/C2/C3/D1 are merged (#1204, #1208, #1210, #1211, #1212, #1213). D1 surfaced whether a generation's score is stale relative to its scenario's active evaluator epoch. D2a adds the revalidation path: re-run the current evaluator against a stale generation's ORIGINAL artifact and report what it scores today. Report-only: it writes nothing (persistence is deferred to D2b).

### What this adds

**`autoctx rescore <run_id> [--generation N] [--json]`.** Re-scores a run's stale generations under the current evaluator and prints old-vs-new score + epoch. By default it targets only the run's stale generations (bounding LLM cost); `--generation N` targets one specific generation.

Two constraints from the code map shaped the design:
- The registry stores only the active `epoch_id`, not the historical rubric text, so D2a re-scores under the **current** evaluator (the scenario's current rubric + settings judge) and reports whether the freshly computed epoch matches the active one. This is the operator-meaningful question ("what does today's rubric say about this old output?") and fails safe when the current spec has drifted.
- Persisting a re-score would clobber the original score's lineage (one row per generation, COALESCE-upsert, no history table). Report-only sidesteps that; persistence is D2b.

### Design

- **Pure core** (`execution/rescore.py`): `revalidate_one(...)` returns a `GenerationRevalidation` (original vs new score/epoch, `was_stale`, `new_matches_active`, `score_delta`, and one of five statuses: `revalidated`, `skipped_no_artifact`, `skipped_no_active_epoch`, `skipped_no_evaluator`, `error`). The scorer is injected, so the core has no provider/network/DB dependency and is fully unit-tested with a fake.
- **CLI** (`cli_rescore.py`): reconstructs the evaluator by reusing the scenario task's own `evaluate_output` (the exact path a fresh run scores through, so the re-score is faithful and scoring is not re-implemented); fetches the original competitor artifact via `get_agent_outputs_by_role`. Read-only: no `upsert_generation`, no registry write, no quarantine clear.
- Registered in `cli-contract.json` (`python: yes`, `typescript: intentional_gap`, consistent with the epoch CLI, since the judge + registry path is Python-only).

### Fail-safe

Every failure mode degrades to a per-generation skip with a reason and exit 0 (no competitor artifact, no active epoch, non-agent-task scenario, scoring error). Only a missing run or missing `--generation N` is a not-found error (exit 1). Nothing crashes; no paid LLM call happens in tests (the scoring seam is injected/patched).

### Acceptance criterion advanced

AC-885 "add a lazy re-score or revalidation path for raw artifacts when stale scored records are touched": `autoctx rescore` re-runs the current evaluator against a stale generation's raw artifact and reports the fresh score and epoch, on operator demand. Covered by `test_rescore_core.py` (all statuses + derived fields) and `test_cli_rescore.py` (revalidated-stale, no-active-epoch, no-artifact, missing-run, non-agent-task).

### Review

Built subagent-driven (fresh opus implementer per task, per-task reviews, opus whole-branch review verdict "ready to merge"). Per-task review confirmed the command is genuinely read-only and fail-safe; two Minors folded in (`--json` errors now emit JSON matching sibling commands; the competitor-artifact last-wins selection documented to match training-export). The full Python suite was run before opening this PR (green); the module-size, serde, and cli-contract parity gates all pass.

### Deferred (D2b)

Persisting a re-score: a `generation_score_revisions` table, an `--apply` flag, clearing quarantine after a successful active-epoch re-score, and TS parity for the new table.

Local gates green: full Python suite, module-size, serde-convention, cli-contract parity (the new `rescore` entry), schema-parity (unchanged: no new columns). `uv.lock` untouched, no em dashes in added lines. Python-only slice (no TS changes).

Left open for review; do not merge without authorization.
