### PR TITLE
AC-885 Slice D2c: surface recorded re-scores in show/status/run_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ All notable changes to this project will be documented in this file.
   reported but never written, and the default (no `--apply`) stays report-only. The table is
   Python-written and TypeScript-schema-parity only (byte-identical migrations, no TypeScript write
   path), matching the existing `rescore`/`epoch` asymmetry. This closes the AC-885 re-score thread.
+- AC-885 Slice D2c: surfacing recorded re-scores. `autoctx show`, `autoctx status`, and the cockpit
+  `GET /api/cockpit/runs/{run_id}/status` now surface a generation's latest active-epoch re-score
+  recorded via `rescore --apply` (`has_active_revision`, `revised_score`, `revised_by`, `revised_at`)
+  alongside the unchanged live score. Only the latest revision recorded under the scenario's current
+  active epoch is surfaced; the live score of record is untouched. Read-only, Python-only, no new
+  command, flag, or schema.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -73,6 +73,7 @@ JSON output shape:
 ```json
 {
   "run_id": "abc123",
+  "active_evaluator_epoch": "e2sha256...",
   "generations": [
     {
       "generation": 1,
@@ -82,11 +83,27 @@ JSON output shape:
       "wins": 3,
       "losses": 2,
       "gate_decision": "advance",
-      "status": "completed"
+      "status": "completed",
+      "evaluator_epoch": "e1sha256...",
+      "evaluator_epoch_status": "stale",
+      "quarantined": false,
+      "has_active_revision": true,
+      "revised_score": 0.55,
+      "revised_by": "jay",
+      "revised_at": "2026-07-13T19:12:05Z"
     }
   ]
 }
 ```
+
+The evaluator-epoch lineage fields (AC-885) are Python-only and always present. `active_evaluator_epoch`
+(top level) is the scenario's active evaluator epoch, or null. Per generation, `evaluator_epoch` is the
+epoch that produced `best_score` and `evaluator_epoch_status` classifies it against the active epoch
+(`current` / `stale` / `unknown` / `no_active_epoch`). When `autoctx rescore --apply` has recorded a
+re-score under the active epoch, `has_active_revision` is true and `revised_score` / `revised_by` /
+`revised_at` describe it. `revised_score` SUPPLEMENTS `best_score` (the unchanged score of record), it
+does not replace it; the fields are null when no active-epoch revision exists. `show --json` carries the
+same fields (its top-level payload also includes `scenario` and `status`).
 
 The TypeScript CLI also includes an optional `runtime_session` object in
 `status`, `show`, and `watch --json` output when a CLI-backed provider run has a
@@ -680,8 +697,8 @@ Key environment variables:
 | `AUTOCONTEXT_LEAN_TOOL_ALLOWLIST`                                    | Comma-separated tool-affordance allowlist exported in the lean profile metadata                                                                                                                                                                                                                     |
 | `AUTOCONTEXT_EXTENSIONS`                                             | Comma-separated Python modules or `.py` files that register runtime hooks                                                                                                                                                                                                                           |
 | `AUTOCONTEXT_EXTENSION_FAIL_FAST`                                    | Stop the run when an extension hook raises instead of recording a non-fatal hook error                                                                                                                                                                                                              |
-| `AUTOCONTEXT_PANEL_ROLES`                                            | Experimental comma-separated roles that run through panel mode, for example `analyst,coach`; disabled by default                                                                                                                                                                                   |
-| `AUTOCONTEXT_PANEL_PARTICIPANTS`                                     | Experimental panel participants as `role=provider:model,provider:model`, with `;` between role specs                                                                                                                                                                                               |
+| `AUTOCONTEXT_PANEL_ROLES`                                            | Experimental comma-separated roles that run through panel mode, for example `analyst,coach`; disabled by default                                                                                                                                                                                    |
+| `AUTOCONTEXT_PANEL_PARTICIPANTS`                                     | Experimental panel participants as `role=provider:model,provider:model`, with `;` between role specs                                                                                                                                                                                                |
 | `AUTOCONTEXT_PANEL_SYNTHESIZER_PROVIDER`                             | Optional synthesizer provider; falls back to the role provider when blank                                                                                                                                                                                                                           |
 | `AUTOCONTEXT_PANEL_SYNTHESIZER_MODEL`                                | Optional synthesizer model; falls back to the role model when blank                                                                                                                                                                                                                                 |
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -36,6 +36,8 @@ from autocontext.cli_rescore import rescore_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_run_inspect import (
     _lineage_cell,
+    _revised_cell,
+    _revised_note_line,
     _stale_warning_line,
     annotate_run_status_rows,
     register_run_inspect_commands,
@@ -580,7 +582,7 @@ def status(
 
     run = store.get_run(run_id)
     scenario = run.get("scenario") if run else None
-    rows, active_epoch_id = annotate_run_status_rows(settings, scenario, rows)
+    rows, active_epoch_id = annotate_run_status_rows(settings, scenario, rows, store, run_id)
 
     if json_output:
         generations = []
@@ -598,6 +600,10 @@ def status(
                     "evaluator_epoch": row.get("evaluator_epoch"),
                     "evaluator_epoch_status": row["evaluator_epoch_status"],
                     "quarantined": bool(row.get("quarantined")),
+                    "has_active_revision": row["has_active_revision"],
+                    "revised_score": row.get("revised_score"),
+                    "revised_by": row.get("revised_by"),
+                    "revised_at": row.get("revised_at"),
                 }
             )
         sys.stdout.write(
@@ -621,6 +627,7 @@ def status(
         table.add_column("Gate")
         table.add_column("Status")
         table.add_column("Lineage")
+        table.add_column("Revised")
         for row in rows:
             table.add_row(
                 str(row["generation_index"]),
@@ -632,11 +639,15 @@ def status(
                 row["gate_decision"],
                 row["status"],
                 _lineage_cell(row),
+                _revised_cell(row),
             )
         console.print(table)
         warning = _stale_warning_line(rows, active_epoch_id)
         if warning is not None:
             console.print(warning)
+        note = _revised_note_line(rows)
+        if note is not None:
+            console.print(note)
 
 
 def _run_http_serve(host: str, port: int) -> None:

--- a/autocontext/src/autocontext/cli_run_inspect.py
+++ b/autocontext/src/autocontext/cli_run_inspect.py
@@ -28,13 +28,14 @@ from typing import TYPE_CHECKING, Any
 import typer
 from rich.table import Table
 
-from autocontext.execution.epoch_lineage import annotate_status_rows
+from autocontext.execution.epoch_lineage import annotate_status_rows, revision_fields
 from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
 
 if TYPE_CHECKING:
     from rich.console import Console
 
     from autocontext.config.settings import AppSettings
+    from autocontext.storage.sqlite_store import SQLiteStore
 
 _TERMINAL_STATUSES = frozenset({"completed", "failed", "succeeded", "errored"})
 
@@ -46,15 +47,25 @@ def annotate_run_status_rows(
     settings: AppSettings,
     scenario: str | None,
     rows: list[dict[str, Any]],
+    store: SQLiteStore,
+    run_id: str,
 ) -> tuple[list[dict[str, Any]], str | None]:
-    """Annotate run_status rows with epoch lineage (AC-885 Slice D1).
+    """Annotate run_status rows with epoch lineage (AC-885 Slice D1) + recorded re-scores (Slice D2c).
 
     Shared by ``show`` and ``status`` so the registry root is constructed in one place. Builds the
     per-scenario epoch registry under ``settings.knowledge_root / "_evaluator_epochs"`` (same root as
-    ``cli_epoch``) and delegates to ``annotate_status_rows``. Read-only.
+    ``cli_epoch``) and delegates to ``annotate_status_rows``. Then merges the latest active-epoch re-score
+    per generation (recorded by ``rescore --apply``) onto each row via ``revision_fields``. Read-only.
+
+    ``store.latest_active_revisions`` returns ``{}`` when ``active_epoch_id`` is None, so every row still
+    gains the null-revision fields, keeping the surfaced shape consistent. Inputs are not mutated.
     """
     registry = EvaluatorEpochRegistry(settings.knowledge_root / "_evaluator_epochs")
-    return annotate_status_rows(rows, scenario, registry)
+    rows, active_epoch_id = annotate_status_rows(rows, scenario, registry)
+    revs = store.latest_active_revisions(run_id, active_epoch_id)
+    for row in rows:
+        row.update(revision_fields(revs.get(row["generation_index"])))
+    return rows, active_epoch_id
 
 
 def _lineage_cell(row: dict[str, Any]) -> str:
@@ -63,6 +74,23 @@ def _lineage_cell(row: dict[str, Any]) -> str:
     if row.get("quarantined"):
         label = f"{label}+quarantined"
     return label
+
+
+def _revised_cell(row: dict[str, Any]) -> str:
+    """Render the compact ``Revised`` column value: the latest active-epoch re-score, or ``-`` (AC-885 D2c)."""
+    revised = row.get("revised_score")
+    return f"{revised:.4f}" if revised is not None else "-"
+
+
+def _revised_note_line(rows: list[dict[str, Any]]) -> str | None:
+    """Return a single note line if any row carries an active-epoch re-score, else None (AC-885 D2c)."""
+    revised = [r for r in rows if r.get("has_active_revision")]
+    if not revised:
+        return None
+    return (
+        f"[cyan]{len(revised)} generation(s) have an active-epoch re-score recorded via `rescore --apply`; "
+        "the live score of record is unchanged.[/cyan]"
+    )
 
 
 def _stale_warning_line(rows: list[dict[str, Any]], active_epoch_id: str | None) -> str | None:
@@ -141,7 +169,7 @@ def register_run_inspect_commands(
                     console.print(f"[red]{message}[/red]")
                 raise typer.Exit(code=1)
 
-        rows, active_epoch_id = annotate_run_status_rows(settings, run.get("scenario"), rows)
+        rows, active_epoch_id = annotate_run_status_rows(settings, run.get("scenario"), rows, store, run_id)
 
         if json_output:
             payload: dict[str, Any] = {
@@ -162,6 +190,10 @@ def register_run_inspect_commands(
                         "evaluator_epoch": r.get("evaluator_epoch"),
                         "evaluator_epoch_status": r["evaluator_epoch_status"],
                         "quarantined": bool(r.get("quarantined")),
+                        "has_active_revision": r["has_active_revision"],
+                        "revised_score": r.get("revised_score"),
+                        "revised_by": r.get("revised_by"),
+                        "revised_at": r.get("revised_at"),
                     }
                     for r in rows
                 ],
@@ -183,6 +215,7 @@ def register_run_inspect_commands(
         table.add_column("Gate")
         table.add_column("Status")
         table.add_column("Lineage")
+        table.add_column("Revised")
         for row in rows:
             table.add_row(
                 str(row["generation_index"]),
@@ -194,11 +227,15 @@ def register_run_inspect_commands(
                 row["gate_decision"],
                 row["status"],
                 _lineage_cell(row),
+                _revised_cell(row),
             )
         console.print(table)
         warning = _stale_warning_line(rows, active_epoch_id)
         if warning is not None:
             console.print(warning)
+        note = _revised_note_line(rows)
+        if note is not None:
+            console.print(note)
 
     @app.command()
     def watch(

--- a/autocontext/src/autocontext/execution/epoch_lineage.py
+++ b/autocontext/src/autocontext/execution/epoch_lineage.py
@@ -8,10 +8,13 @@ self-heal a multiple-active state) and classifies each status row.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from autocontext.execution.evaluator_epoch import classify_epoch_lineage
 from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+if TYPE_CHECKING:
+    from autocontext.storage.row_types import GenerationScoreRevisionRow
 
 
 def annotate_status_rows(
@@ -32,3 +35,13 @@ def annotate_status_rows(
         copy["evaluator_epoch_status"] = classify_epoch_lineage(copy.get("evaluator_epoch"), active_id)
         annotated.append(copy)
     return annotated, active_id
+
+
+def revision_fields(revision: GenerationScoreRevisionRow | None) -> dict[str, Any]:
+    """Shape the four surfacing fields for a generation's latest active-epoch revision (or absence)."""
+    return {
+        "has_active_revision": revision is not None,
+        "revised_score": revision["revision_score"] if revision is not None else None,
+        "revised_by": revision["created_by"] if revision is not None else None,
+        "revised_at": revision["created_at"] if revision is not None else None,
+    }

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -410,7 +410,7 @@ def run_status(run_id: str, request: Request) -> dict[str, Any]:
             (run_id,),
         ).fetchall()
 
-    generations, active_id, warnings = build_run_status_generations(gen_rows, run_dict["scenario"], request)
+    generations, active_id, warnings = build_run_status_generations(gen_rows, run_dict["scenario"], request, store, run_id)
 
     runtime_store = _get_runtime_session_store(request)
     try:

--- a/autocontext/src/autocontext/server/run_status_lineage.py
+++ b/autocontext/src/autocontext/server/run_status_lineage.py
@@ -12,8 +12,9 @@ from typing import Any
 
 from fastapi import HTTPException, Request
 
-from autocontext.execution.epoch_lineage import annotate_status_rows
+from autocontext.execution.epoch_lineage import annotate_status_rows, revision_fields
 from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+from autocontext.storage.sqlite_store import SQLiteStore
 
 
 def _epoch_registry_from_request(request: Request) -> EvaluatorEpochRegistry:
@@ -27,6 +28,8 @@ def build_run_status_generations(
     gen_rows: list[Any],
     scenario: str | None,
     request: Request,
+    store: SQLiteStore,
+    run_id: str,
 ) -> tuple[list[dict[str, Any]], str | None, list[dict[str, Any]]]:
     """Return (generation dicts with lineage, active epoch id, stale-epoch warnings).
 
@@ -54,6 +57,9 @@ def build_run_status_generations(
         )
 
     generations, active_id = annotate_status_rows(generations, scenario, _epoch_registry_from_request(request))
+    revs = store.latest_active_revisions(run_id, active_id)
+    for g in generations:
+        g.update(revision_fields(revs.get(g["generation"])))
     warnings = [
         {
             "warning_type": "stale_epoch",

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -228,6 +228,28 @@ class SQLiteStore(
             ).fetchall()
             return [cast(GenerationScoreRevisionRow, dict(row)) for row in rows]
 
+    def latest_active_revisions(self, run_id: str, active_epoch: str | None) -> dict[int, GenerationScoreRevisionRow]:
+        """Return, per generation_index, the LATEST revision recorded under ``active_epoch`` for the run.
+
+        Only revisions whose ``revision_epoch`` equals ``active_epoch`` are considered; the most recent
+        (highest ``id``) wins. Empty when ``active_epoch`` is None or nothing matches. Read-only.
+        """
+        if active_epoch is None:
+            return {}
+        with self.connect() as conn:
+            rows = conn.execute(
+                "SELECT id, run_id, generation_index, revision_epoch, revision_score, "
+                "previous_epoch, previous_score, previous_quarantined, created_by, created_at "
+                "FROM generation_score_revisions "
+                "WHERE run_id = ? AND revision_epoch = ? ORDER BY id ASC",
+                (run_id, active_epoch),
+            ).fetchall()
+        # ASC then overwrite -> the highest-id (latest) revision per generation wins.
+        latest: dict[int, GenerationScoreRevisionRow] = {}
+        for row in rows:
+            latest[int(row["generation_index"])] = cast(GenerationScoreRevisionRow, dict(row))
+        return latest
+
     def update_generation_duration(
         self,
         run_id: str,

--- a/autocontext/tests/test_cli_rescore_surfacing.py
+++ b/autocontext/tests/test_cli_rescore_surfacing.py
@@ -1,0 +1,148 @@
+"""CLI recorded-re-score surfacing for ``show`` + ``status`` (AC-885 Slice D2c).
+
+A generation whose latest active-epoch re-score was recorded by ``rescore --apply`` must surface that
+revision (score, who, when) alongside the unchanged live score. Read-only: the live ``best_score`` is
+never modified. Every generation dict always gains the four fields (null when no active-epoch revision).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+
+runner = CliRunner()
+
+_SCENARIO = "grid_ctf"
+_MIGRATIONS = Path(__file__).resolve().parents[1] / "migrations"
+
+
+def _env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_KNOWLEDGE_ROOT", str(tmp_path / "knowledge"))
+    monkeypatch.setenv("AUTOCONTEXT_DB_PATH", str(tmp_path / "t.sqlite3"))
+
+
+def _store(tmp_path: Path):
+    from autocontext.storage.sqlite_store import SQLiteStore
+
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(_MIGRATIONS)
+    return store
+
+
+def _seed_epochs(tmp_path: Path) -> tuple[str, str]:
+    reg = EvaluatorEpochRegistry(tmp_path / "knowledge" / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe(_SCENARIO, e1, now_fn=lambda: "t0")  # active (bootstrap)
+    reg.observe(_SCENARIO, e2, now_fn=lambda: "t1")  # candidate
+    reg.activate(_SCENARIO, e2.epoch_id)  # promote e2 -> e1-scored rows now stale
+    return e1.epoch_id, e2.epoch_id
+
+
+def _seed_run(tmp_path: Path, run_id: str, epoch_id: str | None) -> None:
+    store = _store(tmp_path)
+    store.create_run(run_id, _SCENARIO, 1, "local")
+    store.upsert_generation(
+        run_id,
+        1,
+        mean_score=0.5,
+        best_score=0.6,
+        elo=1000.0,
+        wins=1,
+        losses=0,
+        gate_decision="pass",
+        status="completed",
+        evaluator_epoch=epoch_id,
+    )
+
+
+def _seed_run_with_revision(tmp_path: Path) -> tuple[str, str]:
+    """Seed a stale generation (scored under e1, e2 active) plus an active-epoch re-score under e2."""
+    e1, e2 = _seed_epochs(tmp_path)
+    _seed_run(tmp_path, "run-rev", e1)
+    store = _store(tmp_path)
+    assert store.record_rescore_revision("run-rev", 1, 0.55, e2, created_by="jay")
+    return e1, e2
+
+
+def test_show_json_surfaces_revision(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    _seed_run_with_revision(tmp_path)
+
+    result = runner.invoke(app, ["show", "run-rev", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["has_active_revision"] is True
+    assert gen["revised_score"] == 0.55
+    assert gen["revised_by"] == "jay"
+    assert gen["revised_at"] is not None
+    # The live score of record is unchanged (read-only surfacing).
+    assert gen["best_score"] == 0.6
+
+
+def test_status_json_surfaces_revision(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    _seed_run_with_revision(tmp_path)
+
+    result = runner.invoke(app, ["status", "run-rev", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["has_active_revision"] is True
+    assert gen["revised_score"] == 0.55
+    assert gen["revised_by"] == "jay"
+    assert gen["revised_at"] is not None
+    assert gen["best_score"] == 0.6
+
+
+def test_show_rich_surfaces_revision(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    _seed_run_with_revision(tmp_path)
+
+    result = runner.invoke(app, ["show", "run-rev"])
+    assert result.exit_code == 0, result.output
+    normalized = " ".join(result.output.split())
+    assert "0.5500" in normalized  # revised-score cell
+    assert "re-score recorded" in normalized  # the note line
+
+
+def test_status_rich_surfaces_revision(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    _seed_run_with_revision(tmp_path)
+
+    result = runner.invoke(app, ["status", "run-rev"])
+    assert result.exit_code == 0, result.output
+    normalized = " ".join(result.output.split())
+    assert "0.5500" in normalized
+    assert "re-score recorded" in normalized
+
+
+def test_show_json_no_revision(tmp_path: Path, monkeypatch) -> None:
+    _env(monkeypatch, tmp_path)
+    e1, _e2 = _seed_epochs(tmp_path)
+    _seed_run(tmp_path, "run-plain", e1)
+
+    result = runner.invoke(app, ["show", "run-plain", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["has_active_revision"] is False
+    assert gen["revised_score"] is None
+    assert gen["revised_by"] is None
+    assert gen["revised_at"] is None
+
+
+def test_status_json_no_active_epoch_still_has_fields(tmp_path: Path, monkeypatch) -> None:
+    """A scenario with no active epoch still yields the four null-revision fields (consistent shape)."""
+    _env(monkeypatch, tmp_path)
+    _seed_run(tmp_path, "run-bare", "e1")  # no epochs registered -> active_epoch_id None
+
+    result = runner.invoke(app, ["status", "run-bare", "--json"])
+    assert result.exit_code == 0, result.output
+    gen = json.loads(result.stdout)["generations"][0]
+    assert gen["has_active_revision"] is False
+    assert gen["revised_score"] is None

--- a/autocontext/tests/test_cli_show_watch.py
+++ b/autocontext/tests/test_cli_show_watch.py
@@ -45,6 +45,9 @@ def _make_store_stub(run_row: dict[str, Any] | None, generations: list[dict[str,
         def run_status(self, _run_id: str) -> list[dict[str, Any]]:
             return generations
 
+        def latest_active_revisions(self, _run_id: str, _active_epoch: str | None) -> dict[int, Any]:
+            return {}
+
         def close(self) -> None:
             pass
 

--- a/autocontext/tests/test_cockpit_rescore_surfacing.py
+++ b/autocontext/tests/test_cockpit_rescore_surfacing.py
@@ -1,0 +1,81 @@
+"""Recorded re-score surfacing in the HTTP cockpit run_status (AC-885 Slice D2c)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from autocontext.config.settings import AppSettings
+from autocontext.execution.evaluator_epoch import compute_evaluator_epoch
+from autocontext.execution.evaluator_epoch_registry import EvaluatorEpochRegistry
+from autocontext.server.cockpit_api import cockpit_router
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations"
+
+
+def _client(tmp_path: Path, store: SQLiteStore) -> TestClient:
+    settings = AppSettings(
+        db_path=tmp_path / "test.db",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+    )
+    app = FastAPI()
+    app.state.store = store
+    app.state.app_settings = settings
+    app.include_router(cockpit_router)
+    return TestClient(app)
+
+
+def test_run_status_surfaces_active_epoch_revision(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "test.db")
+    store.migrate(MIGRATIONS_DIR)
+
+    reg = EvaluatorEpochRegistry(tmp_path / "knowledge" / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    e2 = compute_evaluator_epoch("rub2", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.observe("grid_ctf", e2, now_fn=lambda: "t1")
+    reg.activate("grid_ctf", e2.epoch_id)
+
+    store.create_run("run1", "grid_ctf", 1, "local")
+    store.upsert_generation("run1", 1, 0.40, 0.50, 1000.0, 2, 1, "advance", "completed", 30.0, evaluator_epoch=e1.epoch_id)
+    store.mark_run_completed("run1")
+
+    assert store.record_rescore_revision("run1", 1, 0.55, e2.epoch_id, created_by="jay")
+
+    client = _client(tmp_path, store)
+    payload = client.get("/api/cockpit/runs/run1/status").json()
+
+    gen = payload["generations"][0]
+    assert gen["has_active_revision"] is True
+    assert gen["revised_score"] == 0.55
+    assert gen["revised_by"] == "jay"
+    assert gen["revised_at"] is not None
+    assert gen["best_score"] == 0.50
+
+
+def test_run_status_no_revision(tmp_path: Path) -> None:
+    store = SQLiteStore(tmp_path / "test.db")
+    store.migrate(MIGRATIONS_DIR)
+
+    reg = EvaluatorEpochRegistry(tmp_path / "knowledge" / "_evaluator_epochs")
+    e1 = compute_evaluator_epoch("rub1", "anthropic", "m")
+    reg.observe("grid_ctf", e1, now_fn=lambda: "t0")
+    reg.activate("grid_ctf", e1.epoch_id)
+
+    store.create_run("run1", "grid_ctf", 1, "local")
+    store.upsert_generation("run1", 1, 0.40, 0.50, 1000.0, 2, 1, "advance", "completed", 30.0, evaluator_epoch=e1.epoch_id)
+    store.mark_run_completed("run1")
+
+    client = _client(tmp_path, store)
+    gen = client.get("/api/cockpit/runs/run1/status").json()["generations"][0]
+
+    assert gen["has_active_revision"] is False
+    assert gen["revised_score"] is None
+    assert gen["revised_by"] is None
+    assert gen["revised_at"] is None

--- a/autocontext/tests/test_rescore_revision_surfacing.py
+++ b/autocontext/tests/test_rescore_revision_surfacing.py
@@ -1,0 +1,100 @@
+"""Tests for surfacing recorded re-scores (AC-885 Slice D2c).
+
+Covers the read-only store method ``SQLiteStore.latest_active_revisions`` (per generation, the LATEST
+revision whose ``revision_epoch`` equals the active epoch) and the pure ``revision_fields`` helper that
+shapes the four additive surfacing fields. No writes in either surface; tests seed via
+``record_rescore_revision`` / a raw INSERT.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.execution.epoch_lineage import revision_fields
+from autocontext.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def _make_store(tmp_path: Path) -> SQLiteStore:
+    store = SQLiteStore(tmp_path / "t.sqlite3")
+    store.migrate(MIGRATIONS)
+    return store
+
+
+def _seed_generation(store: SQLiteStore) -> None:
+    store.create_run("run-a", "grid_ctf", 1, "local", agent_provider="anthropic")
+    store.upsert_generation(
+        "run-a",
+        1,
+        mean_score=0.42,
+        best_score=0.9,
+        elo=1200.0,
+        wins=3,
+        losses=1,
+        gate_decision="completed",
+        status="completed",
+        evaluator_epoch="e1",
+        quarantined=True,
+    )
+
+
+def test_latest_active_revisions_returns_latest_active_epoch_revision(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _seed_generation(store)
+
+    # Two active-epoch (e2) revisions; the later (highest id) one wins.
+    assert store.record_rescore_revision("run-a", 1, 0.5, "e2") is True
+    assert store.record_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+    # A non-active-epoch revision (e_other) must be excluded from the active-epoch view.
+    with store.connect() as conn:
+        conn.execute(
+            "INSERT INTO generation_score_revisions "
+            "(run_id, generation_index, revision_epoch, revision_score) VALUES (?, ?, ?, ?)",
+            ("run-a", 1, "e_other", 0.99),
+        )
+
+    latest = store.latest_active_revisions("run-a", "e2")
+    assert set(latest) == {1}
+    rev = latest[1]
+    assert rev["revision_epoch"] == "e2"
+    assert rev["revision_score"] == 0.55
+    assert rev["created_by"] == "jay"
+
+
+def test_latest_active_revisions_none_epoch_returns_empty(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _seed_generation(store)
+    assert store.record_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+
+    assert store.latest_active_revisions("run-a", None) == {}
+
+
+def test_latest_active_revisions_no_matching_epoch_returns_empty(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _seed_generation(store)
+    assert store.record_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+
+    assert store.latest_active_revisions("run-a", "e_nomatch") == {}
+
+
+def test_revision_fields_none_is_all_null_absent() -> None:
+    assert revision_fields(None) == {
+        "has_active_revision": False,
+        "revised_score": None,
+        "revised_by": None,
+        "revised_at": None,
+    }
+
+
+def test_revision_fields_maps_revision_row(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _seed_generation(store)
+    assert store.record_rescore_revision("run-a", 1, 0.55, "e2", created_by="jay") is True
+    rev = store.latest_active_revisions("run-a", "e2")[1]
+
+    fields = revision_fields(rev)
+    assert fields["has_active_revision"] is True
+    assert fields["revised_score"] == 0.55
+    assert fields["revised_by"] == "jay"
+    assert fields["revised_at"] == rev["created_at"]

--- a/docs/ac-885-slice-d2c-revision-surfacing-design.md
+++ b/docs/ac-885-slice-d2c-revision-surfacing-design.md
@@ -1,0 +1,130 @@
+# AC-885 Slice D2c: surface recorded re-scores in show/status
+
+Date: 2026-07-13
+Status: approved in brainstorming; pending written review
+Linear: AC-885 (Add evaluator epochs and score lineage for evolving rubrics/judges)
+Scope: sub-slice D2c of Slice D. Slice 1, B, C1, C2, C3, D1, D2a, D2b are merged (#1204, #1208, #1210, #1211, #1212, #1213, #1214, #1216).
+
+## Purpose
+
+D2b's `rescore --apply` records active-epoch re-scores as append-only audit revisions in
+`generation_score_revisions`, but nothing reads them: an operator looking at a stale run cannot see that
+a re-score was recorded. D2c makes the audit trail consumable by surfacing, per generation, the latest
+recorded active-epoch revision inline in the run views operators already use (`show`, `status`, and the
+HTTP cockpit `run_status`). This closes the D2b loop and is read-only, no new schema.
+
+## Decisions of record
+
+1. **Surface only active-epoch revisions.** For each generation, the LATEST revision whose
+   `revision_epoch` equals the scenario's active epoch is surfaced. Non-active-epoch revisions (drifted
+   re-scores are never recorded anyway) are ignored. With no active epoch, nothing is surfaced.
+2. **The live score is untouched (D2b invariant holds).** The generation stays stale: `show`/`status`
+   still show the original `best_score`/`evaluator_epoch` as the score of record. The revision is shown
+   ALONGSIDE it ("re-scored to X under the active epoch"), never replacing it. This is a read enrichment.
+3. **Reuse the D1 annotation seam.** The revision fields are added right after the D1 epoch-lineage
+   annotation, inside the two existing shared helpers, so the CLI and HTTP surfaces stay consistent.
+4. **Read-only, Python-only.** No writes, no new schema. No TypeScript change: the revision data lives in
+   a Python-written table that the TS `run_status` does not query, so this is a Python-only read
+   enrichment, consistent with the rescore/registry Python-only asymmetry (as D1's classification was).
+5. **Fields always present, consistent shape.** Every generation dict gains `has_active_revision`
+   (bool), `revised_score`, `revised_by`, `revised_at` (null when no active-epoch revision exists), so
+   the JSON shape does not vary by whether a revision exists.
+
+## Architecture
+
+### D2c.1: the store read + the pure field helper
+
+- `SQLiteStore.latest_active_revisions(run_id, active_epoch) -> dict[int, GenerationScoreRevisionRow]`:
+  one query returning, per `generation_index`, the most recent (`ORDER BY id DESC`, keep first)
+  revision whose `revision_epoch == active_epoch` for the run. Empty dict when `active_epoch` is None or
+  no revisions match.
+- A pure `revision_fields(revision: GenerationScoreRevisionRow | None) -> dict[str, Any]` (in
+  `execution/epoch_lineage.py`, next to the D1 annotation) returning:
+  ```python
+  {
+      "has_active_revision": revision is not None,
+      "revised_score": revision["revision_score"] if revision else None,
+      "revised_by": revision["created_by"] if revision else None,
+      "revised_at": revision["created_at"] if revision else None,
+  }
+  ```
+  Each render site merges these onto its generation dict, keyed by its own index field (CLI rows use
+  `generation_index`, HTTP dicts use `generation`).
+
+### D2c.2: CLI wiring (`show`, `status`)
+
+- Extend `cli_run_inspect.annotate_run_status_rows(settings, scenario, rows, store, run_id)` (add
+  `store` + `run_id`): after `annotate_status_rows`, when `active_epoch_id` is not None fetch
+  `store.latest_active_revisions(run_id, active_epoch_id)` and, for each row,
+  `row.update(revision_fields(revs.get(row["generation_index"])))`; when None, merge
+  `revision_fields(None)` onto every row so the fields are always present. `show` (cli_run_inspect) and
+  `status` (cli.py) both call it, threading their existing `store` + `run_id`.
+- `--json`: each generation dict gains `has_active_revision`, `revised_score`, `revised_by`,
+  `revised_at`.
+- Rich table: add a compact `Revised` column showing `revised_score` (or `-`); when any row has a
+  recorded active-epoch revision, print a one-line note ("N generation(s) have an active-epoch re-score
+  recorded via `rescore --apply`; the live score of record is unchanged").
+
+### D2c.3: HTTP wiring (`GET /api/cockpit/runs/{run_id}/status`)
+
+Extend `server/run_status_lineage.build_run_status_generations(gen_rows, scenario, request, store, run_id)`
+(add `store` + `run_id`; the cockpit `run_status` handler has both): after the D1 annotation, merge
+`revision_fields(...)` onto each generation dict keyed by `generation`. The response gains the four
+fields per generation. (No new warning type; the existing `stale_epoch` warning is unchanged.)
+
+## Data flow
+
+```
+operator: autoctx show <run_id> --json   (or status, or GET /api/cockpit/runs/{id}/status)
+  -> run_status(run_id) -> rows ; annotate_status_rows -> evaluator_epoch_status + active_epoch
+  -> latest_active_revisions(run_id, active_epoch) -> {gen_idx: latest active-epoch revision}
+  -> each row += {has_active_revision, revised_score, revised_by, revised_at}
+  => a stale generation shows: live best=0.90/e1 (stale) + revised 0.55 (by jay, 2026-07-13)
+```
+
+## Error handling and edge cases
+
+- **No active epoch:** `latest_active_revisions` returns empty; every row gets `has_active_revision:
+false` and null revision fields.
+- **No revision for a generation:** same null fields for that row (the common case for a run never
+  re-scored).
+- **Multiple revisions for a generation** (re-applied): the LATEST active-epoch one wins (`ORDER BY id
+DESC`).
+- **A revision under a non-active epoch:** ignored (only `revision_epoch == active_epoch` is surfaced).
+- **Missing run:** unchanged from D1 (`show` not-found exit 1; `status` empty-success; HTTP 404).
+
+## Testing
+
+- Store: `latest_active_revisions` returns the latest active-epoch revision per generation, filters out
+  non-active-epoch revisions, returns empty for no active epoch / no matches.
+- Pure helper: `revision_fields(None)` and `revision_fields(row)` field shapes.
+- CLI: `show`/`status` `--json` carry the four fields; a generation with a recorded active-epoch
+  revision surfaces `revised_score`; the rich table shows the `Revised` value and the note.
+- HTTP: `GET /api/cockpit/runs/{id}/status` carries the four fields; the revised generation surfaces
+  `revised_score`.
+- Regression: record a revision via `record_rescore_revision`, then assert `show`, `status`, and
+  `run_status` all report `revised_score` for that generation while the live `best_score` is unchanged.
+- Gates: module-size, serde-convention, cli-contract parity (no new command/flags, unchanged),
+  schema-parity (no schema change), full Python suite, lockfiles unchanged.
+
+## Documentation
+
+`docs/evaluator-epochs.md` gains a "Surfacing recorded re-scores (Slice D2c)" subsection: `show` /
+`status` / `run_status` now show, per generation, the latest active-epoch re-score recorded by
+`rescore --apply` (score, who, when) alongside the unchanged live score; only active-epoch revisions are
+surfaced; read-only and Python-only. Update the D2b "Not in this slice" note (reading from the archive)
+to point at D2c. CHANGELOG entry.
+
+## Deferred / out of scope
+
+- A full revision-history dump (all revisions, not just the latest active-epoch one), e.g.
+  `rescore --history`, remains future work.
+- Teaching training-export to prefer the latest active-epoch revision over the live score (a trust
+  change, out of scope for a read-only surfacing slice).
+- TypeScript surfacing (revision data is Python-only).
+
+## Acceptance criteria advanced by this slice
+
+- AC-885 "surface stale evaluator lineage in CLI/API/dashboard outputs so operators know when numbers
+  are not directly comparable": `show`/`status`/`run_status` now also show when a stale score has a
+  recorded active-epoch re-score, so the operator sees both the stale number and the fresh one.

--- a/docs/ac-885-slice-d2c-revision-surfacing-design.md
+++ b/docs/ac-885-slice-d2c-revision-surfacing-design.md
@@ -35,7 +35,7 @@ HTTP cockpit `run_status`). This closes the D2b loop and is read-only, no new sc
 ### D2c.1: the store read + the pure field helper
 
 - `SQLiteStore.latest_active_revisions(run_id, active_epoch) -> dict[int, GenerationScoreRevisionRow]`:
-  one query returning, per `generation_index`, the most recent (`ORDER BY id DESC`, keep first)
+  one query returning, per `generation_index`, the most recent (highest `id`)
   revision whose `revision_epoch == active_epoch` for the run. Empty dict when `active_epoch` is None or
   no revisions match.
 - A pure `revision_fields(revision: GenerationScoreRevisionRow | None) -> dict[str, Any]` (in

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -492,9 +492,10 @@ under a since-superseded epoch are ignored). With no active epoch, nothing is su
 
 **The live score is unchanged.** `show` / `status` / `run_status` still report the generation's original
 `best_score` and `evaluator_epoch` as the score of record: a stale generation stays stale. The revision
-is shown alongside it (a `Revised` column in the rich table, plus a one-line note when any generation in
-the run has a recorded active-epoch re-score), never in place of it. This is a pure read enrichment, in
-keeping with D2b's append-only, non-destructive design.
+is shown alongside it (a `Revised` column in the rich table, plus a one-line note when any DISPLAYED
+generation has a recorded active-epoch re-score; `show --best` / `--generation N` filter the rows before
+annotation, so the note reflects only the generations shown), never in place of it. This is a pure read
+enrichment, in keeping with D2b's append-only, non-destructive design.
 
 **Read-only and Python-only.** No writes: this slice only reads the `generation_score_revisions` table
 that D2b's `rescore --apply` writes. Like the rest of the rescore/registry path, the revision data lives

--- a/docs/evaluator-epochs.md
+++ b/docs/evaluator-epochs.md
@@ -466,9 +466,40 @@ packages' migrations (Python `018_generation_score_revisions.sql` and TypeScript
 schema-compatible, but only the Python `rescore --apply` path writes to it, matching the `rescore` /
 `epoch` CLI's existing Python-only asymmetry: TypeScript carries no `--apply` equivalent.
 
-**Not in this slice.** Reading from the archive (a `revisions`/history CLI or API view), and teaching
-reads/exports to prefer the latest active-epoch revision over the live score, are future work; the
-table is queryable today but nothing yet consumes it beyond the archive itself.
+**Not in this slice.** Reading the latest active-epoch revision inline is now shipped, see "Surfacing
+recorded re-scores (Slice D2c)" below. A full revision-history dump (a `revisions`/history CLI or API
+view listing every recorded revision, not just the latest active-epoch one) and teaching reads/exports
+to prefer the latest active-epoch revision over the live score (a trust change) remain future work.
+
+## Surfacing recorded re-scores (Slice D2c)
+
+Slice D2b records a matching re-score as an append-only audit revision, but nothing read it back: an
+operator looking at a stale run could not see that a re-score had already been recorded. Slice D2c
+closes that loop by surfacing, per generation, the latest recorded active-epoch revision inline in the
+run views operators already use: `autoctx show`, `autoctx status`, and the HTTP cockpit
+`GET /api/cockpit/runs/{run_id}/status`. It is read-only, adds no new command or flag, and changes no
+schema.
+
+**What's surfaced.** Every generation dict gains four fields: `has_active_revision` (bool),
+`revised_score`, `revised_by`, `revised_at`. When no active-epoch revision has been recorded for that
+generation (the common case), the three value fields are null and `has_active_revision` is `false`, so
+the JSON shape does not vary by whether a revision exists.
+
+**Only the latest active-epoch revision is surfaced.** For each generation, the LATEST revision whose
+`revision_epoch` equals the scenario's current active epoch is looked up (a `generation_score_revisions`
+row can accumulate several revisions if `rescore --apply` is run more than once, and revisions recorded
+under a since-superseded epoch are ignored). With no active epoch, nothing is surfaced.
+
+**The live score is unchanged.** `show` / `status` / `run_status` still report the generation's original
+`best_score` and `evaluator_epoch` as the score of record: a stale generation stays stale. The revision
+is shown alongside it (a `Revised` column in the rich table, plus a one-line note when any generation in
+the run has a recorded active-epoch re-score), never in place of it. This is a pure read enrichment, in
+keeping with D2b's append-only, non-destructive design.
+
+**Read-only and Python-only.** No writes: this slice only reads the `generation_score_revisions` table
+that D2b's `rescore --apply` writes. Like the rest of the rescore/registry path, the revision data lives
+in a Python-written table that the TypeScript `run_status` does not query, so there is no TypeScript
+change; this is the same Python-only asymmetry documented for D1 and D2b.
 
 ## Deferred slices
 


### PR DESCRIPTION
## AC-885 Slice D2c: surface recorded re-scores in show/status

Follow-on to D2b, closing the loop it left open. D2b's `rescore --apply` records active-epoch re-scores as append-only audit revisions in `generation_score_revisions`, but nothing read them: an operator looking at a stale run could not see that a re-score had been recorded. D2c makes that audit trail consumable.

### What this adds

`autoctx show`, `autoctx status`, and the HTTP cockpit `GET /api/cockpit/runs/{run_id}/status` now surface, per generation, the LATEST active-epoch re-score recorded by `rescore --apply`, alongside the unchanged live score. Each generation gains four fields:
- `has_active_revision` (bool)
- `revised_score`, `revised_by`, `revised_at` (null when no active-epoch revision exists)

The rich `show`/`status` tables gain a `Revised` column and a one-line note when any generation has a recorded active-epoch re-score.

So a stale generation now reads as: live `best=0.90` epoch `e1` (stale), plus "re-scored to 0.55 under the active epoch (by jay, 2026-07-13)".

### Design

- **One store read**: `latest_active_revisions(run_id, active_epoch)` returns, per generation, the most recent revision whose `revision_epoch` equals the active epoch (latest by id wins; non-active-epoch revisions ignored; empty when there is no active epoch). Called once per render, not per row.
- **Reuses the D1 annotation seam**: a pure `revision_fields(revision | None)` helper is merged onto each generation right after the D1 epoch-lineage annotation, inside the two existing shared helpers (`annotate_run_status_rows` for CLI, `build_run_status_generations` for HTTP), so CLI and HTTP stay consistent. The fields are always present (null when absent), so the JSON shape does not vary.

### Invariants

- **Read-only**: the only DB call added is a SELECT; the branch writes nothing and never touches the `generations` row.
- **The live score of record is unchanged**: `best_score`/`evaluator_epoch` are still the score of record; the revision is shown ALONGSIDE, never replacing it (the D2b non-destructive invariant + the AC-885 thesis hold).
- **No new schema, command, or flag**; cli-contract parity and schema-parity are unchanged.
- **Python-only**: revision data lives in a Python-written table the TS `run_status` does not query, so this is a Python-only read enrichment (no TypeScript change), consistent with the rescore/registry asymmetry.

### Review

Built subagent-driven (fresh opus implementer per task, per-task reviews, opus whole-branch review verdict "ready to merge, no Critical/Important"). The whole-branch review confirmed read-only end to end, the four fields consistent across all surfaces, the live score untouched, latest-wins + active-epoch-only, correct per-surface index keys (`generation_index` vs `generation`), and one-query-per-render. One Minor doc-wording alignment folded in.

Regression tests assert a recorded revision surfaces in `show`, `status`, AND `run_status` while `best_score` is unchanged. Local gates green: full Python suite (exit 0), module-size (cockpit_api 789/800), serde, cli-contract parity (unchanged), schema-parity (unchanged, no schema touched). `uv.lock` untouched, no em dashes.

### Deferred

A full revision-history dump (`rescore --history`), and teaching training-export to prefer the latest active-epoch revision over the live score (a trust change), remain future work.

Left open for review; do not merge without authorization.
