### PR TITLE
AC-896: Emit agent-authored task plans over the interactive run protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- TypeScript interactive runs now advertise `agent_task_plan_v1` to transcript clients and emit strict, redacted `task_plan_updated` snapshots as work moves through meaningful execution phases. Plans carry stable run/plan identity, monotonic versions and revisions, sticky completion, explicit replan receipts, terminal step state before the run terminal event, and exact durable replay across reconnects and server restarts. Python parity is deferred until its interactive server can supply the same durable transcript identity and replay guarantees (AC-896).
+
 ## [0.13.0] - 2026-07-20
 
 ### Added

--- a/autocontext/tests/test_websocket_protocol_contract.py
+++ b/autocontext/tests/test_websocket_protocol_contract.py
@@ -8,7 +8,12 @@ import pytest
 from pydantic import ValidationError
 
 from autocontext.harness.core.events import EventStreamEmitter
-from autocontext.server.protocol import PROTOCOL_VERSION, export_json_schema, parse_client_message
+from autocontext.server.protocol import (
+    PROTOCOL_VERSION,
+    SERVER_CAPABILITIES,
+    export_json_schema,
+    parse_client_message,
+)
 
 
 def _contract() -> dict[str, Any]:
@@ -75,6 +80,16 @@ def test_safe_stop_capability_advertised_by_python_and_typescript() -> None:
     assert durable["requires_transcript_protocol_version"] == 1
     assert durable["advertised_runtimes"] == ["typescript"]
     assert "stop" in contract["shared_client_messages"]
+
+
+def test_agent_task_plan_capability_remains_typescript_only() -> None:
+    extension = _contract()["agent_task_plan_extension"]
+
+    assert extension["capability"] == "agent_task_plan_v1"
+    assert extension["advertised_runtimes"] == ["typescript"]
+    assert extension["requires_transcript_protocol_version"] == 1
+    assert extension["python_support"] == "deferred_until_durable_transcript_metadata_is_available"
+    assert "agent_task_plan_v1" not in SERVER_CAPABILITIES
 
 
 def test_python_event_stream_envelope_matches_shared_contract(tmp_path: Path) -> None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 
 ## Architecture And Parity
 
+- [Interactive WebSocket protocol contract](websocket-protocol-contract.json)
 - [Core/control package split](core-control-package-split.md)
 - [Strategy package import side-effect contract](strategy-package-import-contract.json)
 - [Generic edge runtime compatibility spike](edge-runtime-compatibility.md)

--- a/docs/websocket-protocol-contract.json
+++ b/docs/websocket-protocol-contract.json
@@ -19,6 +19,80 @@
       "idempotency_horizon": "same as retained command and response records"
     }
   },
+  "agent_task_plan_extension": {
+    "capability": "agent_task_plan_v1",
+    "advertised_runtimes": ["typescript"],
+    "requires_transcript_protocol_version": 1,
+    "event": "task_plan_updated",
+    "event_order": [
+      "run_started",
+      "task_plan_updated:initial",
+      "task_plan_updated:progress_or_replan",
+      "task_plan_updated:terminal_snapshot",
+      "run_completed_or_run_failed_or_run_stopped"
+    ],
+    "payload": {
+      "required_fields": [
+        "run_id",
+        "plan_id",
+        "version",
+        "plan_revision",
+        "update_kind",
+        "active_step_id",
+        "steps"
+      ],
+      "optional_fields": ["summary"],
+      "update_kinds": ["initial", "progress", "replan"],
+      "step_statuses": [
+        "pending",
+        "in_progress",
+        "completed",
+        "blocked",
+        "failed",
+        "skipped",
+        "interrupted"
+      ],
+      "step_count": { "minimum": 1, "maximum": 50 },
+      "id": {
+        "maximum_characters": 200,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+        "credential_shaped_values_allowed": false
+      },
+      "copy_limits": {
+        "label_characters": 160,
+        "detail_characters": 2000,
+        "summary_characters": 240,
+        "aggregate_characters": 20000,
+        "empty_or_whitespace_only_values_allowed": false
+      },
+      "full_snapshot": true,
+      "initial_version": 1,
+      "initial_plan_revision": 1,
+      "version_rule": "strictly_increases_for_every_update",
+      "progress_revision_rule": "unchanged",
+      "replan_revision_rule": "strictly_increases",
+      "completed_steps_are_sticky": true,
+      "active_step_rule": "zero_or_one_in_progress_step_exactly_matches_active_step_id",
+      "terminal_snapshot_rule": "active_step_id_is_null_and_no_step_is_in_progress"
+    },
+    "identity": {
+      "payload_run_id_matches_outer_run_id": true,
+      "stable_fields": ["run_id", "plan_id"],
+      "outer_transcript_fields": [
+        "client_run_id",
+        "event_id",
+        "sequence",
+        "occurred_at"
+      ]
+    },
+    "retention": {
+      "full_snapshot_or_drop": true,
+      "max_serialized_event_bytes": 12288,
+      "redacted_before_persistence": true,
+      "restart_replay": true
+    },
+    "python_support": "deferred_until_durable_transcript_metadata_is_available"
+  },
   "safe_stop_extension": {
     "capability": "safe_run_stop_v1",
     "advertised_runtimes": ["typescript", "python"],

--- a/ts/README.md
+++ b/ts/README.md
@@ -102,7 +102,8 @@ The TypeScript `/ws/interactive` server keeps the base WebSocket
 legacy v1 hello and run-frame shapes. Clients explicitly opt into durable
 transcripts with `/ws/interactive?transcript_protocol_version=1`; that connection
 advertises `transcript_protocol_version: 1` plus the `run_transcript_v1` and
-`safe_run_stop_v1` capabilities.
+`safe_run_stop_v1` capabilities. TypeScript engines that publish live execution
+plans also advertise `agent_task_plan_v1` on the same transcript-enabled hello.
 Clients may attach a stable `client_run_id` and `command_id` to `start_run`,
 operator-control, and chat commands. Run-scoped responses then include stable
 `event_id`, monotonic `sequence`, `client_run_id`, and `occurred_at` fields.
@@ -128,6 +129,50 @@ idempotency has the same finite horizon as its retained request and response.
 Compaction uses an fsync-backed atomic replacement. The Python server accepts the
 additive metadata fields for schema compatibility but does not advertise this
 TypeScript-only retention capability.
+
+Transcript-enabled TypeScript runs expose their current semantic execution plan
+as `task_plan_updated` events. Every event is a complete snapshot rather than a
+patch, so a client can render the latest valid event directly:
+
+```json
+{
+  "type": "event",
+  "event": "task_plan_updated",
+  "run_id": "engine-run-id",
+  "client_run_id": "control-plane-run-id",
+  "event_id": "7db8149c-8302-45dc-98c8-6d8c11f34d27",
+  "sequence": 4,
+  "occurred_at": "2026-07-21T16:20:00.000Z",
+  "payload": {
+    "run_id": "engine-run-id",
+    "plan_id": "engine-run-id:task-plan",
+    "version": 2,
+    "plan_revision": 1,
+    "update_kind": "progress",
+    "active_step_id": "evaluate",
+    "steps": [
+      { "id": "draft", "label": "Draft the result", "status": "completed" },
+      { "id": "evaluate", "label": "Evaluate and refine", "status": "in_progress" },
+      { "id": "finalize", "label": "Finalize the result", "status": "pending" }
+    ]
+  }
+}
+```
+
+The initial snapshot uses version/revision `1/1`. Every update increments
+`version`; ordinary progress keeps `plan_revision` stable, while a `replan`
+increments it and includes a bounded summary. Completed steps never regress.
+Exactly one step may be `in_progress`, and it must match `active_step_id`;
+terminal snapshots use a null active step and mark unfinished work as failed,
+interrupted, or skipped before `run_completed`, `run_failed`, or `run_stopped`.
+Snapshots are redacted and validated atomically before persistence: an invalid or
+oversized plan is omitted rather than truncated into a misleading partial plan.
+The TypeScript producer limits the complete serialized event to 12 KiB so its
+escaped transcript record remains within the transcript's 32 KiB record ceiling.
+Cursor replay returns the exact retained snapshots with their original identity
+and ordering. See the
+[shared WebSocket contract](../docs/websocket-protocol-contract.json) for the
+machine-readable invariants. Python does not advertise this capability yet.
 
 To stop the currently bound run, send a retry-stable command:
 

--- a/ts/src/execution/improvement-loop.ts
+++ b/ts/src/execution/improvement-loop.ts
@@ -18,6 +18,16 @@ import { EVALUATOR_EPOCH_REBASELINE, resolveEpochRebaseline } from "../judge/eva
 
 export { isImproved, isParseFailure } from "./improvement-loop-detection.js";
 
+export interface ImprovementLoopProgress {
+  phase: "evaluation" | "revision";
+  status: "started" | "completed";
+  round: number;
+}
+
+export type ImprovementLoopProgressObserver = (
+  progress: ImprovementLoopProgress,
+) => void | Promise<void>;
+
 export interface ImprovementLoopOpts {
   task: AgentTaskInterface;
   maxRounds?: number;
@@ -27,6 +37,7 @@ export interface ImprovementLoopOpts {
   capScoreJumps?: boolean;
   dimensionThreshold?: number;
   timeBudget?: { check(phase: string): void };
+  onProgress?: ImprovementLoopProgressObserver;
 }
 
 export class ImprovementLoop {
@@ -38,6 +49,7 @@ export class ImprovementLoop {
   #capScoreJumps: boolean;
   #dimensionThreshold: number | null;
   #timeBudget: { check(phase: string): void } | null;
+  #onProgress: ImprovementLoopProgressObserver | null;
 
   constructor(opts: ImprovementLoopOpts) {
     this.#task = opts.task;
@@ -48,6 +60,7 @@ export class ImprovementLoop {
     this.#capScoreJumps = opts.capScoreJumps ?? false;
     this.#dimensionThreshold = opts.dimensionThreshold ?? null;
     this.#timeBudget = opts.timeBudget ?? null;
+    this.#onProgress = opts.onProgress ?? null;
   }
 
   async run(opts: {
@@ -83,6 +96,7 @@ export class ImprovementLoop {
     for (let roundNum = 1; roundNum <= this.#maxRounds; roundNum++) {
       const roundStart = performance.now();
       this.#timeBudget?.check(`round ${roundNum} evaluation`);
+      this.reportProgress({ phase: "evaluation", status: "started", round: roundNum });
       const result = await this.#task.evaluateOutput(currentOutput, opts.state, {
         referenceContext: opts.referenceContext,
         requiredConcepts: opts.requiredConcepts,
@@ -90,6 +104,7 @@ export class ImprovementLoop {
         pinnedDimensions,
       });
       this.#timeBudget?.check(`round ${roundNum} evaluation`);
+      this.reportProgress({ phase: "evaluation", status: "completed", round: roundNum });
       judgeCalls += 1;
       const roundMs = Math.round(performance.now() - roundStart);
       totalInternalRetries += result.internalRetries ?? 0;
@@ -124,8 +139,10 @@ export class ImprovementLoop {
             evaluatorEpoch: lastGoodResult.evaluatorEpoch ?? null,
           };
           this.#timeBudget?.check(`round ${roundNum} revision`);
+          this.reportProgress({ phase: "revision", status: "started", round: roundNum });
           const revised = await this.#task.reviseOutput(currentOutput, feedbackResult, opts.state);
           this.#timeBudget?.check(`round ${roundNum} revision`);
+          this.reportProgress({ phase: "revision", status: "completed", round: roundNum });
           const cleaned = cleanRevisionOutput(revised);
           if (cleaned !== currentOutput) {
             currentOutput = cleaned;
@@ -251,8 +268,10 @@ export class ImprovementLoop {
           previousValidRound: previousValidRound ?? undefined,
         });
         this.#timeBudget?.check(`round ${roundNum} revision`);
+        this.reportProgress({ phase: "revision", status: "started", round: roundNum });
         const revised = await this.#task.reviseOutput(currentOutput, revisionFeedback, opts.state);
         this.#timeBudget?.check(`round ${roundNum} revision`);
+        this.reportProgress({ phase: "revision", status: "completed", round: roundNum });
         const cleaned = cleanRevisionOutput(revised);
         if (cleaned === currentOutput) {
           terminationReason = "unchanged_output";
@@ -276,6 +295,15 @@ export class ImprovementLoop {
       judgeCalls,
       evaluatorEpoch: bestRoundEpoch(rounds, bestRound),
     });
+  }
+
+  private reportProgress(progress: ImprovementLoopProgress): void {
+    try {
+      const result = this.#onProgress?.(progress);
+      result?.catch(() => undefined);
+    } catch {
+      // Progress telemetry must never alter solve results.
+    }
   }
 }
 

--- a/ts/src/knowledge/agent-task-solve-execution.ts
+++ b/ts/src/knowledge/agent-task-solve-execution.ts
@@ -1,4 +1,7 @@
-import { ImprovementLoop } from "../execution/improvement-loop.js";
+import {
+  ImprovementLoop,
+  type ImprovementLoopProgressObserver,
+} from "../execution/improvement-loop.js";
 import { createAgentTask } from "../scenarios/agent-task-factory.js";
 import { AgentTaskSpecSchema, type AgentTaskSpec } from "../scenarios/agent-task-spec.js";
 import { SolveGenerationBudget } from "./solve-generation-budget.js";
@@ -93,6 +96,12 @@ export type AgentTaskSolveTask = AgentTaskInterface & {
   readonly spec: AgentTaskSpec;
 };
 
+export interface AgentTaskSolveProgress {
+  phase: "context_preparation" | "draft" | "evaluation" | "revision" | "finalization";
+  status: "started" | "completed";
+  round?: number;
+}
+
 export interface AgentTaskSolveLoop {
   run(opts: {
     initialOutput: string;
@@ -115,6 +124,7 @@ export interface AgentTaskSolveExecutionDeps {
     maxRounds: number;
     qualityThreshold: number;
     timeBudget?: SolveGenerationBudget;
+    onProgress?: ImprovementLoopProgressObserver;
   }) => AgentTaskSolveLoop;
 }
 
@@ -128,13 +138,27 @@ function defaultCreateLoop(opts: {
   maxRounds: number;
   qualityThreshold: number;
   timeBudget?: SolveGenerationBudget;
+  onProgress?: ImprovementLoopProgressObserver;
 }): AgentTaskSolveLoop {
   return new ImprovementLoop({
     task: opts.task,
     maxRounds: opts.maxRounds,
     qualityThreshold: opts.qualityThreshold,
     timeBudget: opts.timeBudget,
+    onProgress: opts.onProgress,
   });
+}
+
+function reportSolveProgress(
+  onProgress: ((progress: AgentTaskSolveProgress) => void | Promise<void>) | undefined,
+  progress: AgentTaskSolveProgress,
+): void {
+  try {
+    const result = onProgress?.(progress);
+    result?.catch(() => undefined);
+  } catch {
+    // Progress telemetry must never alter solve results.
+  }
 }
 
 export async function executeAgentTaskSolve(opts: {
@@ -143,6 +167,7 @@ export async function executeAgentTaskSolve(opts: {
   generations: number;
   generationTimeBudgetSeconds?: number | null;
   hookBus?: HookBus | null;
+  onProgress?: (progress: AgentTaskSolveProgress) => void | Promise<void>;
   deps?: AgentTaskSolveExecutionDeps;
 }): Promise<AgentTaskSolveExecutionResult> {
   const spec = buildAgentTaskSolveSpec(
@@ -168,9 +193,16 @@ export async function executeAgentTaskSolve(opts: {
     maxRounds: spec.maxRounds,
     qualityThreshold: spec.qualityThreshold,
     timeBudget,
+    onProgress: (progress) => {
+      reportSolveProgress(opts.onProgress, progress);
+    },
   });
 
   timeBudget.check("initial state");
+  reportSolveProgress(opts.onProgress, {
+    phase: "context_preparation",
+    status: "started",
+  });
   const initialState = task.prepareContext
     ? await task.prepareContext(task.initialState())
     : task.initialState();
@@ -182,8 +214,13 @@ export async function executeAgentTaskSolve(opts: {
   if (contextErrors.length > 0) {
     throw new Error(`agent_task context preparation failed: ${contextErrors.join("; ")}`);
   }
+  reportSolveProgress(opts.onProgress, {
+    phase: "context_preparation",
+    status: "completed",
+  });
 
   timeBudget.check("initial generation");
+  reportSolveProgress(opts.onProgress, { phase: "draft", status: "started" });
   const initialOutput = await completeWithProviderHooks({
     hookBus: opts.hookBus ?? null,
     provider: opts.provider,
@@ -192,6 +229,7 @@ export async function executeAgentTaskSolve(opts: {
     userPrompt: task.getTaskPrompt(initialState),
   });
   timeBudget.check("initial generation");
+  reportSolveProgress(opts.onProgress, { phase: "draft", status: "completed" });
 
   const result = await loop.run({
     initialOutput: initialOutput.text,
@@ -202,8 +240,9 @@ export async function executeAgentTaskSolve(opts: {
   });
   timeBudget.check("improvement loop");
 
+  reportSolveProgress(opts.onProgress, { phase: "finalization", status: "started" });
   const bestRound = result.rounds.find((round) => round.roundNumber === result.bestRound);
-  return {
+  const executionResult = {
     progress: result.totalRounds,
     result: buildAgentTaskSolvePackage({
       scenarioName: opts.created.name,
@@ -224,4 +263,6 @@ export async function executeAgentTaskSolve(opts: {
       contextPreparation: spec.contextPreparation ?? null,
     }),
   };
+  reportSolveProgress(opts.onProgress, { phase: "finalization", status: "completed" });
+  return executionResult;
 }

--- a/ts/src/loop/agent-task-plan.ts
+++ b/ts/src/loop/agent-task-plan.ts
@@ -1,0 +1,358 @@
+import { z } from "zod";
+
+import {
+  isCredentialShapedPresentationId,
+  redactPresentationText,
+} from "../security/presentation-redaction.js";
+
+export const AGENT_TASK_PLAN_CAPABILITY = "agent_task_plan_v1";
+export const AGENT_TASK_PLAN_EVENT_NAME = "task_plan_updated";
+
+export const MAX_RETAINED_AGENT_TASK_PLAN_BYTES = 12 * 1_024;
+export const MAX_AGENT_TASK_PLAN_STEPS = 50;
+export const MAX_AGENT_TASK_PLAN_STRING_CHARACTERS = 20_000;
+
+const MAX_ID_LENGTH = 200;
+const MAX_LABEL_LENGTH = 160;
+const MAX_DETAIL_LENGTH = 2_000;
+const MAX_SUMMARY_LENGTH = 240;
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
+export const AgentTaskPlanIdSchema = z
+  .string()
+  .min(1)
+  .max(MAX_ID_LENGTH)
+  .regex(SAFE_ID_PATTERN)
+  .refine(
+    (value) => !isCredentialShapedPresentationId(value),
+    "credential-shaped IDs are not allowed",
+  );
+
+export const AgentTaskPlanStepStatusSchema = z.enum([
+  "pending",
+  "in_progress",
+  "completed",
+  "blocked",
+  "failed",
+  "skipped",
+  "interrupted",
+]);
+
+export const AgentTaskPlanStepSchema = z
+  .object({
+    id: AgentTaskPlanIdSchema,
+    label: z.string().trim().min(1).max(MAX_LABEL_LENGTH),
+    detail: z.string().trim().min(1).max(MAX_DETAIL_LENGTH).optional(),
+    status: AgentTaskPlanStepStatusSchema,
+  })
+  .strict();
+
+export const AgentTaskPlanPayloadSchema = z
+  .object({
+    run_id: AgentTaskPlanIdSchema,
+    plan_id: AgentTaskPlanIdSchema,
+    version: z.number().int().positive(),
+    plan_revision: z.number().int().positive(),
+    update_kind: z.enum(["initial", "progress", "replan"]),
+    active_step_id: AgentTaskPlanIdSchema.nullable(),
+    summary: z.string().trim().min(1).max(MAX_SUMMARY_LENGTH).optional(),
+    steps: z.array(AgentTaskPlanStepSchema).min(1).max(MAX_AGENT_TASK_PLAN_STEPS),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const ids = new Set<string>();
+    let activeCount = 0;
+    let aggregateCharacters =
+      value.run_id.length +
+      value.plan_id.length +
+      (value.active_step_id?.length ?? 0) +
+      (value.summary?.length ?? 0);
+
+    for (const [index, step] of value.steps.entries()) {
+      if (ids.has(step.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "step IDs must be unique",
+          path: ["steps", index, "id"],
+        });
+      }
+      ids.add(step.id);
+      aggregateCharacters += step.id.length + step.label.length + (step.detail?.length ?? 0);
+      if (step.status === "in_progress") activeCount += 1;
+    }
+
+    if (activeCount > 1) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "at most one step may be in progress",
+        path: ["steps"],
+      });
+    }
+
+    const activeStep = value.steps.find((step) => step.id === value.active_step_id);
+    if (
+      (value.active_step_id === null && activeCount !== 0) ||
+      (value.active_step_id !== null &&
+        (activeCount !== 1 || activeStep?.status !== "in_progress"))
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "active_step_id must identify the only in-progress step",
+        path: ["active_step_id"],
+      });
+    }
+
+    if (aggregateCharacters > MAX_AGENT_TASK_PLAN_STRING_CHARACTERS) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "task plan exceeds its aggregate character budget",
+        path: [],
+      });
+    }
+  });
+
+export type AgentTaskPlanStepStatus = z.infer<typeof AgentTaskPlanStepStatusSchema>;
+export type AgentTaskPlanStep = z.infer<typeof AgentTaskPlanStepSchema>;
+export type AgentTaskPlanPayload = z.infer<typeof AgentTaskPlanPayloadSchema>;
+
+export interface AgentTaskPlanStepInput {
+  id: string;
+  label: string;
+  detail?: string;
+}
+
+export interface AgentTaskPlanStepDetailUpdate {
+  detail?: string;
+  label?: string;
+}
+
+export type AgentTaskPlanStepDetails = Readonly<
+  Record<string, AgentTaskPlanStepDetailUpdate>
+>;
+
+interface AgentTaskPlanUpdateInput {
+  activeStepId: string | null;
+  completedStepIds?: readonly string[];
+  skippedStepIds?: readonly string[];
+  stepDetails?: AgentTaskPlanStepDetails;
+  summary?: string;
+}
+
+export interface AgentTaskPlanPublisher {
+  initial(input: Pick<AgentTaskPlanUpdateInput, "activeStepId" | "stepDetails" | "summary">): boolean;
+  progress(input: AgentTaskPlanUpdateInput): boolean;
+  replan(input: AgentTaskPlanUpdateInput & { summary: string }): boolean;
+  terminal(
+    status: "completed" | "failed" | "interrupted",
+    input?: Pick<AgentTaskPlanUpdateInput, "stepDetails" | "summary">,
+  ): boolean;
+}
+
+interface AgentTaskPlanEventSink {
+  emit(event: string, payload: Record<string, unknown>): void;
+}
+
+export interface CreateAgentTaskPlanPublisherOptions {
+  events: AgentTaskPlanEventSink;
+  planId?: string;
+  runId: string;
+  steps: readonly AgentTaskPlanStepInput[];
+}
+
+function sanitizeCopy(value: string, maxLength: number): string {
+  const redacted = redactPresentationText(value.trim());
+  if (redacted.length <= maxLength) return redacted;
+  return `${redacted.slice(0, maxLength - 1)}…`;
+}
+
+function sanitizeStep(step: AgentTaskPlanStep): AgentTaskPlanStep {
+  return {
+    id: step.id,
+    label: sanitizeCopy(step.label, MAX_LABEL_LENGTH),
+    ...(step.detail === undefined
+      ? {}
+      : { detail: sanitizeCopy(step.detail, MAX_DETAIL_LENGTH) }),
+    status: step.status,
+  };
+}
+
+export function sanitizeAgentTaskPlanPayload(value: unknown): AgentTaskPlanPayload | null {
+  const parsed = AgentTaskPlanPayloadSchema.safeParse(value);
+  if (!parsed.success) return null;
+  const sanitized = {
+    ...parsed.data,
+    ...(parsed.data.summary === undefined
+      ? {}
+      : { summary: sanitizeCopy(parsed.data.summary, MAX_SUMMARY_LENGTH) }),
+    steps: parsed.data.steps.map(sanitizeStep),
+  };
+  const safe = AgentTaskPlanPayloadSchema.safeParse(sanitized);
+  if (!safe.success) return null;
+  if (!isAgentTaskPlanPayloadRetainable(safe.data)) {
+    return null;
+  }
+  return safe.data;
+}
+
+export function isAgentTaskPlanPayloadRetainable(payload: AgentTaskPlanPayload): boolean {
+  const message = {
+    type: "event",
+    event: AGENT_TASK_PLAN_EVENT_NAME,
+    payload,
+  };
+  return (
+    Buffer.byteLength(JSON.stringify(message), "utf-8") <=
+    MAX_RETAINED_AGENT_TASK_PLAN_BYTES
+  );
+}
+
+function applyStepDetails(
+  steps: readonly AgentTaskPlanStep[],
+  stepDetails: AgentTaskPlanStepDetails | undefined,
+): AgentTaskPlanStep[] {
+  if (!stepDetails) return steps.map((step) => ({ ...step }));
+  return steps.map((step) => {
+    const update = stepDetails[step.id];
+    if (!update) return { ...step };
+    return {
+      ...step,
+      ...(update.label === undefined
+        ? {}
+        : { label: sanitizeCopy(update.label, MAX_LABEL_LENGTH) }),
+      ...(update.detail === undefined
+        ? {}
+        : { detail: sanitizeCopy(update.detail, MAX_DETAIL_LENGTH) }),
+    };
+  });
+}
+
+function hasOnlyKnownStepIds(ids: readonly string[] | undefined, knownIds: Set<string>): boolean {
+  return ids === undefined || ids.every((id) => knownIds.has(id));
+}
+
+export function createAgentTaskPlanPublisher(
+  options: CreateAgentTaskPlanPublisherOptions,
+): AgentTaskPlanPublisher | null {
+  const runIdResult = AgentTaskPlanIdSchema.safeParse(options.runId);
+  const planIdResult = AgentTaskPlanIdSchema.safeParse(options.planId ?? "task-plan");
+  if (!runIdResult.success || !planIdResult.success) return null;
+  if (options.steps.length < 1 || options.steps.length > MAX_AGENT_TASK_PLAN_STEPS) return null;
+
+  const stepIds = new Set<string>();
+  const initialSteps: AgentTaskPlanStep[] = [];
+  for (const step of options.steps) {
+    const id = AgentTaskPlanIdSchema.safeParse(step.id);
+    if (!id.success || stepIds.has(id.data)) return null;
+    stepIds.add(id.data);
+    const initialStep = AgentTaskPlanStepSchema.safeParse({
+      id: id.data,
+      label: sanitizeCopy(step.label, MAX_LABEL_LENGTH),
+      ...(step.detail === undefined
+        ? {}
+        : { detail: sanitizeCopy(step.detail, MAX_DETAIL_LENGTH) }),
+      status: "pending",
+    });
+    if (!initialStep.success) return null;
+    initialSteps.push(initialStep.data);
+  }
+
+  let steps = initialSteps;
+  let version = 0;
+  let planRevision = 1;
+  let terminal = false;
+
+  const publish = (
+    updateKind: AgentTaskPlanPayload["update_kind"],
+    activeStepId: string | null,
+    candidateSteps: readonly AgentTaskPlanStep[],
+    summary?: string,
+    nextPlanRevision = planRevision,
+  ): boolean => {
+    if (terminal || (activeStepId !== null && !stepIds.has(activeStepId))) return false;
+    const payload = sanitizeAgentTaskPlanPayload({
+      run_id: runIdResult.data,
+      plan_id: planIdResult.data,
+      version: version + 1,
+      plan_revision: nextPlanRevision,
+      update_kind: updateKind,
+      active_step_id: activeStepId,
+      ...(summary === undefined ? {} : { summary }),
+      steps: candidateSteps,
+    });
+    if (!payload) return false;
+    try {
+      options.events.emit(AGENT_TASK_PLAN_EVENT_NAME, payload);
+    } catch {
+      return false;
+    }
+    steps = payload.steps.map((step) => ({ ...step }));
+    version = payload.version;
+    planRevision = payload.plan_revision;
+    return true;
+  };
+
+  const update = (
+    input: AgentTaskPlanUpdateInput,
+    updateKind: "progress" | "replan",
+  ): boolean => {
+    if (
+      !hasOnlyKnownStepIds(input.completedStepIds, stepIds) ||
+      !hasOnlyKnownStepIds(input.skippedStepIds, stepIds)
+    ) {
+      return false;
+    }
+    const completed = new Set(input.completedStepIds ?? []);
+    const skipped = new Set(input.skippedStepIds ?? []);
+    let candidate = applyStepDetails(steps, input.stepDetails).map((step) => {
+      if (step.status === "completed" || completed.has(step.id)) {
+        return { ...step, status: "completed" as const };
+      }
+      if (skipped.has(step.id)) return { ...step, status: "skipped" as const };
+      if (step.id === input.activeStepId) return { ...step, status: "in_progress" as const };
+      if (step.status === "in_progress") return { ...step, status: "pending" as const };
+      return step;
+    });
+    if (input.activeStepId !== null) {
+      candidate = candidate.map((step) =>
+        step.id === input.activeStepId && step.status !== "completed"
+          ? { ...step, status: "in_progress" as const }
+          : step,
+      );
+    }
+    const nextRevision = updateKind === "replan" ? planRevision + 1 : planRevision;
+    return publish(updateKind, input.activeStepId, candidate, input.summary, nextRevision);
+  };
+
+  return {
+    initial(input) {
+      if (version !== 0) return false;
+      const candidate = applyStepDetails(steps, input.stepDetails).map((step) =>
+        step.id === input.activeStepId
+          ? { ...step, status: "in_progress" as const }
+          : step,
+      );
+      return publish("initial", input.activeStepId, candidate, input.summary);
+    },
+    progress(input) {
+      if (version === 0) return false;
+      return update(input, "progress");
+    },
+    replan(input) {
+      if (version === 0) return false;
+      return update(input, "replan");
+    },
+    terminal(status, input = {}) {
+      if (version === 0 || terminal) return false;
+      const activeStep = steps.find((step) => step.status === "in_progress");
+      const candidate = applyStepDetails(steps, input.stepDetails).map((step) => {
+        if (step.status === "completed" || step.status === "skipped") return step;
+        if (status === "completed") return { ...step, status: "completed" as const };
+        if (activeStep?.id === step.id) return { ...step, status };
+        return { ...step, status: "skipped" as const };
+      });
+      const emitted = publish("progress", null, candidate, input.summary);
+      if (emitted) terminal = true;
+      return emitted;
+    },
+  };
+}

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -45,6 +45,10 @@ import {
   type RunStopRequestedError,
 } from "./controller.js";
 import type { EventStreamEmitter } from "./events.js";
+import {
+  createAgentTaskPlanPublisher,
+  type AgentTaskPlanPublisher,
+} from "./agent-task-plan.js";
 import { StagnationDetector } from "./stagnation.js";
 import {
   buildCompetitorPrompt,
@@ -88,6 +92,12 @@ import {
   type ExplorationSnapshot,
   type GuidanceChange,
 } from "../analytics/exploration-collapse-guard.js";
+
+const BUILT_IN_GAME_PLAN_STEPS = [
+  { id: "prepare_run", label: "Prepare the strategy context" },
+  { id: "iterate_strategies", label: "Generate, evaluate, and refine strategies" },
+  { id: "finalize_run", label: "Finalize run artifacts" },
+] as const;
 
 export interface GenerationRunnerOpts {
   provider: LLMProvider;
@@ -189,6 +199,8 @@ export class GenerationRunner {
   #loadedExtensions: string[];
   #runtimeSession?: RuntimeSession;
   #runState: GenerationRunState | null = null;
+  #taskPlan: AgentTaskPlanPublisher | null = null;
+  #taskPlanFinished = false;
 
   constructor(opts: GenerationRunnerOpts) {
     this.#provider = opts.provider;
@@ -279,12 +291,18 @@ export class GenerationRunner {
     this.#runState = orchestration.runState;
     try {
       this.emit("run_started", orchestration.events.runStarted!);
+      this.startTaskPlan(runId);
 
       while (hasRemainingGenerationCycles(orchestration.cycleState)) {
         orchestration = await this.runGeneration(runId, orchestration);
       }
 
       this.#controller?.throwIfStopRequested();
+      this.publishTaskPlan((taskPlan) => taskPlan.progress({
+        activeStepId: "finalize_run",
+        completedStepIds: ["prepare_run", "iterate_strategies"],
+        summary: "Strategy generations completed; finalizing run artifacts.",
+      }));
       return await this.finalizeSuccessfulRun(runId, orchestration);
     } catch (error) {
       const stopRequest = this.resolveStopRequest(error);
@@ -382,6 +400,15 @@ export class GenerationRunner {
   }> {
     await this.#controller?.waitAtBoundary();
     const competitorPrompt = this.buildCompetitorPrompt(runId, generation);
+    this.publishTaskPlan((taskPlan) => taskPlan.progress({
+      activeStepId: "iterate_strategies",
+      completedStepIds: ["prepare_run"],
+      stepDetails: {
+        iterate_strategies: {
+          detail: `Working on strategy generation ${generation}`,
+        },
+      },
+    }));
     return runGenerationAttemptWorkflow(
       createGenerationAttemptWorkflow({
         attemptOrchestration,
@@ -431,7 +458,6 @@ export class GenerationRunner {
     runId: RunId,
     orchestration: GenerationLoopOrchestration,
   ): Promise<RunResult> {
-    this.#store.updateRunStatus(runId, "completed");
     const sessionReportPath = this.#journal.persistSessionReport(runId, {
       runStartedAtMs: this.#runState!.startedAtMs,
       explorationMode: this.#explorationMode,
@@ -442,7 +468,6 @@ export class GenerationRunner {
       deadEndsFound: this.#journal.countDeadEnds(),
     });
     this.#runState = orchestration.runState;
-    this.emit("run_completed", orchestration.events.runCompleted!);
     this.emitHook(HookEvents.RUN_END, {
       run_id: runId,
       scenario: this.#scenario.name,
@@ -453,6 +478,9 @@ export class GenerationRunner {
       session_report_path: sessionReportPath,
       dead_ends_found: this.#journal.countDeadEnds(),
     });
+    this.#store.updateRunStatus(runId, "completed");
+    this.finishTaskPlan("completed", "Strategy run completed.");
+    this.emit("run_completed", orchestration.events.runCompleted!);
     await this.notify("completion", runId, this.#runState.bestScore, {
       roundCount: orchestration.cycleState.completedGenerations,
       metadata: { session_report_path: sessionReportPath },
@@ -476,8 +504,7 @@ export class GenerationRunner {
       completedGenerations: trajectory.length,
       ...(Number.isFinite(bestScore) ? { bestScore } : {}),
     };
-    this.#store.updateRunStatus(runId, "stopped");
-    this.emitHook(HookEvents.RUN_END, {
+    this.emitResolvedTerminalHook(HookEvents.RUN_END, {
       run_id: runId,
       scenario: this.#scenario.name,
       status: "stopped",
@@ -485,6 +512,8 @@ export class GenerationRunner {
       ...(progress.bestScore === undefined ? {} : { best_score: progress.bestScore }),
       elo: this.#runState?.currentElo ?? 1000,
     });
+    this.#store.updateRunStatus(runId, "stopped");
+    this.finishTaskPlan("interrupted", "Strategy run was interrupted.");
     throw stopRequest.withProgress(progress);
   }
 
@@ -498,9 +527,7 @@ export class GenerationRunner {
       error: error instanceof Error ? error.message : String(error),
     });
     this.#runState = orchestration.runState;
-    this.#store.updateRunStatus(runId, "failed");
-    this.emit("run_failed", orchestration.events.runFailed!);
-    this.emitHook(HookEvents.RUN_END, {
+    this.emitResolvedTerminalHook(HookEvents.RUN_END, {
       run_id: runId,
       scenario: this.#scenario.name,
       status: "failed",
@@ -509,6 +536,9 @@ export class GenerationRunner {
       elo: this.#runState.currentElo,
       error: error instanceof Error ? error.message : String(error),
     });
+    this.#store.updateRunStatus(runId, "failed");
+    this.finishTaskPlan("failed", "Strategy run failed before completion.");
+    this.emit("run_failed", orchestration.events.runFailed!);
     await this.notify("failure", runId, this.#runState.bestScore, {
       roundCount: this.#store.getScoreTrajectory(runId).length,
       error: error instanceof Error ? error.message : String(error),
@@ -883,6 +913,18 @@ export class GenerationRunner {
     if (outcome.freshStartHint) {
       this.#runState = queueFreshStartHint(this.#runState!, outcome.freshStartHint);
     }
+    if (attempt.gateDecision === "rollback" || outcome.freshStartHint) {
+      this.publishTaskPlan((taskPlan) => taskPlan.replan({
+        activeStepId: "iterate_strategies",
+        completedStepIds: ["prepare_run"],
+        summary: "Adjusting the strategy approach after a recovery signal.",
+        stepDetails: {
+          iterate_strategies: {
+            detail: `Revising the approach for generation ${gen}`,
+          },
+        },
+      }));
+    }
     this.persistExplorationCollapseGuard(runId, gen);
   }
 
@@ -967,8 +1009,62 @@ export class GenerationRunner {
     return event;
   }
 
+  private emitResolvedTerminalHook(
+    name: HookEvents,
+    payload: Record<string, unknown>,
+  ): void {
+    try {
+      this.emitHook(name, payload);
+    } catch {
+      // A hook cannot reclassify an already-resolved failed or stopped run.
+    }
+  }
+
   private emit(event: string, payload: Record<string, unknown>): void {
     this.#events?.emit(event, payload);
+  }
+
+  private startTaskPlan(runId: RunId): void {
+    this.#taskPlan = null;
+    this.#taskPlanFinished = false;
+    if (!this.#events) {
+      return;
+    }
+    try {
+      this.#taskPlan = createAgentTaskPlanPublisher({
+        runId,
+        steps: BUILT_IN_GAME_PLAN_STEPS,
+        events: this.#events,
+      });
+    } catch {
+      this.#taskPlan = null;
+    }
+    this.publishTaskPlan((taskPlan) => taskPlan.initial({
+      activeStepId: "prepare_run",
+      summary: "Preparing the strategy run.",
+    }));
+  }
+
+  private publishTaskPlan(action: (taskPlan: AgentTaskPlanPublisher) => boolean): void {
+    if (!this.#taskPlan || this.#taskPlanFinished) {
+      return;
+    }
+    try {
+      action(this.#taskPlan);
+    } catch {
+      // Task-plan telemetry must never alter run results.
+    }
+  }
+
+  private finishTaskPlan(
+    status: "completed" | "failed" | "interrupted",
+    summary: string,
+  ): void {
+    if (this.#taskPlanFinished) {
+      return;
+    }
+    this.publishTaskPlan((taskPlan) => taskPlan.terminal(status, { summary }));
+    this.#taskPlanFinished = true;
   }
 
   private emitRoleCompleted(

--- a/ts/src/security/presentation-redaction.ts
+++ b/ts/src/security/presentation-redaction.ts
@@ -1,0 +1,56 @@
+export const REDACTED_PRESENTATION_VALUE = "[Redacted]";
+
+const AUTHORIZATION_PATTERN =
+  /\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer\s+)?[^\s,;]+/gi;
+const CREDENTIAL_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|access[_-]?key|client[_-]?secret|refresh[_-]?token|session[_-]?(?:key|token)|token|secret|password|passphrase|cookie|credential)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
+const QUERY_CREDENTIAL_PATTERN =
+  /([?&](?:api[_-]?key|access[_-]?key|client[_-]?secret|refresh[_-]?token|session[_-]?(?:key|token)|token|secret|password|passphrase|signature)=)[^&#\s]+/gi;
+const URL_USERINFO_PATTERN = /(https?:\/\/)[^/@\s]+@/gi;
+const BARE_BEARER_PATTERN =
+  /\bbearer\s+[A-Za-z0-9._~+/-]{12,}={0,2}(?=\s|$|[,;])/gi;
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
+const PRIVATE_KEY_PATTERN =
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g;
+const DASHED_PROVIDER_TOKEN_PATTERN = /\b(?:sk|pk)-[A-Za-z0-9_-]{8,}\b/g;
+const UNDERSCORED_PROVIDER_TOKEN_PATTERN = /\b(?:dp|gsk|sk|pk)_[A-Za-z0-9_-]{8,}\b/g;
+const GOOGLE_API_KEY_PATTERN = /\bAIza[0-9A-Za-z_-]{20,}\b/g;
+const AWS_ACCESS_KEY_PATTERN =
+  /\b(?:A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA)[A-Z0-9]{16}\b/g;
+const GITHUB_TOKEN_PATTERN = /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b/g;
+const GITHUB_PAT_PATTERN = /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g;
+const GITLAB_TOKEN_PATTERN = /\bglpat-[A-Za-z0-9_-]{12,}\b/g;
+const LINEAR_TOKEN_PATTERN = /\blin_api_[A-Za-z0-9]{20,}\b/g;
+const NPM_TOKEN_PATTERN = /\bnpm_[A-Za-z0-9]{20,}\b/g;
+const PYPI_TOKEN_PATTERN = /\bpypi-AgEI[A-Za-z0-9_-]{20,}\b/g;
+const SENDGRID_TOKEN_PATTERN = /\bSG\.[A-Za-z0-9_-]{20,}\b/g;
+const SLACK_TOKEN_PATTERN = /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g;
+const RECEIVER_SENSITIVE_ID_PATTERN =
+  /(?:(?:sk[-_]|ghp_|github_pat_|xox[baprs]-|dp_)[A-Za-z0-9_-]{8,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)/;
+
+export function redactPresentationText(value: string): string {
+  return value
+    .replace(AUTHORIZATION_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(CREDENTIAL_ASSIGNMENT_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(QUERY_CREDENTIAL_PATTERN, `$1${REDACTED_PRESENTATION_VALUE}`)
+    .replace(URL_USERINFO_PATTERN, "$1[Redacted]@")
+    .replace(BARE_BEARER_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(JWT_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(PRIVATE_KEY_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(DASHED_PROVIDER_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(UNDERSCORED_PROVIDER_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(GOOGLE_API_KEY_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(AWS_ACCESS_KEY_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(GITHUB_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(GITHUB_PAT_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(GITLAB_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(LINEAR_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(NPM_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(PYPI_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(SENDGRID_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE)
+    .replace(SLACK_TOKEN_PATTERN, REDACTED_PRESENTATION_VALUE);
+}
+
+export function isCredentialShapedPresentationId(value: string): boolean {
+  return RECEIVER_SENSITIVE_ID_PATTERN.test(value) || redactPresentationText(value) !== value;
+}

--- a/ts/src/server/index.ts
+++ b/ts/src/server/index.ts
@@ -6,6 +6,12 @@ export {
   PROTOCOL_VERSION,
   TRANSCRIPT_PROTOCOL_VERSION,
   SERVER_CAPABILITIES,
+  AGENT_TASK_PLAN_CAPABILITY,
+  AGENT_TASK_PLAN_EVENT_NAME,
+  AgentTaskPlanIdSchema,
+  AgentTaskPlanPayloadSchema,
+  AgentTaskPlanStepSchema,
+  AgentTaskPlanStepStatusSchema,
   HelloMsgSchema,
   EventMsgSchema,
   StateMsgSchema,
@@ -42,7 +48,13 @@ export {
   parseClientMessage,
   parseServerMessage,
 } from "./protocol.js";
-export type { ServerMessage, ClientMessage } from "./protocol.js";
+export type {
+  AgentTaskPlanPayload,
+  AgentTaskPlanStep,
+  AgentTaskPlanStepStatus,
+  ServerMessage,
+  ClientMessage,
+} from "./protocol.js";
 
 export {
   handleTuiLogin,

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -5,11 +5,32 @@
 
 import { z } from "zod";
 
+import { AGENT_TASK_PLAN_CAPABILITY } from "../loop/agent-task-plan.js";
+
+export {
+  AGENT_TASK_PLAN_CAPABILITY,
+  AGENT_TASK_PLAN_EVENT_NAME,
+  AgentTaskPlanIdSchema,
+  AgentTaskPlanPayloadSchema,
+  AgentTaskPlanStepSchema,
+  AgentTaskPlanStepStatusSchema,
+  MAX_RETAINED_AGENT_TASK_PLAN_BYTES,
+} from "../loop/agent-task-plan.js";
+export type {
+  AgentTaskPlanPayload,
+  AgentTaskPlanStep,
+  AgentTaskPlanStepStatus,
+} from "../loop/agent-task-plan.js";
+
 export const PROTOCOL_VERSION = 1;
 export const TRANSCRIPT_PROTOCOL_VERSION = 1;
 export const TRANSCRIPT_PROTOCOL_QUERY_PARAM = "transcript_protocol_version";
 export const TRANSCRIPT_PROTOCOL_QUERY_VALUE = String(TRANSCRIPT_PROTOCOL_VERSION);
-export const SERVER_CAPABILITIES = ["run_transcript_v1", "safe_run_stop_v1"] as const;
+export const SERVER_CAPABILITIES = [
+  "run_transcript_v1",
+  "safe_run_stop_v1",
+  AGENT_TASK_PLAN_CAPABILITY,
+] as const;
 
 const protocolObject = <T extends z.ZodRawShape>(shape: T) => z.object(shape).strict();
 

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -8,16 +8,125 @@ import {
 } from "../loop/controller.js";
 import type { EventStreamEmitter } from "../loop/events.js";
 import { GenerationRunner } from "../loop/generation-runner.js";
+import { createAgentTaskPlanPublisher } from "../loop/agent-task-plan.js";
 import type { RoleProviderBundle } from "../providers/index.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
 import type { ScenarioInterface } from "../scenarios/game-interface.js";
 import type { CustomScenarioEntry } from "../scenarios/custom-loader.js";
 import { executeGeneratedScenarioEntry } from "../scenarios/codegen/executor.js";
-import { executeAgentTaskSolve } from "../knowledge/agent-task-solve-execution.js";
+import {
+  executeAgentTaskSolve,
+  type AgentTaskSolveProgress,
+} from "../knowledge/agent-task-solve-execution.js";
 import { HookEvents, initializeHookBus, type HookBus } from "../extensions/index.js";
 import type { ScenarioFamilyName } from "../scenarios/families.js";
 import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
 import { SQLiteStore } from "../storage/index.js";
+
+const SAVED_AGENT_TASK_PLAN_STEPS = [
+  { id: "prepare_context", label: "Prepare task context" },
+  { id: "draft_response", label: "Draft the initial response" },
+  { id: "improve_response", label: "Evaluate and refine the response" },
+  { id: "finalize_result", label: "Finalize the best result" },
+] as const;
+
+const GENERATED_CUSTOM_PLAN_STEPS = [
+  { id: "execute_scenario", label: "Execute scenario generations" },
+  { id: "aggregate_results", label: "Aggregate generation results" },
+  { id: "finalize_run", label: "Finalize the run" },
+] as const;
+
+type RuntimeTaskPlanPublisher = NonNullable<
+  ReturnType<typeof createAgentTaskPlanPublisher>
+>;
+
+function createRuntimeTaskPlan(opts: {
+  runId: string;
+  steps: readonly { id: string; label: string; detail?: string }[];
+  events: EventStreamEmitter;
+}): RuntimeTaskPlanPublisher | null {
+  try {
+    return createAgentTaskPlanPublisher(opts);
+  } catch {
+    return null;
+  }
+}
+
+function publishTaskPlan(
+  taskPlan: RuntimeTaskPlanPublisher | null,
+  action: (publisher: RuntimeTaskPlanPublisher) => boolean,
+): void {
+  if (!taskPlan) {
+    return;
+  }
+  try {
+    action(taskPlan);
+  } catch {
+    // Task-plan telemetry must never alter run results.
+  }
+}
+
+function reportSavedAgentTaskProgress(
+  taskPlan: RuntimeTaskPlanPublisher | null,
+  progress: AgentTaskSolveProgress,
+): void {
+  if (!taskPlan) {
+    return;
+  }
+  const iterativeDetail =
+    progress.round === undefined
+      ? "Evaluating the current response"
+      : `Working through evaluation round ${progress.round}`;
+  if (progress.phase === "context_preparation" && progress.status === "completed") {
+    publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+      activeStepId: "draft_response",
+      completedStepIds: ["prepare_context"],
+    }));
+    return;
+  }
+  if (progress.phase === "draft" && progress.status === "completed") {
+    publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+      activeStepId: "improve_response",
+      completedStepIds: ["prepare_context", "draft_response"],
+      stepDetails: { improve_response: { detail: iterativeDetail } },
+    }));
+    return;
+  }
+  if (progress.phase === "evaluation") {
+    publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+      activeStepId: "improve_response",
+      completedStepIds: ["prepare_context", "draft_response"],
+      stepDetails: { improve_response: { detail: iterativeDetail } },
+    }));
+    return;
+  }
+  if (progress.phase === "revision" && progress.status === "started") {
+    publishTaskPlan(taskPlan, (publisher) => publisher.replan({
+      activeStepId: "improve_response",
+      completedStepIds: ["prepare_context", "draft_response"],
+      summary:
+        progress.round === undefined
+          ? "Refining the response after evaluation."
+          : `Refining the response after evaluation round ${progress.round}.`,
+      stepDetails: { improve_response: { detail: iterativeDetail } },
+    }));
+    return;
+  }
+  if (progress.phase === "revision") {
+    publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+      activeStepId: "improve_response",
+      completedStepIds: ["prepare_context", "draft_response"],
+      stepDetails: { improve_response: { detail: iterativeDetail } },
+    }));
+    return;
+  }
+  if (progress.phase === "finalization") {
+    publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+      activeStepId: "finalize_result",
+      completedStepIds: ["prepare_context", "draft_response", "improve_response"],
+    }));
+  }
+}
 
 export type RunStartPlan =
   | { kind: "builtin_game"; scenarioName: string }
@@ -270,6 +379,26 @@ export async function executeAgentTaskCustomStartRun(opts: {
     family: "agent_task",
     saved_custom: true,
   });
+  const taskPlan = createRuntimeTaskPlan({
+    runId: opts.runId,
+    steps: SAVED_AGENT_TASK_PLAN_STEPS,
+    events: opts.events,
+  });
+  publishTaskPlan(taskPlan, (publisher) => publisher.initial({
+    activeStepId: "prepare_context",
+    summary: "Preparing the saved agent task.",
+  }));
+  let taskPlanFinished = false;
+  const finishTaskPlan = (
+    status: "completed" | "failed" | "interrupted",
+    summary: string,
+  ): void => {
+    if (taskPlanFinished) {
+      return;
+    }
+    taskPlanFinished = true;
+    publishTaskPlan(taskPlan, (publisher) => publisher.terminal(status, { summary }));
+  };
   let activeGeneration: number | null = null;
   let completedGenerations = 0;
   let bestScore: number | undefined;
@@ -295,6 +424,9 @@ export async function executeAgentTaskCustomStartRun(opts: {
         },
         generations: opts.generations,
         ...(hookBus ? { hookBus } : {}),
+        onProgress: (progress) => {
+          reportSavedAgentTaskProgress(taskPlan, progress);
+        },
       });
     } catch (error) {
       const stopRequest = isRunStopRequestedError(error)
@@ -388,7 +520,7 @@ export async function executeAgentTaskCustomStartRun(opts: {
       completedGenerations,
       bestScore,
     });
-    opts.events.emit("run_completed", {
+    const completedPayload = {
       run_id: opts.runId,
       completed_generations: completedGenerations,
       best_score: bestScore,
@@ -397,24 +529,20 @@ export async function executeAgentTaskCustomStartRun(opts: {
       dead_ends_found: 0,
       family: "agent_task",
       saved_custom: true,
-    });
+    };
     emitHook(hookBus, HookEvents.RUN_END, {
-      run_id: opts.runId,
+      ...completedPayload,
       scenario: opts.scenarioName,
       status: "completed",
-      completed_generations: completedGenerations,
-      best_score: bestScore,
-      elo: 1000,
-      session_report_path: null,
-      dead_ends_found: 0,
-      family: "agent_task",
-      saved_custom: true,
     });
+    finishTaskPlan("completed", "Saved agent task completed.");
+    opts.events.emit("run_completed", completedPayload);
   } catch (error) {
     const stopRequest = isRunStopRequestedError(error)
       ? error
       : opts.controller.getStopRequest();
     if (!stopRequest) {
+      finishTaskPlan("failed", "Saved agent task failed before completion.");
       throw error;
     }
     const stopped = stopRequest.withProgress({
@@ -422,7 +550,7 @@ export async function executeAgentTaskCustomStartRun(opts: {
       ...(bestScore === undefined ? {} : { bestScore }),
     });
     if (activeGeneration !== null) {
-      emitHook(hookBus, HookEvents.GENERATION_END, {
+      emitResolvedTerminalHook(hookBus, HookEvents.GENERATION_END, {
         run_id: opts.runId,
         scenario: opts.scenarioName,
         generation: activeGeneration,
@@ -431,7 +559,7 @@ export async function executeAgentTaskCustomStartRun(opts: {
         saved_custom: true,
       });
     }
-    emitHook(hookBus, HookEvents.RUN_END, {
+    emitResolvedTerminalHook(hookBus, HookEvents.RUN_END, {
       run_id: opts.runId,
       scenario: opts.scenarioName,
       status: "stopped",
@@ -441,6 +569,7 @@ export async function executeAgentTaskCustomStartRun(opts: {
       family: "agent_task",
       saved_custom: true,
     });
+    finishTaskPlan("interrupted", "Saved agent task was interrupted.");
     throw stopped;
   }
 }
@@ -485,71 +614,110 @@ export async function executeGeneratedCustomStartRun(opts: {
     family: opts.family,
     generated_custom: true,
   });
+  const taskPlan = createRuntimeTaskPlan({
+    runId: opts.runId,
+    steps: GENERATED_CUSTOM_PLAN_STEPS,
+    events: opts.events,
+  });
+  publishTaskPlan(taskPlan, (publisher) => publisher.initial({
+    activeStepId: "execute_scenario",
+    summary: "Starting the generated scenario run.",
+  }));
+  let taskPlanFinished = false;
+  const finishTaskPlan = (
+    status: "completed" | "failed" | "interrupted",
+    summary: string,
+  ): void => {
+    if (taskPlanFinished) {
+      return;
+    }
+    taskPlanFinished = true;
+    publishTaskPlan(taskPlan, (publisher) => publisher.terminal(status, { summary }));
+  };
 
   let bestScoreOverall = 0;
   let completedGenerations = 0;
-  for (let generation = 1; generation <= opts.generations; generation++) {
-    await opts.controller.waitAtBoundary({
-      completedGenerations,
-      ...(completedGenerations === 0 ? {} : { bestScore: bestScoreOverall }),
-    });
-    opts.events.emit("generation_started", { run_id: opts.runId, generation });
+  try {
+    for (let generation = 1; generation <= opts.generations; generation++) {
+      publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+        activeStepId: "execute_scenario",
+        stepDetails: {
+          execute_scenario: {
+            detail: `Running generation ${generation} of ${opts.generations}`,
+          },
+        },
+      }));
+      await opts.controller.waitAtBoundary({
+        completedGenerations,
+        ...(completedGenerations === 0 ? {} : { bestScore: bestScoreOverall }),
+      });
+      opts.events.emit("generation_started", { run_id: opts.runId, generation });
 
-    let result: Awaited<ReturnType<typeof executeGeneratedScenarioEntry>>;
-    try {
-      result = await executeScenario({
+      const result = await executeScenario({
         customDir,
         name: opts.scenarioName,
         family: opts.family,
         seed: generation,
         ...(typeof maxSteps === "number" ? { maxSteps } : {}),
       });
-    } catch (error) {
-      const stopRequest = isRunStopRequestedError(error)
-        ? error
-        : opts.controller.getStopRequest();
-      if (stopRequest) {
-        throw stopRequest.withProgress({
-          completedGenerations,
-          ...(completedGenerations === 0 ? {} : { bestScore: bestScoreOverall }),
-        });
-      }
-      throw error;
+
+      bestScoreOverall = Math.max(bestScoreOverall, result.score);
+      completedGenerations = generation;
+      opts.events.emit("generation_completed", {
+        run_id: opts.runId,
+        generation,
+        mean_score: result.score,
+        best_score: result.score,
+        elo: 1000,
+        gate_decision: "advance",
+        family: opts.family,
+        steps_executed: result.stepsExecuted,
+        reasoning: result.reasoning,
+      });
+      opts.controller.throwIfStopRequested({
+        completedGenerations,
+        bestScore: bestScoreOverall,
+      });
     }
 
-    bestScoreOverall = Math.max(bestScoreOverall, result.score);
-    completedGenerations = generation;
-    opts.events.emit("generation_completed", {
-      run_id: opts.runId,
-      generation,
-      mean_score: result.score,
-      best_score: result.score,
-      elo: 1000,
-      gate_decision: "advance",
-      family: opts.family,
-      steps_executed: result.stepsExecuted,
-      reasoning: result.reasoning,
-    });
     opts.controller.throwIfStopRequested({
       completedGenerations,
-      bestScore: bestScoreOverall,
+      ...(completedGenerations === 0 ? {} : { bestScore: bestScoreOverall }),
     });
+    publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+      activeStepId: "aggregate_results",
+      completedStepIds: ["execute_scenario"],
+      summary: "Scenario generations completed; aggregating results.",
+    }));
+    publishTaskPlan(taskPlan, (publisher) => publisher.progress({
+      activeStepId: "finalize_run",
+      completedStepIds: ["execute_scenario", "aggregate_results"],
+    }));
+    finishTaskPlan("completed", "Generated scenario run completed.");
+    opts.events.emit("run_completed", {
+      run_id: opts.runId,
+      completed_generations: completedGenerations,
+      best_score: bestScoreOverall,
+      elo: 1000,
+      session_report_path: null,
+      dead_ends_found: 0,
+      family: opts.family,
+      generated_custom: true,
+    });
+  } catch (error) {
+    const stopRequest = isRunStopRequestedError(error)
+      ? error
+      : opts.controller.getStopRequest();
+    if (stopRequest) {
+      finishTaskPlan("interrupted", "Generated scenario run was interrupted.");
+      throw stopRequest.withProgress({
+        completedGenerations,
+        ...(completedGenerations === 0 ? {} : { bestScore: bestScoreOverall }),
+      });
+    }
+    finishTaskPlan("failed", "Generated scenario run failed before completion.");
+    throw error;
   }
-
-  opts.controller.throwIfStopRequested({
-    completedGenerations,
-    ...(completedGenerations === 0 ? {} : { bestScore: bestScoreOverall }),
-  });
-  opts.events.emit("run_completed", {
-    run_id: opts.runId,
-    completed_generations: completedGenerations,
-    best_score: bestScoreOverall,
-    elo: 1000,
-    session_report_path: null,
-    dead_ends_found: 0,
-    family: opts.family,
-    generated_custom: true,
-  });
 }
 
 function emitHook(
@@ -562,4 +730,16 @@ function emitHook(
   }
   const event = hookBus.emit(name, payload);
   event.raiseIfBlocked();
+}
+
+function emitResolvedTerminalHook(
+  hookBus: HookBus | null,
+  name: HookEvents,
+  payload: Record<string, unknown>,
+): void {
+  try {
+    emitHook(hookBus, name, payload);
+  } catch {
+    // A hook cannot reclassify an already-resolved failed or stopped run.
+  }
 }

--- a/ts/src/server/run-transcript-frame.ts
+++ b/ts/src/server/run-transcript-frame.ts
@@ -1,6 +1,14 @@
 import type { ServerMessage } from "./protocol.js";
+import {
+  AGENT_TASK_PLAN_EVENT_NAME,
+  isAgentTaskPlanPayloadRetainable,
+  sanitizeAgentTaskPlanPayload,
+} from "../loop/agent-task-plan.js";
+import {
+  REDACTED_PRESENTATION_VALUE,
+  redactPresentationText,
+} from "../security/presentation-redaction.js";
 
-const REDACTED_VALUE = "[Redacted]";
 const TRUNCATED_VALUE = "[Truncated]";
 const MAX_TEXT_LENGTH = 4_000;
 const MAX_ARRAY_ITEMS = 16;
@@ -34,28 +42,6 @@ const SAFE_TOKEN_METRIC_KEYS = new Set([
   "tokens",
   "totaltokens",
 ]);
-
-const AUTHORIZATION_PATTERN =
-  /\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer\s+)?[^\s,;]+/gi;
-const CREDENTIAL_ASSIGNMENT_PATTERN =
-  /\b(?:api[_-]?key|access[_-]?key|client[_-]?secret|refresh[_-]?token|session[_-]?(?:key|token)|token|secret|password|passphrase|cookie|credential)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
-const QUERY_CREDENTIAL_PATTERN =
-  /([?&](?:api[_-]?key|access[_-]?key|client[_-]?secret|refresh[_-]?token|session[_-]?(?:key|token)|token|secret|password|passphrase|signature)=)[^&#\s]+/gi;
-const URL_USERINFO_PATTERN = /(https?:\/\/)[^/@\s]+@/gi;
-const BARE_BEARER_PATTERN =
-  /\bbearer\s+[A-Za-z0-9._~+/-]{12,}={0,2}(?=\s|$|[,;])/gi;
-const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
-const PRIVATE_KEY_PATTERN =
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g;
-const DASHED_PROVIDER_TOKEN_PATTERN = /\b(?:sk|pk)-[A-Za-z0-9_-]{8,}\b/g;
-const UNDERSCORED_PROVIDER_TOKEN_PATTERN = /\b(?:gsk|sk|pk)_[A-Za-z0-9_-]{8,}\b/g;
-const GOOGLE_API_KEY_PATTERN = /\bAIza[0-9A-Za-z_-]{20,}\b/g;
-const AWS_ACCESS_KEY_PATTERN =
-  /\b(?:A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA)[A-Z0-9]{16}\b/g;
-const GITHUB_TOKEN_PATTERN = /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b/g;
-const GITHUB_PAT_PATTERN = /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g;
-const GITLAB_TOKEN_PATTERN = /\bglpat-[A-Za-z0-9_-]{12,}\b/g;
-const SLACK_TOKEN_PATTERN = /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g;
 
 const EVENT_PAYLOAD_FIELDS: Readonly<Record<string, readonly string[]>> = {
   action_detail: [
@@ -130,28 +116,23 @@ type PresentationValue =
   string | number | boolean | null | PresentationValue[] | { [key: string]: PresentationValue };
 
 export function sanitizeRunTranscriptText(value: string): string {
-  const sanitized = value
-    .replace(AUTHORIZATION_PATTERN, REDACTED_VALUE)
-    .replace(CREDENTIAL_ASSIGNMENT_PATTERN, REDACTED_VALUE)
-    .replace(QUERY_CREDENTIAL_PATTERN, `$1${REDACTED_VALUE}`)
-    .replace(URL_USERINFO_PATTERN, "$1[Redacted]@")
-    .replace(BARE_BEARER_PATTERN, REDACTED_VALUE)
-    .replace(JWT_PATTERN, REDACTED_VALUE)
-    .replace(PRIVATE_KEY_PATTERN, REDACTED_VALUE)
-    .replace(DASHED_PROVIDER_TOKEN_PATTERN, REDACTED_VALUE)
-    .replace(UNDERSCORED_PROVIDER_TOKEN_PATTERN, REDACTED_VALUE)
-    .replace(GOOGLE_API_KEY_PATTERN, REDACTED_VALUE)
-    .replace(AWS_ACCESS_KEY_PATTERN, REDACTED_VALUE)
-    .replace(GITHUB_TOKEN_PATTERN, REDACTED_VALUE)
-    .replace(GITHUB_PAT_PATTERN, REDACTED_VALUE)
-    .replace(GITLAB_TOKEN_PATTERN, REDACTED_VALUE)
-    .replace(SLACK_TOKEN_PATTERN, REDACTED_VALUE);
+  const sanitized = redactPresentationText(value);
   return sanitized.length <= MAX_TEXT_LENGTH
     ? sanitized
     : `${sanitized.slice(0, MAX_TEXT_LENGTH)}…`;
 }
 
 export function sanitizeRunTranscriptMessage(message: ServerMessage): ServerMessage | null {
+  if (message.type === "event" && message.event === AGENT_TASK_PLAN_EVENT_NAME) {
+    const payload = sanitizeAgentTaskPlanPayload(message.payload);
+    if (!payload || !isAgentTaskPlanPayloadRetainable(payload)) return null;
+    const safe: ServerMessage = {
+      type: "event",
+      event: AGENT_TASK_PLAN_EVENT_NAME,
+      payload,
+    };
+    return safe;
+  }
   const safe = sanitizeRunTranscriptMessageInternal(message);
   if (!safe) return null;
   if (Buffer.byteLength(JSON.stringify(safe), "utf-8") <= MAX_RETAINED_MESSAGE_BYTES) {
@@ -276,7 +257,7 @@ function sanitizePayload(
   const result: Record<string, PresentationValue> = Object.create(null);
   for (const [key, value] of Object.entries(payload)) {
     if (!allowed.has(key)) continue;
-    result[key] = isSensitiveKey(key) ? REDACTED_VALUE : sanitizeValue(value, 0);
+    result[key] = isSensitiveKey(key) ? REDACTED_PRESENTATION_VALUE : sanitizeValue(value, 0);
   }
   return result;
 }
@@ -299,7 +280,8 @@ function sanitizeValue(value: unknown, depth: number): PresentationValue {
   for (const [key, entry] of entries.slice(0, MAX_OBJECT_KEYS)) {
     const sanitizedKey = sanitizeRunTranscriptText(key);
     if (isSensitiveKey(key) || sanitizedKey !== key) {
-      result[sanitizedKey === key ? key : REDACTED_VALUE] = REDACTED_VALUE;
+      result[sanitizedKey === key ? key : REDACTED_PRESENTATION_VALUE] =
+        REDACTED_PRESENTATION_VALUE;
       continue;
     }
     result[key] = sanitizeValue(entry, depth + 1);

--- a/ts/src/server/run-transcript-store.ts
+++ b/ts/src/server/run-transcript-store.ts
@@ -16,6 +16,7 @@ import { dirname } from "node:path";
 import { z } from "zod";
 
 import {
+  AGENT_TASK_PLAN_EVENT_NAME,
   ServerMessageSchema,
   TRANSCRIPT_PROTOCOL_VERSION,
   type ClientMessage,
@@ -151,6 +152,13 @@ export class RunTranscriptStore {
 
     const existingRunId = this.#runIdByClientRunId.get(opts.clientRunId);
     const runId = opts.runId ?? existingRunId ?? readRunId(safeMessage);
+    if (
+      safeMessage.type === "event" &&
+      safeMessage.event === AGENT_TASK_PLAN_EVENT_NAME &&
+      safeMessage.payload.run_id !== runId
+    ) {
+      return null;
+    }
     this.#assertScopeAvailable(opts.clientRunId, runId);
 
     const sequence = (this.latestSequence(opts.clientRunId) ?? 0) + 1;

--- a/ts/tests/agent-task-plan.test.ts
+++ b/ts/tests/agent-task-plan.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_TASK_PLAN_EVENT_NAME,
+  AgentTaskPlanPayloadSchema,
+  createAgentTaskPlanPublisher,
+  type AgentTaskPlanPayload,
+} from "../src/loop/agent-task-plan.js";
+import {
+  sanitizeRunTranscriptMessage,
+  sanitizeRunTranscriptText,
+} from "../src/server/run-transcript-frame.js";
+
+const CREDENTIAL_SHAPED_IDS = [
+  "AKIAABCDEFGHIJKLMNOP",
+  "AIzaabcdefghijklmnopqrstuvwxyz123456",
+  "gho_abcdefghijklmnopqrstuvwxyz123456",
+  "glpat-abcdefghijklmnopqrstuvwxyz",
+  "lin_api_abcdefghijklmnopqrstuvwxyz123456",
+  "npm_abcdefghijklmnopqrstuvwxyz123456",
+  "pk-abcdefghijklmnopqrstuvwxyz",
+  "pypi-AgEIabcdefghijklmnopqrstuvwxyz123456",
+  "SG.abcdefghijklmnopqrstuvwxyz123456",
+] as const;
+
+function validPayload(): AgentTaskPlanPayload {
+  return {
+    run_id: "run-1",
+    plan_id: "plan-1",
+    version: 1,
+    plan_revision: 1,
+    update_kind: "initial",
+    active_step_id: "inspect",
+    summary: "Starting",
+    steps: [
+      { id: "inspect", label: "Inspect", status: "in_progress" },
+      { id: "change", label: "Change", status: "pending" },
+    ],
+  };
+}
+
+describe("agent task plan protocol", () => {
+  it("enforces strict identity, step, active-step, and aggregate invariants", () => {
+    expect(AgentTaskPlanPayloadSchema.safeParse(validPayload()).success).toBe(true);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        unexpected: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        plan_id: "ghp_abcdefghijklmnopqrstuvwxyz123456",
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        plan_id: "plan-dp_abcdefghijklmnopqrstuvwxyz",
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        steps: [
+          ...validPayload().steps,
+          { id: "inspect", label: "Duplicate", status: "pending" },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        active_step_id: "change",
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        summary: "x".repeat(241),
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        summary: "   ",
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        steps: [{ id: "inspect", label: "Inspect", detail: " ", status: "in_progress" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        steps: Array.from({ length: 50 }, (_, index) => ({
+          id: `step-${index}`,
+          label: "x".repeat(160),
+          detail: "x".repeat(400),
+          status: "pending" as const,
+        })),
+        active_step_id: null,
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each(CREDENTIAL_SHAPED_IDS)("rejects and redacts credential-shaped ID %s", (id) => {
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        plan_id: id,
+      }).success,
+    ).toBe(false);
+    expect(sanitizeRunTranscriptText(`credential ${id}`)).not.toContain(id);
+  });
+
+  it("publishes monotonic full snapshots, increments replan revision, and keeps completion sticky", () => {
+    const emissions: Array<{ event: string; payload: AgentTaskPlanPayload }> = [];
+    const publisher = createAgentTaskPlanPublisher({
+      runId: "run-1",
+      planId: "plan-1",
+      steps: [
+        { id: "inspect", label: "Inspect" },
+        { id: "change", label: "Change" },
+        { id: "verify", label: "Verify" },
+      ],
+      events: {
+        emit(event, payload) {
+          emissions.push({ event, payload: AgentTaskPlanPayloadSchema.parse(payload) });
+        },
+      },
+    });
+
+    expect(publisher).not.toBeNull();
+    expect(publisher?.initial({ activeStepId: "inspect", summary: "Starting" })).toBe(true);
+    expect(
+      publisher?.progress({
+        activeStepId: "change",
+        completedStepIds: ["inspect"],
+        summary: "Implementing",
+      }),
+    ).toBe(true);
+    expect(
+      publisher?.replan({
+        activeStepId: "verify",
+        completedStepIds: ["inspect"],
+        skippedStepIds: ["change"],
+        summary: "Verification is now the best next step",
+        stepDetails: { verify: { detail: "Run focused tests" } },
+      }),
+    ).toBe(true);
+    expect(
+      publisher?.progress({
+        activeStepId: "verify",
+        summary: "Still verifying",
+      }),
+    ).toBe(true);
+
+    expect(emissions.map(({ event }) => event)).toEqual([
+      AGENT_TASK_PLAN_EVENT_NAME,
+      AGENT_TASK_PLAN_EVENT_NAME,
+      AGENT_TASK_PLAN_EVENT_NAME,
+      AGENT_TASK_PLAN_EVENT_NAME,
+    ]);
+    expect(emissions.map(({ payload }) => payload.version)).toEqual([1, 2, 3, 4]);
+    expect(emissions.map(({ payload }) => payload.plan_revision)).toEqual([1, 1, 2, 2]);
+    expect(emissions.map(({ payload }) => payload.update_kind)).toEqual([
+      "initial",
+      "progress",
+      "replan",
+      "progress",
+    ]);
+    expect(emissions.at(-1)?.payload.steps).toEqual([
+      { id: "inspect", label: "Inspect", status: "completed" },
+      { id: "change", label: "Change", status: "skipped" },
+      {
+        id: "verify",
+        label: "Verify",
+        detail: "Run focused tests",
+        status: "in_progress",
+      },
+    ]);
+    for (const emission of emissions) {
+      expect(
+        sanitizeRunTranscriptMessage({
+          type: "event",
+          event: emission.event,
+          payload: emission.payload,
+        }),
+      ).not.toBeNull();
+    }
+  });
+
+  it.each(["completed", "failed", "interrupted"] as const)(
+    "emits a terminal %s snapshot with no active step",
+    (status) => {
+      const emissions: AgentTaskPlanPayload[] = [];
+      const publisher = createAgentTaskPlanPublisher({
+        runId: "run-terminal",
+        steps: [
+          { id: "first", label: "First" },
+          { id: "second", label: "Second" },
+        ],
+        events: {
+          emit(_event, payload) {
+            emissions.push(AgentTaskPlanPayloadSchema.parse(payload));
+          },
+        },
+      });
+      publisher?.initial({ activeStepId: "first" });
+      expect(publisher?.terminal(status)).toBe(true);
+      const terminal = emissions.at(-1);
+      expect(terminal?.active_step_id).toBeNull();
+      expect(terminal?.steps.map((step) => step.status)).toEqual(
+        status === "completed" ? ["completed", "completed"] : [status, "skipped"],
+      );
+      expect(publisher?.terminal(status)).toBe(false);
+    },
+  );
+
+  it("redacts plan copy before the raw event emitter sees it", () => {
+    const rawPayloads: Record<string, unknown>[] = [];
+    const publisher = createAgentTaskPlanPublisher({
+      runId: "run-redaction",
+      steps: [
+        {
+          id: "inspect",
+          label: "  Inspect token=super-secret-value  ",
+          detail: "Authorization: Bearer another-secret-value",
+        },
+      ],
+      events: {
+        emit(_event, payload) {
+          rawPayloads.push(payload);
+        },
+      },
+    });
+    expect(
+      publisher?.initial({
+        activeStepId: "inspect",
+        summary: "Using ghp_abcdefghijklmnopqrstuvwxyz123456",
+      }),
+    ).toBe(true);
+    const wire = JSON.stringify(rawPayloads);
+    expect(wire).toContain("[Redacted]");
+    expect(wire).not.toContain("super-secret-value");
+    expect(wire).not.toContain("another-secret-value");
+    expect(wire).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz123456");
+    expect((rawPayloads.at(0)?.steps as Array<{ label: string }>).at(0)?.label).toBe(
+      "Inspect [Redacted]",
+    );
+  });
+
+  it("rejects empty copy and credential-shaped IDs before publishing", () => {
+    expect(
+      createAgentTaskPlanPublisher({
+        runId: "run-dp_abcdefghijklmnopqrstuvwxyz",
+        steps: [{ id: "inspect", label: "Inspect" }],
+        events: { emit() {} },
+      }),
+    ).toBeNull();
+    expect(
+      createAgentTaskPlanPublisher({
+        runId: "run-valid",
+        steps: [{ id: "inspect", label: "   " }],
+        events: { emit() {} },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a complete oversized snapshot atomically", () => {
+    const rawPayloads: Record<string, unknown>[] = [];
+    const publisher = createAgentTaskPlanPublisher({
+      runId: "run-oversized",
+      steps: Array.from({ length: 20 }, (_, index) => ({
+        id: `step-${index}`,
+        label: `Step ${index}`,
+        detail: "x".repeat(600),
+      })),
+      events: { emit: (_event, payload) => rawPayloads.push(payload) },
+    });
+    expect(publisher).not.toBeNull();
+    expect(
+      AgentTaskPlanPayloadSchema.safeParse({
+        ...validPayload(),
+        active_step_id: "step-0",
+        steps: Array.from({ length: 20 }, (_, index) => ({
+          id: `step-${index}`,
+          label: `Step ${index}`,
+          detail: "x".repeat(600),
+          status: index === 0 ? "in_progress" : "pending",
+        })),
+      }).success,
+    ).toBe(true);
+    expect(publisher?.initial({ activeStepId: "step-0" })).toBe(false);
+    expect(rawPayloads).toEqual([]);
+  });
+});

--- a/ts/tests/agent-task-solve-execution.test.ts
+++ b/ts/tests/agent-task-solve-execution.test.ts
@@ -31,6 +31,11 @@ describe("agent-task solve execution", () => {
   });
 
   it("executes the agent-task solve workflow and builds the exported package", async () => {
+    const progressEvents: Array<{
+      phase: string;
+      status: string;
+      round?: number;
+    }> = [];
     const provider: LLMProvider = {
       name: "test-provider",
       defaultModel: () => "test-model",
@@ -106,12 +111,21 @@ describe("agent-task solve execution", () => {
       },
       generations: 2,
       generationTimeBudgetSeconds: 11,
+      onProgress: (progress) => {
+        progressEvents.push(progress);
+      },
       deps: {
         createTask: () => task,
         createLoop: (opts) => {
           expect(opts.timeBudget).toBeDefined();
           return {
-            run: vi.fn(async () => loopResult),
+            run: vi.fn(async () => {
+              opts.onProgress?.({ phase: "evaluation", status: "started", round: 1 });
+              opts.onProgress?.({ phase: "evaluation", status: "completed", round: 1 });
+              opts.onProgress?.({ phase: "revision", status: "started", round: 1 });
+              opts.onProgress?.({ phase: "revision", status: "completed", round: 1 });
+              return loopResult;
+            }),
           };
         },
       },
@@ -122,6 +136,66 @@ describe("agent-task solve execution", () => {
     expect(result.result.scenario_name).toBe("incident_triage");
     expect(result.result.best_score).toBe(0.93);
     expect(result.result.skill_markdown).toContain("Best round: 1");
+    expect(progressEvents).toEqual([
+      { phase: "context_preparation", status: "started" },
+      { phase: "context_preparation", status: "completed" },
+      { phase: "draft", status: "started" },
+      { phase: "draft", status: "completed" },
+      { phase: "evaluation", status: "started", round: 1 },
+      { phase: "evaluation", status: "completed", round: 1 },
+      { phase: "revision", status: "started", round: 1 },
+      { phase: "revision", status: "completed", round: 1 },
+      { phase: "finalization", status: "started" },
+      { phase: "finalization", status: "completed" },
+    ]);
+  });
+
+  it("keeps progress observer failures from changing solve results", async () => {
+    const provider: LLMProvider = {
+      name: "test-provider",
+      defaultModel: () => "test-model",
+      complete: vi.fn(async () => ({
+        text: "Initial response",
+        model: "test-model",
+        usage: {},
+      })),
+    };
+    const task: AgentTaskInterface & {
+      name: string;
+      spec: ReturnType<typeof buildAgentTaskSolveSpec>;
+    } = {
+      name: "observer_safety",
+      spec: buildAgentTaskSolveSpec({
+        taskPrompt: "Do work",
+        judgeRubric: "Evaluate work",
+      }, 1),
+      getTaskPrompt: () => "Do work",
+      getRubric: () => "Evaluate work",
+      describeTask: () => "Do work",
+      initialState: () => ({}),
+      validateContext: () => [],
+      evaluateOutput: async () => ({
+        score: 1,
+        reasoning: "complete",
+        dimensionScores: {},
+      }),
+    };
+
+    const result = await executeAgentTaskSolve({
+      provider,
+      created: {
+        name: "observer_safety",
+        spec: { taskPrompt: "Do work", judgeRubric: "Evaluate work" },
+      },
+      generations: 1,
+      onProgress: async () => {
+        throw new Error("telemetry unavailable");
+      },
+      deps: { createTask: () => task },
+    });
+
+    expect(result.progress).toBe(1);
+    expect(result.result.best_score).toBe(1);
   });
 
   it("lets the requested generation count override saved maxRounds", async () => {

--- a/ts/tests/generation-runner-task-plan.test.ts
+++ b/ts/tests/generation-runner-task-plan.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { LoopController } from "../src/loop/controller.js";
+import { EventStreamEmitter } from "../src/loop/events.js";
+import { GenerationRunner } from "../src/loop/generation-runner.js";
+import { HookBus, HookEvents, HookResult } from "../src/extensions/index.js";
+import { DeterministicProvider } from "../src/providers/deterministic.js";
+import { GridCtfScenario } from "../src/scenarios/grid-ctf.js";
+import { SQLiteStore } from "../src/storage/index.js";
+
+const TEST_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+
+describe("GenerationRunner task plans", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "autoctx-task-plan-runner-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("publishes an ordered replan on rollback before completing the run", async () => {
+    const store = createStore(root, "rollback.db");
+    const events = new EventStreamEmitter(join(root, "rollback-events.ndjson"));
+    const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    events.subscribe((event, payload) => {
+      emitted.push({ event, payload });
+    });
+    const runner = new GenerationRunner({
+      provider: new DeterministicProvider(),
+      scenario: new GridCtfScenario(),
+      store,
+      runsRoot: join(root, "runs"),
+      knowledgeRoot: join(root, "knowledge"),
+      matchesPerGeneration: 1,
+      maxRetries: 0,
+      minDelta: 2,
+      events,
+    });
+
+    try {
+      await runner.run("built_in_plan", 1);
+    } finally {
+      store.close();
+    }
+
+    const planEvents = emitted.filter((entry) => entry.event === "task_plan_updated");
+    expect(emitted.at(0)?.event).toBe("run_started");
+    expect(planEvents.at(0)?.payload).toMatchObject({
+      update_kind: "initial",
+      plan_revision: 1,
+      active_step_id: "prepare_run",
+    });
+    expect(planEvents.find((entry) => entry.payload.update_kind === "replan")?.payload)
+      .toMatchObject({
+        plan_revision: 2,
+        active_step_id: "iterate_strategies",
+        summary: "Adjusting the strategy approach after a recovery signal.",
+      });
+    expect(planEvents.at(-1)?.payload).toMatchObject({
+      plan_revision: 2,
+      active_step_id: null,
+    });
+    expect(planEvents.at(-1)?.payload.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "finalize_run", status: "completed" }),
+      ]),
+    );
+    expect(emitted.findLastIndex((entry) => entry.event === "task_plan_updated"))
+      .toBeLessThan(emitted.findIndex((entry) => entry.event === "run_completed"));
+  });
+
+  it("publishes an interrupted terminal plan before propagating a stop", async () => {
+    const store = createStore(root, "stopped.db");
+    const events = new EventStreamEmitter(join(root, "stopped-events.ndjson"));
+    const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    events.subscribe((event, payload) => {
+      emitted.push({ event, payload });
+    });
+    const controller = new LoopController();
+    controller.requestStop("built_in_stop", "stop-command");
+    const hookBus = new HookBus();
+    hookBus.on(
+      HookEvents.RUN_END,
+      () => new HookResult({
+        block: true,
+        reason: "terminal hook cannot replace the resolved stop",
+      }),
+    );
+    const runner = new GenerationRunner({
+      provider: new DeterministicProvider(),
+      scenario: new GridCtfScenario(),
+      store,
+      runsRoot: join(root, "runs"),
+      knowledgeRoot: join(root, "knowledge"),
+      controller,
+      events,
+      hookBus,
+    });
+
+    try {
+      await expect(runner.run("built_in_stop", 1)).rejects.toMatchObject({
+        name: "RunStopRequestedError",
+        runId: "built_in_stop",
+        commandId: "stop-command",
+      });
+    } finally {
+      store.close();
+    }
+
+    const terminalPlan = emitted
+      .filter((entry) => entry.event === "task_plan_updated")
+      .at(-1)?.payload;
+    expect(terminalPlan?.active_step_id).toBeNull();
+    expect(terminalPlan?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "prepare_run", status: "interrupted" }),
+      ]),
+    );
+    expect(emitted.some((entry) => entry.event === "run_completed")).toBe(false);
+    expect(emitted.some((entry) => entry.event === "run_failed")).toBe(false);
+  });
+
+  it("turns a blocked completion hook into one failed terminal outcome", async () => {
+    const store = createStore(root, "blocked-completion.db");
+    const events = new EventStreamEmitter(join(root, "blocked-completion-events.ndjson"));
+    const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    events.subscribe((event, payload) => {
+      emitted.push({ event, payload });
+    });
+    const hookBus = new HookBus();
+    hookBus.on(HookEvents.RUN_END, (event) =>
+      event.payload.status === "completed"
+        ? new HookResult({ block: true, reason: "completion policy rejected" })
+        : undefined,
+    );
+    const runner = new GenerationRunner({
+      provider: new DeterministicProvider(),
+      scenario: new GridCtfScenario(),
+      store,
+      runsRoot: join(root, "runs"),
+      knowledgeRoot: join(root, "knowledge"),
+      matchesPerGeneration: 1,
+      maxRetries: 0,
+      minDelta: 0,
+      events,
+      hookBus,
+    });
+
+    try {
+      await expect(runner.run("blocked_completion", 1)).rejects.toThrow(
+        "extension hook blocked run_end: completion policy rejected",
+      );
+    } finally {
+      store.close();
+    }
+
+    const terminalPlan = emitted
+      .filter((entry) => entry.event === "task_plan_updated")
+      .at(-1)?.payload;
+    expect(terminalPlan?.active_step_id).toBeNull();
+    expect(terminalPlan?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "finalize_run", status: "failed" }),
+      ]),
+    );
+    expect(emitted.some((entry) => entry.event === "run_completed")).toBe(false);
+    expect(emitted.filter((entry) => entry.event === "run_failed")).toHaveLength(1);
+    expect(emitted.findLastIndex((entry) => entry.event === "task_plan_updated"))
+      .toBeLessThan(emitted.findIndex((entry) => entry.event === "run_failed"));
+  });
+});
+
+function createStore(root: string, name: string): SQLiteStore {
+  const store = new SQLiteStore(join(root, name));
+  store.migrate(join(TEST_DIRECTORY, "..", "migrations"));
+  return store;
+}

--- a/ts/tests/improvement-loop.test.ts
+++ b/ts/tests/improvement-loop.test.ts
@@ -83,6 +83,52 @@ describe("ImprovementLoop", () => {
     expect(result.terminationReason).toBe("threshold_met");
   });
 
+  it("reports evaluation and revision boundaries without judge feedback", async () => {
+    const progress: Array<Record<string, unknown>> = [];
+    const task = makeFakeTask([
+      { score: 0.5, reasoning: "private judge feedback", dimensionScores: {} },
+      { score: 0.95, reasoning: "also private", dimensionScores: {} },
+    ]);
+    const loop = new ImprovementLoop({
+      task,
+      maxRounds: 2,
+      qualityThreshold: 0.9,
+      onProgress: (event) => {
+        progress.push(event);
+      },
+    });
+
+    await loop.run({ initialOutput: "test", state: {} });
+
+    expect(progress).toEqual([
+      { phase: "evaluation", status: "started", round: 1 },
+      { phase: "evaluation", status: "completed", round: 1 },
+      { phase: "revision", status: "started", round: 1 },
+      { phase: "revision", status: "completed", round: 1 },
+      { phase: "evaluation", status: "started", round: 2 },
+      { phase: "evaluation", status: "completed", round: 2 },
+    ]);
+    expect(JSON.stringify(progress)).not.toContain("private judge feedback");
+  });
+
+  it("keeps rejected async progress observers from changing loop results", async () => {
+    const loop = new ImprovementLoop({
+      task: makeFakeTask([
+        { score: 0.95, reasoning: "complete", dimensionScores: {} },
+      ]),
+      maxRounds: 1,
+      qualityThreshold: 0.9,
+      onProgress: async () => {
+        throw new Error("async telemetry unavailable");
+      },
+    });
+
+    const result = await loop.run({ initialOutput: "test", state: {} });
+
+    expect(result.bestScore).toBe(0.95);
+    expect(result.terminationReason).toBe("threshold_met");
+  });
+
   it("stops when output unchanged", async () => {
     const task = makeFakeTask(
       [{ score: 0.5, reasoning: "ok", dimensionScores: {} }],

--- a/ts/tests/run-start-workflow.test.ts
+++ b/ts/tests/run-start-workflow.test.ts
@@ -9,6 +9,7 @@ import type { CustomScenarioEntry } from "../src/scenarios/custom-loader.js";
 import type { ScenarioFamilyName } from "../src/scenarios/families.js";
 import type { RoleProviderBundle } from "../src/providers/index.js";
 import { HookBus } from "../src/extensions/index.js";
+import type { AgentTaskSolveProgress } from "../src/knowledge/agent-task-solve-execution.js";
 import {
   executeAgentTaskCustomStartRun,
   executeBuiltInGameStartRun,
@@ -226,6 +227,21 @@ describe("run start workflow", () => {
     expect(emitted[0]?.event).toBe("run_started");
     expect(emitted.filter((entry) => entry.event === "generation_started")).toHaveLength(2);
     expect(emitted.filter((entry) => entry.event === "generation_completed")).toHaveLength(2);
+    const generatedPlanEvents = emitted.filter(
+      (entry) => entry.event === "task_plan_updated",
+    );
+    expect(generatedPlanEvents.at(0)?.payload.update_kind).toBe("initial");
+    expect(generatedPlanEvents.at(-1)?.payload.active_step_id).toBeNull();
+    expect(generatedPlanEvents.at(-1)?.payload.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "execute_scenario", status: "completed" }),
+        expect.objectContaining({ id: "finalize_run", status: "completed" }),
+      ]),
+    );
+    expect(emitted.findIndex((entry) => entry.event === "task_plan_updated"))
+      .toBeGreaterThan(emitted.findIndex((entry) => entry.event === "run_started"));
+    expect(emitted.findLastIndex((entry) => entry.event === "task_plan_updated"))
+      .toBeLessThan(emitted.findIndex((entry) => entry.event === "run_completed"));
     const completed = emitted.find((entry) => entry.event === "run_completed");
     expect(completed?.payload.best_score).toBe(0.9);
     expect(completed?.payload.completed_generations).toBe(2);
@@ -292,6 +308,15 @@ describe("run start workflow", () => {
     ]);
     expect(emitted.some((entry) => entry.event === "run_completed")).toBe(false);
     expect(emitted.some((entry) => entry.event === "run_failed")).toBe(false);
+    const interruptedPlan = emitted
+      .filter((entry) => entry.event === "task_plan_updated")
+      .at(-1)?.payload;
+    expect(interruptedPlan?.active_step_id).toBeNull();
+    expect(interruptedPlan?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "execute_scenario", status: "interrupted" }),
+      ]),
+    );
   });
 
   it("executes saved agent-task runs and emits lifecycle events", async () => {
@@ -332,6 +357,7 @@ describe("run start workflow", () => {
       },
       generations: 2,
       hookBus: expect.any(HookBus),
+      onProgress: expect.any(Function),
     });
     expect(emitted[0]?.event).toBe("run_started");
     expect(emitted.filter((entry) => entry.event === "generation_started")).toEqual([
@@ -346,6 +372,145 @@ describe("run start workflow", () => {
     expect(completed?.payload.elo).toBe(1000);
     expect(completed?.payload.session_report_path).toBeNull();
     expect(completed?.payload.dead_ends_found).toBe(0);
+    const savedTaskPlan = emitted
+      .filter((entry) => entry.event === "task_plan_updated")
+      .at(-1)?.payload;
+    expect(savedTaskPlan?.active_step_id).toBeNull();
+    expect(savedTaskPlan?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "finalize_result", status: "completed" }),
+      ]),
+    );
+  });
+
+  it("publishes saved task evaluation and revision progress as a semantic replan", async () => {
+    const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+
+    await executeAgentTaskCustomStartRun({
+      runId: "run_task_plan",
+      scenarioName: "saved_task",
+      entry: {
+        name: "saved_task",
+        type: "agent_task",
+        spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+        path: "/tmp/saved_task",
+        hasGeneratedSource: false,
+      },
+      generations: 2,
+      provider: { name: "test", defaultModel: () => "test", complete: vi.fn() },
+      controller: new LoopController(),
+      events: {
+        emit: (event: string, payload: Record<string, unknown>) => {
+          emitted.push({ event, payload });
+        },
+      } as never,
+      deps: {
+        executeAgentTaskSolve: vi.fn(async (solveOpts: {
+          onProgress?: (progress: AgentTaskSolveProgress) => void;
+        }) => {
+          solveOpts.onProgress?.({ phase: "context_preparation", status: "completed" });
+          solveOpts.onProgress?.({ phase: "draft", status: "completed" });
+          solveOpts.onProgress?.({ phase: "evaluation", status: "started", round: 1 });
+          solveOpts.onProgress?.({ phase: "revision", status: "started", round: 1 });
+          solveOpts.onProgress?.({ phase: "revision", status: "completed", round: 1 });
+          solveOpts.onProgress?.({ phase: "finalization", status: "started" });
+          return {
+            progress: 1,
+            result: { best_score: 0.9, scenario_name: "saved_task" },
+          };
+        }) as never,
+      },
+    });
+
+    const planEvents = emitted.filter((entry) => entry.event === "task_plan_updated");
+    expect(planEvents.at(0)?.payload).toMatchObject({
+      update_kind: "initial",
+      plan_revision: 1,
+      active_step_id: "prepare_context",
+    });
+    expect(planEvents.find((entry) => entry.payload.update_kind === "replan")?.payload)
+      .toMatchObject({
+        plan_revision: 2,
+        active_step_id: "improve_response",
+        summary: "Refining the response after evaluation round 1.",
+      });
+    expect(planEvents.at(-1)?.payload).toMatchObject({
+      update_kind: "progress",
+      plan_revision: 2,
+      active_step_id: null,
+    });
+    expect(emitted.findLastIndex((entry) => entry.event === "task_plan_updated"))
+      .toBeLessThan(emitted.findIndex((entry) => entry.event === "run_completed"));
+  });
+
+  it("turns a blocked saved-task completion hook into a failed terminal plan", async () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-agent-task-plan-hook-"));
+    const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    try {
+      const extensionPath = join(root, "block-completion.mjs");
+      writeFileSync(
+        extensionPath,
+        `
+          export function register(api) {
+            api.on("run_end", (event) => {
+              if (event.payload.status === "completed") {
+                throw new Error("completion policy rejected");
+              }
+            });
+          }
+        `,
+        "utf-8",
+      );
+
+      await expect(executeAgentTaskCustomStartRun({
+        runId: "blocked-completion-run",
+        scenarioName: "saved_task",
+        entry: {
+          name: "saved_task",
+          type: "agent_task",
+          spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+          path: "/tmp/saved_task",
+          hasGeneratedSource: false,
+        },
+        generations: 1,
+        provider: { name: "test", defaultModel: () => "test", complete: vi.fn() },
+        settings: {
+          ...makeSettings(),
+          extensions: extensionPath,
+          extensionFailFast: true,
+        },
+        controller: new LoopController(),
+        events: {
+          emit: (event: string, payload: Record<string, unknown>) => {
+            emitted.push({ event, payload });
+          },
+        } as never,
+        deps: {
+          executeAgentTaskSolve: vi.fn(async (solveOpts: {
+            onProgress?: (progress: AgentTaskSolveProgress) => void;
+          }) => {
+            solveOpts.onProgress?.({ phase: "finalization", status: "started" });
+            return {
+              progress: 1,
+              result: { best_score: 0.9, scenario_name: "saved_task" },
+            };
+          }) as never,
+        },
+      })).rejects.toThrow("completion policy rejected");
+
+      const terminalPlan = emitted
+        .filter((entry) => entry.event === "task_plan_updated")
+        .at(-1)?.payload;
+      expect(terminalPlan?.active_step_id).toBeNull();
+      expect(terminalPlan?.steps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "finalize_result", status: "failed" }),
+        ]),
+      );
+      expect(emitted.some((entry) => entry.event === "run_completed")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("retains completed agent-task rounds when stop races natural completion", async () => {
@@ -390,6 +555,14 @@ describe("run start workflow", () => {
     expect(emitted.filter((entry) => entry.event === "generation_completed")).toHaveLength(2);
     expect(emitted.some((entry) => entry.event === "run_completed")).toBe(false);
     expect(emitted.some((entry) => entry.event === "run_failed")).toBe(false);
+    const interruptedPlan = emitted
+      .filter((entry) => entry.event === "task_plan_updated")
+      .at(-1)?.payload;
+    expect(interruptedPlan?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "interrupted" }),
+      ]),
+    );
   });
 
   it("prefers an agent-task stop request over a concurrent provider failure", async () => {
@@ -568,6 +741,17 @@ describe("run start workflow", () => {
                 status: event.payload.status ?? "",
                 generation: event.payload.generation ?? 0
               });
+            });
+            api.on("run_end", (event) => {
+              if (event.payload.status === "stopped") {
+                globalThis.__autoctxLifecycleEvents.push({
+                  name: event.name,
+                  status: event.payload.status,
+                  generation: event.payload.generation ?? 0
+                });
+                event.blocked = true;
+                event.blockReason = "stop policy cannot replace the resolved stop";
+              }
             });
           }
         `,

--- a/ts/tests/run-transcript-store.test.ts
+++ b/ts/tests/run-transcript-store.test.ts
@@ -55,6 +55,103 @@ afterEach(() => {
 });
 
 describe("RunTranscriptStore", () => {
+  it("retains complete long agent plans exactly across restart and replay", () => {
+    const { path, store } = makeStore();
+    const steps = Array.from({ length: 24 }, (_, index) => ({
+      id: `step-${index}`,
+      label: `Step ${index}`,
+      detail: index === 0 ? "token=super-secret-value" : `Detail ${index}`,
+      status: index === 0 ? ("in_progress" as const) : ("pending" as const),
+    }));
+    const frame = store.record({
+      clientRunId: "client-plan",
+      runId: "engine-plan",
+      occurredAt: "2026-07-21T15:00:00.000Z",
+      message: {
+        type: "event",
+        event: "task_plan_updated",
+        payload: {
+          run_id: "engine-plan",
+          plan_id: "plan-1",
+          version: 1,
+          plan_revision: 1,
+          update_kind: "initial",
+          active_step_id: "step-0",
+          summary: "Starting the full plan",
+          steps,
+        },
+      },
+    });
+
+    expect(frame).not.toBeNull();
+    const payload = frame?.message.type === "event" ? frame.message.payload : {};
+    expect(payload.steps).toHaveLength(24);
+    expect(JSON.stringify(payload)).not.toContain("super-secret-value");
+    expect(JSON.stringify(payload)).toContain("[Redacted]");
+
+    const reloaded = new RunTranscriptStore(path);
+    const replay = reloaded.framesAfter("client-plan", 0);
+    expect(replay).toHaveLength(1);
+    expect(replay.at(0)?.wire).toBe(frame?.wire);
+    expect(replay.at(0)?.message).toEqual(frame?.message);
+  });
+
+  it("drops oversized agent plans atomically instead of retaining a truncated shape", () => {
+    const { path, store } = makeStore();
+    const frame = store.record({
+      clientRunId: "client-oversized-plan",
+      runId: "engine-oversized-plan",
+      message: {
+        type: "event",
+        event: "task_plan_updated",
+        payload: {
+          run_id: "engine-oversized-plan",
+          plan_id: "plan-oversized",
+          version: 1,
+          plan_revision: 1,
+          update_kind: "initial",
+          active_step_id: "step-0",
+          steps: Array.from({ length: 20 }, (_, index) => ({
+            id: `step-${index}`,
+            label: `Step ${index}`,
+            detail: "x".repeat(600),
+            status: index === 0 ? "in_progress" : "pending",
+          })),
+        },
+      },
+    });
+
+    expect(frame).toBeNull();
+    expect(store.framesAfter("client-oversized-plan", 0)).toEqual([]);
+    expect(() => readFileSync(path, "utf-8")).toThrow();
+  });
+
+  it("drops agent plans whose payload run ID differs from the retained scope", () => {
+    const { path, store } = makeStore();
+
+    const frame = store.record({
+      clientRunId: "client-mismatched-plan",
+      runId: "engine-outer",
+      message: {
+        type: "event",
+        event: "task_plan_updated",
+        payload: {
+          run_id: "engine-inner",
+          plan_id: "plan-mismatch",
+          version: 1,
+          plan_revision: 1,
+          update_kind: "initial",
+          active_step_id: "inspect",
+          steps: [{ id: "inspect", label: "Inspect", status: "in_progress" }],
+        },
+      },
+    });
+
+    expect(frame).toBeNull();
+    expect(store.framesAfter("client-mismatched-plan", 0)).toEqual([]);
+    expect(() => readFileSync(path, "utf-8")).toThrow();
+  });
+
   it("assigns stable identity and persists presentation-safe exact wire frames", () => {
     const { path, store } = makeStore();
     store.registerRun("client-run-1", "engine-run-1");

--- a/ts/tests/server-protocol.test.ts
+++ b/ts/tests/server-protocol.test.ts
@@ -215,7 +215,7 @@ describe("Protocol types", () => {
         type: "hello",
         protocol_version: 1,
         transcript_protocol_version: 1,
-        capabilities: ["run_transcript_v1", "safe_run_stop_v1"],
+        capabilities: ["run_transcript_v1", "safe_run_stop_v1", "agent_task_plan_v1"],
       }),
     ).toMatchObject({
       protocol_version: 1,
@@ -920,7 +920,7 @@ describe("InteractiveServer", () => {
       expect(hello).toMatchObject({
         protocol_version: 1,
         transcript_protocol_version: 1,
-        capabilities: ["run_transcript_v1", "safe_run_stop_v1"],
+        capabilities: ["run_transcript_v1", "safe_run_stop_v1", "agent_task_plan_v1"],
       });
       await socket.waitFor((msg) => msg.type === "environments");
       await socket.waitFor((msg) => msg.type === "state");
@@ -936,9 +936,39 @@ describe("InteractiveServer", () => {
       const started = await socket.waitFor(
         (msg) => msg.type === "event" && msg.event === "run_started",
       );
+      const initialPlan = await socket.waitFor(
+        (msg) =>
+          msg.type === "event" &&
+          msg.event === "task_plan_updated" &&
+          (msg.payload as Record<string, unknown>).update_kind === "initial",
+      );
+      const terminalPlan = await socket.waitFor(
+        (msg) =>
+          msg.type === "event" &&
+          msg.event === "task_plan_updated" &&
+          (msg.payload as Record<string, unknown>).active_step_id === null,
+      );
       const completed = await socket.waitFor(
         (msg) => msg.type === "event" && msg.event === "run_completed",
       );
+      expect(initialPlan.payload).toMatchObject({
+        run_id: accepted.run_id,
+        version: 1,
+        plan_revision: 1,
+        update_kind: "initial",
+      });
+      expect(terminalPlan.payload).toMatchObject({
+        run_id: accepted.run_id,
+        active_step_id: null,
+      });
+      expect(Number(started.sequence)).toBeLessThan(Number(initialPlan.sequence));
+      expect(Number(initialPlan.sequence)).toBeLessThan(Number(terminalPlan.sequence));
+      expect(Number(terminalPlan.sequence)).toBeLessThan(Number(completed.sequence));
+      expect(
+        (terminalPlan.payload as { steps: { status: string }[] }).steps.some(
+          (step) => step.status === "in_progress",
+        ),
+      ).toBe(false);
       socket.send({
         type: "stop",
         client_run_id: "client-run-1",
@@ -987,7 +1017,15 @@ describe("InteractiveServer", () => {
         otherScope.waitFor((msg) => msg.client_run_id === "client-run-1", 250),
       ).rejects.toThrow(/Timed out/);
 
-      for (const frame of [accepted, started, completed, monitor, futureCheckpoint]) {
+      for (const frame of [
+        accepted,
+        started,
+        initialPlan,
+        terminalPlan,
+        completed,
+        monitor,
+        futureCheckpoint,
+      ]) {
         expect(frame.client_run_id).toBe("client-run-1");
         expect(frame.run_id).toBe(accepted.run_id);
         expect(frame.event_id).toMatch(/^[0-9a-f-]{36}$/);
@@ -1035,9 +1073,15 @@ describe("InteractiveServer", () => {
       reconnect.send({
         type: "resume_run",
         client_run_id: "client-run-1",
-        after_sequence: Number(completed.sequence),
+        after_sequence: Number(started.sequence),
         command_id: "command-backfill-1",
       });
+      expect(await reconnect.waitFor((msg) => msg.event_id === initialPlan.event_id)).toEqual(
+        initialPlan,
+      );
+      expect(await reconnect.waitFor((msg) => msg.event_id === terminalPlan.event_id)).toEqual(
+        terminalPlan,
+      );
       expect(await reconnect.waitFor((msg) => msg.event_id === chat.event_id)).toEqual(chat);
       expect(await reconnect.waitFor((msg) => msg.event_id === pauseAck.event_id)).toEqual(
         pauseAck,

--- a/ts/tests/websocket-protocol-contract.test.ts
+++ b/ts/tests/websocket-protocol-contract.test.ts
@@ -35,6 +35,42 @@ type EventStreamEnvelopeContract = {
 };
 
 type WebSocketProtocolContract = {
+  agent_task_plan_extension: {
+    advertised_runtimes: ["typescript"];
+    capability: "agent_task_plan_v1";
+    event: "task_plan_updated";
+    requires_transcript_protocol_version: 1;
+    payload: {
+      completed_steps_are_sticky: true;
+      copy_limits: {
+        aggregate_characters: 20000;
+        detail_characters: 2000;
+        empty_or_whitespace_only_values_allowed: false;
+        label_characters: 160;
+        summary_characters: 240;
+      };
+      full_snapshot: true;
+      id: {
+        credential_shaped_values_allowed: false;
+        maximum_characters: 200;
+        pattern: string;
+      };
+      initial_plan_revision: 1;
+      initial_version: 1;
+      progress_revision_rule: "unchanged";
+      replan_revision_rule: "strictly_increases";
+      step_count: { maximum: 50; minimum: 1 };
+      terminal_snapshot_rule: string;
+      update_kinds: ["initial", "progress", "replan"];
+    };
+    python_support: "deferred_until_durable_transcript_metadata_is_available";
+    retention: {
+      full_snapshot_or_drop: true;
+      max_serialized_event_bytes: 12288;
+      redacted_before_persistence: true;
+      restart_replay: true;
+    };
+  };
   event_stream_envelope: EventStreamEnvelopeContract;
   protocol_version: number;
   safe_stop_extension: {
@@ -137,6 +173,45 @@ describe("WebSocket protocol shared contract", () => {
         unexpected: true,
       }),
     ).toThrow();
+  });
+
+  it("keeps agent task plans strict, replayable, and TypeScript-only", () => {
+    expect(CONTRACT.agent_task_plan_extension).toMatchObject({
+      advertised_runtimes: ["typescript"],
+      capability: "agent_task_plan_v1",
+      event: "task_plan_updated",
+      requires_transcript_protocol_version: 1,
+      payload: {
+        completed_steps_are_sticky: true,
+        copy_limits: {
+          aggregate_characters: 20_000,
+          detail_characters: 2_000,
+          empty_or_whitespace_only_values_allowed: false,
+          label_characters: 160,
+          summary_characters: 240,
+        },
+        full_snapshot: true,
+        id: {
+          credential_shaped_values_allowed: false,
+          maximum_characters: 200,
+          pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+        },
+        initial_plan_revision: 1,
+        initial_version: 1,
+        progress_revision_rule: "unchanged",
+        replan_revision_rule: "strictly_increases",
+        step_count: { maximum: 50, minimum: 1 },
+        update_kinds: ["initial", "progress", "replan"],
+      },
+      python_support: "deferred_until_durable_transcript_metadata_is_available",
+      retention: {
+        full_snapshot_or_drop: true,
+        max_serialized_event_bytes: 12_288,
+        redacted_before_persistence: true,
+        restart_replay: true,
+      },
+    });
+    expect(SERVER_CAPABILITIES).toContain("agent_task_plan_v1");
   });
 
   it("keeps representative shared payload shapes aligned with Python's generated schema", () => {

--- a/ts/tests/websocket-session-bootstrap.test.ts
+++ b/ts/tests/websocket-session-bootstrap.test.ts
@@ -70,7 +70,7 @@ describe("websocket session bootstrap", () => {
         type: "hello",
         protocol_version: 1,
         transcript_protocol_version: 1,
-        capabilities: ["run_transcript_v1", "safe_run_stop_v1"],
+        capabilities: ["run_transcript_v1", "safe_run_stop_v1", "agent_task_plan_v1"],
       },
       {
         type: "environments",


### PR DESCRIPTION
## Summary

- advertise and emit strict, full-snapshot `agent_task_plan_v1` task plans across interactive TypeScript run lifecycles
- retain sanitized plans for reconnect/restart replay so Autowork can render live progress and replanning without inferring intent from logs

## Surfaces Touched

- [x] Parity decision: cross-runtime parity is user-visible and required now, or explicitly deferred below
- [ ] Python package
- [x] TypeScript package
- [x] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [ ] `cd autocontext && uv run ruff check ...`
- [ ] `cd autocontext && uv run mypy ...`
- [ ] `cd autocontext && uv run pytest ...`
- [x] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Focused TypeScript protocol, lifecycle, transcript, websocket, and runtime suites pass (101 tests). Real-socket server protocol coverage passes (26 tests). The Python websocket protocol contract passes (6 tests). The TypeScript package builds and `npm pack --dry-run` succeeds. The full TypeScript run passed 5,817 tests and reported four unrelated spawned-process failures whose child exit status was `null`; a clean-main reproduction is being checked separately.

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [x] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- Linear: https://linear.app/greyhaven/issue/AC-896/emit-agent-authored-task-plans-over-the-interactive-run-protocol
- The capability is additive and does not require a protocol-version bump. Python producer parity is explicitly deferred; Python does not advertise `agent_task_plan_v1`.
- Valid task-plan snapshots are capped at 12 KiB serialized, are redacted before retention, and are dropped atomically when malformed, mismatched, or oversized.
- This PR is the producer half consumed by greyhaven-ai/autowork#117; a core release and Autowork engine bump follow after merge.