### PR TITLE
AC-885 Slice D2b: persist a re-score (promote + archive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,14 +57,17 @@ All notable changes to this project will be documented in this file.
   clear) and degrades every failure mode (no artifact, no active epoch, no evaluator, a scorer error)
   to a per-generation skip status rather than crashing. Persisting a re-score is deferred to Slice D2b.
 - AC-885 Slice D2b: persisting a re-score. `autoctx rescore` gains an `--apply` flag (plus `--by` for
-  reviewer attribution) that promotes a matching re-score onto the generation: it updates `best_score`
-  and `evaluator_epoch` and clears quarantine, while archiving the original `(score, epoch,
-quarantined)` into a new `generation_score_revisions` table so nothing is silently lost. Only
-  `revalidated` generations whose fresh epoch equals the scenario's active epoch are promoted; a
-  drifted re-score is still reported but never written, and the default (no `--apply`) stays
-  report-only. The table is Python-written and TypeScript-schema-parity only (byte-identical
-  migrations, no TypeScript write path), matching the existing `rescore`/`epoch` asymmetry. This
-  closes the AC-885 re-score thread.
+  reviewer attribution) that records a matching re-score as an append-only audit revision in a new
+  `generation_score_revisions` table: the fresh `(revision_epoch, revision_score)` with the
+  generation's current `(evaluator_epoch, best_score, quarantined)` archived as the `previous_*`
+  columns, in a single atomic `INSERT ... SELECT`. It is deliberately non-destructive: it never changes
+  the live `generations` score, its quarantine marker, or the `knowledge_snapshots` cache, so it cannot
+  poison training-export or cross-run rankings (an earlier promote-onto-the-row design was revised to
+  append-only after review found concurrency and derived-state consistency hazards). Only `revalidated`
+  generations whose fresh epoch equals the scenario's active epoch are recorded; a drifted re-score is
+  reported but never written, and the default (no `--apply`) stays report-only. The table is
+  Python-written and TypeScript-schema-parity only (byte-identical migrations, no TypeScript write
+  path), matching the existing `rescore`/`epoch` asymmetry. This closes the AC-885 re-score thread.
 
 ## [0.11.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ All notable changes to this project will be documented in this file.
   scenario's active one. It writes nothing (no `upsert_generation`, no registry write, no quarantine
   clear) and degrades every failure mode (no artifact, no active epoch, no evaluator, a scorer error)
   to a per-generation skip status rather than crashing. Persisting a re-score is deferred to Slice D2b.
+- AC-885 Slice D2b: persisting a re-score. `autoctx rescore` gains an `--apply` flag (plus `--by` for
+  reviewer attribution) that promotes a matching re-score onto the generation: it updates `best_score`
+  and `evaluator_epoch` and clears quarantine, while archiving the original `(score, epoch,
+quarantined)` into a new `generation_score_revisions` table so nothing is silently lost. Only
+  `revalidated` generations whose fresh epoch equals the scenario's active epoch are promoted; a
+  drifted re-score is still reported but never written, and the default (no `--apply`) stays
+  report-only. The table is Python-written and TypeScript-schema-parity only (byte-identical
+  migrations, no TypeScript write path), matching the existing `rescore`/`epoch` asymmetry. This
+  closes the AC-885 re-score thread.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/migrations/018_generation_score_revisions.sql
+++ b/autocontext/migrations/018_generation_score_revisions.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS generation_score_revisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    generation_index INTEGER NOT NULL,
+    revision_epoch TEXT NOT NULL,
+    revision_score REAL NOT NULL,
+    previous_epoch TEXT,
+    previous_score REAL,
+    previous_quarantined INTEGER,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (run_id, generation_index)
+        REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_generation_score_revisions_run_gen
+    ON generation_score_revisions(run_id, generation_index);

--- a/autocontext/src/autocontext/cli_rescore.py
+++ b/autocontext/src/autocontext/cli_rescore.py
@@ -1,10 +1,13 @@
-"""``autoctx rescore <run_id> [--generation N] [--json]`` (AC-885 Slice D2a).
+"""``autoctx rescore <run_id> [--generation N] [--json] [--apply] [--by WHO]`` (AC-885 Slice D2a/D2b).
 
 Re-score a stale generation's ORIGINAL competitor artifact under the CURRENT evaluator and report the
-old-vs-new score + epoch. This command writes no score, generation, or evaluator-epoch lineage data: it
-performs no ``upsert_generation``, no registry activation/promotion, and no quarantine clear. (Like every
-other inspect command it opens the existing sqlite store, and it runs the configured evaluator hooks so
-the re-score reproduces the production evaluator; it does not create a database for a missing run.)
+old-vs-new score + epoch. Without ``--apply`` this command writes nothing: no ``upsert_generation``, no
+registry activation/promotion, no quarantine clear. With ``--apply`` (Slice D2b) it promotes matching
+re-scores (``revalidated`` generations whose fresh epoch equals the active epoch), updating each
+generation's ``best_score``/``evaluator_epoch`` and clearing its quarantine, and archives the original
+into ``generation_score_revisions``. Drifted, skipped, and error generations are never promoted. (Like
+every other inspect command it opens the existing sqlite store, and it runs the configured evaluator hooks
+so the re-score reproduces the production evaluator; it does not create a database for a missing run.)
 Re-scoring goes through the scenario task's own ``evaluate_output`` (the production path) inside the
 configured hook bus, so the score is faithful; the whole thing is fail-safe via ``revalidate_one``.
 """
@@ -151,7 +154,7 @@ def _epoch8(epoch: str | None) -> str:
     return epoch[:8] if epoch else "-"
 
 
-def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None) -> None:
+def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None, applied: list[int]) -> None:
     active8 = active_epoch[:8] if active_epoch else "none"
     table = Table(title=f"Re-score (active epoch {active8}...)")
     table.add_column("Gen", justify="right")
@@ -163,6 +166,7 @@ def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None
     table.add_column("Old epoch")
     table.add_column("New epoch")
     table.add_column("Matches active")
+    table.add_column("Applied")
     for rep in reports:
         old = "-" if rep.original_score is None else f"{rep.original_score:.3f}"
         new = "-" if rep.new_score is None else f"{rep.new_score:.3f}"
@@ -178,12 +182,15 @@ def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None
             _epoch8(rep.original_epoch),
             _epoch8(rep.new_epoch),
             matches,
+            "yes" if rep.generation_index in applied else "-",
         )
     _console.print(table)
     revalidated = sum(1 for r in reports if r.status == "revalidated")
-    _console.print(
-        f"[dim]{revalidated} of {len(reports)} generation(s) re-scored; no score, generation, or lineage data was written.[/dim]"
-    )
+    if applied:
+        written = f"{len(applied)} re-score(s) promoted onto their generation(s) and the original(s) archived"
+    else:
+        written = "no score, generation, or lineage data was written"
+    _console.print(f"[dim]{revalidated} of {len(reports)} generation(s) re-scored; {written}.[/dim]")
     drifted = [r for r in reports if r.status == "revalidated" and not r.new_matches_active]
     if drifted:
         _console.print(
@@ -199,8 +206,14 @@ def rescore_command(
         None, "--generation", min=1, help="Re-score a single generation by index (default: all stale rows)"
     ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Persist re-scores that match the active epoch: promote them onto the generation and clear quarantine",
+    ),
+    by: str = typer.Option("", "--by", help="Reviewer identity recorded on applied revisions"),
 ) -> None:
-    """Re-score stale generations under the current evaluator and report drift (read-only)."""
+    """Re-score stale generations under the current evaluator and report drift (read-only without --apply)."""
     settings = load_settings()
     store = _open_store(settings)
     if store is None or store.get_run(run_id) is None:
@@ -236,14 +249,27 @@ def rescore_command(
         for r in targets
     ]
 
+    # Promote matching re-scores only under --apply (default writes nothing). A report is promotable when
+    # it is ``revalidated`` AND its fresh epoch equals the active epoch (``new_matches_active``) with a
+    # concrete score/epoch. Drifted, skipped, and error generations are never written.
+    applied: list[int] = []
+    if apply:
+        for rep in reports:
+            if rep.status == "revalidated" and rep.new_matches_active and rep.new_score is not None and rep.new_epoch is not None:
+                if store.persist_rescore_revision(
+                    run_id, rep.generation_index, rep.new_score, rep.new_epoch, created_by=by or None
+                ):
+                    applied.append(rep.generation_index)
+
     if json_output:
         payload = {
             "run_id": run_id,
             "scenario": scenario,
             "active_evaluator_epoch": active_epoch,
-            "generations": [asdict(rep) for rep in reports],
+            "applied": applied,
+            "generations": [{**asdict(rep), "applied": rep.generation_index in applied} for rep in reports],
         }
         typer.echo(json.dumps(payload))
         return
 
-    _print_table(reports, active_epoch)
+    _print_table(reports, active_epoch, applied)

--- a/autocontext/src/autocontext/cli_rescore.py
+++ b/autocontext/src/autocontext/cli_rescore.py
@@ -2,12 +2,14 @@
 
 Re-score a stale generation's ORIGINAL competitor artifact under the CURRENT evaluator and report the
 old-vs-new score + epoch. Without ``--apply`` this command writes nothing: no ``upsert_generation``, no
-registry activation/promotion, no quarantine clear. With ``--apply`` (Slice D2b) it promotes matching
-re-scores (``revalidated`` generations whose fresh epoch equals the active epoch), updating each
-generation's ``best_score``/``evaluator_epoch`` and clearing its quarantine, and archives the original
-into ``generation_score_revisions``. Drifted, skipped, and error generations are never promoted. (Like
-every other inspect command it opens the existing sqlite store, and it runs the configured evaluator hooks
-so the re-score reproduces the production evaluator; it does not create a database for a missing run.)
+registry write, no quarantine clear. With ``--apply`` (Slice D2b) it APPENDS an audit revision to
+``generation_score_revisions`` for each matching re-score (``revalidated`` generations whose fresh epoch
+equals the active epoch): the fresh score and its epoch, with the generation's current values archived as
+the ``previous_*`` columns. It does NOT modify the ``generations`` row, its quarantine marker, or any
+derived table (``knowledge_snapshots`` etc.): the live score of record is left untouched, so this cannot
+poison training-export or cross-run rankings. Drifted, skipped, and error generations are never recorded.
+(Like every other inspect command it opens the existing sqlite store, and it runs the configured evaluator
+hooks so the re-score reproduces the production evaluator; it does not create a database for a missing run.)
 Re-scoring goes through the scenario task's own ``evaluate_output`` (the production path) inside the
 configured hook bus, so the score is faithful; the whole thing is fail-safe via ``revalidate_one``.
 """
@@ -166,7 +168,7 @@ def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None
     table.add_column("Old epoch")
     table.add_column("New epoch")
     table.add_column("Matches active")
-    table.add_column("Applied")
+    table.add_column("Recorded")
     for rep in reports:
         old = "-" if rep.original_score is None else f"{rep.original_score:.3f}"
         new = "-" if rep.new_score is None else f"{rep.new_score:.3f}"
@@ -187,7 +189,7 @@ def _print_table(reports: list[GenerationRevalidation], active_epoch: str | None
     _console.print(table)
     revalidated = sum(1 for r in reports if r.status == "revalidated")
     if applied:
-        written = f"{len(applied)} re-score(s) promoted onto their generation(s) and the original(s) archived"
+        written = f"{len(applied)} audit revision(s) recorded (the live score of record was NOT changed)"
     else:
         written = "no score, generation, or lineage data was written"
     _console.print(f"[dim]{revalidated} of {len(reports)} generation(s) re-scored; {written}.[/dim]")
@@ -209,9 +211,9 @@ def rescore_command(
     apply: bool = typer.Option(
         False,
         "--apply",
-        help="Persist re-scores that match the active epoch: promote them onto the generation and clear quarantine",
+        help="Record active-epoch re-scores as audit revisions (does NOT change the live score or quarantine)",
     ),
-    by: str = typer.Option("", "--by", help="Reviewer identity recorded on applied revisions"),
+    by: str = typer.Option("", "--by", help="Reviewer identity recorded on the audit revisions"),
 ) -> None:
     """Re-score stale generations under the current evaluator and report drift (read-only without --apply)."""
     settings = load_settings()
@@ -249,14 +251,15 @@ def rescore_command(
         for r in targets
     ]
 
-    # Promote matching re-scores only under --apply (default writes nothing). A report is promotable when
-    # it is ``revalidated`` AND its fresh epoch equals the active epoch (``new_matches_active``) with a
-    # concrete score/epoch. Drifted, skipped, and error generations are never written.
+    # Record matching re-scores as audit revisions only under --apply (default writes nothing). A report is
+    # recordable when it is ``revalidated`` AND its fresh epoch equals the active epoch (``new_matches_active``)
+    # with a concrete score/epoch. Drifted, skipped, and error generations are never recorded. Recording is
+    # append-only: it never touches the live ``generations`` row, its quarantine marker, or derived tables.
     applied: list[int] = []
     if apply:
         for rep in reports:
             if rep.status == "revalidated" and rep.new_matches_active and rep.new_score is not None and rep.new_epoch is not None:
-                if store.persist_rescore_revision(
+                if store.record_rescore_revision(
                     run_id, rep.generation_index, rep.new_score, rep.new_epoch, created_by=by or None
                 ):
                     applied.append(rep.generation_index)

--- a/autocontext/src/autocontext/storage/bootstrap_schema.py
+++ b/autocontext/src/autocontext/storage/bootstrap_schema.py
@@ -24,6 +24,7 @@ _BOOTSTRAP_MIGRATIONS = (
     "015_match_replay.sql",
     "016_generation_evaluator_epoch.sql",
     "017_generation_quarantined.sql",
+    "018_generation_score_revisions.sql",
 )
 
 
@@ -203,6 +204,23 @@ def bootstrap_core_schema(conn: sqlite3.Connection) -> None:
             FOREIGN KEY (run_id, generation_index)
                 REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
         );
+
+        CREATE TABLE IF NOT EXISTS generation_score_revisions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            revision_epoch TEXT NOT NULL,
+            revision_score REAL NOT NULL,
+            previous_epoch TEXT,
+            previous_score REAL,
+            previous_quarantined INTEGER,
+            created_by TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (run_id, generation_index)
+                REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_generation_score_revisions_run_gen
+            ON generation_score_revisions(run_id, generation_index);
 
         CREATE TABLE IF NOT EXISTS consultation_log (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/autocontext/src/autocontext/storage/migration_ledgers.py
+++ b/autocontext/src/autocontext/storage/migration_ledgers.py
@@ -16,6 +16,7 @@ TYPESCRIPT_TO_PYTHON_BASELINES: dict[str, tuple[str, ...]] = {
     ),
     "014_generation_evaluator_epoch.sql": ("016_generation_evaluator_epoch.sql",),
     "015_generation_quarantined.sql": ("017_generation_quarantined.sql",),
+    "016_generation_score_revisions.sql": ("018_generation_score_revisions.sql",),
 }
 
 PYTHON_TO_TYPESCRIPT_BASELINES: dict[str, tuple[str, ...]] = {

--- a/autocontext/src/autocontext/storage/row_types.py
+++ b/autocontext/src/autocontext/storage/row_types.py
@@ -42,6 +42,21 @@ class GenerationMetricsRow(TypedDict):
     updated_at: str
 
 
+class GenerationScoreRevisionRow(TypedDict):
+    """Row from the ``generation_score_revisions`` table (AC-885)."""
+
+    id: int
+    run_id: str
+    generation_index: int
+    revision_epoch: str
+    revision_score: float
+    previous_epoch: str | None
+    previous_score: float | None
+    previous_quarantined: int | None
+    created_by: str | None
+    created_at: str
+
+
 class MatchRow(TypedDict):
     """Row from the ``matches`` table."""
 

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from autocontext.storage.bootstrap_schema import bootstrap_core_schema, default_migrations_dir
-from autocontext.storage.row_types import GenerationMetricsRow, RunRow
+from autocontext.storage.row_types import GenerationMetricsRow, GenerationScoreRevisionRow, RunRow
 from autocontext.storage.sqlite_migrations import apply_python_migration_files
 from autocontext.storage.sqlite_store_consultations import SQLiteConsultationStoreMixin
 from autocontext.storage.sqlite_store_hub import SQLiteHubStoreMixin
@@ -182,6 +182,68 @@ class SQLiteStore(
                 (epoch_id, scenario),
             )
             return cur.rowcount
+
+    def persist_rescore_revision(
+        self,
+        run_id: str,
+        generation_index: int,
+        new_score: float,
+        new_epoch: str,
+        *,
+        created_by: str | None = None,
+    ) -> bool:
+        """Promote a re-score onto a generation, archiving the original. Returns False if the row is absent.
+
+        Atomic per-(run_id, generation_index): read the current generation; insert an archive row into
+        ``generation_score_revisions`` (revision_* = the new values, previous_* = the archived original);
+        update the generation's ``best_score``, ``evaluator_epoch``, and clear ``quarantined``. No other row
+        or column is touched.
+        """
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT best_score, evaluator_epoch, quarantined FROM generations WHERE run_id = ? AND generation_index = ?",
+                (run_id, generation_index),
+            ).fetchone()
+            if row is None:
+                return False
+            conn.execute(
+                "INSERT INTO generation_score_revisions "
+                "(run_id, generation_index, revision_epoch, revision_score, previous_epoch, "
+                " previous_score, previous_quarantined, created_by) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    generation_index,
+                    new_epoch,
+                    new_score,
+                    row["evaluator_epoch"],
+                    row["best_score"],
+                    row["quarantined"],
+                    created_by,
+                ),
+            )
+            conn.execute(
+                "UPDATE generations SET best_score = ?, evaluator_epoch = ?, quarantined = NULL "
+                "WHERE run_id = ? AND generation_index = ?",
+                (new_score, new_epoch, run_id, generation_index),
+            )
+            return True
+
+    def list_rescore_revisions(
+        self,
+        run_id: str,
+        generation_index: int,
+    ) -> list[GenerationScoreRevisionRow]:
+        """Return the archived score revisions for a generation, oldest first."""
+        with self.connect() as conn:
+            rows = conn.execute(
+                "SELECT id, run_id, generation_index, revision_epoch, revision_score, "
+                "previous_epoch, previous_score, previous_quarantined, created_by, created_at "
+                "FROM generation_score_revisions "
+                "WHERE run_id = ? AND generation_index = ? ORDER BY id",
+                (run_id, generation_index),
+            ).fetchall()
+            return [cast(GenerationScoreRevisionRow, dict(row)) for row in rows]
 
     def update_generation_duration(
         self,

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -183,7 +183,7 @@ class SQLiteStore(
             )
             return cur.rowcount
 
-    def persist_rescore_revision(
+    def record_rescore_revision(
         self,
         run_id: str,
         generation_index: int,
@@ -192,42 +192,25 @@ class SQLiteStore(
         *,
         created_by: str | None = None,
     ) -> bool:
-        """Promote a re-score onto a generation, archiving the original. Returns False if the row is absent.
+        """Append an audit revision recording a re-score. Returns False if the generation is absent.
 
-        Atomic per-(run_id, generation_index): read the current generation; insert an archive row into
-        ``generation_score_revisions`` (revision_* = the new values, previous_* = the archived original);
-        update the generation's ``best_score``, ``evaluator_epoch``, and clear ``quarantined``. No other row
-        or column is touched.
+        Append-only and non-destructive: this records the fresh ``(revision_epoch, revision_score)`` and
+        archives the generation's CURRENT ``(evaluator_epoch, best_score, quarantined)`` as the ``previous_*``
+        values, in a single atomic ``INSERT ... SELECT`` (so there is no read-then-write gap and no
+        concurrent writer can be lost). It does NOT modify the ``generations`` row, its quarantine marker, or
+        any derived table (``knowledge_snapshots`` etc.); the live score of record is left untouched. The
+        ``SELECT`` matches no row when the generation does not exist, so nothing is inserted (returns False).
         """
         with self.connect() as conn:
-            row = conn.execute(
-                "SELECT best_score, evaluator_epoch, quarantined FROM generations WHERE run_id = ? AND generation_index = ?",
-                (run_id, generation_index),
-            ).fetchone()
-            if row is None:
-                return False
-            conn.execute(
+            cur = conn.execute(
                 "INSERT INTO generation_score_revisions "
                 "(run_id, generation_index, revision_epoch, revision_score, previous_epoch, "
                 " previous_score, previous_quarantined, created_by) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    run_id,
-                    generation_index,
-                    new_epoch,
-                    new_score,
-                    row["evaluator_epoch"],
-                    row["best_score"],
-                    row["quarantined"],
-                    created_by,
-                ),
+                "SELECT ?, ?, ?, ?, evaluator_epoch, best_score, quarantined, ? "
+                "FROM generations WHERE run_id = ? AND generation_index = ?",
+                (run_id, generation_index, new_epoch, new_score, created_by, run_id, generation_index),
             )
-            conn.execute(
-                "UPDATE generations SET best_score = ?, evaluator_epoch = ?, quarantined = NULL "
-                "WHERE run_id = ? AND generation_index = ?",
-                (new_score, new_epoch, run_id, generation_index),
-            )
-            return True
+            return cur.rowcount > 0
 
     def list_rescore_revisions(
         self,

--- a/autocontext/tests/test_cli_rescore.py
+++ b/autocontext/tests/test_cli_rescore.py
@@ -211,6 +211,107 @@ def test_rescore_loads_custom_scenarios_from_configured_root(tmp_path: Path, mon
     assert gen["status"] == "skipped_no_evaluator"
 
 
+def _read_revisions(tmp_path: Path, run_id: str, generation_index: int) -> list[dict]:
+    store = _store(tmp_path)
+    with store.connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM generation_score_revisions WHERE run_id = ? AND generation_index = ? ORDER BY id",
+            (run_id, generation_index),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def test_rescore_apply_promotes_matching(tmp_path: Path, monkeypatch) -> None:
+    # --apply on a stale generation whose re-score matches the active epoch promotes it: the generation
+    # row is updated (best_score/epoch, quarantine cleared), the original is archived, and the output
+    # marks it applied.
+    _env(monkeypatch, tmp_path)
+    e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-apply", e1, with_output=True)
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.55, e2))
+
+    result = runner.invoke(app, ["rescore", "run-apply", "--apply", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["applied"] == [1]
+    gen = payload["generations"][0]
+    assert gen["applied"] is True
+
+    store = _store(tmp_path)
+    row = store.get_generation("run-apply", 1)
+    assert row is not None
+    assert row["best_score"] == 0.55
+    assert row["evaluator_epoch"] == e2
+    assert row["quarantined"] is None
+
+    revisions = _read_revisions(tmp_path, "run-apply", 1)
+    assert len(revisions) == 1
+    assert revisions[0]["revision_epoch"] == e2
+    assert revisions[0]["revision_score"] == 0.55
+    assert revisions[0]["previous_epoch"] == e1
+    assert revisions[0]["previous_score"] == 0.6
+
+
+def test_rescore_apply_skips_drifted(tmp_path: Path, monkeypatch) -> None:
+    # --apply on a DRIFTED re-score (fresh epoch != active) writes nothing: the generation row is
+    # unchanged, no revision is written, and the report shows applied=false + new_matches_active=false.
+    _env(monkeypatch, tmp_path)
+    e1, _e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-drift-apply", e1, with_output=True)
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.5, "e_other"))
+
+    result = runner.invoke(app, ["rescore", "run-drift-apply", "--apply", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["applied"] == []
+    gen = payload["generations"][0]
+    assert gen["applied"] is False
+    assert gen["new_matches_active"] is False
+
+    store = _store(tmp_path)
+    row = store.get_generation("run-drift-apply", 1)
+    assert row is not None
+    assert row["best_score"] == 0.6  # unchanged
+    assert row["evaluator_epoch"] == e1  # unchanged
+    assert _read_revisions(tmp_path, "run-drift-apply", 1) == []
+
+
+def test_rescore_without_apply_writes_nothing(tmp_path: Path, monkeypatch) -> None:
+    # No --apply must write nothing even when the re-score matches the active epoch (D2a preserved).
+    _env(monkeypatch, tmp_path)
+    e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-noapply", e1, with_output=True)
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.55, e2))
+
+    result = runner.invoke(app, ["rescore", "run-noapply", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["applied"] == []
+    gen = payload["generations"][0]
+    assert gen["applied"] is False
+
+    store = _store(tmp_path)
+    row = store.get_generation("run-noapply", 1)
+    assert row is not None
+    assert row["best_score"] == 0.6  # unchanged
+    assert row["evaluator_epoch"] == e1  # unchanged
+    assert _read_revisions(tmp_path, "run-noapply", 1) == []
+
+
+def test_rescore_apply_records_by(tmp_path: Path, monkeypatch) -> None:
+    # --by is recorded on the revision's created_by.
+    _env(monkeypatch, tmp_path)
+    e1, e2 = _seed_epochs_active_e2(tmp_path)
+    _seed_generation(tmp_path, "run-by", e1, with_output=True)
+    monkeypatch.setattr("autocontext.cli_rescore._build_score_fn", _fixed_build(0.55, e2))
+
+    result = runner.invoke(app, ["rescore", "run-by", "--apply", "--by", "jay", "--json"])
+    assert result.exit_code == 0, result.output
+    revisions = _read_revisions(tmp_path, "run-by", 1)
+    assert len(revisions) == 1
+    assert revisions[0]["created_by"] == "jay"
+
+
 class _FakeAgentTask:
     """Minimal agent-task double whose evaluate_output records the active hook bus at call time."""
 

--- a/autocontext/tests/test_cli_rescore.py
+++ b/autocontext/tests/test_cli_rescore.py
@@ -221,10 +221,10 @@ def _read_revisions(tmp_path: Path, run_id: str, generation_index: int) -> list[
         return [dict(r) for r in rows]
 
 
-def test_rescore_apply_promotes_matching(tmp_path: Path, monkeypatch) -> None:
-    # --apply on a stale generation whose re-score matches the active epoch promotes it: the generation
-    # row is updated (best_score/epoch, quarantine cleared), the original is archived, and the output
-    # marks it applied.
+def test_rescore_apply_records_matching_audit_revision(tmp_path: Path, monkeypatch) -> None:
+    # --apply on a stale generation whose re-score matches the active epoch APPENDS an audit revision:
+    # the generation row is left UNCHANGED (append-only), the revision archives the current values, and
+    # the output marks it recorded.
     _env(monkeypatch, tmp_path)
     e1, e2 = _seed_epochs_active_e2(tmp_path)
     _seed_generation(tmp_path, "run-apply", e1, with_output=True)
@@ -240,9 +240,10 @@ def test_rescore_apply_promotes_matching(tmp_path: Path, monkeypatch) -> None:
     store = _store(tmp_path)
     row = store.get_generation("run-apply", 1)
     assert row is not None
-    assert row["best_score"] == 0.55
-    assert row["evaluator_epoch"] == e2
-    assert row["quarantined"] is None
+    # The live score of record is NOT changed by --apply (append-only audit).
+    assert row["best_score"] == 0.6
+    assert row["evaluator_epoch"] == e1
+    assert row["quarantined"] is None  # as seeded; --apply never touches the quarantine marker
 
     revisions = _read_revisions(tmp_path, "run-apply", 1)
     assert len(revisions) == 1

--- a/autocontext/tests/test_rescore_revision_store.py
+++ b/autocontext/tests/test_rescore_revision_store.py
@@ -1,9 +1,9 @@
-"""Tests for SQLiteStore.persist_rescore_revision (AC-885 Slice D2b).
+"""Tests for SQLiteStore.record_rescore_revision (AC-885 Slice D2b).
 
-The promote-and-archive write method reads the current generation row, archives the
-original score/epoch/quarantined into ``generation_score_revisions``, and promotes the
-new score/epoch onto the generation while clearing quarantine. It is per-(run_id,
-generation_index) and atomic, and leaves ``mean_score``/``elo`` untouched.
+The append-only audit write records a fresh ``(revision_epoch, revision_score)`` and archives the
+generation's CURRENT ``(evaluator_epoch, best_score, quarantined)`` as the ``previous_*`` columns, in a
+single atomic ``INSERT ... SELECT``. It NEVER modifies the ``generations`` row, its quarantine marker, or
+any derived table: the live score of record is left untouched.
 """
 
 from __future__ import annotations
@@ -47,21 +47,22 @@ def _read_revisions(store: SQLiteStore, run_id: str, generation_index: int) -> l
         return [dict(r) for r in rows]
 
 
-def test_persist_rescore_revision_promotes_and_archives(tmp_path: Path) -> None:
+def test_record_rescore_revision_archives_without_touching_generation(tmp_path: Path) -> None:
     store = _make_store(tmp_path)
     _seed_generation(store)
 
-    assert store.persist_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+    assert store.record_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
 
+    # The live generation row is UNCHANGED (append-only, non-destructive).
     gen = store.get_generation("run-a", 1)
     assert gen is not None
-    assert gen["best_score"] == 0.55
-    assert gen["evaluator_epoch"] == "e2"
-    assert gen["quarantined"] is None
-    # untouched columns
+    assert gen["best_score"] == 0.6
+    assert gen["evaluator_epoch"] == "e1"
+    assert gen["quarantined"] == 1
     assert gen["mean_score"] == 0.42
     assert gen["elo"] == 1200.0
 
+    # The audit revision records the fresh values and archives the generation's current values.
     revisions = _read_revisions(store, "run-a", 1)
     assert len(revisions) == 1
     rev = revisions[0]
@@ -73,33 +74,33 @@ def test_persist_rescore_revision_promotes_and_archives(tmp_path: Path) -> None:
     assert rev["created_by"] == "jay"
 
 
-def test_persist_rescore_revision_missing_run_returns_false(tmp_path: Path) -> None:
+def test_record_rescore_revision_missing_run_returns_false(tmp_path: Path) -> None:
     store = _make_store(tmp_path)
     _seed_generation(store)
 
-    assert store.persist_rescore_revision("missing-run", 1, 0.55, "e2") is False
+    assert store.record_rescore_revision("missing-run", 1, 0.55, "e2") is False
     assert _read_revisions(store, "missing-run", 1) == []
 
 
-def test_persist_rescore_revision_reapply_appends_history(tmp_path: Path) -> None:
+def test_record_rescore_revision_reapply_appends_history(tmp_path: Path) -> None:
     store = _make_store(tmp_path)
     _seed_generation(store)
 
-    assert store.persist_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
-    assert store.persist_rescore_revision("run-a", 1, 0.7, "e3", created_by="sam") is True
+    assert store.record_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+    assert store.record_rescore_revision("run-a", 1, 0.7, "e3", created_by="sam") is True
 
     revisions = _read_revisions(store, "run-a", 1)
     assert len(revisions) == 2
-    # second revision archives the first promotion's values
+    # Because the generation is never mutated, BOTH revisions archive the same unchanged current values.
     assert revisions[1]["revision_epoch"] == "e3"
     assert revisions[1]["revision_score"] == 0.7
-    assert revisions[1]["previous_epoch"] == "e2"
-    assert revisions[1]["previous_score"] == 0.55
-    assert revisions[1]["previous_quarantined"] is None
+    assert revisions[1]["previous_epoch"] == "e1"
+    assert revisions[1]["previous_score"] == 0.6
+    assert revisions[1]["previous_quarantined"] == 1
     assert revisions[1]["created_by"] == "sam"
 
     gen = store.get_generation("run-a", 1)
     assert gen is not None
-    assert gen["best_score"] == 0.7
-    assert gen["evaluator_epoch"] == "e3"
-    assert gen["quarantined"] is None
+    assert gen["best_score"] == 0.6
+    assert gen["evaluator_epoch"] == "e1"
+    assert gen["quarantined"] == 1

--- a/autocontext/tests/test_rescore_revision_store.py
+++ b/autocontext/tests/test_rescore_revision_store.py
@@ -1,0 +1,105 @@
+"""Tests for SQLiteStore.persist_rescore_revision (AC-885 Slice D2b).
+
+The promote-and-archive write method reads the current generation row, archives the
+original score/epoch/quarantined into ``generation_score_revisions``, and promotes the
+new score/epoch onto the generation while clearing quarantine. It is per-(run_id,
+generation_index) and atomic, and leaves ``mean_score``/``elo`` untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def _make_store(tmp_path: Path) -> SQLiteStore:
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+    return store
+
+
+def _seed_generation(store: SQLiteStore) -> None:
+    store.create_run("run-a", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-a",
+        1,
+        mean_score=0.42,
+        best_score=0.6,
+        elo=1200.0,
+        wins=3,
+        losses=1,
+        gate_decision="completed",
+        status="completed",
+        evaluator_epoch="e1",
+        quarantined=True,
+    )
+
+
+def _read_revisions(store: SQLiteStore, run_id: str, generation_index: int) -> list[dict[str, object]]:
+    with store.connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM generation_score_revisions WHERE run_id = ? AND generation_index = ? ORDER BY id",
+            (run_id, generation_index),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def test_persist_rescore_revision_promotes_and_archives(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _seed_generation(store)
+
+    assert store.persist_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+
+    gen = store.get_generation("run-a", 1)
+    assert gen is not None
+    assert gen["best_score"] == 0.55
+    assert gen["evaluator_epoch"] == "e2"
+    assert gen["quarantined"] is None
+    # untouched columns
+    assert gen["mean_score"] == 0.42
+    assert gen["elo"] == 1200.0
+
+    revisions = _read_revisions(store, "run-a", 1)
+    assert len(revisions) == 1
+    rev = revisions[0]
+    assert rev["revision_epoch"] == "e2"
+    assert rev["revision_score"] == 0.55
+    assert rev["previous_epoch"] == "e1"
+    assert rev["previous_score"] == 0.6
+    assert rev["previous_quarantined"] == 1
+    assert rev["created_by"] == "jay"
+
+
+def test_persist_rescore_revision_missing_run_returns_false(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _seed_generation(store)
+
+    assert store.persist_rescore_revision("missing-run", 1, 0.55, "e2") is False
+    assert _read_revisions(store, "missing-run", 1) == []
+
+
+def test_persist_rescore_revision_reapply_appends_history(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _seed_generation(store)
+
+    assert store.persist_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+    assert store.persist_rescore_revision("run-a", 1, 0.7, "e3", created_by="sam") is True
+
+    revisions = _read_revisions(store, "run-a", 1)
+    assert len(revisions) == 2
+    # second revision archives the first promotion's values
+    assert revisions[1]["revision_epoch"] == "e3"
+    assert revisions[1]["revision_score"] == 0.7
+    assert revisions[1]["previous_epoch"] == "e2"
+    assert revisions[1]["previous_score"] == 0.55
+    assert revisions[1]["previous_quarantined"] is None
+    assert revisions[1]["created_by"] == "sam"
+
+    gen = store.get_generation("run-a", 1)
+    assert gen is not None
+    assert gen["best_score"] == 0.7
+    assert gen["evaluator_epoch"] == "e3"
+    assert gen["quarantined"] is None

--- a/docs/ac-885-slice-d2b-rescore-persist-design.md
+++ b/docs/ac-885-slice-d2b-rescore-persist-design.md
@@ -1,7 +1,7 @@
-# AC-885 Slice D2b: persist a re-score (promote + archive)
+# AC-885 Slice D2b: persist a re-score (append-only audit)
 
 Date: 2026-07-12
-Status: approved in brainstorming; pending written review
+Status: revised after code review (originally promote + archive; see below)
 Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
 Scope: sub-slice D2b of Slice D. Slice 1, B, C1, C2, C3, D1, D2a are merged (#1204, #1208, #1210, #1211, #1212, #1213, #1214).
 
@@ -9,21 +9,26 @@ Scope: sub-slice D2b of Slice D. Slice 1, B, C1, C2, C3, D1, D2a are merged (#12
 
 D2a added `autoctx rescore`, which re-runs the current evaluator against a stale generation's original
 artifact and reports the fresh score, report-only. D2b adds the persistence path: an `--apply` flag that
-promotes a fresh active-epoch re-score onto the generation as its score of record, while archiving the
-original score's lineage so nothing is silently lost. This closes the last AC-885 thread.
+records a fresh active-epoch re-score as an APPEND-ONLY audit revision, preserving lineage without ever
+mutating the live score. This closes the last AC-885 thread.
 
-## Decision of record: promote + archive (not append-only)
+## Decision of record: append-only audit (revised from promote + archive)
 
-`--apply` archives the original `(score, epoch, quarantined)` into a new `generation_score_revisions`
-table, then updates the generation to the fresh active-epoch score and clears its quarantine, all
-atomically. The generation row becomes current and trusted, so D1 surfacing (`show`/`status`) shows
-`current` and training-export includes it; the original is preserved verbatim in the archive.
+`--apply` appends one row to a new `generation_score_revisions` table capturing the fresh
+`(revision_epoch, revision_score)` and archiving the generation's current `(evaluator_epoch, best_score,
+quarantined)` as the `previous_*` columns. It does NOT modify the `generations` row, its quarantine
+marker, or any derived table.
 
-This is consistent with the AC-885 thesis (no SILENT cross-epoch overwrite): a promotion is explicit
-(opt-in `--apply`, default stays report-only), narrow (only generations whose fresh epoch equals the
-active epoch), and audited (the original is archived, so it is reversible in principle). The rejected
-alternative (append-only audit that never touches the live row) was declined because nothing yet
-consumes the revisions, so it would be a persisted no-op until an unscheduled follow-up.
+This is deliberately non-destructive. The original draft PROMOTED the re-score onto the `generations`
+row (updating `best_score`/`evaluator_epoch`, clearing quarantine). Code review found three consequences
+of mutating the live row plus its derived state: (1) the read-then-write archive had a TOCTOU race under
+concurrency; (2) clearing quarantine on a score whose active epoch could shift mid-scoring would let a
+stale score become trusted training data; (3) `knowledge_snapshots` (a separate cache that drives
+cross-run inheritance, search/list rankings, and default skill export) would desync from the mutated
+`generations.best_score`. Append-only dissolves all three: nothing live or derived is touched, so there
+is no race, no trust change, and no desync. The cost is that reads/exports do not automatically reflect
+the recorded re-score; teaching a consumer to prefer the latest active-epoch revision is possible future
+work.
 
 ## Decisions of record
 
@@ -31,18 +36,18 @@ consumes the revisions, so it would be a persisted no-op until an unscheduled fo
    exists in both packages' migrations (Python 018 + TS 016, byte-identical) so cross-package databases
    stay schema-compatible; only Python writes to it, matching the C1-D2a "registry/judge path is
    Python-only" asymmetry. It is a SHARED table in the parity manifest, not python-only.
-2. **`--apply` promotes only `revalidated` generations whose fresh epoch equals the active epoch**
+2. **`--apply` records only `revalidated` generations whose fresh epoch equals the active epoch**
    (`status == "revalidated"` and `new_matches_active`). A drifted re-score (fresh epoch != active,
-   because the current spec no longer reproduces the active epoch) is NEVER promoted: it is reported
+   because the current spec no longer reproduces the active epoch) is NEVER recorded: it is reported
    with the D2a drift warning but not written. Skipped/error generations are not written.
-3. **Atomic per-generation promote.** Each promote reads the generation row, inserts the archive
-   revision, and updates the generation (`best_score`, `evaluator_epoch`, `quarantined = NULL`) in one
-   transaction. This is per-`(run_id, generation_index)`, so it never over-clears quarantine on other
-   rows (unlike the epoch-scoped `clear_quarantine_for_epoch`, which is for the promotion workflow).
-4. **`best_score` is the score of record.** `show`/`status`/`run_status`/training-export all surface
-   `best_score`; the promote updates `best_score` (and the row's `evaluator_epoch` + `quarantined`).
-   `mean_score`, `elo`, and tournament counters are run-time metadata and are left untouched; the
-   archive preserves the original `best_score` as `previous_score`.
+3. **Single atomic `INSERT ... SELECT`.** Recording pulls the generation's current `(evaluator_epoch,
+best_score, quarantined)` into the `previous_*` columns and inserts the `revision_*` values in one
+   statement, so there is no read-then-write gap and a concurrent writer cannot be lost. The `SELECT`
+   matches no row when the generation is absent, so nothing is inserted (returns False).
+4. **The live score of record is never changed.** `show`/`status`/`run_status`/training-export continue
+   to surface the original `generations.best_score`; `--apply` only appends an audit revision. Nothing in
+   the `generations` row, its quarantine marker, or `knowledge_snapshots` is touched, so this cannot
+   poison training-export trust or cross-run rankings.
 5. **Default stays report-only.** Without `--apply`, `rescore` behaves exactly as D2a (writes nothing).
    The module docstring and the summary line become conditional on `--apply`.
 
@@ -88,16 +93,16 @@ does not raise "table already exists". Cross-package plumbing to add:
 ### D2b.2: the write method (`storage/sqlite_store.py`)
 
 ```python
-def persist_rescore_revision(
+def record_rescore_revision(
     self, run_id: str, generation_index: int, new_score: float, new_epoch: str,
     *, created_by: str | None = None,
 ) -> bool:
-    """Promote a re-score onto a generation, archiving the original. Returns False if the row is absent.
+    """Append an audit revision recording a re-score. Returns False if the generation is absent.
 
-    In one transaction: read the current generation row; insert an archive row into
-    ``generation_score_revisions`` (revision_epoch/score = the new values; previous_* = the archived
-    original); update the generation's ``best_score`` = new_score, ``evaluator_epoch`` = new_epoch,
-    ``quarantined`` = NULL. Per-(run_id, generation_index); no other row is touched.
+    A single atomic ``INSERT ... SELECT``: pull the generation's current ``(evaluator_epoch, best_score,
+    quarantined)`` into the ``previous_*`` columns and insert ``revision_epoch/score`` = the new values.
+    Does NOT modify the generations row, its quarantine marker, or any derived table. The SELECT matches
+    no row when the generation is absent, so nothing is inserted.
     """
 ```
 
@@ -106,18 +111,18 @@ Optional typed read `list_rescore_revisions(run_id, generation_index) -> list[Ge
 
 ### D2b.3: the `--apply` CLI wiring (`cli_rescore.py`)
 
-- Add `apply: bool = typer.Option(False, "--apply", help="Persist matching re-scores...")` and
-  `by: str = typer.Option("", "--by", help="Reviewer identity recorded on applied revisions")`.
+- Add `apply: bool = typer.Option(False, "--apply", help="Record active-epoch re-scores as audit revisions...")` and
+  `by: str = typer.Option("", "--by", help="Reviewer identity recorded on the audit revisions")`.
 - After `reports` is built and before output: when `apply`, for each `rep` with `rep.status ==
-"revalidated"` and `rep.new_matches_active`, call `store.persist_rescore_revision(run_id,
-rep.generation_index, rep.new_score, rep.new_epoch, created_by=by or None)`; collect the applied
+"revalidated"` and `rep.new_matches_active`, call `store.record_rescore_revision(run_id,
+rep.generation_index, rep.new_score, rep.new_epoch, created_by=by or None)`; collect the recorded
   generation indices.
-- Output: `--json` payload gains a top-level `"applied"` (list of promoted generation indices) and each
-  generation dict gains `"applied": bool`. The rich table gains an `Applied` column and the summary line
-  reports how many were promoted vs re-scored. Update the module docstring + summary so the
-  "writes nothing" language is conditional on `--apply`.
+- Output: `--json` payload gains a top-level `"applied"` (list of recorded generation indices) and each
+  generation dict gains `"applied": bool`. The rich table gains a `Recorded` column and the summary line
+  reports how many audit revisions were recorded (noting the live score was not changed). Update the
+  module docstring + summary so the "writes nothing" language is conditional on `--apply`.
 - `--apply` changes nothing about the fail-safe contract: only revalidated+matches-active generations
-  are written; drifted, skipped, and error generations are never persisted.
+  are recorded; drifted, skipped, and error generations are never written.
 - Contract: add the `--apply` and `--by` flags to the `rescore` entry in `docs/cli-contract.json`.
 
 ## Data flow
@@ -126,11 +131,12 @@ rep.generation_index, rep.new_score, rep.new_epoch, created_by=by or None)`; col
 operator: autoctx rescore <run_id> --apply [--by jay]
   -> D2a: re-score stale generations under the current evaluator -> reports
   -> for each report where revalidated AND new_matches_active:
-       persist_rescore_revision(run_id, gen, new_score, active_epoch, created_by=by)
-         [txn] archive original (score,epoch,quarantined) into generation_score_revisions
-               update generations SET best_score=new, evaluator_epoch=active, quarantined=NULL
-  -> print report with an Applied column / applied[] list
-  => show/status now show the generation as `current`; training-export includes it; history in revisions
+       record_rescore_revision(run_id, gen, new_score, active_epoch, created_by=by)
+         [1 stmt] INSERT INTO generation_score_revisions
+                  SELECT ..revision_epoch/score.., evaluator_epoch, best_score, quarantined, by
+                  FROM generations WHERE run_id=? AND generation_index=?
+  -> print report with a Recorded column / applied[] list
+  => generations row + quarantine + knowledge_snapshots UNCHANGED; the revision is a pure audit record
 ```
 
 ## Error handling and edge cases
@@ -139,11 +145,10 @@ operator: autoctx rescore <run_id> --apply [--by jay]
   written. The operator must reconcile the spec with the active epoch first (or promote a new epoch via
   the C-slice workflow).
 - **`--apply` with no qualifying generation:** nothing is written; the report still prints.
-- **Missing generation row at write time** (raced deletion): `persist_rescore_revision` returns False;
-  the CLI records it as not-applied for that generation. No crash.
-- **Re-applying** the same generation: appends another revision (full history; the archive `previous_*`
-  reflects whatever the row held at that apply, which after a prior apply is the already-promoted
-  value). Idempotent in effect on the generations row (same active epoch), additive in the archive.
+- **Missing generation row at write time** (raced deletion): the `INSERT ... SELECT` matches no row, so
+  `record_rescore_revision` returns False and the CLI records it as not-applied. No crash.
+- **Re-applying** the same generation: appends another revision (full history). Because the generation is
+  never mutated, each revision archives the same unchanged current `previous_*` values.
 - **Report-only (no `--apply`):** unchanged from D2a, writes nothing.
 
 ## Testing
@@ -154,36 +159,38 @@ operator: autoctx rescore <run_id> --apply [--by jay]
 - Migration/parity (Python): `test_cross_runtime_migration_ledgers` reconciles both ledgers with the
   new pairing; `test_sqlite_store_bootstrap` bootstrap-then-migrate equivalence holds with the new
   table.
-- Storage: `persist_rescore_revision` archives the original, updates `best_score`/`evaluator_epoch`,
-  clears `quarantined`, is atomic, returns False for a missing row; `mean_score`/`elo` untouched.
-- CLI: `rescore --apply` on a matching stale generation promotes it (generation now `current`, quarantine
-  cleared, one revision row with the archived original) and the output marks it applied; `--apply` on a
-  DRIFTED re-score does NOT write (generation untouched, no revision); default (no `--apply`) writes
-  nothing (D2a preserved); `--by` is recorded on the revision.
+- Storage: `record_rescore_revision` archives the generation's current `(evaluator_epoch, best_score,
+quarantined)` as `previous_*` and inserts the `revision_*` values, leaves the generation row
+  UNCHANGED, is a single atomic statement, and returns False for a missing row.
+- CLI: `rescore --apply` on a matching stale generation records an audit revision (generation row
+  UNCHANGED, one revision row with the archived current values) and the output marks it recorded;
+  `--apply` on a DRIFTED re-score does NOT write (no revision); default (no `--apply`) writes nothing
+  (D2a preserved); `--by` is recorded on the revision.
 - Gates: module-size, serde-convention, cli-contract parity (the updated `rescore` flags), schema-parity,
   the TS ledger tests, full Python + TS suites, lockfiles unchanged.
 
 ## Documentation
 
 Extend `docs/evaluator-epochs.md` with a "Persisting a re-score (Slice D2b)" subsection: `--apply`
-promotes a matching re-score onto the generation and clears quarantine, the original is archived in
-`generation_score_revisions`, only active-epoch matches are promoted, and the table is Python-written /
-TS-schema-parity. Update the D2a section's "writes nothing" note to "writes nothing without `--apply`".
-CHANGELOG entry.
+records a matching re-score as an append-only audit revision in `generation_score_revisions` without
+changing the live score or quarantine, only active-epoch matches are recorded, and the table is
+Python-written / TS-schema-parity. Update the D2a section's "writes nothing" note to "writes nothing
+without `--apply`". CHANGELOG entry.
 
 ## Deferred / out of scope
 
-- Teaching reads to prefer the latest revision without promoting (not needed once promote updates the
-  live row).
+- Teaching reads/exports to prefer the latest active-epoch revision over the live score (the append-only
+  design does not do this yet; a possible future slice).
 - A `revisions`/history CLI or API surface (the table is queryable; a dedicated view is future work).
-- Reverting a promotion from the archive (the data supports it; no CLI in this slice).
+- The promote-onto-the-live-row variant (updating `generations.best_score`, clearing quarantine,
+  reconciling `knowledge_snapshots`), declined for this slice on the consistency grounds above.
 - TS write path or a TS `rescore` command (Python-only, documented intentional gap).
 
 ## Acceptance criteria advanced by this slice
 
 - AC-885 "Add a lazy re-score or revalidation path for raw artifacts when stale scored records are
-  touched": `rescore --apply` persists the revalidated score under the active epoch, closing the
-  re-score thread (D2a report + D2b persist).
+  touched": `rescore --apply` records the revalidated active-epoch score as an audit revision, closing
+  the re-score thread (D2a report + D2b persist).
 - AC-885 "Changing a rubric/judge/harness evaluator cannot silently overwrite the active scoring
-  baseline": the promote is explicit, active-epoch-gated, and archives the original, so no baseline is
-  silently overwritten.
+  baseline": recording is explicit, active-epoch-gated, and never mutates the live score, so no baseline
+  is overwritten at all.

--- a/docs/ac-885-slice-d2b-rescore-persist-design.md
+++ b/docs/ac-885-slice-d2b-rescore-persist-design.md
@@ -1,0 +1,189 @@
+# AC-885 Slice D2b: persist a re-score (promote + archive)
+
+Date: 2026-07-12
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: sub-slice D2b of Slice D. Slice 1, B, C1, C2, C3, D1, D2a are merged (#1204, #1208, #1210, #1211, #1212, #1213, #1214).
+
+## Purpose
+
+D2a added `autoctx rescore`, which re-runs the current evaluator against a stale generation's original
+artifact and reports the fresh score, report-only. D2b adds the persistence path: an `--apply` flag that
+promotes a fresh active-epoch re-score onto the generation as its score of record, while archiving the
+original score's lineage so nothing is silently lost. This closes the last AC-885 thread.
+
+## Decision of record: promote + archive (not append-only)
+
+`--apply` archives the original `(score, epoch, quarantined)` into a new `generation_score_revisions`
+table, then updates the generation to the fresh active-epoch score and clears its quarantine, all
+atomically. The generation row becomes current and trusted, so D1 surfacing (`show`/`status`) shows
+`current` and training-export includes it; the original is preserved verbatim in the archive.
+
+This is consistent with the AC-885 thesis (no SILENT cross-epoch overwrite): a promotion is explicit
+(opt-in `--apply`, default stays report-only), narrow (only generations whose fresh epoch equals the
+active epoch), and audited (the original is archived, so it is reversible in principle). The rejected
+alternative (append-only audit that never touches the live row) was declined because nothing yet
+consumes the revisions, so it would be a persisted no-op until an unscheduled follow-up.
+
+## Decisions of record
+
+1. **New shared table `generation_score_revisions`, Python-written, TS schema-parity only.** The table
+   exists in both packages' migrations (Python 018 + TS 016, byte-identical) so cross-package databases
+   stay schema-compatible; only Python writes to it, matching the C1-D2a "registry/judge path is
+   Python-only" asymmetry. It is a SHARED table in the parity manifest, not python-only.
+2. **`--apply` promotes only `revalidated` generations whose fresh epoch equals the active epoch**
+   (`status == "revalidated"` and `new_matches_active`). A drifted re-score (fresh epoch != active,
+   because the current spec no longer reproduces the active epoch) is NEVER promoted: it is reported
+   with the D2a drift warning but not written. Skipped/error generations are not written.
+3. **Atomic per-generation promote.** Each promote reads the generation row, inserts the archive
+   revision, and updates the generation (`best_score`, `evaluator_epoch`, `quarantined = NULL`) in one
+   transaction. This is per-`(run_id, generation_index)`, so it never over-clears quarantine on other
+   rows (unlike the epoch-scoped `clear_quarantine_for_epoch`, which is for the promotion workflow).
+4. **`best_score` is the score of record.** `show`/`status`/`run_status`/training-export all surface
+   `best_score`; the promote updates `best_score` (and the row's `evaluator_epoch` + `quarantined`).
+   `mean_score`, `elo`, and tournament counters are run-time metadata and are left untouched; the
+   archive preserves the original `best_score` as `previous_score`.
+5. **Default stays report-only.** Without `--apply`, `rescore` behaves exactly as D2a (writes nothing).
+   The module docstring and the summary line become conditional on `--apply`.
+
+## Architecture
+
+### D2b.1: the table (migrations + schema parity + bootstrap)
+
+`autocontext/migrations/018_generation_score_revisions.sql` and its byte-identical twin
+`ts/migrations/016_generation_score_revisions.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS generation_score_revisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    generation_index INTEGER NOT NULL,
+    revision_epoch TEXT NOT NULL,
+    revision_score REAL NOT NULL,
+    previous_epoch TEXT,
+    previous_score REAL,
+    previous_quarantined INTEGER,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (run_id, generation_index)
+        REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_generation_score_revisions_run_gen
+    ON generation_score_revisions(run_id, generation_index);
+```
+
+`IF NOT EXISTS` is required so a Python migration re-applied over a TS-created table (or vice versa)
+does not raise "table already exists". Cross-package plumbing to add:
+
+- Python ledger `storage/migration_ledgers.py` `TYPESCRIPT_TO_PYTHON_BASELINES`:
+  `"016_generation_score_revisions.sql": ("018_generation_score_revisions.sql",)`.
+- TS ledger `ts/src/storage/storage-migration-workflow.ts` `TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES`:
+  `"016_generation_score_revisions.sql": ["018_generation_score_revisions.sql"]`.
+- TS parity manifest `ts/src/storage/schema-parity-manifest.ts` `SCHEMA_PARITY_SHARED_TABLES`: add
+  `"generation_score_revisions"` (alphabetical, between `generation_recovery` and `generations`).
+- Python `storage/bootstrap_schema.py`: add the same `CREATE TABLE IF NOT EXISTS` + index block (the
+  pip-install fallback schema), and append `"018_generation_score_revisions.sql"` to
+  `_BOOTSTRAP_MIGRATIONS`.
+
+### D2b.2: the write method (`storage/sqlite_store.py`)
+
+```python
+def persist_rescore_revision(
+    self, run_id: str, generation_index: int, new_score: float, new_epoch: str,
+    *, created_by: str | None = None,
+) -> bool:
+    """Promote a re-score onto a generation, archiving the original. Returns False if the row is absent.
+
+    In one transaction: read the current generation row; insert an archive row into
+    ``generation_score_revisions`` (revision_epoch/score = the new values; previous_* = the archived
+    original); update the generation's ``best_score`` = new_score, ``evaluator_epoch`` = new_epoch,
+    ``quarantined`` = NULL. Per-(run_id, generation_index); no other row is touched.
+    """
+```
+
+Optional typed read `list_rescore_revisions(run_id, generation_index) -> list[GenerationScoreRevisionRow]`
+(a new `TypedDict` in `row_types.py`) for tests and later consumers.
+
+### D2b.3: the `--apply` CLI wiring (`cli_rescore.py`)
+
+- Add `apply: bool = typer.Option(False, "--apply", help="Persist matching re-scores...")` and
+  `by: str = typer.Option("", "--by", help="Reviewer identity recorded on applied revisions")`.
+- After `reports` is built and before output: when `apply`, for each `rep` with `rep.status ==
+"revalidated"` and `rep.new_matches_active`, call `store.persist_rescore_revision(run_id,
+rep.generation_index, rep.new_score, rep.new_epoch, created_by=by or None)`; collect the applied
+  generation indices.
+- Output: `--json` payload gains a top-level `"applied"` (list of promoted generation indices) and each
+  generation dict gains `"applied": bool`. The rich table gains an `Applied` column and the summary line
+  reports how many were promoted vs re-scored. Update the module docstring + summary so the
+  "writes nothing" language is conditional on `--apply`.
+- `--apply` changes nothing about the fail-safe contract: only revalidated+matches-active generations
+  are written; drifted, skipped, and error generations are never persisted.
+- Contract: add the `--apply` and `--by` flags to the `rescore` entry in `docs/cli-contract.json`.
+
+## Data flow
+
+```
+operator: autoctx rescore <run_id> --apply [--by jay]
+  -> D2a: re-score stale generations under the current evaluator -> reports
+  -> for each report where revalidated AND new_matches_active:
+       persist_rescore_revision(run_id, gen, new_score, active_epoch, created_by=by)
+         [txn] archive original (score,epoch,quarantined) into generation_score_revisions
+               update generations SET best_score=new, evaluator_epoch=active, quarantined=NULL
+  -> print report with an Applied column / applied[] list
+  => show/status now show the generation as `current`; training-export includes it; history in revisions
+```
+
+## Error handling and edge cases
+
+- **`--apply` on a drifted re-score** (`new_matches_active` False): reported with the drift warning, not
+  written. The operator must reconcile the spec with the active epoch first (or promote a new epoch via
+  the C-slice workflow).
+- **`--apply` with no qualifying generation:** nothing is written; the report still prints.
+- **Missing generation row at write time** (raced deletion): `persist_rescore_revision` returns False;
+  the CLI records it as not-applied for that generation. No crash.
+- **Re-applying** the same generation: appends another revision (full history; the archive `previous_*`
+  reflects whatever the row held at that apply, which after a prior apply is the already-promoted
+  value). Idempotent in effect on the generations row (same active epoch), additive in the archive.
+- **Report-only (no `--apply`):** unchanged from D2a, writes nothing.
+
+## Testing
+
+- Migration/parity (TS): schema-parity gate covers the new shared table (add to manifest); ledger
+  tests assert TS 016 <-> Python 018 pairing (Python-owned-then-TS marks TS applied without re-run;
+  TS-owned-then-Python re-runs safely via `IF NOT EXISTS`); the new table exists once, not duplicated.
+- Migration/parity (Python): `test_cross_runtime_migration_ledgers` reconciles both ledgers with the
+  new pairing; `test_sqlite_store_bootstrap` bootstrap-then-migrate equivalence holds with the new
+  table.
+- Storage: `persist_rescore_revision` archives the original, updates `best_score`/`evaluator_epoch`,
+  clears `quarantined`, is atomic, returns False for a missing row; `mean_score`/`elo` untouched.
+- CLI: `rescore --apply` on a matching stale generation promotes it (generation now `current`, quarantine
+  cleared, one revision row with the archived original) and the output marks it applied; `--apply` on a
+  DRIFTED re-score does NOT write (generation untouched, no revision); default (no `--apply`) writes
+  nothing (D2a preserved); `--by` is recorded on the revision.
+- Gates: module-size, serde-convention, cli-contract parity (the updated `rescore` flags), schema-parity,
+  the TS ledger tests, full Python + TS suites, lockfiles unchanged.
+
+## Documentation
+
+Extend `docs/evaluator-epochs.md` with a "Persisting a re-score (Slice D2b)" subsection: `--apply`
+promotes a matching re-score onto the generation and clears quarantine, the original is archived in
+`generation_score_revisions`, only active-epoch matches are promoted, and the table is Python-written /
+TS-schema-parity. Update the D2a section's "writes nothing" note to "writes nothing without `--apply`".
+CHANGELOG entry.
+
+## Deferred / out of scope
+
+- Teaching reads to prefer the latest revision without promoting (not needed once promote updates the
+  live row).
+- A `revisions`/history CLI or API surface (the table is queryable; a dedicated view is future work).
+- Reverting a promotion from the archive (the data supports it; no CLI in this slice).
+- TS write path or a TS `rescore` command (Python-only, documented intentional gap).
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 "Add a lazy re-score or revalidation path for raw artifacts when stale scored records are
+  touched": `rescore --apply` persists the revalidated score under the active epoch, closing the
+  re-score thread (D2a report + D2b persist).
+- AC-885 "Changing a rubric/judge/harness evaluator cannot silently overwrite the active scoring
+  baseline": the promote is explicit, active-epoch-gated, and archives the original, so no baseline is
+  silently overwritten.

--- a/docs/cli-contract.json
+++ b/docs/cli-contract.json
@@ -472,7 +472,7 @@
     {
       "id": "rescore",
       "path": ["rescore"],
-      "summary": "Re-score a run's stale generations under the current evaluator and report drift, read-only.",
+      "summary": "Re-score a run's stale generations under the current evaluator and report drift; read-only unless --apply, which appends audit revisions without changing the live score.",
       "audience": "advanced",
       "maturity": "experimental",
       "domain_concept": null,

--- a/docs/cli-contract.json
+++ b/docs/cli-contract.json
@@ -493,6 +493,20 @@
           "aliases": [],
           "required": false,
           "description": "Re-score a single generation by index (default: all stale generations)."
+        },
+        {
+          "name": "apply",
+          "type": "bool",
+          "aliases": [],
+          "required": false,
+          "description": "Promote matching active-epoch re-scores onto the generation and clear quarantine, archiving the original."
+        },
+        {
+          "name": "by",
+          "type": "string",
+          "aliases": [],
+          "required": false,
+          "description": "Reviewer identity recorded on applied revisions."
         }
       ],
       "output_contract": "json"

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -429,32 +429,36 @@ within-epoch variance rather than deciding cross-epoch comparability.
 
 Slice D2a re-scored a stale generation and reported the result, without touching the database. Slice
 D2b adds the persistence path: an `--apply` flag on `autoctx rescore <run_id> [--generation N] --apply
-[--by REVIEWER]` that promotes a matching fresh re-score onto the generation as its score of record,
-while archiving the original so nothing is silently lost.
+[--by REVIEWER]` that records a matching fresh re-score as an APPEND-ONLY audit revision. It is
+deliberately non-destructive: it never changes the live score of record, so it cannot poison
+training-export or cross-run rankings. (An earlier draft of this slice promoted the re-score onto the
+`generations` row; review found that mutating the live row plus its derived state, quarantine and the
+`knowledge_snapshots` cache that drives inheritance / search / skill export, introduced concurrency and
+consistency hazards, so the design was revised to append-only. Making reads prefer a revision is a
+possible future slice.)
 
-**Who gets promoted.** Only generations whose D2a report status is `revalidated` AND whose fresh epoch
+**Who gets recorded.** Only generations whose D2a report status is `revalidated` AND whose fresh epoch
 equals the scenario's active epoch (`new_matches_active`) are ever written. A drifted re-score (fresh
 epoch does not match the active one, because the current spec no longer reproduces it) is reported
-with the D2a drift warning but never promoted: the operator must reconcile the spec with the active
+with the D2a drift warning but never recorded: the operator must reconcile the spec with the active
 epoch first, or promote a new epoch via `autoctx epoch`. Skipped and error generations are likewise
 never written.
 
-**What promotion does.** For each qualifying generation, `--apply` archives the original `(score,
-epoch, quarantined)` into a new `generation_score_revisions` table, then updates the generation's
-`best_score` and `evaluator_epoch` to the fresh values and clears its `quarantined` marker, all in one
-atomic, per-`(run_id, generation_index)` transaction. `mean_score`, `elo`, and tournament counters are
-left untouched, only `best_score` is the score of record that `show`/`status`/`run_status` and
-training-export surface. The generation immediately reads back as `current` rather than `stale`.
-Because only `best_score` moves, a promoted `best_score` can end up below the run-time `mean_score` if
-the current evaluator scores the artifact lower than the original run did; that is expected (the
-promoted `best_score` is the post-re-score value of record, not the run's original sample statistics,
-which the archive preserves).
+**What recording does.** For each qualifying generation, `--apply` appends one row to a new
+`generation_score_revisions` table capturing the fresh `(revision_epoch, revision_score)` and archiving
+the generation's CURRENT `(evaluator_epoch, best_score, quarantined)` as the `previous_*` columns, in a
+single atomic `INSERT ... SELECT` (so there is no read-then-write gap and no concurrent writer can be
+lost). It does NOT modify the `generations` row, its quarantine marker, `knowledge_snapshots`, or any
+other table: the live `best_score` that `show` / `status` / `run_status` and training-export surface is
+left exactly as it was. Re-applying appends another revision (full history); because the generation is
+never mutated, each revision archives the same unchanged current values.
 
-**`--by`** records a reviewer identity on the archived revision, so a promotion is attributable.
+**`--by`** records a reviewer identity on the audit revision, so a recorded re-score is attributable.
 
-**Output.** `--json` gains a top-level `applied` list of promoted generation indices and each
-generation entry gains an `applied` boolean; the Rich table gains an `Applied` column, and the summary
-line reports how many generations were promoted versus re-scored.
+**Output.** `--json` gains a top-level `applied` list of recorded generation indices and each
+generation entry gains an `applied` boolean (true when a revision was recorded); the Rich table gains a
+`Recorded` column, and the summary line reports how many audit revisions were recorded, noting the live
+score of record was not changed.
 
 **Python-written, TypeScript schema-parity only.** `generation_score_revisions` exists in both
 packages' migrations (Python `018_generation_score_revisions.sql` and TypeScript
@@ -462,9 +466,9 @@ packages' migrations (Python `018_generation_score_revisions.sql` and TypeScript
 schema-compatible, but only the Python `rescore --apply` path writes to it, matching the `rescore` /
 `epoch` CLI's existing Python-only asymmetry: TypeScript carries no `--apply` equivalent.
 
-**Not in this slice.** Reading from the archive (a `revisions`/history CLI or API view), and reverting
-a promotion from the archive back onto the generation, are future work; the table is queryable today
-but nothing yet consumes it beyond the archive itself.
+**Not in this slice.** Reading from the archive (a `revisions`/history CLI or API view), and teaching
+reads/exports to prefer the latest active-epoch revision over the live score, are future work; the
+table is queryable today but nothing yet consumes it beyond the archive itself.
 
 ## Deferred slices
 

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -445,6 +445,10 @@ epoch, quarantined)` into a new `generation_score_revisions` table, then updates
 atomic, per-`(run_id, generation_index)` transaction. `mean_score`, `elo`, and tournament counters are
 left untouched, only `best_score` is the score of record that `show`/`status`/`run_status` and
 training-export surface. The generation immediately reads back as `current` rather than `stale`.
+Because only `best_score` moves, a promoted `best_score` can end up below the run-time `mean_score` if
+the current evaluator scores the artifact lower than the original run did; that is expected (the
+promoted `best_score` is the post-re-score value of record, not the run's original sample statistics,
+which the archive preserves).
 
 **`--by`** records a reviewer identity on the archived revision, so a promotion is attributable.
 

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -394,22 +394,22 @@ next to the new score/epoch, plus `was_stale`, `new_matches_active`, and `score_
 Only a missing run is a hard failure (exit 1, matching `show`); every other failure mode degrades to
 a per-generation skip and the command still exits 0.
 
-**It writes no score or lineage.** No `upsert_generation`, no registry activation/promotion, no
-quarantine clear, anywhere in this path. It opens only an existing store (a missing database is
-reported as not-found, never created) and runs the configured evaluator hooks so the re-score matches
-production. The command fetches, re-scores in memory, and prints, either a Rich table (which surfaces
-the old / new epoch and a warning when the fresh epoch does not match the active one) or a `--json`
-payload of `{run_id, scenario, active_evaluator_epoch, generations: [...]}`.
+**It writes nothing without `--apply`.** No `upsert_generation`, no registry activation/promotion, no
+quarantine clear, anywhere in this path by default. It opens only an existing store (a missing database
+is reported as not-found, never created) and runs the configured evaluator hooks so the re-score
+matches production. The command fetches, re-scores in memory, and prints, either a Rich table (which
+surfaces the old / new epoch and a warning when the fresh epoch does not match the active one) or a
+`--json` payload of `{run_id, scenario, active_evaluator_epoch, generations: [...]}`. Persisting a
+matching re-score is opt-in via `--apply`, see "Persisting a re-score (Slice D2b)" below.
 
 **Python-only.** Like the `epoch` CLI, `rescore` depends on the Python-only LLM-judge and
 evaluator-epoch registry path, so it has no TypeScript equivalent; this is a documented intentional
 gap in `docs/cli-contract.json`, not an oversight.
 
-**What remains deferred.** Persisting a re-score (an `--apply` flag that writes the fresh score
-somewhere durable, backed by a net-new `generation_score_revisions`-style table so the original
-score's lineage is not clobbered) is Slice D2b. Auto-re-scoring on every read (`show`/`status`) was
-considered and rejected: it would fire paid LLM calls on reads and make them slow and
-nondeterministic, which is why `rescore` is an explicit operator-triggered command instead.
+**What remains deferred.** Auto-re-scoring on every read (`show`/`status`) was considered and
+rejected: it would fire paid LLM calls on reads and make them slow and nondeterministic, which is why
+`rescore` is an explicit operator-triggered command instead. Persisting a re-score is no longer
+deferred, see "Persisting a re-score (Slice D2b)" below.
 
 ## Relationship to the ambient `eval_fingerprint` / `anchor_model`
 
@@ -424,6 +424,43 @@ a rubric or judge change was compared as if nothing had changed. The ambient fin
 evaluator epoch are the same pattern applied in two places; this slice closes the gap on the judge
 path and the improve loop. It stays distinct from AC-881 noise calibration, which measures
 within-epoch variance rather than deciding cross-epoch comparability.
+
+## Persisting a re-score (Slice D2b)
+
+Slice D2a re-scored a stale generation and reported the result, without touching the database. Slice
+D2b adds the persistence path: an `--apply` flag on `autoctx rescore <run_id> [--generation N] --apply
+[--by REVIEWER]` that promotes a matching fresh re-score onto the generation as its score of record,
+while archiving the original so nothing is silently lost.
+
+**Who gets promoted.** Only generations whose D2a report status is `revalidated` AND whose fresh epoch
+equals the scenario's active epoch (`new_matches_active`) are ever written. A drifted re-score (fresh
+epoch does not match the active one, because the current spec no longer reproduces it) is reported
+with the D2a drift warning but never promoted: the operator must reconcile the spec with the active
+epoch first, or promote a new epoch via `autoctx epoch`. Skipped and error generations are likewise
+never written.
+
+**What promotion does.** For each qualifying generation, `--apply` archives the original `(score,
+epoch, quarantined)` into a new `generation_score_revisions` table, then updates the generation's
+`best_score` and `evaluator_epoch` to the fresh values and clears its `quarantined` marker, all in one
+atomic, per-`(run_id, generation_index)` transaction. `mean_score`, `elo`, and tournament counters are
+left untouched, only `best_score` is the score of record that `show`/`status`/`run_status` and
+training-export surface. The generation immediately reads back as `current` rather than `stale`.
+
+**`--by`** records a reviewer identity on the archived revision, so a promotion is attributable.
+
+**Output.** `--json` gains a top-level `applied` list of promoted generation indices and each
+generation entry gains an `applied` boolean; the Rich table gains an `Applied` column, and the summary
+line reports how many generations were promoted versus re-scored.
+
+**Python-written, TypeScript schema-parity only.** `generation_score_revisions` exists in both
+packages' migrations (Python `018_generation_score_revisions.sql` and TypeScript
+`016_generation_score_revisions.sql`, byte-identical) so cross-package databases stay
+schema-compatible, but only the Python `rescore --apply` path writes to it, matching the `rescore` /
+`epoch` CLI's existing Python-only asymmetry: TypeScript carries no `--apply` equivalent.
+
+**Not in this slice.** Reading from the archive (a `revisions`/history CLI or API view), and reverting
+a promotion from the archive back onto the generation, are future work; the table is queryable today
+but nothing yet consumes it beyond the archive itself.
 
 ## Deferred slices
 
@@ -440,10 +477,11 @@ The remaining slices are explicitly deferred, not dropped:
   registry, the mechanical observe trigger, and the `quarantined` marker) is shipped (see "Epoch
   lifecycle (Slice C1)" above); the enforcement that consumes the marker and the promotion workflow
   land in C2 and C3.
-- **Slice D (surfacing + lazy re-score):** stale-epoch warnings in CLI / status / replay, REST /
-  API, and dashboard, plus revalidation of raw artifacts when a stale scored record is touched.
-  D1 (read-only surfacing: the four-state classification, the `show` / `status` / `run_status`
+- **Slice D (surfacing + lazy re-score, fully shipped):** stale-epoch warnings in CLI / status /
+  replay, REST / API, and dashboard, plus revalidation of raw artifacts when a stale scored record is
+  touched. D1 (read-only surfacing: the four-state classification, the `show` / `status` / `run_status`
   fields, and the `stale_epoch` HTTP warning) is shipped, see "Slice D1: stale surfacing" above. D2a
   (the on-demand, report-only `autoctx rescore` command) is shipped, see "On-demand re-score (Slice
-  D2a)" above. D2b (persisting a re-score behind an `--apply` flag and a score-revisions table)
-  remains.
+  D2a)" above. D2b (persisting a re-score behind an `--apply` flag and a `generation_score_revisions`
+  table) is shipped, see "Persisting a re-score (Slice D2b)" above. Slice D, and the AC-885 re-score
+  thread it closes, is done.

--- a/ts/migrations/016_generation_score_revisions.sql
+++ b/ts/migrations/016_generation_score_revisions.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS generation_score_revisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    generation_index INTEGER NOT NULL,
+    revision_epoch TEXT NOT NULL,
+    revision_score REAL NOT NULL,
+    previous_epoch TEXT,
+    previous_score REAL,
+    previous_quarantined INTEGER,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (run_id, generation_index)
+        REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_generation_score_revisions_run_gen
+    ON generation_score_revisions(run_id, generation_index);

--- a/ts/src/storage/schema-parity-manifest.ts
+++ b/ts/src/storage/schema-parity-manifest.ts
@@ -3,6 +3,7 @@ export const SCHEMA_PARITY_SHARED_TABLES = [
   "agent_role_metrics",
   "consultation_log",
   "generation_recovery",
+  "generation_score_revisions",
   "generations",
   "hub_packages",
   "hub_promotions",
@@ -27,7 +28,4 @@ export const SCHEMA_PARITY_PYTHON_ONLY_TABLES = [
 
 export const SCHEMA_PARITY_TYPESCRIPT_ONLY_TABLES = [] as const;
 
-export const SCHEMA_PARITY_LEDGER_TABLES = [
-  "schema_migrations",
-  "schema_version",
-] as const;
+export const SCHEMA_PARITY_LEDGER_TABLES = ["schema_migrations", "schema_version"] as const;

--- a/ts/src/storage/storage-migration-workflow.ts
+++ b/ts/src/storage/storage-migration-workflow.ts
@@ -22,6 +22,7 @@ export const TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES: Record<string, readonly s
   "012_research_hub.sql": ["012_research_hub.sql"],
   "014_generation_evaluator_epoch.sql": ["016_generation_evaluator_epoch.sql"],
   "015_generation_quarantined.sql": ["017_generation_quarantined.sql"],
+  "016_generation_score_revisions.sql": ["018_generation_score_revisions.sql"],
 };
 
 const TYPESCRIPT_BASELINE_SCHEMA_RECONCILIATION: Record<string, readonly string[]> = {

--- a/ts/tests/storage-migration-workflow.test.ts
+++ b/ts/tests/storage-migration-workflow.test.ts
@@ -123,6 +123,41 @@ describe("storage migration workflow", () => {
     ).toEqual({ filename: "015_generation_quarantined.sql" });
   });
 
+  it("migrates a fully Python-owned database without duplicating the score revisions table", () => {
+    applyEveryPythonMigration(db);
+    expect(
+      db
+        .prepare("SELECT version FROM schema_migrations WHERE version = ?")
+        .get("018_generation_score_revisions.sql"),
+    ).toEqual({ version: "018_generation_score_revisions.sql" });
+
+    expect(() => migrateDatabase(db, MIGRATIONS_DIR)).not.toThrow();
+
+    const scoreRevisionTables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .all("generation_score_revisions") as Array<{ name: string }>;
+    expect(scoreRevisionTables).toHaveLength(1);
+    expect(
+      db
+        .prepare("SELECT filename FROM schema_version WHERE filename = ?")
+        .get("016_generation_score_revisions.sql"),
+    ).toEqual({ filename: "016_generation_score_revisions.sql" });
+  });
+
+  it("creates the score revisions table exactly once on a fresh TypeScript migrate", () => {
+    migrateDatabase(db, MIGRATIONS_DIR);
+
+    const scoreRevisionTables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .all("generation_score_revisions") as Array<{ name: string }>;
+    expect(scoreRevisionTables).toHaveLength(1);
+    expect(
+      db
+        .prepare("SELECT version FROM schema_migrations WHERE version = ?")
+        .get("018_generation_score_revisions.sql"),
+    ).toEqual({ version: "018_generation_score_revisions.sql" });
+  });
+
   it("marks TypeScript migrations applied when Python already owns the equivalent schema", () => {
     db.exec(
       `CREATE TABLE schema_migrations (


### PR DESCRIPTION
## AC-885 Slice D2b: persist a re-score (promote + archive)

Final sub-slice of Slice D, closing the AC-885 re-score thread. Slices 1/B/C1/C2/C3/D1/D2a are merged (#1204, #1208, #1210, #1211, #1212, #1213, #1214). D2a added `autoctx rescore` report-only; D2b adds the persistence path.

### What this adds

`autoctx rescore <run_id> --apply [--by REVIEWER]` **promotes** a matching active-epoch re-score onto the generation as its score of record, while **archiving** the original into a new `generation_score_revisions` table.

- **Promote:** for each generation whose re-score is `revalidated` and whose fresh epoch equals the active epoch, update `best_score` + `evaluator_epoch` to the fresh values and clear `quarantined`. The generation immediately reads back as `current` (D1 surfacing) and is included by training-export.
- **Archive:** the original `(score, epoch, quarantined)` is written to `generation_score_revisions` first, in the same atomic per-`(run_id, generation_index)` transaction, so nothing is silently lost.
- **Default stays report-only:** without `--apply`, `rescore` writes nothing (D2a behavior preserved).

### Data-safety design (the reason this was gated behind a design fork)

The AC-885 thesis is that an evaluator change must not *silently* overwrite the scoring baseline. This promote is the opposite of silent:
- **Explicit** (opt-in `--apply`; default writes nothing),
- **Narrow** (only `revalidated` + `new_matches_active`; a drifted re-score where the current spec no longer reproduces the active epoch is reported with the drift warning but **never written**),
- **Atomic + archived** (original preserved in the revisions table before the update; reversible in principle).

`mean_score`/`elo`/counters are left untouched; only `best_score` (the surfaced score of record) moves. A promoted `best_score` can fall below the run-time `mean_score` if the current evaluator scores lower; that is expected and documented, and the archive preserves the run's original statistics.

### Cross-package schema

New shared table `generation_score_revisions`, created by byte-identical migrations in both packages (Python `018` + TS `016`, `CREATE TABLE IF NOT EXISTS`), paired in both migration ledgers, added to `SCHEMA_PARITY_SHARED_TABLES`, and mirrored in `bootstrap_schema`. Only Python writes to it (matching the C1-D2a "judge/registry path is Python-only" asymmetry); the TS side ships the schema for cross-package database compatibility, verified by the schema-parity gate.

### Review

Built subagent-driven (fresh opus implementer per task, per-task reviews, opus whole-branch review verdict "ready to merge, no Critical/Important"). The whole-branch review traced the promote end to end and confirmed: strictly opt-in, only-matching-active promoted, archive-before-update, atomic, per-row quarantine clear (no over-clear vs the epoch-scoped promotion-workflow clear), and idempotent re-apply. One Minor doc note folded in (best_score/mean_score divergence).

Local gates: **full Python suite green (exit 0)**, **full TS suite green (5808 passed)**, schema-parity (new shared table), migration-ledger idempotency (both directions), bootstrap equivalence, module-size, serde, cli-contract parity (the new `--apply`/`--by` flags). `uv.lock` untouched, no em dashes in added lines.

### Closes AC-885

With D2b, every AC-885 thread is delivered: identity + comparability guard (Slice 1), persisted/derived lineage (B), epoch lifecycle + promotion + enforcement (C1-C3), stale surfacing (D1), on-demand re-score report (D2a), and re-score persistence (D2b). "Changing an evaluator cannot silently overwrite the baseline" is satisfied end to end.

Left open for review; do not merge without authorization.
