### PR TITLE
AC-894 Slice A1: cooperative-stop wire protocol (stop_run / run_stopped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ All notable changes to this project will be documented in this file.
   alongside the unchanged live score. Only the latest revision recorded under the scenario's current
   active epoch is surfaced; the live score of record is untouched. Read-only, Python-only, no new
   command, flag, or schema.
+- AC-894 Slice A1: the interactive-run protocol gains a `stop_run` client command and a `run_stopped`
+  terminal server receipt (wire contract only). Cooperative-stop behavior and the `safe_run_stop_v1`
+  capability follow in the engine slices.
 
 ## [0.11.0] - 2026-07-02
 

--- a/autocontext/src/autocontext/server/protocol.py
+++ b/autocontext/src/autocontext/server/protocol.py
@@ -19,6 +19,7 @@ PROTOCOL_VERSION = 1
 def _is_none(value: object) -> bool:
     return value is None
 
+
 # ---------------------------------------------------------------------------
 # Nested / shared models
 # ---------------------------------------------------------------------------
@@ -151,6 +152,14 @@ class AckMsg(RunMessageMetadata):
     command_id: str | None = Field(default=None, exclude_if=_is_none)
 
 
+class RunStoppedMsg(RunMessageMetadata):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["run_stopped"] = "run_stopped"
+    command_id: str | None = Field(default=None, exclude_if=_is_none)
+    reason: str | None = Field(default=None, exclude_if=_is_none)
+
+
 class ErrorMsg(RunMessageMetadata):
     model_config = ConfigDict(extra="forbid")
 
@@ -217,6 +226,7 @@ ServerMessage = Annotated[
     | EnvironmentsMsg
     | RunAcceptedMsg
     | AckMsg
+    | RunStoppedMsg
     | ErrorMsg
     | ScenarioGeneratingMsg
     | ScenarioPreviewMsg
@@ -242,6 +252,13 @@ class ResumeCmd(RunCommandMetadata):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["resume"] = "resume"
+
+
+class StopCmd(RunCommandMetadata):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["stop_run"] = "stop_run"
+    reason: str | None = Field(default=None, exclude_if=_is_none)
 
 
 class InjectHintCmd(RunCommandMetadata):
@@ -310,6 +327,7 @@ class CancelScenarioCmd(BaseModel):
 ClientMessage = Annotated[
     PauseCmd
     | ResumeCmd
+    | StopCmd
     | InjectHintCmd
     | OverrideGateCmd
     | ChatAgentCmd

--- a/autocontext/tests/test_protocol.py
+++ b/autocontext/tests/test_protocol.py
@@ -37,6 +37,7 @@ from autocontext.server.protocol import (
     RunAcceptedMsg,
     RunCompletedPayload,
     RunStartedPayload,
+    RunStoppedMsg,
     ScenarioErrorMsg,
     ScenarioGeneratingMsg,
     ScenarioInfo,
@@ -45,6 +46,7 @@ from autocontext.server.protocol import (
     ScoringComponent,
     StartRunCmd,
     StateMsg,
+    StopCmd,
     StrategyParam,
     TournamentCompletedPayload,
     TournamentStartedPayload,
@@ -179,6 +181,7 @@ class TestClientMessageParsing:
             ({"type": "confirm_scenario"}, ConfirmScenarioCmd),
             ({"type": "revise_scenario", "feedback": "change X"}, ReviseScenarioCmd),
             ({"type": "cancel_scenario"}, CancelScenarioCmd),
+            ({"type": "stop_run"}, StopCmd),
         ],
     )
     def test_valid_messages(self, raw: dict, expected_type: type) -> None:
@@ -301,3 +304,43 @@ class TestNestedModels:
     def test_scoring_component(self) -> None:
         comp = ScoringComponent(name="s", description="score", weight=0.5)
         assert comp.model_dump() == {"name": "s", "description": "score", "weight": 0.5}
+
+
+class TestStopProtocol:
+    """AC-894 Slice A1: stop_run client command + run_stopped server receipt."""
+
+    def test_stop_run_parses_to_stop_cmd(self) -> None:
+        msg = parse_client_message({"type": "stop_run"})
+        assert isinstance(msg, StopCmd)
+        assert msg.type == "stop_run"
+
+    def test_stop_run_fields_round_trip(self) -> None:
+        msg = parse_client_message(
+            {
+                "type": "stop_run",
+                "reason": "operator abort",
+                "command_id": "c1",
+                "client_run_id": "r1",
+            }
+        )
+        assert isinstance(msg, StopCmd)
+        assert msg.reason == "operator abort"
+        assert msg.command_id == "c1"
+        assert msg.client_run_id == "r1"
+
+    def test_run_stopped_dump_includes_set_optional_fields(self) -> None:
+        d = RunStoppedMsg(command_id="c1", reason="x").model_dump()
+        assert d["type"] == "run_stopped"
+        assert d["command_id"] == "c1"
+        assert d["reason"] == "x"
+
+    def test_run_stopped_dump_excludes_unset_optional_fields(self) -> None:
+        d = RunStoppedMsg().model_dump()
+        assert d["type"] == "run_stopped"
+        assert "command_id" not in d
+        assert "reason" not in d
+
+    def test_schema_export_contains_new_literals(self) -> None:
+        serialized = json.dumps(export_json_schema())
+        assert "stop_run" in serialized
+        assert "run_stopped" in serialized

--- a/docs/ac-894-slice-a1-stop-protocol-design.md
+++ b/docs/ac-894-slice-a1-stop-protocol-design.md
@@ -38,7 +38,9 @@ TS), not here, a server should never claim a capability it cannot honor.
 2. **Terminal receipt as a server message.** `RunStoppedMsg(RunMessageMetadata)` with
    `type: Literal["run_stopped"] = "run_stopped"` is added to the `ServerMessage` union. It carries
    `command_id: str | None` (to correlate with the stop command that caused it) and `reason: str | None`.
-   It is the durable terminal receipt A2/A3 emit when a stop wins the terminal race.
+   It is the terminal receipt that A2/A3 emit when a stop wins the terminal race. A1 only DEFINES this
+   type; making it DURABLE (persisted and replayable) is engine behavior and lands in A3 (see below):
+   A1 wiring nothing means the TS transcript layer does not yet retain it, which is expected.
 3. **Protocol is generated, parity is gated.** After editing `protocol.py`, run
    `scripts/generate_protocol.py` to regenerate the `.generated.ts` + JSON; never hand-edit the generated
    file. Add the two schemas to the hand-authored Zod mirror and the two new literals to the
@@ -114,6 +116,14 @@ capability follow in the engine slices.
   stop check, the first-terminal-wins status CAS, command dispatch + ack + `run_stopped` receipt,
   idempotent dedup + run-scope validation, and the `safe_run_stop_v1` capability advertisement, on the
   Python side (A2) and the TypeScript side (A3).
+- **A3 must make `run_stopped` durable** (required for it to be replayable and for dedup to complete on
+  the terminal result, not only the earlier ack): add a `run_stopped` case to
+  `sanitizeRunTranscriptMessageInternal` (`ts/src/server/run-transcript-frame.ts`), add `"run_stopped"`
+  to `RETAINED_MESSAGE_TYPES` (`ts/src/server/run-transcript-store.ts`), and ensure the stop command's
+  durable dedup is completed by the terminal `run_stopped` frame (via `completeCommand` /
+  command_id correlation), so a retried/reconnected stop replays the terminal receipt rather than only
+  the acknowledgement. (Confirmed today: without this, `RunTranscriptStore.record({message: {type:
+"run_stopped", ...}})` returns null and persists no frame.)
 
 ## Acceptance criteria advanced by this slice
 

--- a/docs/ac-894-slice-a1-stop-protocol-design.md
+++ b/docs/ac-894-slice-a1-stop-protocol-design.md
@@ -1,0 +1,121 @@
+# AC-894 Slice A1: cooperative-stop wire protocol
+
+Date: 2026-07-13
+Status: approved in brainstorming; pending written review
+Linear: AC-894 (Add cooperative, idempotent active-run stopping)
+Scope: first of three slices. A1 = the wire protocol (this slice). A2 = the Python cooperative-stop engine. A3 = the TypeScript engine.
+
+## Purpose
+
+AC-894 lets an operator safely stop an active interactive run at a cooperative execution boundary. It is
+decomposed into three slices: A1 defines the stop command, its terminal receipt, and their cross-package
+parity so A2 (Python engine) and A3 (TS engine) build behavior on a settled contract. A1 adds NO
+behavior: receiving the command does nothing yet, and no server advertises the capability yet.
+
+## Context (from the code map)
+
+The interactive-run protocol is defined in `autocontext/src/autocontext/server/protocol.py` (Pydantic
+models). `export_json_schema()` there is the single source of truth: `scripts/generate_protocol.py`
+regenerates `ts/src/tui/protocol.generated.ts` + `protocol/autocontext-protocol.json` from it, and its
+`--check` mode is a CI parity gate. A separate hand-authored Zod mirror,
+`ts/src/server/protocol.ts`, carries the runtime validators plus parity lists
+(`PYTHON_SHARED_CLIENT_MESSAGE_TYPES`, `PYTHON_SHARED_SERVER_MESSAGE_TYPES`) that must stay in sync with
+the Python union. Client commands subclass `RunCommandMetadata` (`client_run_id`, `command_id`); the
+existing `AckMsg` already echoes `command_id`.
+
+Confirmed: Python advertises no `hello` capabilities today while TS advertises `run_transcript_v1`, and
+the suite is green, so there is no cross-package capability-parity gate. Capabilities are therefore
+advertised per package, so the `safe_run_stop_v1` advertisement belongs with each engine (A2 Python, A3
+TS), not here, a server should never claim a capability it cannot honor.
+
+## Decisions of record
+
+1. **Mirror the existing command pattern exactly.** `StopCmd(RunCommandMetadata)` with
+   `type: Literal["stop_run"] = "stop_run"` is added to the `ClientMessage` union, mirroring `PauseCmd`.
+   It reuses the inherited `client_run_id` + `command_id` envelope and adds one optional field
+   `reason: str | None` (operator context, echoed on the receipt). The command's acknowledgement reuses
+   the existing `AckMsg` (which already carries `command_id`); no new ack type.
+2. **Terminal receipt as a server message.** `RunStoppedMsg(RunMessageMetadata)` with
+   `type: Literal["run_stopped"] = "run_stopped"` is added to the `ServerMessage` union. It carries
+   `command_id: str | None` (to correlate with the stop command that caused it) and `reason: str | None`.
+   It is the durable terminal receipt A2/A3 emit when a stop wins the terminal race.
+3. **Protocol is generated, parity is gated.** After editing `protocol.py`, run
+   `scripts/generate_protocol.py` to regenerate the `.generated.ts` + JSON; never hand-edit the generated
+   file. Add the two schemas to the hand-authored Zod mirror and the two new literals to the
+   `PYTHON_SHARED_*_MESSAGE_TYPES` parity lists.
+4. **No behavior, no capability advertisement in A1.** The command type and receipt exist on the wire;
+   dispatch, the stop primitive, the terminal CAS, dedup/scope, and the `safe_run_stop_v1` advertisement
+   land in A2 (Python) and A3 (TS). Because no server advertises the capability, no conforming client
+   sends `stop_run` in the A1-only state.
+
+## Architecture
+
+### A1.1: Python protocol (`server/protocol.py`)
+
+```python
+class StopCmd(RunCommandMetadata):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["stop_run"] = "stop_run"
+    reason: str | None = Field(default=None, exclude_if=_is_none)
+```
+
+Add `StopCmd` to the `ClientMessage` union (line ~310, next to `PauseCmd`).
+
+```python
+class RunStoppedMsg(RunMessageMetadata):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["run_stopped"] = "run_stopped"
+    command_id: str | None = Field(default=None, exclude_if=_is_none)
+    reason: str | None = Field(default=None, exclude_if=_is_none)
+```
+
+Add `RunStoppedMsg` to the `ServerMessage` union (line ~212). (Follow the `AckMsg` `command_id`
+`exclude_if=_is_none` convention.)
+
+### A1.2: regenerate the TS artifacts
+
+Run `python scripts/generate_protocol.py` (from the repo root, or wherever the script expects) to
+regenerate `ts/src/tui/protocol.generated.ts` and `protocol/autocontext-protocol.json`. Confirm
+`scripts/generate_protocol.py --check` then exits clean.
+
+### A1.3: TS Zod mirror (`ts/src/server/protocol.ts`)
+
+- Add `StopRunCmdSchema` (extends `RunCommandMetadataSchema` with `type: z.literal("stop_run")`,
+  `reason: z.string().nullish()`) and register it in `ClientMessageSchema`.
+- Add `RunStoppedMsgSchema` (extends `RunMessageMetadataSchema` with `type: z.literal("run_stopped")`,
+  `command_id: z.string().nullish()`, `reason: z.string().nullish()`) and register it in
+  `ServerMessageSchema`.
+- Add `"stop_run"` to `PYTHON_SHARED_CLIENT_MESSAGE_TYPES` and `"run_stopped"` to
+  `PYTHON_SHARED_SERVER_MESSAGE_TYPES` (NOT the `TYPESCRIPT_ONLY_*` lists, these are shared).
+
+## Testing
+
+- Python (`autocontext/tests/test_protocol.py`): `parse_client_message` round-trips a `stop_run` command
+  (with and without `reason`); `RunStoppedMsg` serializes with `type: "run_stopped"` and correlates
+  `command_id`; `export_json_schema()` includes both new types.
+- Python parity: `test_protocol_parity.py` + `test_websocket_protocol_contract.py` stay green, and
+  `scripts/generate_protocol.py --check` exits 0 (the regenerated file matches).
+- TS (`ts/tests/server-protocol.test.ts`): `ClientMessageSchema` parses a `stop_run` command;
+  `ServerMessageSchema` parses a `run_stopped` message; the shared-type lists include the two literals.
+- TS parity (`ts/tests/websocket-protocol-contract.test.ts`): the contract test stays green with the two
+  new shared message types.
+
+## Documentation
+
+CHANGELOG entry: the interactive-run protocol gains a `stop_run` client command and a `run_stopped`
+terminal server receipt (AC-894 wire contract); cooperative-stop behavior and the `safe_run_stop_v1`
+capability follow in the engine slices.
+
+## Deferred (A2, A3)
+
+- The controller stop primitive (`request_stop()` that wakes a paused run), the loop cooperative-boundary
+  stop check, the first-terminal-wins status CAS, command dispatch + ack + `run_stopped` receipt,
+  idempotent dedup + run-scope validation, and the `safe_run_stop_v1` capability advertisement, on the
+  Python side (A2) and the TypeScript side (A3).
+
+## Acceptance criteria advanced by this slice
+
+- AC-894 "Preserve ... TypeScript/Python protocol parity": A1 lands the `stop_run` / `run_stopped` types
+  on both packages with the parity gates green, the contract A2/A3 implement against.

--- a/docs/websocket-protocol-contract.json
+++ b/docs/websocket-protocol-contract.json
@@ -69,6 +69,7 @@
     "environments",
     "run_accepted",
     "ack",
+    "run_stopped",
     "error",
     "scenario_generating",
     "scenario_preview",
@@ -79,6 +80,7 @@
   "shared_client_messages": [
     "pause",
     "resume",
+    "stop_run",
     "inject_hint",
     "override_gate",
     "chat_agent",

--- a/protocol/autocontext-protocol.json
+++ b/protocol/autocontext-protocol.json
@@ -750,6 +750,106 @@
         "title": "RunAcceptedMsg",
         "type": "object"
       },
+      "RunStoppedMsg": {
+        "additionalProperties": false,
+        "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Event Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Run Id"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Occurred At"
+          },
+          "type": {
+            "const": "run_stopped",
+            "default": "run_stopped",
+            "title": "Type",
+            "type": "string"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Reason"
+          }
+        },
+        "title": "RunStoppedMsg",
+        "type": "object"
+      },
       "ScenarioErrorMsg": {
         "additionalProperties": false,
         "properties": {
@@ -1048,6 +1148,7 @@
         "hello": "#/$defs/HelloMsg",
         "monitor_alert": "#/$defs/MonitorAlertMsg",
         "run_accepted": "#/$defs/RunAcceptedMsg",
+        "run_stopped": "#/$defs/RunStoppedMsg",
         "scenario_error": "#/$defs/ScenarioErrorMsg",
         "scenario_generating": "#/$defs/ScenarioGeneratingMsg",
         "scenario_preview": "#/$defs/ScenarioPreviewMsg",
@@ -1077,6 +1178,9 @@
       },
       {
         "$ref": "#/$defs/AckMsg"
+      },
+      {
+        "$ref": "#/$defs/RunStoppedMsg"
       },
       {
         "$ref": "#/$defs/ErrorMsg"
@@ -1453,6 +1557,55 @@
         ],
         "title": "StartRunCmd",
         "type": "object"
+      },
+      "StopCmd": {
+        "additionalProperties": false,
+        "properties": {
+          "client_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Client Run Id"
+          },
+          "command_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command Id"
+          },
+          "type": {
+            "const": "stop_run",
+            "default": "stop_run",
+            "title": "Type",
+            "type": "string"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Reason"
+          }
+        },
+        "title": "StopCmd",
+        "type": "object"
       }
     },
     "discriminator": {
@@ -1467,7 +1620,8 @@
         "pause": "#/$defs/PauseCmd",
         "resume": "#/$defs/ResumeCmd",
         "revise_scenario": "#/$defs/ReviseScenarioCmd",
-        "start_run": "#/$defs/StartRunCmd"
+        "start_run": "#/$defs/StartRunCmd",
+        "stop_run": "#/$defs/StopCmd"
       },
       "propertyName": "type"
     },
@@ -1477,6 +1631,9 @@
       },
       {
         "$ref": "#/$defs/ResumeCmd"
+      },
+      {
+        "$ref": "#/$defs/StopCmd"
       },
       {
         "$ref": "#/$defs/InjectHintCmd"

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -173,10 +173,10 @@ export const AckMsgSchema = protocolObject({
 });
 
 export const RunStoppedMsgSchema = protocolObject({
-  ...RunMessageMetadataSchema,
   type: z.literal("run_stopped"),
   command_id: z.string().nullish(),
   reason: z.string().nullish(),
+  ...RunMessageMetadataSchema,
 });
 
 export const ErrorMsgSchema = protocolObject({
@@ -266,9 +266,9 @@ export const ResumeCmdSchema = protocolObject({
 });
 
 export const StopRunCmdSchema = protocolObject({
-  ...RunCommandMetadataSchema,
   type: z.literal("stop_run"),
   reason: z.string().nullish(),
+  ...RunCommandMetadataSchema,
 });
 
 export const InjectHintCmdSchema = protocolObject({

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -21,6 +21,7 @@ export const PYTHON_SHARED_SERVER_MESSAGE_TYPES = [
   "environments",
   "run_accepted",
   "ack",
+  "run_stopped",
   "error",
   "scenario_generating",
   "scenario_preview",
@@ -39,6 +40,7 @@ export const SERVER_MESSAGE_TYPES = [
 export const PYTHON_SHARED_CLIENT_MESSAGE_TYPES = [
   "pause",
   "resume",
+  "stop_run",
   "inject_hint",
   "override_gate",
   "chat_agent",
@@ -170,6 +172,13 @@ export const AckMsgSchema = protocolObject({
   ...RunMessageMetadataSchema,
 });
 
+export const RunStoppedMsgSchema = protocolObject({
+  ...RunMessageMetadataSchema,
+  type: z.literal("run_stopped"),
+  command_id: z.string().nullish(),
+  reason: z.string().nullish(),
+});
+
 export const ErrorMsgSchema = protocolObject({
   type: z.literal("error"),
   message: z.string(),
@@ -254,6 +263,12 @@ export const PauseCmdSchema = protocolObject({
 export const ResumeCmdSchema = protocolObject({
   type: z.literal("resume"),
   ...RunCommandMetadataSchema,
+});
+
+export const StopRunCmdSchema = protocolObject({
+  ...RunCommandMetadataSchema,
+  type: z.literal("stop_run"),
+  reason: z.string().nullish(),
 });
 
 export const InjectHintCmdSchema = protocolObject({
@@ -347,6 +362,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   EnvironmentsMsgSchema,
   RunAcceptedMsgSchema,
   AckMsgSchema,
+  RunStoppedMsgSchema,
   ErrorMsgSchema,
   ScenarioGeneratingMsgSchema,
   ScenarioPreviewMsgSchema,
@@ -360,6 +376,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
 export const ClientMessageSchema = z.discriminatedUnion("type", [
   PauseCmdSchema,
   ResumeCmdSchema,
+  StopRunCmdSchema,
   InjectHintCmdSchema,
   OverrideGateCmdSchema,
   ChatAgentCmdSchema,

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -100,17 +100,28 @@ export const ScoringComponentSchema = protocolObject({
   weight: z.number(),
 });
 
+// Identifier fields mirror the canonical Python contract (str | None) and the generated schema
+// (z.string().optional().nullable()): nullable and unbounded, so the server accepts the explicit-null
+// (Python's RunCommandMetadata has no exclude_if, so StopCmd()/PauseCmd() serialize null ids) and
+// unbounded identifiers a conforming client may serialize. Null is normalized to undefined on parse so
+// consumers keep a `string | undefined` type. Any server-side length hardening must be a deliberate
+// contract-level decision, not a silent mirror divergence.
+const optionalIdentifier = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined);
+
 const RunMessageMetadataSchema = {
-  client_run_id: z.string().min(1).max(200).optional(),
-  event_id: z.string().min(1).optional(),
+  client_run_id: optionalIdentifier,
+  event_id: optionalIdentifier,
   sequence: z.number().int().nonnegative().optional(),
-  run_id: z.string().min(1).optional(),
+  run_id: optionalIdentifier,
   occurred_at: z.union([z.string(), z.number()]).optional(),
 } as const;
 
 const RunCommandMetadataSchema = {
-  client_run_id: z.string().min(1).max(200).optional(),
-  command_id: z.string().min(1).max(200).optional(),
+  client_run_id: optionalIdentifier,
+  command_id: optionalIdentifier,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/ts/src/tui/protocol.generated.ts
+++ b/ts/src/tui/protocol.generated.ts
@@ -112,6 +112,17 @@ export const AckMsgSchema = z.object({
   command_id: z.string().optional().nullable(),
 }).strict();
 
+export const RunStoppedMsgSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  event_id: z.string().optional().nullable(),
+  sequence: z.number().int().optional().nullable(),
+  run_id: z.string().optional().nullable(),
+  occurred_at: z.union([z.string(), z.number()]).optional().nullable(),
+  type: z.literal("run_stopped"),
+  command_id: z.string().optional().nullable(),
+  reason: z.string().optional().nullable(),
+}).strict();
+
 export const ErrorMsgSchema = z.object({
   client_run_id: z.string().optional().nullable(),
   event_id: z.string().optional().nullable(),
@@ -166,7 +177,7 @@ export const MonitorAlertMsgSchema = z.object({
   detail: z.string(),
 }).strict();
 
-export const ServerMessageSchema = z.discriminatedUnion("type", [HelloMsgSchema, EventMsgSchema, StateMsgSchema, ChatResponseMsgSchema, EnvironmentsMsgSchema, RunAcceptedMsgSchema, AckMsgSchema, ErrorMsgSchema, ScenarioGeneratingMsgSchema, ScenarioPreviewMsgSchema, ScenarioReadyMsgSchema, ScenarioErrorMsgSchema, MonitorAlertMsgSchema]);
+export const ServerMessageSchema = z.discriminatedUnion("type", [HelloMsgSchema, EventMsgSchema, StateMsgSchema, ChatResponseMsgSchema, EnvironmentsMsgSchema, RunAcceptedMsgSchema, AckMsgSchema, RunStoppedMsgSchema, ErrorMsgSchema, ScenarioGeneratingMsgSchema, ScenarioPreviewMsgSchema, ScenarioReadyMsgSchema, ScenarioErrorMsgSchema, MonitorAlertMsgSchema]);
 
 // --- Client -> Server messages ---
 
@@ -180,6 +191,13 @@ export const ResumeCmdSchema = z.object({
   client_run_id: z.string().optional().nullable(),
   command_id: z.string().optional().nullable(),
   type: z.literal("resume"),
+}).strict();
+
+export const StopCmdSchema = z.object({
+  client_run_id: z.string().optional().nullable(),
+  command_id: z.string().optional().nullable(),
+  type: z.literal("stop_run"),
+  reason: z.string().optional().nullable(),
 }).strict();
 
 export const InjectHintCmdSchema = z.object({
@@ -235,7 +253,7 @@ export const CancelScenarioCmdSchema = z.object({
   type: z.literal("cancel_scenario"),
 }).strict();
 
-export const ClientMessageSchema = z.discriminatedUnion("type", [PauseCmdSchema, ResumeCmdSchema, InjectHintCmdSchema, OverrideGateCmdSchema, ChatAgentCmdSchema, StartRunCmdSchema, ListScenariosCmdSchema, CreateScenarioCmdSchema, ConfirmScenarioCmdSchema, ReviseScenarioCmdSchema, CancelScenarioCmdSchema]);
+export const ClientMessageSchema = z.discriminatedUnion("type", [PauseCmdSchema, ResumeCmdSchema, StopCmdSchema, InjectHintCmdSchema, OverrideGateCmdSchema, ChatAgentCmdSchema, StartRunCmdSchema, ListScenariosCmdSchema, CreateScenarioCmdSchema, ConfirmScenarioCmdSchema, ReviseScenarioCmdSchema, CancelScenarioCmdSchema]);
 
 /** Parse a raw JSON string from the server into a typed message. Returns null on failure. */
 export function parseServerMessage(raw: string) {

--- a/ts/tests/server-protocol.test.ts
+++ b/ts/tests/server-protocol.test.ts
@@ -252,6 +252,30 @@ describe("Protocol types", () => {
       OverrideGateCmdSchema.parse({ type: "override_gate", decision: "invalid" }),
     ).toThrow();
   });
+
+  it("ClientMessageSchema parses a stop_run command (AC-894)", async () => {
+    const { ClientMessageSchema } = await import("../src/server/protocol.js");
+    const msg = ClientMessageSchema.parse({
+      type: "stop_run",
+      command_id: "c1",
+      client_run_id: "r1",
+      reason: "x",
+    });
+    expect(msg.type).toBe("stop_run");
+  });
+
+  it("ServerMessageSchema parses a run_stopped receipt (AC-894)", async () => {
+    const { ServerMessageSchema } = await import("../src/server/protocol.js");
+    const msg = ServerMessageSchema.parse({ type: "run_stopped", command_id: "c1" });
+    expect(msg.type).toBe("run_stopped");
+  });
+
+  it("shared parity lists include stop_run and run_stopped (AC-894)", async () => {
+    const { PYTHON_SHARED_CLIENT_MESSAGE_TYPES, PYTHON_SHARED_SERVER_MESSAGE_TYPES } =
+      await import("../src/server/protocol.js");
+    expect(PYTHON_SHARED_CLIENT_MESSAGE_TYPES).toContain("stop_run");
+    expect(PYTHON_SHARED_SERVER_MESSAGE_TYPES).toContain("run_stopped");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/server-protocol.test.ts
+++ b/ts/tests/server-protocol.test.ts
@@ -276,6 +276,33 @@ describe("Protocol types", () => {
     expect(PYTHON_SHARED_CLIENT_MESSAGE_TYPES).toContain("stop_run");
     expect(PYTHON_SHARED_SERVER_MESSAGE_TYPES).toContain("run_stopped");
   });
+
+  it("accepts the null/empty/unbounded identifiers the Python contract emits (AC-894 parity)", async () => {
+    const { ClientMessageSchema, ServerMessageSchema } = await import("../src/server/protocol.js");
+    // Python's StopCmd()/PauseCmd() serialize absent identifiers as explicit null; the mirror must accept
+    // them (the metadata schema mirrors str | None / z.string().optional().nullable(), not min(1).max(200)).
+    const nulls = ClientMessageSchema.parse({
+      type: "stop_run",
+      command_id: null,
+      client_run_id: null,
+    });
+    expect(nulls.type).toBe("stop_run");
+    const pauseNulls = ClientMessageSchema.parse({
+      type: "pause",
+      command_id: null,
+      client_run_id: null,
+    });
+    expect(pauseNulls.type).toBe("pause");
+    // Empty and long identifiers are within the (unbounded) contract.
+    expect(ClientMessageSchema.parse({ type: "stop_run", command_id: "" }).type).toBe("stop_run");
+    expect(ClientMessageSchema.parse({ type: "stop_run", command_id: "c".repeat(300) }).type).toBe(
+      "stop_run",
+    );
+    // Server messages carry the same nullable metadata.
+    expect(
+      ServerMessageSchema.parse({ type: "run_stopped", client_run_id: null, run_id: null }).type,
+    ).toBe("run_stopped");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## AC-894 Slice A1: cooperative-stop wire protocol

First of three slices for AC-894 (cooperative, idempotent active-run stopping). A1 lands the wire contract so the two engine slices build behavior on a settled protocol. **No behavior in this slice**: receiving the command does nothing yet, and no server advertises the capability yet.

- **A1 (this PR): the stop protocol + parity.**
- A2: the Python cooperative-stop engine (controller stop primitive, loop boundary, first-terminal CAS, dispatch/ack/receipt, dedup + run-scope guard, `safe_run_stop_v1` advertisement, tests).
- A3: the TypeScript engine (reusing its existing dedup/scope engine + terminal arbitration + receipt, tests).

### What this adds

- **`StopCmd`** (`type: "stop_run"`) added to the `ClientMessage` union in `server/protocol.py`, mirroring `PauseCmd`: it reuses the inherited `client_run_id` + `command_id` envelope and adds an optional `reason`. The command's acknowledgement reuses the existing `AckMsg` (which already carries `command_id`); no new ack type.
- **`RunStoppedMsg`** (`type: "run_stopped"`) added to the `ServerMessage` union, mirroring `AckMsg`: the terminal receipt A2/A3 will emit when a stop wins the terminal race, carrying `command_id` (correlation) and optional `reason`.
- **Regenerated** `ts/src/tui/protocol.generated.ts` + `protocol/autocontext-protocol.json` via `scripts/generate_protocol.py` (never hand-edited; `--check` is in sync).
- **`ts/src/server/protocol.ts`** (hand-authored Zod mirror): `StopRunCmdSchema` + `RunStoppedMsgSchema` registered in the client/server unions, and `"stop_run"` / `"run_stopped"` added to the `PYTHON_SHARED_*_MESSAGE_TYPES` parity lists (ordered to match `docs/websocket-protocol-contract.json`).

### Design note

Confirmed there is no cross-package capability-parity gate (Python advertises no `hello` capabilities today while TS advertises `run_transcript_v1`, and the suite is green). So the `safe_run_stop_v1` capability is advertised per package, and that advertisement belongs with each engine (A2 Python, A3 TS): a server should never claim a capability it cannot honor. A1 is therefore protocol types only.

### Review

Built subagent-driven (fresh opus implementer per task, per-task reviews). Both reviews PASS/PASS with the parity gates independently re-run: `generate_protocol.py --check` in sync, the regenerated file confirmed not hand-edited, and the shared-type list ordering verified against the contract manifest. One cosmetic style Minor (schema field order) folded in.

Gates green across both packages: Python `test_protocol` / `test_protocol_parity` / `test_websocket_protocol_contract`, `generate_protocol.py --check`, ruff + mypy; TS `server-protocol` / `websocket-protocol-contract` / `websocket-session-bootstrap`, `tsc --noEmit`, lint. `uv.lock` / `bun.lock` untouched, no em dashes.

Left open for review; do not merge without authorization.
