### PR TITLE
feat(server): add durable run transcript replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- TypeScript interactive runs now support an explicit opt-in, capability-versioned durable transcript with stable client/run/event identity, monotonic source sequencing, crash-safe request fingerprints, correlated operator commands, bounded/redacted exact-frame retention, atomic compaction, and `resume_run` reconnect/backfill across server restarts while plain connections remain strict v1-compatible (ERP-88).
 - Ambient per-role live-serving bridge (opt-in, AC-893): the promote stage writes a serving manifest mapping (real scenario, role) to the promoted ambient target, and the serving resolver reads it so a promoted model reaches its role in a live run (ambient candidates are slotted by target name, but generation resolves by real scenario). Off by default; enable by pointing BOTH the ambient daemon and the generation-loop process at one shared file via `AUTOCONTEXT_AMBIENT_SERVING_MANIFEST_PATH`.
 - `autoctx ambient` foundation: a charter-driven resident daemon skeleton (interview wizard, autonomy dial with guardrail floors, durable stage queue, five stages with auto-pause breakers, status/run/once cli). Stages are no-ops pending the ingest, curation, and training plans (docs/ambient-trainer-design.md).
 - The ambient ingest stage is live: charter-enabled sources (autocontext-native runs, jsonl trace feeds) flow through the redaction gate into an append-only trace store with per-source cursors and disk-quota retention; the llm proxy tap follows in the next slice.

--- a/autocontext/src/autocontext/server/protocol.py
+++ b/autocontext/src/autocontext/server/protocol.py
@@ -15,6 +15,10 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 PROTOCOL_VERSION = 1
 
+
+def _is_none(value: object) -> bool:
+    return value is None
+
 # ---------------------------------------------------------------------------
 # Nested / shared models
 # ---------------------------------------------------------------------------
@@ -61,6 +65,23 @@ class ScoringComponent(BaseModel):
     weight: float
 
 
+class RunMessageMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    client_run_id: str | None = Field(default=None, exclude_if=_is_none)
+    event_id: str | None = Field(default=None, exclude_if=_is_none)
+    sequence: int | None = Field(default=None, exclude_if=_is_none)
+    run_id: str | None = Field(default=None, exclude_if=_is_none)
+    occurred_at: str | float | None = Field(default=None, exclude_if=_is_none)
+
+
+class RunCommandMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    client_run_id: str | None = None
+    command_id: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # Server -> Client messages
 # ---------------------------------------------------------------------------
@@ -71,9 +92,11 @@ class HelloMsg(BaseModel):
 
     type: Literal["hello"] = "hello"
     protocol_version: int = PROTOCOL_VERSION
+    transcript_protocol_version: int | None = Field(default=None, exclude_if=_is_none)
+    capabilities: list[str] | None = Field(default=None, exclude_if=_is_none)
 
 
-class EventMsg(BaseModel):
+class EventMsg(RunMessageMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["event"] = "event"
@@ -81,7 +104,7 @@ class EventMsg(BaseModel):
     payload: dict[str, Any]
 
 
-class StateMsg(BaseModel):
+class StateMsg(RunMessageMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["state"] = "state"
@@ -90,12 +113,13 @@ class StateMsg(BaseModel):
     phase: str = ""
 
 
-class ChatResponseMsg(BaseModel):
+class ChatResponseMsg(RunMessageMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["chat_response"] = "chat_response"
     role: str
     text: str
+    command_id: str | None = Field(default=None, exclude_if=_is_none)
 
 
 class EnvironmentsMsg(BaseModel):
@@ -108,28 +132,31 @@ class EnvironmentsMsg(BaseModel):
     agent_provider: str
 
 
-class RunAcceptedMsg(BaseModel):
+class RunAcceptedMsg(RunMessageMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["run_accepted"] = "run_accepted"
     run_id: str
     scenario: str
     generations: int
+    command_id: str | None = Field(default=None, exclude_if=_is_none)
 
 
-class AckMsg(BaseModel):
+class AckMsg(RunMessageMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["ack"] = "ack"
     action: str
     decision: str | None = None
+    command_id: str | None = Field(default=None, exclude_if=_is_none)
 
 
-class ErrorMsg(BaseModel):
+class ErrorMsg(RunMessageMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["error"] = "error"
     message: str
+    command_id: str | None = Field(default=None, exclude_if=_is_none)
 
 
 class ScenarioGeneratingMsg(BaseModel):
@@ -168,7 +195,7 @@ class ScenarioErrorMsg(BaseModel):
     stage: str
 
 
-class MonitorAlertMsg(BaseModel):
+class MonitorAlertMsg(RunMessageMetadata):
     """Pushed to WebSocket clients when a monitor condition fires (AC-209)."""
 
     model_config = ConfigDict(extra="forbid")
@@ -205,33 +232,33 @@ ServerMessage = Annotated[
 # ---------------------------------------------------------------------------
 
 
-class PauseCmd(BaseModel):
+class PauseCmd(RunCommandMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["pause"] = "pause"
 
 
-class ResumeCmd(BaseModel):
+class ResumeCmd(RunCommandMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["resume"] = "resume"
 
 
-class InjectHintCmd(BaseModel):
+class InjectHintCmd(RunCommandMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["inject_hint"] = "inject_hint"
     text: str = Field(min_length=1)
 
 
-class OverrideGateCmd(BaseModel):
+class OverrideGateCmd(RunCommandMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["override_gate"] = "override_gate"
     decision: Literal["advance", "retry", "rollback"]
 
 
-class ChatAgentCmd(BaseModel):
+class ChatAgentCmd(RunCommandMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["chat_agent"] = "chat_agent"
@@ -239,7 +266,7 @@ class ChatAgentCmd(BaseModel):
     message: str = Field(min_length=1)
 
 
-class StartRunCmd(BaseModel):
+class StartRunCmd(RunCommandMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["start_run"] = "start_run"

--- a/autocontext/tests/test_protocol.py
+++ b/autocontext/tests/test_protocol.py
@@ -93,9 +93,28 @@ class TestHelloMsg:
         restored = HelloMsg(**d)
         assert restored == msg
 
+    def test_transcript_capability_is_explicit(self) -> None:
+        msg = HelloMsg(
+            transcript_protocol_version=1,
+            capabilities=["run_transcript_v1"],
+        )
+        assert msg.model_dump() == {
+            "type": "hello",
+            "protocol_version": PROTOCOL_VERSION,
+            "transcript_protocol_version": 1,
+            "capabilities": ["run_transcript_v1"],
+        }
+
 
 class TestServerMessageRoundTrip:
     """Verify every server message type can be serialized and deserialized."""
+
+    def test_unset_transcript_metadata_does_not_change_legacy_wire_shape(self) -> None:
+        assert EventMsg(event="run_started", payload={"run_id": "r1"}).model_dump() == {
+            "type": "event",
+            "event": "run_started",
+            "payload": {"run_id": "r1"},
+        }
 
     @pytest.mark.parametrize(
         "model,kwargs",
@@ -165,6 +184,20 @@ class TestClientMessageParsing:
     def test_valid_messages(self, raw: dict, expected_type: type) -> None:
         msg = parse_client_message(raw)
         assert isinstance(msg, expected_type)
+
+    def test_run_command_correlation_fields_are_additive(self) -> None:
+        msg = parse_client_message(
+            {
+                "type": "start_run",
+                "scenario": "grid_ctf",
+                "generations": 3,
+                "client_run_id": "client-run-1",
+                "command_id": "command-start-1",
+            }
+        )
+        assert isinstance(msg, StartRunCmd)
+        assert msg.client_run_id == "client-run-1"
+        assert msg.command_id == "command-start-1"
 
     def test_unknown_type_rejected(self) -> None:
         with pytest.raises(ValidationError):

--- a/docs/websocket-protocol-contract.json
+++ b/docs/websocket-protocol-contract.json
@@ -2,6 +2,23 @@
   "version": 1,
   "contract": "interactive WebSocket protocol surface shared by Python and TypeScript with runtime-only extensions marked explicitly",
   "protocol_version": 1,
+  "transcript_extension": {
+    "capability": "run_transcript_v1",
+    "transcript_protocol_version": 1,
+    "opt_in_query": "transcript_protocol_version=1",
+    "legacy_default": true,
+    "resume_command": "resume_run",
+    "identity_fields": ["client_run_id", "event_id", "sequence", "occurred_at"],
+    "retention": {
+      "bounded": true,
+      "max_age_days": 7,
+      "max_file_bytes": 33554432,
+      "max_frames": 20000,
+      "max_frames_per_run": 2000,
+      "max_commands": 20000,
+      "idempotency_horizon": "same as retained command and response records"
+    }
+  },
   "endpoints": [
     {
       "path": "/ws/interactive",
@@ -83,6 +100,10 @@
     }
   ],
   "typescript_only_client_messages": [
+    {
+      "type": "resume_run",
+      "reason": "TypeScript durable run transcript resume/backfill extension"
+    },
     {
       "type": "login",
       "reason": "TypeScript TUI provider-auth workflow"

--- a/protocol/autocontext-protocol.json
+++ b/protocol/autocontext-protocol.json
@@ -5,6 +5,69 @@
       "AckMsg": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Run Id"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
           "type": {
             "const": "ack",
             "default": "ack",
@@ -26,6 +89,18 @@
             ],
             "default": null,
             "title": "Decision"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
           }
         },
         "required": [
@@ -37,6 +112,69 @@
       "ChatResponseMsg": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Run Id"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
           "type": {
             "const": "chat_response",
             "default": "chat_response",
@@ -50,6 +188,18 @@
           "text": {
             "title": "Text",
             "type": "string"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
           }
         },
         "required": [
@@ -103,6 +253,69 @@
       "ErrorMsg": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Run Id"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
           "type": {
             "const": "error",
             "default": "error",
@@ -112,6 +325,18 @@
           "message": {
             "title": "Message",
             "type": "string"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
           }
         },
         "required": [
@@ -123,6 +348,69 @@
       "EventMsg": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Run Id"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
           "type": {
             "const": "event",
             "default": "event",
@@ -228,6 +516,33 @@
             "default": 1,
             "title": "Protocol Version",
             "type": "integer"
+          },
+          "transcript_protocol_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Transcript Protocol Version"
+          },
+          "capabilities": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Capabilities"
           }
         },
         "title": "HelloMsg",
@@ -237,6 +552,69 @@
         "additionalProperties": false,
         "description": "Pushed to WebSocket clients when a monitor condition fires (AC-209).",
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Run Id"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
           "type": {
             "const": "monitor_alert",
             "default": "monitor_alert",
@@ -282,14 +660,65 @@
       "RunAcceptedMsg": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "title": "Run Id",
+            "type": "string"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
           "type": {
             "const": "run_accepted",
             "default": "run_accepted",
             "title": "Type",
-            "type": "string"
-          },
-          "run_id": {
-            "title": "Run Id",
             "type": "string"
           },
           "scenario": {
@@ -299,6 +728,18 @@
           "generations": {
             "title": "Generations",
             "type": "integer"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
           }
         },
         "required": [
@@ -487,6 +928,69 @@
       "StateMsg": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Run Id"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
           "type": {
             "const": "state",
             "default": "state",
@@ -612,6 +1116,30 @@
       "ChatAgentCmd": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
           "type": {
             "const": "chat_agent",
             "default": "chat_agent",
@@ -672,6 +1200,30 @@
       "InjectHintCmd": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
           "type": {
             "const": "inject_hint",
             "default": "inject_hint",
@@ -706,6 +1258,30 @@
       "OverrideGateCmd": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
           "type": {
             "const": "override_gate",
             "default": "override_gate",
@@ -731,6 +1307,30 @@
       "PauseCmd": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
           "type": {
             "const": "pause",
             "default": "pause",
@@ -744,6 +1344,30 @@
       "ResumeCmd": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
           "type": {
             "const": "resume",
             "default": "resume",
@@ -778,6 +1402,30 @@
       "StartRunCmd": {
         "additionalProperties": false,
         "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
           "type": {
             "const": "start_run",
             "default": "start_run",

--- a/ts/README.md
+++ b/ts/README.md
@@ -82,6 +82,39 @@ autoctx mcp-serve
 
 The MCP server exposes 40+ tools across scenarios, runs, knowledge, evaluation, feedback, solve (`solve_scenario`, `solve_status`, `solve_result`), sandbox (`sandbox_create`, `sandbox_run`, `sandbox_status`, ...), export, and discovery (`capabilities`). Python and TypeScript share the same high-level vocabulary; parity details are tracked in [../docs/scenario-parity-matrix.md](../docs/scenario-parity-matrix.md).
 
+### Interactive run transcript extension
+
+The TypeScript `/ws/interactive` server keeps the base WebSocket
+`protocol_version` at `1`. Plain `/ws/interactive` connections retain the exact
+legacy v1 hello and run-frame shapes. Clients explicitly opt into durable
+transcripts with `/ws/interactive?transcript_protocol_version=1`; that connection
+advertises `transcript_protocol_version: 1` and the `run_transcript_v1` capability.
+Clients may attach a stable `client_run_id` and `command_id` to `start_run`,
+operator-control, and chat commands. Run-scoped responses then include stable
+`event_id`, monotonic `sequence`, `client_run_id`, and `occurred_at` fields.
+
+Reconnect with:
+
+```json
+{
+  "type": "resume_run",
+  "client_run_id": "control-plane-run-id",
+  "after_sequence": 42,
+  "command_id": "resume-attempt-id"
+}
+```
+
+The server replays the exact retained wire frames after that cursor and finishes
+with a correlated `ack`. Frames and request fingerprints are synchronously
+persisted before side effects or delivery under
+`runs/_interactive/run-transcript.ndjson`, survive server restarts, and only store
+an allowlisted, size-bounded, redacted presentation payload. Retention is bounded
+by age, file bytes, global/per-run frame counts, and command count; command
+idempotency has the same finite horizon as its retained request and response.
+Compaction uses an fsync-backed atomic replacement. The Python server accepts the
+additive metadata fields for schema compatibility but does not advertise this
+TypeScript-only retention capability.
+
 ## Library usage
 
 ```ts

--- a/ts/src/server/chat-agent-command-workflow.ts
+++ b/ts/src/server/chat-agent-command-workflow.ts
@@ -5,6 +5,8 @@ export interface ChatAgentCommandRunManager {
 }
 
 export function buildChatResponseMessage(opts: {
+  clientRunId?: string;
+  commandId?: string;
   role: string;
   text: string;
 }): ServerMessage {
@@ -12,6 +14,8 @@ export function buildChatResponseMessage(opts: {
     type: "chat_response",
     role: opts.role,
     text: opts.text,
+    ...(opts.clientRunId ? { client_run_id: opts.clientRunId } : {}),
+    ...(opts.commandId ? { command_id: opts.commandId } : {}),
   };
 }
 
@@ -22,6 +26,8 @@ export async function executeChatAgentCommand(opts: {
   const text = await opts.runManager.chatAgent(opts.command.role, opts.command.message);
   return [
     buildChatResponseMessage({
+      clientRunId: opts.command.client_run_id,
+      commandId: opts.command.command_id,
       role: opts.command.role,
       text,
     }),

--- a/ts/src/server/client-error-workflow.ts
+++ b/ts/src/server/client-error-workflow.ts
@@ -8,10 +8,10 @@ export function isInteractiveScenarioCommand(
 > {
   const type = message && typeof message === "object" ? message.type : null;
   return (
-    type === "create_scenario"
-    || type === "confirm_scenario"
-    || type === "revise_scenario"
-    || type === "cancel_scenario"
+    type === "create_scenario" ||
+    type === "confirm_scenario" ||
+    type === "revise_scenario" ||
+    type === "cancel_scenario"
   );
 }
 
@@ -27,8 +27,23 @@ export function buildClientErrorMessage(
       stage: "server",
     };
   }
+  const correlation = commandCorrelation(message);
   return {
     type: "error",
     message: detail,
+    ...correlation,
+  };
+}
+
+function commandCorrelation(message: ClientMessage | null): {
+  client_run_id?: string;
+  command_id?: string;
+} {
+  if (!message) return {};
+  const clientRunId = "client_run_id" in message ? message.client_run_id : undefined;
+  const commandId = "command_id" in message ? message.command_id : undefined;
+  return {
+    ...(clientRunId ? { client_run_id: clientRunId } : {}),
+    ...(commandId ? { command_id: commandId } : {}),
   };
 }

--- a/ts/src/server/index.ts
+++ b/ts/src/server/index.ts
@@ -4,6 +4,8 @@
 
 export {
   PROTOCOL_VERSION,
+  TRANSCRIPT_PROTOCOL_VERSION,
+  SERVER_CAPABILITIES,
   HelloMsgSchema,
   EventMsgSchema,
   StateMsgSchema,
@@ -23,6 +25,7 @@ export {
   OverrideGateCmdSchema,
   ChatAgentCmdSchema,
   StartRunCmdSchema,
+  ResumeRunCmdSchema,
   ListScenariosCmdSchema,
   CreateScenarioCmdSchema,
   ConfirmScenarioCmdSchema,
@@ -40,7 +43,12 @@ export {
 } from "./protocol.js";
 export type { ServerMessage, ClientMessage } from "./protocol.js";
 
-export { handleTuiLogin, handleTuiLogout, handleTuiSwitchProvider, handleTuiWhoami } from "./tui-auth.js";
+export {
+  handleTuiLogin,
+  handleTuiLogout,
+  handleTuiSwitchProvider,
+  handleTuiWhoami,
+} from "./tui-auth.js";
 export type { TuiLoginResult, TuiAuthStatus } from "./tui-auth.js";
 
 export { RunManager } from "./run-manager.js";

--- a/ts/src/server/interactive-control-command-workflow.ts
+++ b/ts/src/server/interactive-control-command-workflow.ts
@@ -20,6 +20,8 @@ export interface InteractiveControlRunManager {
 }
 
 export function buildRunAcceptedMessage(opts: {
+  clientRunId?: string;
+  commandId?: string;
   runId: string;
   scenario: string;
   generations: number;
@@ -29,6 +31,8 @@ export function buildRunAcceptedMessage(opts: {
     run_id: opts.runId,
     scenario: opts.scenario,
     generations: opts.generations,
+    ...(opts.clientRunId ? { client_run_id: opts.clientRunId } : {}),
+    ...(opts.commandId ? { command_id: opts.commandId } : {}),
   };
 }
 
@@ -42,16 +46,23 @@ export async function executeInteractiveControlCommand(opts: {
   switch (opts.command.type) {
     case "pause":
       opts.runManager.pause();
-      return [{ type: "ack", action: "pause" }];
+      return [{ type: "ack", action: "pause", ...commandResponseMetadata(opts.command) }];
     case "resume":
       opts.runManager.resume();
-      return [{ type: "ack", action: "resume" }];
+      return [{ type: "ack", action: "resume", ...commandResponseMetadata(opts.command) }];
     case "inject_hint":
       opts.runManager.injectHint(opts.command.text);
-      return [{ type: "ack", action: "inject_hint" }];
+      return [{ type: "ack", action: "inject_hint", ...commandResponseMetadata(opts.command) }];
     case "override_gate":
       opts.runManager.overrideGate(opts.command.decision);
-      return [{ type: "ack", action: "override_gate", decision: opts.command.decision }];
+      return [
+        {
+          type: "ack",
+          action: "override_gate",
+          decision: opts.command.decision,
+          ...commandResponseMetadata(opts.command),
+        },
+      ];
     case "start_run": {
       const runId = await opts.runManager.startRun(
         opts.command.scenario,
@@ -62,6 +73,8 @@ export async function executeInteractiveControlCommand(opts: {
       );
       return [
         buildRunAcceptedMessage({
+          clientRunId: opts.command.client_run_id,
+          commandId: opts.command.command_id,
           runId,
           scenario: opts.command.scenario,
           generations: opts.command.generations,
@@ -75,4 +88,14 @@ export async function executeInteractiveControlCommand(opts: {
         `Unsupported interactive control command: ${String((opts.command as { type?: unknown }).type ?? "unknown")}`,
       );
   }
+}
+
+function commandResponseMetadata(command: { client_run_id?: string; command_id?: string }): {
+  client_run_id?: string;
+  command_id?: string;
+} {
+  return {
+    ...(command.client_run_id ? { client_run_id: command.client_run_id } : {}),
+    ...(command.command_id ? { command_id: command.command_id } : {}),
+  };
 }

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -6,6 +6,10 @@
 import { z } from "zod";
 
 export const PROTOCOL_VERSION = 1;
+export const TRANSCRIPT_PROTOCOL_VERSION = 1;
+export const TRANSCRIPT_PROTOCOL_QUERY_PARAM = "transcript_protocol_version";
+export const TRANSCRIPT_PROTOCOL_QUERY_VALUE = String(TRANSCRIPT_PROTOCOL_VERSION);
+export const SERVER_CAPABILITIES = ["run_transcript_v1"] as const;
 
 const protocolObject = <T extends z.ZodRawShape>(shape: T) => z.object(shape).strict();
 
@@ -47,6 +51,7 @@ export const PYTHON_SHARED_CLIENT_MESSAGE_TYPES = [
 ] as const;
 
 export const TYPESCRIPT_ONLY_CLIENT_MESSAGE_TYPES = [
+  "resume_run",
   "login",
   "logout",
   "switch_provider",
@@ -93,6 +98,19 @@ export const ScoringComponentSchema = protocolObject({
   weight: z.number(),
 });
 
+const RunMessageMetadataSchema = {
+  client_run_id: z.string().min(1).max(200).optional(),
+  event_id: z.string().min(1).optional(),
+  sequence: z.number().int().nonnegative().optional(),
+  run_id: z.string().min(1).optional(),
+  occurred_at: z.union([z.string(), z.number()]).optional(),
+} as const;
+
+const RunCommandMetadataSchema = {
+  client_run_id: z.string().min(1).max(200).optional(),
+  command_id: z.string().min(1).max(200).optional(),
+} as const;
+
 // ---------------------------------------------------------------------------
 // Server → Client messages
 // ---------------------------------------------------------------------------
@@ -100,12 +118,15 @@ export const ScoringComponentSchema = protocolObject({
 export const HelloMsgSchema = protocolObject({
   type: z.literal("hello"),
   protocol_version: z.number().int().optional(),
+  transcript_protocol_version: z.number().int().positive().optional(),
+  capabilities: z.array(z.string()).optional(),
 });
 
 export const EventMsgSchema = protocolObject({
   type: z.literal("event"),
   event: z.string(),
   payload: z.record(z.unknown()),
+  ...RunMessageMetadataSchema,
 });
 
 export const StateMsgSchema = protocolObject({
@@ -113,12 +134,15 @@ export const StateMsgSchema = protocolObject({
   paused: z.boolean(),
   generation: z.number().int().optional(),
   phase: z.string().optional(),
+  ...RunMessageMetadataSchema,
 });
 
 export const ChatResponseMsgSchema = protocolObject({
   type: z.literal("chat_response"),
   role: z.string(),
   text: z.string(),
+  command_id: z.string().min(1).max(200).optional(),
+  ...RunMessageMetadataSchema,
 });
 
 export const EnvironmentsMsgSchema = protocolObject({
@@ -131,20 +155,26 @@ export const EnvironmentsMsgSchema = protocolObject({
 
 export const RunAcceptedMsgSchema = protocolObject({
   type: z.literal("run_accepted"),
+  ...RunMessageMetadataSchema,
   run_id: z.string(),
   scenario: z.string(),
   generations: z.number().int(),
+  command_id: z.string().min(1).max(200).optional(),
 });
 
 export const AckMsgSchema = protocolObject({
   type: z.literal("ack"),
   action: z.string(),
   decision: z.string().optional().nullable(),
+  command_id: z.string().min(1).max(200).optional(),
+  ...RunMessageMetadataSchema,
 });
 
 export const ErrorMsgSchema = protocolObject({
   type: z.literal("error"),
   message: z.string(),
+  command_id: z.string().min(1).max(200).optional(),
+  ...RunMessageMetadataSchema,
 });
 
 export const ScenarioGeneratingMsgSchema = protocolObject({
@@ -183,6 +213,7 @@ export const MonitorAlertMsgSchema = protocolObject({
   condition_type: z.string(),
   scope: z.string(),
   detail: z.string(),
+  ...RunMessageMetadataSchema,
 });
 
 // Mission progress (AC-414)
@@ -216,23 +247,32 @@ export const AuthStatusMsgSchema = protocolObject({
 // Client → Server commands
 // ---------------------------------------------------------------------------
 
-export const PauseCmdSchema = protocolObject({ type: z.literal("pause") });
-export const ResumeCmdSchema = protocolObject({ type: z.literal("resume") });
+export const PauseCmdSchema = protocolObject({
+  type: z.literal("pause"),
+  ...RunCommandMetadataSchema,
+});
+export const ResumeCmdSchema = protocolObject({
+  type: z.literal("resume"),
+  ...RunCommandMetadataSchema,
+});
 
 export const InjectHintCmdSchema = protocolObject({
   type: z.literal("inject_hint"),
   text: z.string().min(1),
+  ...RunCommandMetadataSchema,
 });
 
 export const OverrideGateCmdSchema = protocolObject({
   type: z.literal("override_gate"),
   decision: z.enum(["advance", "retry", "rollback"]),
+  ...RunCommandMetadataSchema,
 });
 
 export const ChatAgentCmdSchema = protocolObject({
   type: z.literal("chat_agent"),
   role: z.string(),
   message: z.string().min(1),
+  ...RunCommandMetadataSchema,
 });
 
 export const StartRunCmdSchema = protocolObject({
@@ -240,6 +280,14 @@ export const StartRunCmdSchema = protocolObject({
   scenario: z.string(),
   generations: z.number().int().positive(),
   require_playbook_approval: z.boolean().default(false),
+  ...RunCommandMetadataSchema,
+});
+
+export const ResumeRunCmdSchema = protocolObject({
+  type: z.literal("resume_run"),
+  client_run_id: z.string().min(1).max(200),
+  after_sequence: z.number().int().nonnegative(),
+  command_id: z.string().min(1).max(200).optional(),
 });
 
 export const ListScenariosCmdSchema = protocolObject({
@@ -321,6 +369,7 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   ConfirmScenarioCmdSchema,
   ReviseScenarioCmdSchema,
   CancelScenarioCmdSchema,
+  ResumeRunCmdSchema,
   LoginCmdSchema,
   LogoutCmdSchema,
   SwitchProviderCmdSchema,

--- a/ts/src/server/run-transcript-frame.ts
+++ b/ts/src/server/run-transcript-frame.ts
@@ -1,0 +1,312 @@
+import type { ServerMessage } from "./protocol.js";
+
+const REDACTED_VALUE = "[Redacted]";
+const TRUNCATED_VALUE = "[Truncated]";
+const MAX_TEXT_LENGTH = 4_000;
+const MAX_ARRAY_ITEMS = 16;
+const MAX_OBJECT_KEYS = 24;
+const MAX_VALUE_DEPTH = 4;
+const MAX_FALLBACK_FIELD_LENGTH = 256;
+export const MAX_RETAINED_MESSAGE_BYTES = 8 * 1_024;
+
+const SENSITIVE_KEY_PARTS = [
+  "accesskey",
+  "apikey",
+  "auth",
+  "authorization",
+  "bearer",
+  "clientsecret",
+  "cookie",
+  "credential",
+  "passphrase",
+  "password",
+  "privatekey",
+  "secret",
+  "sessionkey",
+  "signature",
+  "token",
+] as const;
+
+const SAFE_TOKEN_METRIC_KEYS = new Set([
+  "inputtokens",
+  "outputtokens",
+  "tokencount",
+  "tokens",
+  "totaltokens",
+]);
+
+const AUTHORIZATION_PATTERN =
+  /\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer\s+)?[^\s,;]+/gi;
+const CREDENTIAL_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|access[_-]?key|client[_-]?secret|refresh[_-]?token|session[_-]?(?:key|token)|token|secret|password|passphrase|cookie|credential)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
+const QUERY_CREDENTIAL_PATTERN =
+  /([?&](?:api[_-]?key|access[_-]?key|client[_-]?secret|refresh[_-]?token|session[_-]?(?:key|token)|token|secret|password|passphrase|signature)=)[^&#\s]+/gi;
+const URL_USERINFO_PATTERN = /(https?:\/\/)[^/@\s]+@/gi;
+const BARE_BEARER_PATTERN =
+  /\bbearer\s+[A-Za-z0-9._~+/-]{12,}={0,2}(?=\s|$|[,;])/gi;
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
+const PRIVATE_KEY_PATTERN =
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g;
+const DASHED_PROVIDER_TOKEN_PATTERN = /\b(?:sk|pk)-[A-Za-z0-9_-]{8,}\b/g;
+const UNDERSCORED_PROVIDER_TOKEN_PATTERN = /\b(?:gsk|sk|pk)_[A-Za-z0-9_-]{8,}\b/g;
+const GOOGLE_API_KEY_PATTERN = /\bAIza[0-9A-Za-z_-]{20,}\b/g;
+const AWS_ACCESS_KEY_PATTERN =
+  /\b(?:A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA)[A-Z0-9]{16}\b/g;
+const GITHUB_TOKEN_PATTERN = /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b/g;
+const GITHUB_PAT_PATTERN = /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g;
+const GITLAB_TOKEN_PATTERN = /\bglpat-[A-Za-z0-9_-]{12,}\b/g;
+const SLACK_TOKEN_PATTERN = /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g;
+
+const EVENT_PAYLOAD_FIELDS: Readonly<Record<string, readonly string[]>> = {
+  action_detail: [
+    "action_id",
+    "id",
+    "name",
+    "action_name",
+    "kind",
+    "status",
+    "role",
+    "tool",
+    "tool_name",
+    "generation",
+    "activity_kind",
+    "started_at",
+    "started_at_ms",
+    "completed_at",
+    "completed_at_ms",
+    "duration_ms",
+    "input",
+    "output",
+    "artifacts",
+    "run_id",
+  ],
+  agents_started: ["run_id", "generation", "roles"],
+  curator_completed: ["run_id", "generation", "decision"],
+  gate_decided: ["run_id", "generation", "decision", "delta", "reason"],
+  generation_completed: [
+    "run_id",
+    "generation",
+    "mean_score",
+    "best_score",
+    "elo",
+    "gate_decision",
+    "created_tools",
+  ],
+  generation_started: ["run_id", "generation"],
+  generation_timing: ["run_id", "generation", "elapsed_seconds"],
+  match_completed: ["run_id", "generation", "match_index", "score"],
+  role_completed: ["run_id", "generation", "role", "latency_ms", "tokens"],
+  run_completed: [
+    "run_id",
+    "generation",
+    "completed_generations",
+    "best_score",
+    "elo",
+    "dead_ends_found",
+  ],
+  run_failed: ["run_id", "generation", "error"],
+  run_started: ["run_id", "scenario", "target_generations"],
+  tournament_completed: [
+    "run_id",
+    "generation",
+    "mean_score",
+    "best_score",
+    "wins",
+    "losses",
+    "dimension_means",
+    "dimension_regressions",
+  ],
+  tournament_started: ["run_id", "generation", "matches"],
+};
+
+type PresentationValue =
+  string | number | boolean | null | PresentationValue[] | { [key: string]: PresentationValue };
+
+export function sanitizeRunTranscriptText(value: string): string {
+  const sanitized = value
+    .replace(AUTHORIZATION_PATTERN, REDACTED_VALUE)
+    .replace(CREDENTIAL_ASSIGNMENT_PATTERN, REDACTED_VALUE)
+    .replace(QUERY_CREDENTIAL_PATTERN, `$1${REDACTED_VALUE}`)
+    .replace(URL_USERINFO_PATTERN, "$1[Redacted]@")
+    .replace(BARE_BEARER_PATTERN, REDACTED_VALUE)
+    .replace(JWT_PATTERN, REDACTED_VALUE)
+    .replace(PRIVATE_KEY_PATTERN, REDACTED_VALUE)
+    .replace(DASHED_PROVIDER_TOKEN_PATTERN, REDACTED_VALUE)
+    .replace(UNDERSCORED_PROVIDER_TOKEN_PATTERN, REDACTED_VALUE)
+    .replace(GOOGLE_API_KEY_PATTERN, REDACTED_VALUE)
+    .replace(AWS_ACCESS_KEY_PATTERN, REDACTED_VALUE)
+    .replace(GITHUB_TOKEN_PATTERN, REDACTED_VALUE)
+    .replace(GITHUB_PAT_PATTERN, REDACTED_VALUE)
+    .replace(GITLAB_TOKEN_PATTERN, REDACTED_VALUE)
+    .replace(SLACK_TOKEN_PATTERN, REDACTED_VALUE);
+  return sanitized.length <= MAX_TEXT_LENGTH
+    ? sanitized
+    : `${sanitized.slice(0, MAX_TEXT_LENGTH)}…`;
+}
+
+export function sanitizeRunTranscriptMessage(message: ServerMessage): ServerMessage | null {
+  const safe = sanitizeRunTranscriptMessageInternal(message);
+  if (!safe) return null;
+  if (Buffer.byteLength(JSON.stringify(safe), "utf-8") <= MAX_RETAINED_MESSAGE_BYTES) {
+    return safe;
+  }
+  return truncateRunTranscriptMessage(safe);
+}
+
+function sanitizeRunTranscriptMessageInternal(message: ServerMessage): ServerMessage | null {
+  switch (message.type) {
+    case "event": {
+      const allowedFields = Object.prototype.hasOwnProperty.call(
+        EVENT_PAYLOAD_FIELDS,
+        message.event,
+      )
+        ? EVENT_PAYLOAD_FIELDS[message.event]
+        : undefined;
+      return {
+        type: "event",
+        event: sanitizeRunTranscriptText(message.event),
+        payload: allowedFields ? sanitizePayload(message.payload, allowedFields) : {},
+      };
+    }
+    case "state":
+      return {
+        type: "state",
+        paused: message.paused,
+        generation: message.generation,
+        phase: message.phase ? sanitizeRunTranscriptText(message.phase) : undefined,
+      };
+    case "run_accepted":
+      return {
+        type: "run_accepted",
+        run_id: sanitizeRunTranscriptText(message.run_id),
+        scenario: sanitizeRunTranscriptText(message.scenario),
+        generations: message.generations,
+      };
+    case "ack":
+      return {
+        type: "ack",
+        action: sanitizeRunTranscriptText(message.action),
+        decision: message.decision ? sanitizeRunTranscriptText(message.decision) : message.decision,
+      };
+    case "chat_response":
+      return {
+        type: "chat_response",
+        role: sanitizeRunTranscriptText(message.role),
+        text: sanitizeRunTranscriptText(message.text),
+      };
+    case "error":
+      return {
+        type: "error",
+        message: sanitizeRunTranscriptText(message.message),
+      };
+    case "monitor_alert":
+      return {
+        type: "monitor_alert",
+        alert_id: sanitizeRunTranscriptText(message.alert_id),
+        condition_id: sanitizeRunTranscriptText(message.condition_id),
+        condition_name: sanitizeRunTranscriptText(message.condition_name),
+        condition_type: sanitizeRunTranscriptText(message.condition_type),
+        scope: sanitizeRunTranscriptText(message.scope),
+        detail: sanitizeRunTranscriptText(message.detail),
+      };
+    default:
+      return null;
+  }
+}
+
+function truncateRunTranscriptMessage(message: ServerMessage): ServerMessage | null {
+  switch (message.type) {
+    case "event":
+      return {
+        type: "event",
+        event: message.event.slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        payload: { detail: TRUNCATED_VALUE },
+      };
+    case "state":
+      return {
+        type: "state",
+        paused: message.paused,
+        ...(message.generation === undefined ? {} : { generation: message.generation }),
+        ...(message.phase === undefined ? {} : { phase: TRUNCATED_VALUE }),
+      };
+    case "run_accepted":
+      return {
+        type: "run_accepted",
+        run_id: sanitizeRunTranscriptText(message.run_id).slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        scenario: TRUNCATED_VALUE,
+        generations: message.generations,
+      };
+    case "ack":
+      return { type: "ack", action: TRUNCATED_VALUE, decision: null };
+    case "chat_response":
+      return {
+        type: "chat_response",
+        role: sanitizeRunTranscriptText(message.role).slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        text: TRUNCATED_VALUE,
+      };
+    case "error":
+      return { type: "error", message: TRUNCATED_VALUE };
+    case "monitor_alert":
+      return {
+        type: "monitor_alert",
+        alert_id: message.alert_id.slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        condition_id: message.condition_id.slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        condition_name: message.condition_name.slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        condition_type: message.condition_type.slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        scope: message.scope.slice(0, MAX_FALLBACK_FIELD_LENGTH),
+        detail: TRUNCATED_VALUE,
+      };
+    default:
+      return null;
+  }
+}
+
+function sanitizePayload(
+  payload: Record<string, unknown>,
+  allowedFields: readonly string[],
+): Record<string, PresentationValue> {
+  const allowed = new Set(allowedFields);
+  const result: Record<string, PresentationValue> = Object.create(null);
+  for (const [key, value] of Object.entries(payload)) {
+    if (!allowed.has(key)) continue;
+    result[key] = isSensitiveKey(key) ? REDACTED_VALUE : sanitizeValue(value, 0);
+  }
+  return result;
+}
+
+function sanitizeValue(value: unknown, depth: number): PresentationValue {
+  if (value === null) return null;
+  if (typeof value === "string") return sanitizeRunTranscriptText(value);
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : TRUNCATED_VALUE;
+  if (depth >= MAX_VALUE_DEPTH) return TRUNCATED_VALUE;
+  if (Array.isArray(value)) {
+    const sanitized = value.slice(0, MAX_ARRAY_ITEMS).map((item) => sanitizeValue(item, depth + 1));
+    if (value.length > MAX_ARRAY_ITEMS) sanitized.push(TRUNCATED_VALUE);
+    return sanitized;
+  }
+  if (!isRecord(value)) return TRUNCATED_VALUE;
+
+  const result: Record<string, PresentationValue> = Object.create(null);
+  const entries = Object.entries(value);
+  for (const [key, entry] of entries.slice(0, MAX_OBJECT_KEYS)) {
+    const sanitizedKey = sanitizeRunTranscriptText(key);
+    if (isSensitiveKey(key) || sanitizedKey !== key) {
+      result[sanitizedKey === key ? key : REDACTED_VALUE] = REDACTED_VALUE;
+      continue;
+    }
+    result[key] = sanitizeValue(entry, depth + 1);
+  }
+  if (entries.length > MAX_OBJECT_KEYS) result[TRUNCATED_VALUE] = TRUNCATED_VALUE;
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSensitiveKey(value: string): boolean {
+  const normalized = value.toLowerCase().replaceAll("-", "").replaceAll("_", "");
+  if (SAFE_TOKEN_METRIC_KEYS.has(normalized)) return false;
+  return SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part));
+}

--- a/ts/src/server/run-transcript-store.ts
+++ b/ts/src/server/run-transcript-store.ts
@@ -1,0 +1,736 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { z } from "zod";
+
+import {
+  ServerMessageSchema,
+  TRANSCRIPT_PROTOCOL_VERSION,
+  type ClientMessage,
+  type ServerMessage,
+} from "./protocol.js";
+import { sanitizeRunTranscriptMessage } from "./run-transcript-frame.js";
+
+const RETAINED_MESSAGE_TYPES = new Set([
+  "ack",
+  "chat_response",
+  "error",
+  "event",
+  "monitor_alert",
+  "run_accepted",
+  "state",
+]);
+
+const RetainedRunMessageSchema = ServerMessageSchema.and(
+  z.object({
+    client_run_id: z.string().min(1).max(200),
+    event_id: z.string().min(1),
+    sequence: z.number().int().positive(),
+    occurred_at: z.string().datetime(),
+  }),
+);
+
+export type RetainedRunMessage = z.infer<typeof RetainedRunMessageSchema>;
+
+export interface RetainedRunFrame {
+  clientRunId: string;
+  eventId: string;
+  message: RetainedRunMessage;
+  occurredAt: string;
+  runId: string | null;
+  sequence: number;
+  wire: string;
+}
+
+type CommandStatus = "completed" | "pending";
+
+interface CommandRecord {
+  clientRunId: string;
+  commandId: string;
+  fingerprint: string;
+  occurredAt: string;
+  responseEventId?: string;
+  status: CommandStatus;
+}
+
+interface PersistedRunFrame {
+  record_type: "frame";
+  transcript_protocol_version: number;
+  client_run_id: string;
+  event_id: string;
+  occurred_at: string;
+  run_id?: string;
+  sequence: number;
+  wire: string;
+}
+
+interface PersistedCommandRecord {
+  record_type: "command";
+  transcript_protocol_version: number;
+  client_run_id: string;
+  command_id: string;
+  fingerprint: string;
+  occurred_at: string;
+  response_event_id?: string;
+  status: CommandStatus;
+}
+
+export type BeginCommandResult =
+  | { outcome: "completed"; frame: RetainedRunFrame }
+  | { outcome: "conflict" }
+  | { outcome: "pending" }
+  | { outcome: "proceed" };
+
+export interface RunTranscriptRetentionPolicy {
+  loadTailBytes: number;
+  maxAgeMs: number;
+  maxCommands: number;
+  maxFileBytes: number;
+  maxFrames: number;
+  maxFramesPerRun: number;
+  maxRecordBytes: number;
+}
+
+export const RUN_TRANSCRIPT_RETENTION: RunTranscriptRetentionPolicy = {
+  loadTailBytes: 32 * 1_024 * 1_024,
+  maxAgeMs: 7 * 24 * 60 * 60 * 1_000,
+  maxCommands: 20_000,
+  maxFileBytes: 32 * 1_024 * 1_024,
+  maxFrames: 20_000,
+  maxFramesPerRun: 2_000,
+  maxRecordBytes: 32 * 1_024,
+};
+
+interface SerializedRecord {
+  commandKey?: string;
+  eventId?: string;
+  line: string;
+  occurredAt: string;
+}
+
+export class RunTranscriptStore {
+  readonly path: string;
+  readonly #policy: RunTranscriptRetentionPolicy;
+  readonly #framesByClientRunId = new Map<string, RetainedRunFrame[]>();
+  readonly #commands = new Map<string, CommandRecord>();
+  readonly #clientRunIdByRunId = new Map<string, string>();
+  readonly #runIdByClientRunId = new Map<string, string>();
+
+  constructor(path: string, policy: Partial<RunTranscriptRetentionPolicy> = {}) {
+    this.path = path;
+    this.#policy = validatePolicy({ ...RUN_TRANSCRIPT_RETENTION, ...policy });
+    const requiresCompaction = this.#loadBoundedTail();
+    this.#enforceRetention(requiresCompaction);
+  }
+
+  record(opts: {
+    clientRunId: string;
+    commandId?: string;
+    message: ServerMessage;
+    occurredAt?: string;
+    runId?: string | null;
+  }): RetainedRunFrame | null {
+    const commandId = opts.commandId ?? readCommandId(opts.message) ?? undefined;
+    const safeMessage = sanitizeRunTranscriptMessage(opts.message);
+    if (!safeMessage) return null;
+
+    const existingRunId = this.#runIdByClientRunId.get(opts.clientRunId);
+    const runId = opts.runId ?? existingRunId ?? readRunId(safeMessage);
+    this.#assertScopeAvailable(opts.clientRunId, runId);
+
+    const sequence = (this.latestSequence(opts.clientRunId) ?? 0) + 1;
+    const eventId = randomUUID();
+    const occurredAt = normalizeOccurredAt(opts.occurredAt);
+    const message = RetainedRunMessageSchema.parse({
+      ...safeMessage,
+      ...(runId ? { run_id: runId } : {}),
+      ...(commandId && supportsCommandId(safeMessage) ? { command_id: commandId } : {}),
+      client_run_id: opts.clientRunId,
+      event_id: eventId,
+      sequence,
+      occurred_at: occurredAt,
+    });
+    const wire = JSON.stringify(message);
+    const frame: RetainedRunFrame = {
+      clientRunId: opts.clientRunId,
+      eventId,
+      message,
+      occurredAt,
+      runId: runId ?? null,
+      sequence,
+      wire,
+    };
+    this.#appendLine(serializeFrame(frame));
+    this.#addLoadedFrame(frame);
+    this.#enforceRetention(false);
+    return frame;
+  }
+
+  beginCommand(opts: {
+    clientRunId: string;
+    commandId: string;
+    command: ClientMessage;
+  }): BeginCommandResult {
+    const key = commandKey(opts.clientRunId, opts.commandId);
+    const fingerprint = fingerprintCommand(opts.command);
+    const existing = this.#commands.get(key);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) return { outcome: "conflict" };
+      if (existing.status === "completed" && existing.responseEventId) {
+        const frame = this.#frameByEventId(existing.responseEventId);
+        if (frame) return { outcome: "completed", frame };
+      }
+      return { outcome: "pending" };
+    }
+
+    const record: CommandRecord = {
+      clientRunId: opts.clientRunId,
+      commandId: opts.commandId,
+      fingerprint,
+      occurredAt: new Date().toISOString(),
+      status: "pending",
+    };
+    this.#appendLine(serializeCommand(record));
+    this.#commands.set(key, record);
+    this.#enforceRetention(false);
+    return { outcome: "proceed" };
+  }
+
+  canCompleteCommand(opts: {
+    clientRunId: string;
+    commandId: string;
+    command: ClientMessage;
+  }): boolean {
+    const existing = this.#commands.get(commandKey(opts.clientRunId, opts.commandId));
+    return (
+      existing?.status === "pending" && existing.fingerprint === fingerprintCommand(opts.command)
+    );
+  }
+
+  completeCommand(opts: {
+    clientRunId: string;
+    commandId: string;
+    command: ClientMessage;
+    frame: RetainedRunFrame;
+  }): void {
+    const key = commandKey(opts.clientRunId, opts.commandId);
+    const existing = this.#commands.get(key);
+    const fingerprint = fingerprintCommand(opts.command);
+    if (existing?.status !== "pending" || existing.fingerprint !== fingerprint) {
+      throw new Error("command outcome is not pending");
+    }
+    const completed: CommandRecord = {
+      ...existing,
+      occurredAt: new Date().toISOString(),
+      responseEventId: opts.frame.eventId,
+      status: "completed",
+    };
+    this.#appendLine(serializeCommand(completed));
+    this.#commands.set(key, completed);
+    this.#enforceRetention(false);
+  }
+
+  framesAfter(clientRunId: string, afterSequence: number): RetainedRunFrame[] {
+    return (this.#framesByClientRunId.get(clientRunId) ?? [])
+      .filter((frame) => frame.sequence > afterSequence)
+      .map((frame) => ({ ...frame, message: { ...frame.message } }));
+  }
+
+  latestSequence(clientRunId: string): number | null {
+    return this.#framesByClientRunId.get(clientRunId)?.at(-1)?.sequence ?? null;
+  }
+
+  latestFrameOfType(clientRunId: string, type: ServerMessage["type"]): RetainedRunFrame | null {
+    const frames = this.#framesByClientRunId.get(clientRunId) ?? [];
+    return [...frames].reverse().find((frame) => frame.message.type === type) ?? null;
+  }
+
+  findCommandFrame(clientRunId: string, commandId: string): RetainedRunFrame | null {
+    const frames = this.#framesByClientRunId.get(clientRunId) ?? [];
+    return (
+      [...frames].reverse().find((frame) => readCommandId(frame.message) === commandId) ?? null
+    );
+  }
+
+  registerRun(clientRunId: string, runId: string): void {
+    this.#assertScopeAvailable(clientRunId, runId);
+    this.#runIdByClientRunId.set(clientRunId, runId);
+    this.#clientRunIdByRunId.set(runId, clientRunId);
+  }
+
+  resolveClientRunId(runId: string): string | null {
+    return this.#clientRunIdByRunId.get(runId) ?? null;
+  }
+
+  resolveRunId(clientRunId: string): string | null {
+    return this.#runIdByClientRunId.get(clientRunId) ?? null;
+  }
+
+  hasFrames(clientRunId: string): boolean {
+    return (this.#framesByClientRunId.get(clientRunId)?.length ?? 0) > 0;
+  }
+
+  #loadBoundedTail(): boolean {
+    if (!existsSync(this.path)) return false;
+    const size = statSync(this.path).size;
+    const length = Math.min(size, this.#policy.loadTailBytes);
+    const start = size - length;
+    const descriptor = openSync(this.path, "r");
+    const bytes = Buffer.alloc(length);
+    try {
+      readSync(descriptor, bytes, 0, length, start);
+    } finally {
+      closeSync(descriptor);
+    }
+    let text = bytes.toString("utf-8");
+    let malformed = start > 0;
+    if (start > 0) {
+      const firstNewline = text.indexOf("\n");
+      text = firstNewline === -1 ? "" : text.slice(firstNewline + 1);
+    }
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      if (Buffer.byteLength(line, "utf-8") > this.#policy.maxRecordBytes) {
+        malformed = true;
+        continue;
+      }
+      const value = parseJsonRecord(line);
+      if (!value) {
+        malformed = true;
+        continue;
+      }
+      if (value.record_type === "command") {
+        const command = parsePersistedCommand(value);
+        if (!command) {
+          malformed = true;
+          continue;
+        }
+        this.#commands.set(commandKey(command.clientRunId, command.commandId), command);
+        continue;
+      }
+      const frame = parsePersistedFrame(value);
+      if (!frame) {
+        malformed = true;
+        continue;
+      }
+      try {
+        this.#assertScopeAvailable(frame.clientRunId, frame.runId);
+        this.#addLoadedFrame(frame);
+      } catch {
+        malformed = true;
+      }
+    }
+    this.#downgradeMissingCommandResponses();
+    return malformed || size > this.#policy.maxFileBytes;
+  }
+
+  #addLoadedFrame(frame: RetainedRunFrame): void {
+    const frames = this.#framesByClientRunId.get(frame.clientRunId) ?? [];
+    if (frames.some((existing) => existing.eventId === frame.eventId)) return;
+    if (frames.some((existing) => existing.sequence === frame.sequence)) return;
+    frames.push(frame);
+    frames.sort((first, second) => first.sequence - second.sequence);
+    this.#framesByClientRunId.set(frame.clientRunId, frames);
+    if (frame.runId) {
+      this.#runIdByClientRunId.set(frame.clientRunId, frame.runId);
+      this.#clientRunIdByRunId.set(frame.runId, frame.clientRunId);
+    }
+  }
+
+  #frameByEventId(eventId: string): RetainedRunFrame | null {
+    for (const frames of this.#framesByClientRunId.values()) {
+      const frame = frames.find((candidate) => candidate.eventId === eventId);
+      if (frame) return frame;
+    }
+    return null;
+  }
+
+  #appendLine(line: string): void {
+    if (Buffer.byteLength(line, "utf-8") > this.#policy.maxRecordBytes) {
+      throw new Error("sanitized run transcript record exceeds its size limit");
+    }
+    mkdirSync(dirname(this.path), { recursive: true });
+    appendFileSync(this.path, `${line}\n`, { encoding: "utf-8", mode: 0o600 });
+  }
+
+  #enforceRetention(force: boolean): void {
+    const now = Date.now();
+    const cutoff = now - this.#policy.maxAgeMs;
+    let changed = false;
+
+    for (const [clientRunId, original] of this.#framesByClientRunId) {
+      const sorted = [...original].sort((first, second) => first.sequence - second.sequence);
+      const newest = sorted.at(-1);
+      const retainedByAge = sorted.filter(
+        (frame) => Date.parse(frame.occurredAt) >= cutoff || frame === newest,
+      );
+      const retained = retainedByAge.slice(-this.#policy.maxFramesPerRun);
+      if (retained.length !== original.length) changed = true;
+      if (retained.length === 0) this.#framesByClientRunId.delete(clientRunId);
+      else this.#framesByClientRunId.set(clientRunId, retained);
+    }
+
+    const allFrames = this.#allFrames();
+    if (allFrames.length > this.#policy.maxFrames) {
+      const retainedIds = new Set(
+        allFrames
+          .sort(compareFrameOccurrence)
+          .slice(-this.#policy.maxFrames)
+          .map((frame) => frame.eventId),
+      );
+      this.#filterFrames((frame) => retainedIds.has(frame.eventId));
+      changed = true;
+    }
+
+    const commands = [...this.#commands.entries()].sort((first, second) =>
+      compareOccurredAt(first[1].occurredAt, second[1].occurredAt),
+    );
+    const retainedCommands = commands
+      .filter(([, command]) => Date.parse(command.occurredAt) >= cutoff)
+      .slice(-this.#policy.maxCommands);
+    if (retainedCommands.length !== commands.length) {
+      this.#commands.clear();
+      for (const [key, command] of retainedCommands) this.#commands.set(key, command);
+      changed = true;
+    }
+
+    if (this.#downgradeMissingCommandResponses()) changed = true;
+    this.#rebuildScopeMaps();
+
+    let serialized = this.#serializedRecords();
+    let totalBytes = serialized.reduce(
+      (total, record) => total + Buffer.byteLength(record.line, "utf-8") + 1,
+      0,
+    );
+    if (totalBytes > this.#policy.maxFileBytes) {
+      const retained = new Set<string>();
+      let retainedBytes = 0;
+      for (const record of [...serialized].reverse()) {
+        const bytes = Buffer.byteLength(record.line, "utf-8") + 1;
+        if (retainedBytes + bytes > this.#policy.maxFileBytes) continue;
+        retained.add(recordIdentity(record));
+        retainedBytes += bytes;
+      }
+      this.#filterFrames((frame) => retained.has(`frame:${frame.eventId}`));
+      for (const key of [...this.#commands.keys()]) {
+        if (!retained.has(`command:${key}`)) this.#commands.delete(key);
+      }
+      this.#downgradeMissingCommandResponses();
+      this.#rebuildScopeMaps();
+      serialized = this.#serializedRecords();
+      totalBytes = serialized.reduce(
+        (total, record) => total + Buffer.byteLength(record.line, "utf-8") + 1,
+        0,
+      );
+      changed = true;
+    }
+
+    const physicalTooLarge =
+      existsSync(this.path) && statSync(this.path).size > this.#policy.maxFileBytes;
+    if (force || changed || physicalTooLarge || totalBytes > this.#policy.maxFileBytes) {
+      this.#compact(serialized);
+    }
+  }
+
+  #serializedRecords(): SerializedRecord[] {
+    const frames: SerializedRecord[] = this.#allFrames().map((frame) => ({
+      eventId: frame.eventId,
+      line: serializeFrame(frame),
+      occurredAt: frame.occurredAt,
+    }));
+    const commands: SerializedRecord[] = [...this.#commands.entries()].map(([key, command]) => ({
+      commandKey: key,
+      line: serializeCommand(command),
+      occurredAt: command.occurredAt,
+    }));
+    return [...frames, ...commands].sort((first, second) => {
+      const occurrence = compareOccurredAt(first.occurredAt, second.occurredAt);
+      if (occurrence !== 0) return occurrence;
+      if (first.eventId && second.commandKey) return -1;
+      if (first.commandKey && second.eventId) return 1;
+      return recordIdentity(first).localeCompare(recordIdentity(second));
+    });
+  }
+
+  #compact(records: SerializedRecord[]): void {
+    mkdirSync(dirname(this.path), { recursive: true });
+    const temporary = `${this.path}.${process.pid}.${randomUUID()}.tmp`;
+    const descriptor = openSync(temporary, "wx", 0o600);
+    try {
+      const body =
+        records.length === 0 ? "" : `${records.map((record) => record.line).join("\n")}\n`;
+      writeFileSync(descriptor, body, "utf-8");
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      renameSync(temporary, this.path);
+      const directoryDescriptor = openSync(dirname(this.path), "r");
+      try {
+        fsyncSync(directoryDescriptor);
+      } finally {
+        closeSync(directoryDescriptor);
+      }
+    } catch (error) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Descriptor was already closed after the successful fsync.
+      }
+      rmSync(temporary, { force: true });
+      throw error;
+    }
+  }
+
+  #allFrames(): RetainedRunFrame[] {
+    return [...this.#framesByClientRunId.values()].flat();
+  }
+
+  #filterFrames(predicate: (frame: RetainedRunFrame) => boolean): void {
+    for (const [clientRunId, frames] of this.#framesByClientRunId) {
+      const retained = frames.filter(predicate);
+      if (retained.length === 0) this.#framesByClientRunId.delete(clientRunId);
+      else this.#framesByClientRunId.set(clientRunId, retained);
+    }
+  }
+
+  #downgradeMissingCommandResponses(): boolean {
+    let changed = false;
+    for (const [key, command] of this.#commands) {
+      if (
+        command.status === "completed" &&
+        (!command.responseEventId || !this.#frameByEventId(command.responseEventId))
+      ) {
+        const pending = { ...command, status: "pending" as const };
+        delete pending.responseEventId;
+        this.#commands.set(key, pending);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  #rebuildScopeMaps(): void {
+    this.#clientRunIdByRunId.clear();
+    this.#runIdByClientRunId.clear();
+    for (const frame of this.#allFrames().sort(compareFrameOccurrence)) {
+      if (!frame.runId) continue;
+      const existingRunId = this.#runIdByClientRunId.get(frame.clientRunId);
+      const existingClientRunId = this.#clientRunIdByRunId.get(frame.runId);
+      if (existingRunId && existingRunId !== frame.runId) continue;
+      if (existingClientRunId && existingClientRunId !== frame.clientRunId) continue;
+      this.#runIdByClientRunId.set(frame.clientRunId, frame.runId);
+      this.#clientRunIdByRunId.set(frame.runId, frame.clientRunId);
+    }
+  }
+
+  #assertScopeAvailable(clientRunId: string, runId?: string | null): void {
+    if (!runId) return;
+    const existingRunId = this.#runIdByClientRunId.get(clientRunId);
+    if (existingRunId && existingRunId !== runId) {
+      throw new Error("client_run_id is already associated with a different engine run");
+    }
+    const existingClientRunId = this.#clientRunIdByRunId.get(runId);
+    if (existingClientRunId && existingClientRunId !== clientRunId) {
+      throw new Error("engine run is already associated with a different client_run_id");
+    }
+  }
+}
+
+function validatePolicy(policy: RunTranscriptRetentionPolicy): RunTranscriptRetentionPolicy {
+  for (const value of Object.values(policy)) {
+    if (!Number.isInteger(value) || value < 1) {
+      throw new Error("run transcript retention limits must be positive integers");
+    }
+  }
+  return policy;
+}
+
+function serializeFrame(frame: RetainedRunFrame): string {
+  const persisted: PersistedRunFrame = {
+    record_type: "frame",
+    transcript_protocol_version: TRANSCRIPT_PROTOCOL_VERSION,
+    client_run_id: frame.clientRunId,
+    event_id: frame.eventId,
+    occurred_at: frame.occurredAt,
+    ...(frame.runId ? { run_id: frame.runId } : {}),
+    sequence: frame.sequence,
+    wire: frame.wire,
+  };
+  return JSON.stringify(persisted);
+}
+
+function serializeCommand(command: CommandRecord): string {
+  const persisted: PersistedCommandRecord = {
+    record_type: "command",
+    transcript_protocol_version: TRANSCRIPT_PROTOCOL_VERSION,
+    client_run_id: command.clientRunId,
+    command_id: command.commandId,
+    fingerprint: command.fingerprint,
+    occurred_at: command.occurredAt,
+    status: command.status,
+    ...(command.responseEventId ? { response_event_id: command.responseEventId } : {}),
+  };
+  return JSON.stringify(persisted);
+}
+
+function parsePersistedFrame(value: Record<string, unknown>): RetainedRunFrame | null {
+  try {
+    if (value.record_type !== undefined && value.record_type !== "frame") return null;
+    if (value.transcript_protocol_version !== TRANSCRIPT_PROTOCOL_VERSION) return null;
+    if (typeof value.client_run_id !== "string" || value.client_run_id.length === 0) return null;
+    if (typeof value.event_id !== "string" || value.event_id.length === 0) return null;
+    if (typeof value.occurred_at !== "string" || !Number.isFinite(Date.parse(value.occurred_at))) {
+      return null;
+    }
+    if (
+      typeof value.sequence !== "number" ||
+      !Number.isInteger(value.sequence) ||
+      value.sequence < 1
+    ) {
+      return null;
+    }
+    if (typeof value.wire !== "string") return null;
+
+    const decoded = parseJsonRecord(value.wire);
+    if (!decoded) return null;
+    const parsed = RetainedRunMessageSchema.safeParse(decoded);
+    if (!parsed.success || !RETAINED_MESSAGE_TYPES.has(parsed.data.type)) return null;
+    if (decoded.client_run_id !== value.client_run_id) return null;
+    if (decoded.event_id !== value.event_id) return null;
+    if (decoded.sequence !== value.sequence) return null;
+    if (decoded.occurred_at !== value.occurred_at) return null;
+
+    const runId =
+      typeof value.run_id === "string" && value.run_id.length > 0
+        ? value.run_id
+        : readRunId(parsed.data);
+    return {
+      clientRunId: value.client_run_id,
+      eventId: value.event_id,
+      message: parsed.data,
+      occurredAt: value.occurred_at,
+      runId,
+      sequence: value.sequence,
+      wire: value.wire,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parsePersistedCommand(value: Record<string, unknown>): CommandRecord | null {
+  if (value.transcript_protocol_version !== TRANSCRIPT_PROTOCOL_VERSION) return null;
+  if (typeof value.client_run_id !== "string" || value.client_run_id.length === 0) return null;
+  if (typeof value.command_id !== "string" || value.command_id.length === 0) return null;
+  if (typeof value.fingerprint !== "string" || value.fingerprint.length === 0) return null;
+  if (typeof value.occurred_at !== "string" || !Number.isFinite(Date.parse(value.occurred_at))) {
+    return null;
+  }
+  if (value.status !== "pending" && value.status !== "completed") return null;
+  const responseEventId =
+    typeof value.response_event_id === "string" && value.response_event_id.length > 0
+      ? value.response_event_id
+      : undefined;
+  return {
+    clientRunId: value.client_run_id,
+    commandId: value.command_id,
+    fingerprint: value.fingerprint,
+    occurredAt: value.occurred_at,
+    status: value.status,
+    ...(responseEventId ? { responseEventId } : {}),
+  };
+}
+
+function fingerprintCommand(command: ClientMessage): string {
+  const entries = Object.entries(command).filter(([key]) => key !== "command_id");
+  const canonical = canonicalJson(Object.fromEntries(entries));
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>).sort(([first], [second]) =>
+    first.localeCompare(second),
+  );
+  return `{${entries
+    .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+    .join(",")}}`;
+}
+
+function commandKey(clientRunId: string, commandId: string): string {
+  return JSON.stringify([clientRunId, commandId]);
+}
+
+function normalizeOccurredAt(value?: string): string {
+  if (value && Number.isFinite(Date.parse(value))) return new Date(value).toISOString();
+  return new Date().toISOString();
+}
+
+type CommandResponseMessage = Extract<
+  ServerMessage,
+  { type: "ack" | "chat_response" | "error" | "run_accepted" }
+>;
+
+function supportsCommandId(message: ServerMessage): message is CommandResponseMessage {
+  return (
+    message.type === "ack" ||
+    message.type === "chat_response" ||
+    message.type === "error" ||
+    message.type === "run_accepted"
+  );
+}
+
+function readCommandId(message: ServerMessage): string | null {
+  if (!supportsCommandId(message)) return null;
+  return message.command_id ?? null;
+}
+
+function readRunId(message: ServerMessage): string | null {
+  if ("run_id" in message && typeof message.run_id === "string" && message.run_id.length > 0) {
+    return message.run_id;
+  }
+  if (message.type === "event") {
+    const runId = message.payload.run_id;
+    return typeof runId === "string" && runId.length > 0 ? runId : null;
+  }
+  if (message.type === "monitor_alert" && message.scope.startsWith("run:")) {
+    return message.scope.slice("run:".length) || null;
+  }
+  return null;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return Object.fromEntries(Object.entries(parsed));
+  } catch {
+    return null;
+  }
+}
+
+function compareOccurredAt(first: string, second: string): number {
+  return Date.parse(first) - Date.parse(second);
+}
+
+function compareFrameOccurrence(first: RetainedRunFrame, second: RetainedRunFrame): number {
+  const occurredAt = compareOccurredAt(first.occurredAt, second.occurredAt);
+  return occurredAt === 0 ? first.eventId.localeCompare(second.eventId) : occurredAt;
+}
+
+function recordIdentity(record: SerializedRecord): string {
+  if (record.eventId) return `frame:${record.eventId}`;
+  return `command:${record.commandKey ?? ""}`;
+}

--- a/ts/src/server/websocket-session-bootstrap.ts
+++ b/ts/src/server/websocket-session-bootstrap.ts
@@ -1,4 +1,9 @@
-import { PROTOCOL_VERSION, type ServerMessage } from "./protocol.js";
+import {
+  PROTOCOL_VERSION,
+  SERVER_CAPABILITIES,
+  TRANSCRIPT_PROTOCOL_VERSION,
+  type ServerMessage,
+} from "./protocol.js";
 import type { EnvironmentInfo, RunManagerState } from "./run-manager.js";
 
 export function buildEnvironmentMessage(environment: EnvironmentInfo): ServerMessage {
@@ -23,9 +28,17 @@ export function buildStateMessage(state: RunManagerState): ServerMessage {
 export function buildSessionBootstrapMessages(
   environment: EnvironmentInfo,
   state: RunManagerState,
+  opts: { runTranscript?: boolean } = {},
 ): ServerMessage[] {
   return [
-    { type: "hello", protocol_version: PROTOCOL_VERSION },
+    opts.runTranscript
+      ? {
+          type: "hello",
+          protocol_version: PROTOCOL_VERSION,
+          transcript_protocol_version: TRANSCRIPT_PROTOCOL_VERSION,
+          capabilities: [...SERVER_CAPABILITIES],
+        }
+      : { type: "hello", protocol_version: PROTOCOL_VERSION },
     buildEnvironmentMessage(environment),
     buildStateMessage(state),
   ];

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -10,6 +10,7 @@ import {
 } from "node:http";
 import { WebSocketServer, WebSocket } from "ws";
 import type { AddressInfo } from "node:net";
+import { join } from "node:path";
 import { URL } from "node:url";
 import { MissionEventEmitter } from "../mission/events.js";
 import { CampaignManager } from "../mission/campaign.js";
@@ -58,8 +59,13 @@ import { tryKnowledgeRoutes } from "./routes/knowledge-routes.js";
 import { tryScenarioSimulationRoutes } from "./routes/scenario-simulation-routes.js";
 import { tryCampaignRoutes } from "./routes/campaign-routes.js";
 import { tryMissionRoutes } from "./routes/mission-routes.js";
-import { parseClientMessage } from "./protocol.js";
+import {
+  parseClientMessage,
+  TRANSCRIPT_PROTOCOL_QUERY_PARAM,
+  TRANSCRIPT_PROTOCOL_QUERY_VALUE,
+} from "./protocol.js";
 import type { ClientMessage, ServerMessage } from "./protocol.js";
+import { RunTranscriptStore, type RetainedRunFrame } from "./run-transcript-store.js";
 import type { RunManager } from "./run-manager.js";
 import type { RunManagerState } from "./run-manager.js";
 import type { EventCallback } from "../loop/events.js";
@@ -97,6 +103,22 @@ export class InteractiveServer {
   readonly #missionEvents: MissionEventEmitter;
   readonly #host: string;
   readonly #requestedPort: number;
+  readonly #runTranscripts: RunTranscriptStore;
+  readonly #interactiveClients = new Set<WebSocket>();
+  readonly #transcriptClients = new Set<WebSocket>();
+  readonly #clientRunScopes = new Map<WebSocket, string>();
+  readonly #onRunEvent: EventCallback = (event, payload, record) => {
+    this.#broadcastRunEvent(event, payload, record?.ts);
+  };
+  readonly #onRunState = (state: RunManagerState) => {
+    this.#broadcastRunState(state);
+  };
+  #pendingStart: {
+    clientRunId: string | null;
+    runTranscript: boolean;
+    ws: WebSocket;
+  } | null = null;
+  #runSubscriptionsActive = false;
   #solveManager: SolveManager | null = null;
   #solveStore: SQLiteStore | null = null;
   #solveProvider: LLMProvider | null = null;
@@ -116,6 +138,9 @@ export class InteractiveServer {
     this.#campaignManager = new CampaignManager(this.#missionManager);
     this.#host = opts.host ?? "127.0.0.1";
     this.#requestedPort = opts.port ?? 8000;
+    this.#runTranscripts = new RunTranscriptStore(
+      join(this.#runManager.getRunsRoot(), "_interactive", "run-transcript.ndjson"),
+    );
     // Dashboard removed (AC-467)
   }
 
@@ -144,13 +169,17 @@ export class InteractiveServer {
 
     const wsServer = new WebSocketServer({ noServer: true });
     httpServer.on("upgrade", (req, socket, head) => {
-      if (req.url === "/ws/interactive") {
+      const requestUrl = new URL(req.url ?? "/", "http://localhost");
+      if (requestUrl.pathname === "/ws/interactive") {
+        const runTranscript =
+          requestUrl.searchParams.get(TRANSCRIPT_PROTOCOL_QUERY_PARAM) ===
+          TRANSCRIPT_PROTOCOL_QUERY_VALUE;
         wsServer.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-          this.#attachClient(ws);
+          this.#attachClient(ws, runTranscript);
         });
         return;
       }
-      if (req.url === "/ws/events") {
+      if (requestUrl.pathname === "/ws/events") {
         wsServer.handleUpgrade(req, socket, head, (ws: WebSocket) => {
           this.#attachEventStreamClient(ws);
         });
@@ -176,6 +205,7 @@ export class InteractiveServer {
     this.#httpServer = httpServer;
     this.#wsServer = wsServer;
     this.#boundPort = (httpServer.address() as AddressInfo).port;
+    this.#subscribeToRunUpdates();
     return this.#boundPort;
   }
 
@@ -421,6 +451,7 @@ export class InteractiveServer {
     this.#wsServer = null;
     this.#httpServer = null;
     this.#boundPort = 0;
+    this.#unsubscribeFromRunUpdates();
 
     if (wsServer) {
       for (const client of wsServer.clients) {
@@ -458,19 +489,16 @@ export class InteractiveServer {
     this.#solveProvider?.close?.();
     this.#solveProvider = null;
     this.#solveManager = null;
+    this.#interactiveClients.clear();
+    this.#transcriptClients.clear();
+    this.#clientRunScopes.clear();
+    this.#pendingStart = null;
   }
 
-  #attachClient(ws: WebSocket): void {
+  #attachClient(ws: WebSocket, runTranscript: boolean): void {
     const env = this.#runManager.getEnvironmentInfo();
-    const eventCallback: EventCallback = (event, payload) => {
-      this.#send(ws, { type: "event", event, payload });
-    };
-    const stateCallback = (state: RunManagerState) => {
-      this.#sendState(ws, state);
-    };
-
-    this.#runManager.subscribeEvents(eventCallback);
-    this.#runManager.subscribeState(stateCallback);
+    this.#interactiveClients.add(ws);
+    if (runTranscript) this.#transcriptClients.add(ws);
 
     const unsubscribeMissionProgress = subscribeToMissionProgressEvents({
       missionEvents: this.#missionEvents,
@@ -481,7 +509,17 @@ export class InteractiveServer {
       },
     });
 
-    for (const message of buildSessionBootstrapMessages(env, this.#runManager.getState())) {
+    const state = this.#runManager.getState();
+    for (const message of buildSessionBootstrapMessages(env, state, { runTranscript })) {
+      if (message.type !== "state") {
+        this.#send(ws, message);
+        continue;
+      }
+      const clientRunId = state.runId ? this.#runTranscripts.resolveClientRunId(state.runId) : null;
+      if (runTranscript && clientRunId) {
+        this.#send(ws, { type: "state", paused: state.paused });
+        continue;
+      }
       this.#send(ws, message);
     }
 
@@ -491,13 +529,30 @@ export class InteractiveServer {
         parsedMessage = this.#parseMessage(data.toString());
         await this.#handleClientMessage(ws, parsedMessage);
       } catch (err) {
-        this.#send(ws, buildClientErrorMessage(err, parsedMessage));
+        const response = buildClientErrorMessage(err, parsedMessage);
+        const clientRunId = readClientRunId(parsedMessage);
+        const commandId = readCommandId(parsedMessage);
+        if (
+          clientRunId &&
+          commandId &&
+          parsedMessage &&
+          this.#runTranscripts.canCompleteCommand({
+            clientRunId,
+            commandId,
+            command: parsedMessage,
+          })
+        ) {
+          this.#sendRunResponse(ws, response, clientRunId, parsedMessage);
+        } else {
+          this.#sendLegacyOrCurrent(ws, response);
+        }
       }
     });
 
     ws.on("close", () => {
-      this.#runManager.unsubscribeEvents(eventCallback);
-      this.#runManager.unsubscribeState(stateCallback);
+      this.#interactiveClients.delete(ws);
+      this.#transcriptClients.delete(ws);
+      this.#clientRunScopes.delete(ws);
       unsubscribeMissionProgress();
     });
   }
@@ -547,12 +602,38 @@ export class InteractiveServer {
   }
 
   async #handleClientMessage(ws: WebSocket, msg: ClientMessage): Promise<void> {
+    if (
+      !this.#transcriptClients.has(ws) &&
+      (msg.type === "resume_run" || readClientRunId(msg) || readCommandId(msg))
+    ) {
+      throw new Error("run transcript commands require ?transcript_protocol_version=1");
+    }
     switch (msg.type) {
+      case "resume_run": {
+        this.#resumeRunTranscript(ws, msg);
+        return;
+      }
+      case "start_run": {
+        await this.#startRun(ws, msg);
+        return;
+      }
       case "pause":
       case "resume":
       case "inject_hint":
-      case "override_gate":
-      case "start_run":
+      case "override_gate": {
+        const clientRunId = this.#resolveCommandScope(msg.client_run_id);
+        if (clientRunId) {
+          this.#bindClientScope(ws, clientRunId);
+        }
+        if (!this.#beginDurableCommand(ws, msg, clientRunId)) return;
+        for (const response of await executeInteractiveControlCommand({
+          command: msg,
+          runManager: this.#runManager,
+        })) {
+          this.#sendRunResponse(ws, response, clientRunId, msg);
+        }
+        return;
+      }
       case "list_scenarios": {
         for (const response of await executeInteractiveControlCommand({
           command: msg,
@@ -563,11 +644,16 @@ export class InteractiveServer {
         return;
       }
       case "chat_agent": {
+        const clientRunId = this.#resolveCommandScope(msg.client_run_id);
+        if (clientRunId) {
+          this.#bindClientScope(ws, clientRunId);
+        }
+        if (!this.#beginDurableCommand(ws, msg, clientRunId)) return;
         for (const response of await executeChatAgentCommand({
           command: msg,
           runManager: this.#runManager,
         })) {
-          this.#send(ws, response);
+          this.#sendRunResponse(ws, response, clientRunId, msg);
         }
         return;
       }
@@ -599,8 +685,268 @@ export class InteractiveServer {
     }
   }
 
-  #sendState(ws: WebSocket, state: RunManagerState): void {
-    this.#send(ws, buildStateMessage(state));
+  async #startRun(
+    ws: WebSocket,
+    command: Extract<ClientMessage, { type: "start_run" }>,
+  ): Promise<void> {
+    const requestedClientRunId = command.client_run_id ?? null;
+    if (requestedClientRunId) {
+      this.#bindClientScope(ws, requestedClientRunId);
+      if (!this.#beginDurableCommand(ws, command, requestedClientRunId)) return;
+      const accepted = this.#runTranscripts.latestFrameOfType(requestedClientRunId, "run_accepted");
+      if (accepted) {
+        throw new Error("client_run_id is already associated with an existing run");
+      }
+    }
+    if (this.#pendingStart) {
+      throw new Error("A run start is already being processed");
+    }
+    if (this.#runManager.getState().active) {
+      throw new Error("A run is already active");
+    }
+
+    this.#pendingStart = {
+      clientRunId: requestedClientRunId,
+      runTranscript: this.#transcriptClients.has(ws),
+      ws,
+    };
+    try {
+      const responses = await executeInteractiveControlCommand({
+        command,
+        runManager: this.#runManager,
+      });
+      for (const response of responses) {
+        if (response.type !== "run_accepted") {
+          this.#send(ws, response);
+          continue;
+        }
+        const clientRunId = this.#pendingStart.clientRunId ?? response.run_id;
+        this.#runTranscripts.registerRun(clientRunId, response.run_id);
+        if (this.#pendingStart.runTranscript) {
+          this.#bindClientScope(ws, clientRunId);
+        }
+        this.#sendRunResponse(ws, response, clientRunId, command);
+      }
+    } finally {
+      this.#pendingStart = null;
+    }
+  }
+
+  #resumeRunTranscript(
+    ws: WebSocket,
+    command: Extract<ClientMessage, { type: "resume_run" }>,
+  ): void {
+    this.#bindClientScope(ws, command.client_run_id);
+    const commandResult = command.command_id
+      ? this.#runTranscripts.beginCommand({
+          clientRunId: command.client_run_id,
+          commandId: command.command_id,
+          command,
+        })
+      : ({ outcome: "proceed" } as const);
+    if (commandResult.outcome === "conflict") {
+      this.#sendCommandError(
+        ws,
+        command,
+        "command_id is already associated with a different request",
+      );
+      return;
+    }
+    if (commandResult.outcome === "pending") {
+      this.#sendCommandError(
+        ws,
+        command,
+        "command outcome is pending or unknown; refusing to repeat side effects",
+      );
+      return;
+    }
+    const frames = this.#runTranscripts.framesAfter(command.client_run_id, command.after_sequence);
+    for (const frame of frames) {
+      this.#sendWire(ws, frame.wire);
+    }
+    if (commandResult.outcome === "completed") {
+      if (!frames.some((frame) => frame.eventId === commandResult.frame.eventId)) {
+        this.#sendWire(ws, commandResult.frame.wire);
+      }
+      return;
+    }
+    this.#sendRunResponse(
+      ws,
+      { type: "ack", action: "resume_run", command_id: command.command_id },
+      command.client_run_id,
+      command,
+    );
+  }
+
+  #resolveCommandScope(requestedClientRunId?: string): string | null {
+    const state = this.#runManager.getState();
+    const activeClientRunId = state.runId
+      ? this.#runTranscripts.resolveClientRunId(state.runId)
+      : null;
+    if (!requestedClientRunId) return activeClientRunId;
+    if (!activeClientRunId || activeClientRunId !== requestedClientRunId) {
+      throw new Error("client_run_id does not match the current engine run");
+    }
+    return requestedClientRunId;
+  }
+
+  #broadcastRunEvent(event: string, payload: Record<string, unknown>, occurredAt?: string): void {
+    const message = buildInteractiveEventMessage(event, payload);
+    this.#broadcastLegacy(message);
+    const state = this.#runManager.getState();
+    const runId = readEventRunId(event, payload) ?? (state.active ? state.runId : null);
+    let clientRunId = runId ? this.#runTranscripts.resolveClientRunId(runId) : null;
+    if (!clientRunId && runId && this.#pendingStart) {
+      clientRunId = this.#pendingStart.clientRunId ?? runId;
+      this.#pendingStart.clientRunId = clientRunId;
+      this.#runTranscripts.registerRun(clientRunId, runId);
+      if (this.#pendingStart.runTranscript) {
+        this.#bindClientScope(this.#pendingStart.ws, clientRunId);
+      }
+    }
+    if (!clientRunId) return;
+    const frame = this.#runTranscripts.record({
+      clientRunId,
+      message,
+      occurredAt,
+      runId,
+    });
+    if (frame) {
+      this.#broadcastRetainedFrame(frame);
+    }
+  }
+
+  #broadcastRunState(state: RunManagerState): void {
+    const runId = state.runId;
+    let clientRunId = runId ? this.#runTranscripts.resolveClientRunId(runId) : null;
+    if (state.active && runId && this.#pendingStart) {
+      clientRunId = this.#pendingStart.clientRunId ?? runId;
+      this.#pendingStart.clientRunId = clientRunId;
+      this.#runTranscripts.registerRun(clientRunId, runId);
+      if (this.#pendingStart.runTranscript) {
+        this.#bindClientScope(this.#pendingStart.ws, clientRunId);
+      }
+    }
+    const message = buildStateMessage(state);
+    this.#broadcastLegacy(message);
+    if (!clientRunId) {
+      for (const client of this.#transcriptClients) {
+        if (!this.#clientRunScopes.has(client)) this.#send(client, message);
+      }
+      return;
+    }
+    const frame = this.#runTranscripts.record({
+      clientRunId,
+      message,
+      runId,
+    });
+    if (frame) this.#broadcastRetainedFrame(frame);
+  }
+
+  #sendRunResponse(
+    ws: WebSocket,
+    message: ServerMessage,
+    clientRunId: string | null,
+    command?: ClientMessage,
+  ): void {
+    if (!this.#transcriptClients.has(ws)) {
+      this.#sendLegacy(ws, message);
+      return;
+    }
+    if (!clientRunId) {
+      this.#send(ws, message);
+      return;
+    }
+    const commandId = readCommandId(command ?? null) ?? undefined;
+    const runId = readServerMessageRunId(message) ?? this.#runTranscripts.resolveRunId(clientRunId);
+    const frame = this.#runTranscripts.record({
+      clientRunId,
+      commandId,
+      message,
+      runId,
+    });
+    if (frame) {
+      if (
+        command &&
+        commandId &&
+        this.#runTranscripts.canCompleteCommand({
+          clientRunId,
+          commandId,
+          command,
+        })
+      ) {
+        this.#runTranscripts.completeCommand({
+          clientRunId,
+          commandId,
+          command,
+          frame,
+        });
+      }
+      this.#sendWire(ws, frame.wire);
+      return;
+    }
+    this.#send(ws, message);
+  }
+
+  #beginDurableCommand(ws: WebSocket, command: ClientMessage, clientRunId: string | null): boolean {
+    const commandId = readCommandId(command);
+    if (!this.#transcriptClients.has(ws) || !clientRunId || !commandId) return true;
+    const result = this.#runTranscripts.beginCommand({
+      clientRunId,
+      commandId,
+      command,
+    });
+    if (result.outcome === "proceed") return true;
+    if (result.outcome === "completed") {
+      this.#sendWire(ws, result.frame.wire);
+      return false;
+    }
+    const message =
+      result.outcome === "conflict"
+        ? "command_id is already associated with a different request"
+        : "command outcome is pending or unknown; refusing to repeat side effects";
+    this.#sendCommandError(ws, command, message);
+    return false;
+  }
+
+  #sendCommandError(ws: WebSocket, command: ClientMessage, message: string): void {
+    this.#send(ws, {
+      type: "error",
+      message,
+      ...(readClientRunId(command) ? { client_run_id: readClientRunId(command) ?? undefined } : {}),
+      ...(readCommandId(command) ? { command_id: readCommandId(command) ?? undefined } : {}),
+    });
+  }
+
+  #broadcastRetainedFrame(frame: RetainedRunFrame): void {
+    for (const client of this.#transcriptClients) {
+      const scope = this.#clientRunScopes.get(client);
+      if (scope === frame.clientRunId) this.#sendWire(client, frame.wire);
+    }
+  }
+
+  #broadcastLegacy(message: ServerMessage): void {
+    for (const client of this.#interactiveClients) {
+      if (!this.#transcriptClients.has(client)) this.#sendLegacy(client, message);
+    }
+  }
+
+  #bindClientScope(ws: WebSocket, clientRunId: string): void {
+    this.#clientRunScopes.set(ws, clientRunId);
+  }
+
+  #subscribeToRunUpdates(): void {
+    if (this.#runSubscriptionsActive) return;
+    this.#runSubscriptionsActive = true;
+    this.#runManager.subscribeEvents(this.#onRunEvent);
+    this.#runManager.subscribeState(this.#onRunState);
+  }
+
+  #unsubscribeFromRunUpdates(): void {
+    if (!this.#runSubscriptionsActive) return;
+    this.#runSubscriptionsActive = false;
+    this.#runManager.unsubscribeEvents(this.#onRunEvent);
+    this.#runManager.unsubscribeState(this.#onRunState);
   }
 
   #send(ws: WebSocket, msg: ServerMessage): void {
@@ -608,6 +954,23 @@ export class InteractiveServer {
       return;
     }
     ws.send(JSON.stringify(msg));
+  }
+
+  #sendLegacy(ws: WebSocket, message: ServerMessage): void {
+    this.#send(ws, legacyRunMessage(message));
+  }
+
+  #sendLegacyOrCurrent(ws: WebSocket, message: ServerMessage): void {
+    if (this.#transcriptClients.has(ws)) {
+      this.#send(ws, message);
+      return;
+    }
+    this.#sendLegacy(ws, message);
+  }
+
+  #sendWire(ws: WebSocket, wire: string): void {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    ws.send(wire);
   }
 
   #parseMessage(raw: string): ClientMessage {
@@ -636,5 +999,99 @@ function isTrustedLocalOrigin(origin: string, host: string): boolean {
     return parsed.protocol === "http:" && allowedHosts.has(parsed.hostname);
   } catch {
     return false;
+  }
+}
+
+function buildInteractiveEventMessage(
+  event: string,
+  payload: Record<string, unknown>,
+): ServerMessage {
+  if (event === "monitor_alert") {
+    return {
+      type: "monitor_alert",
+      alert_id: stringField(payload.alert_id),
+      condition_id: stringField(payload.condition_id),
+      condition_name: stringField(payload.condition_name),
+      condition_type: stringField(payload.condition_type),
+      scope: stringField(payload.scope),
+      detail: stringField(payload.detail),
+    };
+  }
+  return { type: "event", event, payload };
+}
+
+function readClientRunId(message: ClientMessage | null): string | null {
+  if (!message || !("client_run_id" in message)) return null;
+  return message.client_run_id ?? null;
+}
+
+function readCommandId(message: ClientMessage | null): string | undefined {
+  if (!message || !("command_id" in message)) return undefined;
+  return message.command_id;
+}
+
+function readEventRunId(event: string, payload: Record<string, unknown>): string | null {
+  if (typeof payload.run_id === "string" && payload.run_id.length > 0) return payload.run_id;
+  if (event === "monitor_alert" && typeof payload.scope === "string") {
+    return payload.scope.startsWith("run:") ? payload.scope.slice("run:".length) || null : null;
+  }
+  return null;
+}
+
+function readServerMessageRunId(message: ServerMessage): string | null {
+  if ("run_id" in message && typeof message.run_id === "string" && message.run_id.length > 0) {
+    return message.run_id;
+  }
+  if (message.type === "event") return readEventRunId(message.event, message.payload);
+  if (message.type === "monitor_alert" && message.scope.startsWith("run:")) {
+    return message.scope.slice("run:".length) || null;
+  }
+  return null;
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function legacyRunMessage(message: ServerMessage): ServerMessage {
+  switch (message.type) {
+    case "event":
+      return { type: "event", event: message.event, payload: message.payload };
+    case "state":
+      return {
+        type: "state",
+        paused: message.paused,
+        ...(message.generation === undefined ? {} : { generation: message.generation }),
+        ...(message.phase === undefined ? {} : { phase: message.phase }),
+      };
+    case "run_accepted":
+      return {
+        type: "run_accepted",
+        run_id: message.run_id,
+        scenario: message.scenario,
+        generations: message.generations,
+      };
+    case "ack":
+      return {
+        type: "ack",
+        action: message.action,
+        ...(message.decision === undefined ? {} : { decision: message.decision }),
+      };
+    case "chat_response":
+      return { type: "chat_response", role: message.role, text: message.text };
+    case "error":
+      return { type: "error", message: message.message };
+    case "monitor_alert":
+      return {
+        type: "monitor_alert",
+        alert_id: message.alert_id,
+        condition_id: message.condition_id,
+        condition_name: message.condition_name,
+        condition_type: message.condition_type,
+        scope: message.scope,
+        detail: message.detail,
+      };
+    default:
+      return message;
   }
 }

--- a/ts/src/tui/protocol.generated.ts
+++ b/ts/src/tui/protocol.generated.ts
@@ -41,15 +41,27 @@ export const StrategyParamSchema = z.object({
 export const HelloMsgSchema = z.object({
   type: z.literal("hello"),
   protocol_version: z.number().int().optional(),
+  transcript_protocol_version: z.number().int().optional().nullable(),
+  capabilities: z.array(z.string()).optional().nullable(),
 }).strict();
 
 export const EventMsgSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
+  run_id: z.string().optional().nullable(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
   type: z.literal("event"),
   event: z.string(),
   payload: z.record(z.unknown()),
 }).strict();
 
 export const StateMsgSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
+  run_id: z.string().optional().nullable(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
   type: z.literal("state"),
   paused: z.boolean(),
   generation: z.number().int().optional(),
@@ -57,9 +69,15 @@ export const StateMsgSchema = z.object({
 }).strict();
 
 export const ChatResponseMsgSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
+  run_id: z.string().optional().nullable(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
   type: z.literal("chat_response"),
   role: z.string(),
   text: z.string(),
+  command_id: z.string().optional().nullable(),
 }).strict();
 
 export const EnvironmentsMsgSchema = z.object({
@@ -71,21 +89,38 @@ export const EnvironmentsMsgSchema = z.object({
 }).strict();
 
 export const RunAcceptedMsgSchema = z.object({
-  type: z.literal("run_accepted"),
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
   run_id: z.string(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
+  type: z.literal("run_accepted"),
   scenario: z.string(),
   generations: z.number().int(),
+  command_id: z.string().optional().nullable(),
 }).strict();
 
 export const AckMsgSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
+  run_id: z.string().optional().nullable(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
   type: z.literal("ack"),
   action: z.string(),
   decision: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
 }).strict();
 
 export const ErrorMsgSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
+  run_id: z.string().optional().nullable(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
   type: z.literal("error"),
   message: z.string(),
+  command_id: z.string().optional().nullable(),
 }).strict();
 
 export const ScenarioGeneratingMsgSchema = z.object({
@@ -117,6 +152,11 @@ export const ScenarioErrorMsgSchema = z.object({
 }).strict();
 
 export const MonitorAlertMsgSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
+  run_id: z.string().optional().nullable(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
   type: z.literal("monitor_alert"),
   alert_id: z.string(),
   condition_id: z.string(),
@@ -131,30 +171,42 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [HelloMsgSchema,
 // --- Client -> Server messages ---
 
 export const PauseCmdSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
   type: z.literal("pause"),
 }).strict();
 
 export const ResumeCmdSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
   type: z.literal("resume"),
 }).strict();
 
 export const InjectHintCmdSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
   type: z.literal("inject_hint"),
   text: z.string().min(1),
 }).strict();
 
 export const OverrideGateCmdSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
   type: z.literal("override_gate"),
   decision: z.enum(["advance", "retry", "rollback"]),
 }).strict();
 
 export const ChatAgentCmdSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
   type: z.literal("chat_agent"),
   role: z.string(),
   message: z.string().min(1),
 }).strict();
 
 export const StartRunCmdSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
   type: z.literal("start_run"),
   scenario: z.string(),
   generations: z.number().int().gt(0),

--- a/ts/tests/chat-agent-command-workflow.test.ts
+++ b/ts/tests/chat-agent-command-workflow.test.ts
@@ -7,10 +7,12 @@ import {
 
 describe("chat agent command workflow", () => {
   it("builds chat response messages", () => {
-    expect(buildChatResponseMessage({
-      role: "analyst",
-      text: "## Findings\n- Issue found",
-    })).toEqual({
+    expect(
+      buildChatResponseMessage({
+        role: "analyst",
+        text: "## Findings\n- Issue found",
+      }),
+    ).toEqual({
       type: "chat_response",
       role: "analyst",
       text: "## Findings\n- Issue found",
@@ -22,14 +24,16 @@ describe("chat agent command workflow", () => {
       chatAgent: vi.fn(async () => "## Findings\n- Issue found"),
     };
 
-    await expect(executeChatAgentCommand({
-      command: {
-        type: "chat_agent",
-        role: "analyst",
-        message: "What changed?",
-      },
-      runManager,
-    })).resolves.toEqual([
+    await expect(
+      executeChatAgentCommand({
+        command: {
+          type: "chat_agent",
+          role: "analyst",
+          message: "What changed?",
+        },
+        runManager,
+      }),
+    ).resolves.toEqual([
       {
         type: "chat_response",
         role: "analyst",
@@ -38,5 +42,32 @@ describe("chat agent command workflow", () => {
     ]);
 
     expect(runManager.chatAgent).toHaveBeenCalledWith("analyst", "What changed?");
+  });
+
+  it("echoes run and command correlation on chat responses", async () => {
+    const runManager = {
+      chatAgent: vi.fn(async () => "Correlated response"),
+    };
+
+    await expect(
+      executeChatAgentCommand({
+        command: {
+          type: "chat_agent",
+          role: "analyst",
+          message: "What changed?",
+          client_run_id: "client-run-1",
+          command_id: "command-chat-1",
+        },
+        runManager,
+      }),
+    ).resolves.toEqual([
+      {
+        type: "chat_response",
+        role: "analyst",
+        text: "Correlated response",
+        client_run_id: "client-run-1",
+        command_id: "command-chat-1",
+      },
+    ]);
   });
 });

--- a/ts/tests/client-error-workflow.test.ts
+++ b/ts/tests/client-error-workflow.test.ts
@@ -7,19 +7,25 @@ import {
 
 describe("client error workflow", () => {
   it("identifies interactive scenario commands", () => {
-    expect(isInteractiveScenarioCommand({ type: "create_scenario", description: "Draft a scenario" })).toBe(true);
+    expect(
+      isInteractiveScenarioCommand({ type: "create_scenario", description: "Draft a scenario" }),
+    ).toBe(true);
     expect(isInteractiveScenarioCommand({ type: "confirm_scenario" })).toBe(true);
-    expect(isInteractiveScenarioCommand({ type: "revise_scenario", feedback: "Add guardrails" })).toBe(true);
+    expect(
+      isInteractiveScenarioCommand({ type: "revise_scenario", feedback: "Add guardrails" }),
+    ).toBe(true);
     expect(isInteractiveScenarioCommand({ type: "cancel_scenario" })).toBe(true);
     expect(isInteractiveScenarioCommand({ type: "pause" })).toBe(false);
     expect(isInteractiveScenarioCommand(null)).toBe(false);
   });
 
   it("builds scenario_error messages for interactive scenario command failures", () => {
-    expect(buildClientErrorMessage(new Error("bad scenario"), {
-      type: "revise_scenario",
-      feedback: "Add escalation logic",
-    })).toEqual({
+    expect(
+      buildClientErrorMessage(new Error("bad scenario"), {
+        type: "revise_scenario",
+        feedback: "Add escalation logic",
+      }),
+    ).toEqual({
       type: "scenario_error",
       message: "bad scenario",
       stage: "server",
@@ -27,11 +33,28 @@ describe("client error workflow", () => {
   });
 
   it("builds generic error messages for non-scenario command failures", () => {
-    expect(buildClientErrorMessage(new Error("bad auth"), {
-      type: "whoami",
-    })).toEqual({
+    expect(
+      buildClientErrorMessage(new Error("bad auth"), {
+        type: "whoami",
+      }),
+    ).toEqual({
       type: "error",
       message: "bad auth",
+    });
+  });
+
+  it("preserves run and command correlation on operator failures", () => {
+    expect(
+      buildClientErrorMessage(new Error("scope mismatch"), {
+        type: "pause",
+        client_run_id: "client-run-1",
+        command_id: "command-pause-1",
+      }),
+    ).toEqual({
+      type: "error",
+      message: "scope mismatch",
+      client_run_id: "client-run-1",
+      command_id: "command-pause-1",
     });
   });
 

--- a/ts/tests/interactive-control-command-workflow.test.ts
+++ b/ts/tests/interactive-control-command-workflow.test.ts
@@ -7,11 +7,13 @@ import {
 
 describe("interactive control command workflow", () => {
   it("builds run accepted messages", () => {
-    expect(buildRunAcceptedMessage({
-      runId: "run_1",
-      scenario: "grid_ctf",
-      generations: 3,
-    })).toEqual({
+    expect(
+      buildRunAcceptedMessage({
+        runId: "run_1",
+        scenario: "grid_ctf",
+        generations: 3,
+      }),
+    ).toEqual({
       type: "run_accepted",
       run_id: "run_1",
       scenario: "grid_ctf",
@@ -29,28 +31,36 @@ describe("interactive control command workflow", () => {
       getEnvironmentInfo: vi.fn(),
     };
 
-    await expect(executeInteractiveControlCommand({
-      command: { type: "pause" },
-      runManager,
-    })).resolves.toEqual([{ type: "ack", action: "pause" }]);
+    await expect(
+      executeInteractiveControlCommand({
+        command: { type: "pause" },
+        runManager,
+      }),
+    ).resolves.toEqual([{ type: "ack", action: "pause" }]);
     expect(runManager.pause).toHaveBeenCalledOnce();
 
-    await expect(executeInteractiveControlCommand({
-      command: { type: "resume" },
-      runManager,
-    })).resolves.toEqual([{ type: "ack", action: "resume" }]);
+    await expect(
+      executeInteractiveControlCommand({
+        command: { type: "resume" },
+        runManager,
+      }),
+    ).resolves.toEqual([{ type: "ack", action: "resume" }]);
     expect(runManager.resume).toHaveBeenCalledOnce();
 
-    await expect(executeInteractiveControlCommand({
-      command: { type: "inject_hint", text: "Focus on rollback safety" },
-      runManager,
-    })).resolves.toEqual([{ type: "ack", action: "inject_hint" }]);
+    await expect(
+      executeInteractiveControlCommand({
+        command: { type: "inject_hint", text: "Focus on rollback safety" },
+        runManager,
+      }),
+    ).resolves.toEqual([{ type: "ack", action: "inject_hint" }]);
     expect(runManager.injectHint).toHaveBeenCalledWith("Focus on rollback safety");
 
-    await expect(executeInteractiveControlCommand({
-      command: { type: "override_gate", decision: "rollback" },
-      runManager,
-    })).resolves.toEqual([{ type: "ack", action: "override_gate", decision: "rollback" }]);
+    await expect(
+      executeInteractiveControlCommand({
+        command: { type: "override_gate", decision: "rollback" },
+        runManager,
+      }),
+    ).resolves.toEqual([{ type: "ack", action: "override_gate", decision: "rollback" }]);
     expect(runManager.overrideGate).toHaveBeenCalledWith("rollback");
   });
 
@@ -69,10 +79,12 @@ describe("interactive control command workflow", () => {
       })),
     };
 
-    await expect(executeInteractiveControlCommand({
-      command: { type: "start_run", scenario: "grid_ctf", generations: 3 },
-      runManager,
-    })).resolves.toEqual([
+    await expect(
+      executeInteractiveControlCommand({
+        command: { type: "start_run", scenario: "grid_ctf", generations: 3 },
+        runManager,
+      }),
+    ).resolves.toEqual([
       {
         type: "run_accepted",
         run_id: "run_1",
@@ -81,16 +93,69 @@ describe("interactive control command workflow", () => {
       },
     ]);
 
-    await expect(executeInteractiveControlCommand({
-      command: { type: "list_scenarios" },
-      runManager,
-    })).resolves.toEqual([
+    await expect(
+      executeInteractiveControlCommand({
+        command: { type: "list_scenarios" },
+        runManager,
+      }),
+    ).resolves.toEqual([
       {
         type: "environments",
         scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],
         executors: [{ mode: "local", available: true, description: "Local executor" }],
         current_executor: "local",
         agent_provider: "deterministic",
+      },
+    ]);
+  });
+
+  it("echoes client run and command correlation on operator responses", async () => {
+    const runManager = {
+      pause: vi.fn(),
+      resume: vi.fn(),
+      injectHint: vi.fn(),
+      overrideGate: vi.fn(),
+      startRun: vi.fn(async () => "engine-run-1"),
+      getEnvironmentInfo: vi.fn(),
+    };
+
+    await expect(
+      executeInteractiveControlCommand({
+        command: {
+          type: "pause",
+          client_run_id: "client-run-1",
+          command_id: "command-pause-1",
+        },
+        runManager,
+      }),
+    ).resolves.toEqual([
+      {
+        type: "ack",
+        action: "pause",
+        client_run_id: "client-run-1",
+        command_id: "command-pause-1",
+      },
+    ]);
+
+    await expect(
+      executeInteractiveControlCommand({
+        command: {
+          type: "start_run",
+          scenario: "grid_ctf",
+          generations: 1,
+          client_run_id: "client-run-1",
+          command_id: "command-start-1",
+        },
+        runManager,
+      }),
+    ).resolves.toEqual([
+      {
+        type: "run_accepted",
+        run_id: "engine-run-1",
+        scenario: "grid_ctf",
+        generations: 1,
+        client_run_id: "client-run-1",
+        command_id: "command-start-1",
       },
     ]);
   });

--- a/ts/tests/run-transcript-store.test.ts
+++ b/ts/tests/run-transcript-store.test.ts
@@ -1,0 +1,414 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ClientMessage, ServerMessage } from "../src/server/protocol.js";
+import { RunTranscriptStore } from "../src/server/run-transcript-store.js";
+
+const tempDirs: string[] = [];
+
+function makeStore(): { dir: string; path: string; store: RunTranscriptStore } {
+  const dir = mkdtempSync(join(tmpdir(), "autoctx-run-transcript-"));
+  tempDirs.push(dir);
+  const path = join(dir, "_interactive", "run-transcript.ndjson");
+  return { dir, path, store: new RunTranscriptStore(path) };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("RunTranscriptStore", () => {
+  it("assigns stable identity and persists presentation-safe exact wire frames", () => {
+    const { path, store } = makeStore();
+    store.registerRun("client-run-1", "engine-run-1");
+
+    const frame = store.record({
+      clientRunId: "client-run-1",
+      occurredAt: "2026-07-11T20:00:00.000Z",
+      runId: "engine-run-1",
+      message: {
+        type: "event",
+        event: "action_detail",
+        payload: {
+          run_id: "engine-run-1",
+          action_id: "action-1",
+          name: "Inspect deployment",
+          input: {
+            api_key: "super-secret-value",
+            apiKeyHeader: "sk-proj_abcdefghijklmnopqrstuvwxyz",
+            my_refresh_token_value: "gsk_abcdefghijklmnopqrstuvwxyz",
+            google: "AIzaSyDabcdefghijklmnopqrstuvwxyz",
+            aws: "AKIAABCDEFGHIJKLMNOP",
+            github: "ghp_abcdefghijklmnopqrstuvwxyz123456",
+            headers: { Authorization: "Bearer nested-secret" },
+            note: "Authorization: Bearer another-secret-value",
+            tokens: 42,
+          },
+          raw_internal_trace: "must-not-be-retained",
+        },
+      },
+    });
+
+    expect(frame).not.toBeNull();
+    expect(frame?.sequence).toBe(1);
+    expect(frame?.message).toMatchObject({
+      client_run_id: "client-run-1",
+      occurred_at: "2026-07-11T20:00:00.000Z",
+      run_id: "engine-run-1",
+      sequence: 1,
+      type: "event",
+    });
+    expect(frame?.eventId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(store.framesAfter("client-run-1", 0).map((item) => item.wire)).toEqual([frame?.wire]);
+
+    const payload = frame?.message.type === "event" ? frame.message.payload : {};
+    expect(payload.raw_internal_trace).toBeUndefined();
+    expect(payload.input).toEqual({
+      api_key: "[Redacted]",
+      apiKeyHeader: "[Redacted]",
+      my_refresh_token_value: "[Redacted]",
+      google: "[Redacted]",
+      aws: "[Redacted]",
+      github: "[Redacted]",
+      headers: { Authorization: "[Redacted]" },
+      note: "[Redacted]",
+      tokens: 42,
+    });
+    const persisted = readFileSync(path, "utf-8");
+    expect(persisted).not.toContain("super-secret-value");
+    expect(persisted).not.toContain("another-secret-value");
+    expect(persisted).not.toContain("must-not-be-retained");
+    for (const secret of [
+      "sk-proj_abcdefghijklmnopqrstuvwxyz",
+      "gsk_abcdefghijklmnopqrstuvwxyz",
+      "AIzaSyDabcdefghijklmnopqrstuvwxyz",
+      "AKIAABCDEFGHIJKLMNOP",
+      "ghp_abcdefghijklmnopqrstuvwxyz123456",
+      "nested-secret",
+    ]) {
+      expect(persisted).not.toContain(secret);
+    }
+  });
+
+  it("reloads retained frames after restart and continues monotonic sequencing", () => {
+    const { path, store } = makeStore();
+    const first = store.record({
+      clientRunId: "client-run-1",
+      runId: "engine-run-1",
+      message: {
+        type: "run_accepted",
+        run_id: "engine-run-1",
+        scenario: "grid_ctf",
+        generations: 2,
+      },
+    });
+    const second = store.record({
+      clientRunId: "client-run-1",
+      runId: "engine-run-1",
+      message: { type: "state", paused: false, generation: 1, phase: "agents" },
+    });
+
+    const reloaded = new RunTranscriptStore(path);
+    expect(reloaded.framesAfter("client-run-1", 0).map((frame) => frame.wire)).toEqual([
+      first?.wire,
+      second?.wire,
+    ]);
+    expect(reloaded.resolveRunId("client-run-1")).toBe("engine-run-1");
+    expect(reloaded.resolveClientRunId("engine-run-1")).toBe("client-run-1");
+
+    const third = reloaded.record({
+      clientRunId: "client-run-1",
+      commandId: "command-1",
+      message: { type: "ack", action: "pause" },
+    });
+    expect(third?.sequence).toBe(3);
+    expect(third?.message).toMatchObject({ command_id: "command-1", sequence: 3 });
+    expect(reloaded.findCommandFrame("client-run-1", "command-1")?.wire).toBe(third?.wire);
+    expect(reloaded.framesAfter("client-run-1", 1).map((frame) => frame.sequence)).toEqual([2, 3]);
+  });
+
+  it("isolates client-run scopes and refuses conflicting engine attribution", () => {
+    const { store } = makeStore();
+    const first = store.record({
+      clientRunId: "client-run-1",
+      runId: "engine-run-1",
+      message: { type: "state", paused: false },
+    });
+    const second = store.record({
+      clientRunId: "client-run-2",
+      runId: "engine-run-2",
+      message: { type: "state", paused: true },
+    });
+
+    expect(first?.sequence).toBe(1);
+    expect(second?.sequence).toBe(1);
+    expect(store.framesAfter("client-run-1", 0)).toHaveLength(1);
+    expect(store.framesAfter("client-run-2", 0)).toHaveLength(1);
+    expect(() => store.registerRun("client-run-1", "engine-run-2")).toThrow(
+      /different engine run|different client_run_id/,
+    );
+  });
+
+  it("retains unknown run event identity without retaining its raw payload", () => {
+    const { store } = makeStore();
+    const frame = store.record({
+      clientRunId: "client-run-1",
+      runId: "engine-run-1",
+      message: {
+        type: "event",
+        event: "raw_model_trace",
+        payload: { prompt: "private raw prompt" },
+      },
+    });
+    expect(frame?.message).toMatchObject({
+      type: "event",
+      client_run_id: "client-run-1",
+      run_id: "engine-run-1",
+      payload: {},
+    });
+    expect(frame?.wire).not.toContain("private raw prompt");
+    expect(store.hasFrames("client-run-1")).toBe(true);
+  });
+
+  it("bounds deeply nested retained records before writing them", () => {
+    const { path, store } = makeStore();
+    store.record({
+      clientRunId: "client-large",
+      runId: "engine-large",
+      message: {
+        type: "event",
+        event: "action_detail",
+        payload: {
+          action_id: "large-action",
+          input: Array.from({ length: 2_000 }, (_, index) => ({
+            index,
+            output: "x".repeat(1_000),
+          })),
+        },
+      },
+    });
+
+    for (const line of readFileSync(path, "utf-8").trim().split("\n")) {
+      expect(Buffer.byteLength(line, "utf-8")).toBeLessThanOrEqual(32 * 1_024);
+    }
+  });
+
+  it("journals request-specific command outcomes before replaying exact responses", () => {
+    const { path, store } = makeStore();
+    const cases: Array<{
+      command: ClientMessage;
+      changed: ClientMessage;
+      response: ServerMessage;
+    }> = [
+      {
+        command: {
+          type: "start_run",
+          scenario: "grid_ctf",
+          generations: 1,
+          client_run_id: "client-commands",
+          command_id: "command-start",
+        },
+        changed: {
+          type: "start_run",
+          scenario: "grid_ctf",
+          generations: 2,
+          client_run_id: "client-commands",
+          command_id: "command-start",
+        },
+        response: {
+          type: "run_accepted",
+          run_id: "engine-commands",
+          scenario: "grid_ctf",
+          generations: 1,
+        },
+      },
+      {
+        command: {
+          type: "pause",
+          client_run_id: "client-commands",
+          command_id: "command-control",
+        },
+        changed: {
+          type: "resume",
+          client_run_id: "client-commands",
+          command_id: "command-control",
+        },
+        response: { type: "ack", action: "pause" },
+      },
+      {
+        command: {
+          type: "chat_agent",
+          role: "analyst",
+          message: "first question",
+          client_run_id: "client-commands",
+          command_id: "command-chat",
+        },
+        changed: {
+          type: "chat_agent",
+          role: "analyst",
+          message: "changed question",
+          client_run_id: "client-commands",
+          command_id: "command-chat",
+        },
+        response: { type: "chat_response", role: "analyst", text: "answer" },
+      },
+      {
+        command: {
+          type: "resume_run",
+          client_run_id: "client-commands",
+          after_sequence: 0,
+          command_id: "command-resume",
+        },
+        changed: {
+          type: "resume_run",
+          client_run_id: "client-commands",
+          after_sequence: 1,
+          command_id: "command-resume",
+        },
+        response: { type: "ack", action: "resume_run" },
+      },
+    ];
+
+    for (const item of cases) {
+      const commandId = "command_id" in item.command ? item.command.command_id : undefined;
+      if (!commandId) throw new Error("expected command id");
+      expect(
+        store.beginCommand({
+          clientRunId: "client-commands",
+          commandId,
+          command: item.command,
+        }),
+      ).toEqual({ outcome: "proceed" });
+      const frame = store.record({
+        clientRunId: "client-commands",
+        commandId,
+        message: item.response,
+        runId: "engine-commands",
+      });
+      if (!frame) throw new Error("expected retained response");
+      store.completeCommand({
+        clientRunId: "client-commands",
+        commandId,
+        command: item.command,
+        frame,
+      });
+      const reloaded = new RunTranscriptStore(path);
+      expect(
+        reloaded.beginCommand({
+          clientRunId: "client-commands",
+          commandId,
+          command: item.command,
+        }),
+      ).toMatchObject({ outcome: "completed", frame: { wire: frame.wire } });
+      expect(
+        reloaded.beginCommand({
+          clientRunId: "client-commands",
+          commandId,
+          command: item.changed,
+        }),
+      ).toEqual({ outcome: "conflict" });
+    }
+  });
+
+  it("fails closed for a pending command after restart", () => {
+    const { path, store } = makeStore();
+    const command = {
+      type: "inject_hint",
+      text: "do this once",
+      client_run_id: "client-pending",
+      command_id: "command-pending",
+    } as const;
+    expect(
+      store.beginCommand({
+        clientRunId: "client-pending",
+        commandId: "command-pending",
+        command,
+      }),
+    ).toEqual({ outcome: "proceed" });
+
+    expect(
+      new RunTranscriptStore(path).beginCommand({
+        clientRunId: "client-pending",
+        commandId: "command-pending",
+        command,
+      }),
+    ).toEqual({ outcome: "pending" });
+    expect(readFileSync(path, "utf-8")).not.toContain("do this once");
+  });
+
+  it("prunes by per-run and global limits and compacts atomically", () => {
+    const { path } = makeStore();
+    const store = new RunTranscriptStore(path, {
+      maxFileBytes: 8 * 1_024,
+      maxFrames: 3,
+      maxFramesPerRun: 2,
+    });
+    const occurredAt = Date.now();
+    for (const [clientRunId, count, offset] of [
+      ["client-a", 3, 0],
+      ["client-b", 2, 10],
+    ] as const) {
+      for (let index = 1; index <= count; index += 1) {
+        store.record({
+          clientRunId,
+          occurredAt: new Date(occurredAt + offset + index).toISOString(),
+          runId: `engine-${clientRunId}`,
+          message: { type: "state", paused: false, generation: index },
+        });
+      }
+    }
+
+    const reloaded = new RunTranscriptStore(path, {
+      maxFileBytes: 8 * 1_024,
+      maxFrames: 3,
+      maxFramesPerRun: 2,
+    });
+    expect(reloaded.framesAfter("client-a", 0).map((frame) => frame.sequence)).toEqual([3]);
+    expect(reloaded.framesAfter("client-b", 0).map((frame) => frame.sequence)).toEqual([1, 2]);
+    expect(statSync(path).size).toBeLessThanOrEqual(8 * 1_024);
+  });
+
+  it("downgrades a completed command to pending when retention evicts its response", () => {
+    const { path } = makeStore();
+    const policy = { maxFrames: 1, maxFramesPerRun: 1 };
+    const store = new RunTranscriptStore(path, policy);
+    const command = {
+      type: "pause",
+      client_run_id: "client-evicted",
+      command_id: "command-evicted",
+    } as const;
+    store.beginCommand({
+      clientRunId: "client-evicted",
+      commandId: "command-evicted",
+      command,
+    });
+    const response = store.record({
+      clientRunId: "client-evicted",
+      commandId: "command-evicted",
+      runId: "engine-evicted",
+      message: { type: "ack", action: "pause" },
+    });
+    if (!response) throw new Error("expected retained response");
+    store.completeCommand({
+      clientRunId: "client-evicted",
+      commandId: "command-evicted",
+      command,
+      frame: response,
+    });
+    store.record({
+      clientRunId: "client-evicted",
+      runId: "engine-evicted",
+      message: { type: "state", paused: true },
+    });
+
+    expect(
+      new RunTranscriptStore(path, policy).beginCommand({
+        clientRunId: "client-evicted",
+        commandId: "command-evicted",
+        command,
+      }),
+    ).toEqual({ outcome: "pending" });
+  });
+});

--- a/ts/tests/server-protocol.test.ts
+++ b/ts/tests/server-protocol.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
+import { z } from "zod";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -38,6 +39,52 @@ interface BufferedSocket {
   ) => Promise<Record<string, unknown>>;
   close: () => void;
 }
+
+const LegacyHelloSchema = z
+  .object({ type: z.literal("hello"), protocol_version: z.number().int().optional() })
+  .strict();
+
+const LegacyRunMessageSchema = z.discriminatedUnion("type", [
+  z
+    .object({ type: z.literal("event"), event: z.string(), payload: z.record(z.unknown()) })
+    .strict(),
+  z
+    .object({
+      type: z.literal("state"),
+      paused: z.boolean(),
+      generation: z.number().int().optional(),
+      phase: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("run_accepted"),
+      run_id: z.string(),
+      scenario: z.string(),
+      generations: z.number().int(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("ack"),
+      action: z.string(),
+      decision: z.string().optional().nullable(),
+    })
+    .strict(),
+  z.object({ type: z.literal("chat_response"), role: z.string(), text: z.string() }).strict(),
+  z.object({ type: z.literal("error"), message: z.string() }).strict(),
+  z
+    .object({
+      type: z.literal("monitor_alert"),
+      alert_id: z.string(),
+      condition_id: z.string(),
+      condition_name: z.string(),
+      condition_type: z.string(),
+      scope: z.string(),
+      detail: z.string(),
+    })
+    .strict(),
+]);
 
 async function openSocket(url: string): Promise<BufferedSocket> {
   const { WebSocket } = await import("ws");
@@ -132,6 +179,7 @@ describe("Protocol types", () => {
     const mod = await import("../src/server/protocol.js");
     expect(mod.PauseCmdSchema).toBeDefined();
     expect(mod.ResumeCmdSchema).toBeDefined();
+    expect(mod.ResumeRunCmdSchema).toBeDefined();
     expect(mod.StartRunCmdSchema).toBeDefined();
     expect(mod.InjectHintCmdSchema).toBeDefined();
     expect(mod.OverrideGateCmdSchema).toBeDefined();
@@ -150,9 +198,39 @@ describe("Protocol types", () => {
       type: "start_run",
       scenario: "grid_ctf",
       generations: 3,
+      client_run_id: "client-run-1",
+      command_id: "command-start-1",
     });
     expect(cmd.scenario).toBe("grid_ctf");
     expect(cmd.generations).toBe(3);
+    expect(cmd.client_run_id).toBe("client-run-1");
+    expect(cmd.command_id).toBe("command-start-1");
+  });
+
+  it("advertises and validates transcript resume metadata without bumping protocol v1", async () => {
+    const { HelloMsgSchema, ResumeRunCmdSchema } = await import("../src/server/protocol.js");
+    expect(
+      HelloMsgSchema.parse({
+        type: "hello",
+        protocol_version: 1,
+        transcript_protocol_version: 1,
+        capabilities: ["run_transcript_v1"],
+      }),
+    ).toMatchObject({
+      protocol_version: 1,
+      transcript_protocol_version: 1,
+    });
+    expect(
+      ResumeRunCmdSchema.parse({
+        type: "resume_run",
+        client_run_id: "client-run-1",
+        after_sequence: 7,
+        command_id: "command-resume-1",
+      }),
+    ).toMatchObject({
+      after_sequence: 7,
+      client_run_id: "client-run-1",
+    });
   });
 
   it("parseClientMessage dispatches correctly", async () => {
@@ -489,59 +567,72 @@ describe("InteractiveServer", () => {
     const socket = await openSocket(server.url);
 
     try {
-      expect((await socket.waitFor((msg) => msg.type === "hello")).protocol_version).toBe(1);
+      const hello = await socket.waitFor((msg) => msg.type === "hello");
+      expect(LegacyHelloSchema.parse(hello).protocol_version).toBe(1);
       expect((await socket.waitFor((msg) => msg.type === "environments")).type).toBe(
         "environments",
       );
-      expect((await socket.waitFor((msg) => msg.type === "state")).paused).toBe(false);
+      const initialState = await socket.waitFor((msg) => msg.type === "state");
+      expect(LegacyRunMessageSchema.parse(initialState)).toMatchObject({ paused: false });
 
       socket.send({ type: "pause" });
       expect(
-        (await socket.waitFor((msg) => msg.type === "state" && msg.paused === true)).paused,
-      ).toBe(true);
+        LegacyRunMessageSchema.parse(
+          await socket.waitFor((msg) => msg.type === "state" && msg.paused === true),
+        ),
+      ).toMatchObject({ paused: true });
       expect(
-        (await socket.waitFor((msg) => msg.type === "ack" && msg.action === "pause")).action,
-      ).toBe("pause");
+        LegacyRunMessageSchema.parse(
+          await socket.waitFor((msg) => msg.type === "ack" && msg.action === "pause"),
+        ),
+      ).toMatchObject({ action: "pause" });
 
       socket.send({ type: "resume" });
-      expect(
-        (await socket.waitFor((msg) => msg.type === "state" && msg.paused === false)).paused,
-      ).toBe(false);
-      expect(
-        (await socket.waitFor((msg) => msg.type === "ack" && msg.action === "resume")).action,
-      ).toBe("resume");
+      LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "state" && msg.paused === false),
+      );
+      LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "ack" && msg.action === "resume"),
+      );
 
       socket.send({ type: "inject_hint", text: "Hold the center lane." });
-      expect(
-        (await socket.waitFor((msg) => msg.type === "ack" && msg.action === "inject_hint")).action,
-      ).toBe("inject_hint");
+      LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "ack" && msg.action === "inject_hint"),
+      );
 
       socket.send({ type: "override_gate", decision: "rollback" });
       expect(
-        (await socket.waitFor((msg) => msg.type === "ack" && msg.action === "override_gate"))
-          .decision,
-      ).toBe("rollback");
+        LegacyRunMessageSchema.parse(
+          await socket.waitFor((msg) => msg.type === "ack" && msg.action === "override_gate"),
+        ),
+      ).toMatchObject({ decision: "rollback" });
 
       socket.send({ type: "chat_agent", role: "analyst", message: "What changed?" });
-      expect((await socket.waitFor((msg) => msg.type === "chat_response")).text).toContain(
+      const chatResponse = LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "chat_response"),
+      );
+      expect(chatResponse.type === "chat_response" ? chatResponse.text : "").toContain(
         "## Findings",
       );
 
       socket.send({ type: "start_run", scenario: "grid_ctf", generations: 1 });
-      const accepted = await socket.waitFor((msg) => msg.type === "run_accepted");
-      expect(accepted.scenario).toBe("grid_ctf");
-      expect(
-        (await socket.waitFor((msg) => msg.type === "event" && msg.event === "run_started")).event,
-      ).toBe("run_started");
-
-      const gateEvent = await socket.waitFor(
-        (msg) => msg.type === "event" && msg.event === "gate_decided",
+      const accepted = LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "run_accepted"),
       );
+      if (accepted.type !== "run_accepted") throw new Error("expected run acceptance");
+      expect(accepted.scenario).toBe("grid_ctf");
+      LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "event" && msg.event === "run_started"),
+      );
+
+      const gateEvent = LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "event" && msg.event === "gate_decided"),
+      );
+      if (gateEvent.type !== "event") throw new Error("expected gate event");
       expect((gateEvent.payload as Record<string, unknown>).decision).toBe("rollback");
-      expect(
-        (await socket.waitFor((msg) => msg.type === "event" && msg.event === "run_completed"))
-          .event,
-      ).toBe("run_completed");
+      LegacyRunMessageSchema.parse(
+        await socket.waitFor((msg) => msg.type === "event" && msg.event === "run_completed"),
+      );
 
       const promptPath = join(
         dir,
@@ -557,6 +648,228 @@ describe("InteractiveServer", () => {
       await server.stop();
     }
   }, 15000);
+
+  it("retains stable run frames for correlated reconnect and restart backfill", async () => {
+    const { RunManager, InteractiveServer } = await import("../src/server/index.js");
+    const managerOpts = {
+      dbPath: join(dir, "test.db"),
+      migrationsDir: join(__dirname, "..", "migrations"),
+      runsRoot: join(dir, "runs"),
+      knowledgeRoot: join(dir, "knowledge"),
+      providerType: "deterministic",
+    };
+    const firstManager = new RunManager(managerOpts);
+    const firstServer = new InteractiveServer({ runManager: firstManager, port: 0 });
+    await firstServer.start();
+
+    const transcriptUrl = `${firstServer.url}?transcript_protocol_version=1`;
+    const socket = await openSocket(transcriptUrl);
+    const reconnect = await openSocket(transcriptUrl);
+    const otherScope = await openSocket(transcriptUrl);
+    let pauseAck: Record<string, unknown> | null = null;
+    let resumeAck: Record<string, unknown> | null = null;
+
+    try {
+      const hello = await socket.waitFor((msg) => msg.type === "hello");
+      expect(hello).toMatchObject({
+        protocol_version: 1,
+        transcript_protocol_version: 1,
+        capabilities: ["run_transcript_v1"],
+      });
+      await socket.waitFor((msg) => msg.type === "environments");
+      await socket.waitFor((msg) => msg.type === "state");
+
+      socket.send({
+        type: "start_run",
+        scenario: "grid_ctf",
+        generations: 1,
+        client_run_id: "client-run-1",
+        command_id: "command-start-1",
+      });
+      const accepted = await socket.waitFor((msg) => msg.type === "run_accepted");
+      const started = await socket.waitFor(
+        (msg) => msg.type === "event" && msg.event === "run_started",
+      );
+      const completed = await socket.waitFor(
+        (msg) => msg.type === "event" && msg.event === "run_completed",
+      );
+      firstManager.events.emit(
+        "monitor_alert",
+        {
+          alert_id: "alert-1",
+          condition_id: "condition-1",
+          condition_name: "Run safety",
+          condition_type: "process_exit",
+          scope: `run:${String(accepted.run_id)}`,
+          detail: "Authorization: Bearer should-not-be-retained",
+        },
+        "monitor",
+      );
+      const monitor = await socket.waitFor((msg) => msg.type === "monitor_alert");
+      expect(monitor.detail).toBe("[Redacted]");
+
+      firstManager.events.emit("future_run_checkpoint", {
+        run_id: accepted.run_id,
+        raw_internal_prompt: "must-not-cross-the-wire",
+      });
+      const futureCheckpoint = await socket.waitFor(
+        (msg) => msg.type === "event" && msg.event === "future_run_checkpoint",
+      );
+      expect(futureCheckpoint).toMatchObject({
+        client_run_id: "client-run-1",
+        payload: {},
+      });
+      expect(JSON.stringify(futureCheckpoint)).not.toContain("must-not-cross-the-wire");
+
+      await expect(
+        otherScope.waitFor((msg) => msg.client_run_id === "client-run-1", 250),
+      ).rejects.toThrow(/Timed out/);
+
+      for (const frame of [accepted, started, completed, monitor, futureCheckpoint]) {
+        expect(frame.client_run_id).toBe("client-run-1");
+        expect(frame.run_id).toBe(accepted.run_id);
+        expect(frame.event_id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(frame.sequence).toEqual(expect.any(Number));
+        expect(Number.isFinite(Date.parse(String(frame.occurred_at)))).toBe(true);
+      }
+      expect(accepted.command_id).toBe("command-start-1");
+
+      socket.send({
+        type: "chat_agent",
+        role: "analyst",
+        message: "What changed?",
+        client_run_id: "client-run-1",
+        command_id: "command-chat-1",
+      });
+      const chat = await socket.waitFor(
+        (msg) => msg.type === "chat_response" && msg.command_id === "command-chat-1",
+      );
+      expect(chat.client_run_id).toBe("client-run-1");
+
+      socket.send({
+        type: "pause",
+        client_run_id: "client-run-1",
+        command_id: "command-pause-1",
+      });
+      pauseAck = await socket.waitFor(
+        (msg) => msg.type === "ack" && msg.command_id === "command-pause-1",
+      );
+      expect(pauseAck.client_run_id).toBe("client-run-1");
+
+      socket.send({
+        type: "pause",
+        client_run_id: "client-run-1",
+        command_id: "command-pause-1",
+      });
+      expect(
+        await socket.waitFor((msg) => msg.type === "ack" && msg.command_id === "command-pause-1"),
+      ).toEqual(pauseAck);
+
+      for (const connection of [reconnect, otherScope]) {
+        await connection.waitFor((msg) => msg.type === "hello");
+        await connection.waitFor((msg) => msg.type === "environments");
+        await connection.waitFor((msg) => msg.type === "state");
+      }
+      reconnect.send({
+        type: "resume_run",
+        client_run_id: "client-run-1",
+        after_sequence: Number(completed.sequence),
+        command_id: "command-backfill-1",
+      });
+      expect(await reconnect.waitFor((msg) => msg.event_id === chat.event_id)).toEqual(chat);
+      expect(await reconnect.waitFor((msg) => msg.event_id === pauseAck.event_id)).toEqual(
+        pauseAck,
+      );
+      resumeAck = await reconnect.waitFor(
+        (msg) => msg.type === "ack" && msg.command_id === "command-backfill-1",
+      );
+      expect(resumeAck).toMatchObject({
+        action: "resume_run",
+        client_run_id: "client-run-1",
+      });
+
+      otherScope.send({
+        type: "resume_run",
+        client_run_id: "client-run-2",
+        after_sequence: 0,
+        command_id: "command-backfill-2",
+      });
+      await otherScope.waitFor(
+        (msg) => msg.type === "ack" && msg.command_id === "command-backfill-2",
+      );
+      socket.send({
+        type: "resume",
+        client_run_id: "client-run-1",
+        command_id: "command-client-1-only",
+      });
+      await socket.waitFor(
+        (msg) => msg.type === "ack" && msg.command_id === "command-client-1-only",
+      );
+      await expect(
+        otherScope.waitFor((msg) => msg.command_id === "command-client-1-only", 250),
+      ).rejects.toThrow(/Timed out/);
+
+      socket.send({
+        type: "start_run",
+        scenario: "grid_ctf",
+        generations: 1,
+        client_run_id: "client-run-1",
+        command_id: "command-start-1",
+      });
+      expect(await socket.waitFor((msg) => msg.event_id === accepted.event_id)).toEqual(accepted);
+      expect(firstManager.getState().active).toBe(false);
+
+      socket.send({
+        type: "start_run",
+        scenario: "grid_ctf",
+        generations: 1,
+        client_run_id: "client-run-1",
+        command_id: "command-start-conflict",
+      });
+      expect(
+        await socket.waitFor(
+          (msg) => msg.type === "error" && msg.command_id === "command-start-conflict",
+        ),
+      ).toMatchObject({
+        client_run_id: "client-run-1",
+        message: expect.stringContaining("existing run"),
+      });
+      expect(firstManager.getState().active).toBe(false);
+    } finally {
+      socket.close();
+      reconnect.close();
+      otherScope.close();
+      await firstServer.stop();
+    }
+
+    if (!pauseAck || !resumeAck) throw new Error("expected retained acknowledgements");
+
+    const secondManager = new RunManager(managerOpts);
+    const secondServer = new InteractiveServer({ runManager: secondManager, port: 0 });
+    await secondServer.start();
+    const restarted = await openSocket(`${secondServer.url}?transcript_protocol_version=1`);
+    try {
+      await restarted.waitFor((msg) => msg.type === "hello");
+      await restarted.waitFor((msg) => msg.type === "environments");
+      await restarted.waitFor((msg) => msg.type === "state");
+      restarted.send({
+        type: "resume_run",
+        client_run_id: "client-run-1",
+        after_sequence: Number(pauseAck.sequence) - 1,
+        command_id: "command-restart-backfill",
+      });
+      expect(await restarted.waitFor((msg) => msg.event_id === pauseAck.event_id)).toEqual(
+        pauseAck,
+      );
+      const restartAck = await restarted.waitFor(
+        (msg) => msg.type === "ack" && msg.command_id === "command-restart-backfill",
+      );
+      expect(Number(restartAck.sequence)).toBeGreaterThan(Number(resumeAck.sequence));
+    } finally {
+      restarted.close();
+      await secondServer.stop();
+    }
+  }, 20000);
 
   it("creates, revises, confirms, and catalogs custom scenarios through the live server", async () => {
     const { RunManager, InteractiveServer } = await import("../src/server/index.js");

--- a/ts/tests/type-assertions.test.ts
+++ b/ts/tests/type-assertions.test.ts
@@ -155,7 +155,7 @@ describe("TypeScript type assertion budget", () => {
     // whose AJV validators use the same ajv CJS-default-interop cast pattern
     // already sanctioned above, plus manifest/fixture field-access casts in
     // the cross-package parity tests. Same "bump, don't reverse-engineer" policy.
-    expect(total).toBeLessThanOrEqual(1062);
+    expect(total).toBeLessThanOrEqual(1063);
   });
 
   it("mission/store.ts should use row types instead of inline casts", () => {

--- a/ts/tests/websocket-session-bootstrap.test.ts
+++ b/ts/tests/websocket-session-bootstrap.test.ts
@@ -44,7 +44,34 @@ describe("websocket session bootstrap", () => {
 
   it("builds the initial websocket bootstrap sequence in protocol order", () => {
     expect(buildSessionBootstrapMessages(environment, state)).toEqual([
-      { type: "hello", protocol_version: 1 },
+      {
+        type: "hello",
+        protocol_version: 1,
+      },
+      {
+        type: "environments",
+        scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],
+        executors: [{ mode: "local", available: true, description: "Local executor" }],
+        current_executor: "local",
+        agent_provider: "deterministic",
+      },
+      {
+        type: "state",
+        paused: false,
+        generation: undefined,
+        phase: undefined,
+      },
+    ]);
+  });
+
+  it("advertises transcript capability only after explicit opt-in", () => {
+    expect(buildSessionBootstrapMessages(environment, state, { runTranscript: true })).toEqual([
+      {
+        type: "hello",
+        protocol_version: 1,
+        transcript_protocol_version: 1,
+        capabilities: ["run_transcript_v1"],
+      },
       {
         type: "environments",
         scenarios: [{ name: "grid_ctf", description: "Capture the flag" }],


### PR DESCRIPTION
## Summary

Adds the engine half of ERP-88: stable run-scoped event identity, crash-durable transcript replay, and request-correlated command idempotency for interactive WebSocket clients.

- Adds explicit `?transcript_protocol_version=1` opt-in while preserving strict protocol-v1 wire shapes for existing clients.
- Retains sanitized run frames with stable event IDs, monotonic sequences, timestamps, and client/engine run correlation.
- Adds bounded restart-safe replay, request fingerprints, pending/completed command journaling, and fail-closed crash recovery.
- Enforces age, byte, global, per-run, command, and record limits with atomic compaction.
- Keeps Python, TypeScript, generated protocol, and published contract definitions in sync.

Linear: https://linear.app/greyhaven/issue/ERP-88

## Surfaces Touched

- [x] TypeScript interactive server and protocol
- [x] Python protocol models
- [x] Generated protocol artifacts
- [x] WebSocket contract and documentation
- [x] Security, retention, and compatibility tests

## Verification

- [x] `cd ts && npm run lint`
- [x] Focused TypeScript protocol/store/WebSocket/workflow suite: 55 tests passed
- [x] Post-rebase protocol/store/WebSocket regression suite: 39 tests passed
- [x] `cd autocontext && uv run pytest tests/test_protocol.py tests/test_protocol_parity.py tests/test_websocket_protocol_contract.py`: 70 tests passed
- [x] `cd autocontext && uv run ruff check src tests`
- [x] `cd autocontext && uv run mypy src`

## Docs And Release Impact

- Documents transcript opt-in, strict legacy behavior, bounded retention, redaction, and the finite idempotency horizon.
- Adds a changelog entry for the interactive transcript protocol.

## Notes

Autowork consumer: https://github.com/greyhaven-ai/autowork/pull/102
