### PR TITLE
feat(providers): add MiniMax OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,10 @@ AUTOCONTEXT_COACH_BASE_URL=
 AUTOCONTEXT_ARCHITECT_API_KEY=
 AUTOCONTEXT_ARCHITECT_BASE_URL=
 
+# MiniMax (OpenAI-compatible). Global endpoint by default; set AUTOCONTEXT_AGENT_BASE_URL
+# (or the role-scoped *_BASE_URL) to https://api.minimaxi.com/v1 for the China endpoint.
+MINIMAX_API_KEY=
+
 # Execution / loop tuning
 AUTOCONTEXT_DEFAULT_GENERATIONS=1
 AUTOCONTEXT_SEED_BASE=1000

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -655,6 +655,13 @@ AUTOCONTEXT_COMPETITOR_PROVIDER=openai-compatible \
 AUTOCONTEXT_COMPETITOR_API_KEY=sk-role \
 AUTOCONTEXT_COMPETITOR_BASE_URL=http://localhost:8000/v1 \
 autoctx run my_task --json
+
+# MiniMax (OpenAI-compatible). Defaults to the global endpoint; point the base
+# URL at https://api.minimaxi.com/v1 to use the China endpoint instead.
+AUTOCONTEXT_AGENT_PROVIDER=minimax \
+MINIMAX_API_KEY=... \
+AUTOCONTEXT_AGENT_DEFAULT_MODEL=MiniMax-M3 \
+autoctx run my_task --json
 ```
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -685,7 +685,7 @@ def build_client_from_settings(
             temperature=settings.mlx_temperature,
             max_tokens=settings.mlx_max_tokens,
         )
-    if settings.agent_provider in ("openai", "openai-compatible", "ollama", "vllm"):
+    if settings.agent_provider in ("openai", "openai-compatible", "ollama", "vllm", "minimax"):
         from autocontext.agents.provider_bridge import ProviderBridgeClient
         from autocontext.providers.registry import create_provider
 

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -341,6 +341,13 @@ def _provider_api_key(provider_type: str, settings: AppSettings, *, role: str = 
         )
     if provider_type == "vllm":
         return settings.agent_api_key or settings.judge_api_key or "no-key"
+    if provider_type == "minimax":
+        return (
+            settings.agent_api_key
+            or settings.judge_api_key
+            or os.getenv("MINIMAX_API_KEY")
+            or os.getenv("AUTOCONTEXT_MINIMAX_API_KEY")
+        )
     return settings.agent_api_key or settings.judge_api_key
 
 
@@ -555,7 +562,7 @@ def create_role_client(
         return RuntimeBridgeClient(HermesCLIRuntime(hermes_config))
 
     # LLMProvider-based providers — use the bridge
-    if provider_type in ("mlx", "openai", "openai-compatible", "openrouter", "ollama", "vllm"):
+    if provider_type in ("mlx", "openai", "openai-compatible", "openrouter", "ollama", "vllm", "minimax"):
         return _create_provider_bridge(provider_type, settings, model_override=model_override, role=role)
 
     raise ValueError(f"unsupported role provider: {provider_type!r}")

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -97,6 +97,22 @@ def create_provider(
             )
         )
 
+    if provider_type == "minimax":
+        from autocontext.providers.openai_compat import OpenAICompatibleProvider
+        from autocontext.providers.retry import RetryProvider
+
+        return RetryProvider(
+            OpenAICompatibleProvider(
+                api_key=(
+                    api_key
+                    or os.getenv("MINIMAX_API_KEY")
+                    or os.getenv("AUTOCONTEXT_MINIMAX_API_KEY")
+                ),
+                base_url=base_url or "https://api.minimax.io/v1",
+                default_model_name=model or "MiniMax-M3",
+            )
+        )
+
     if provider_type == "mlx":
         from autocontext.providers.mlx_provider import MLXProvider
 
@@ -104,7 +120,7 @@ def create_provider(
             raise ProviderError("MLX provider requires a model path (model_path). Set AUTOCONTEXT_MLX_MODEL_PATH.")
         return MLXProvider(model_path=model)
 
-    supported = "anthropic, openai, openai-compatible, openrouter, ollama, vllm, mlx"
+    supported = "anthropic, openai, openai-compatible, openrouter, ollama, vllm, minimax, mlx"
     raise ProviderError(f"Unknown provider type: {provider_type!r}. Supported: {supported}")
 
 
@@ -244,6 +260,8 @@ def get_provider(settings: AppSettings) -> LLMProvider:
     if not api_key:
         if provider_type in ("openai", "openai-compatible"):
             api_key = os.getenv("OPENAI_API_KEY")
+        elif provider_type == "minimax":
+            api_key = os.getenv("MINIMAX_API_KEY") or os.getenv("AUTOCONTEXT_MINIMAX_API_KEY")
         else:
             api_key = settings.anthropic_api_key or os.getenv("ANTHROPIC_API_KEY") or os.getenv("AUTOCONTEXT_ANTHROPIC_API_KEY")
 

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -331,7 +331,7 @@ class TrainingRunner:
             return self.config.agent_model
 
         settings = load_settings().model_copy(update={"agent_provider": self.config.agent_provider})
-        if self.config.agent_provider in {"openai", "openai-compatible", "ollama", "vllm"}:
+        if self.config.agent_provider in {"openai", "openai-compatible", "ollama", "vllm", "minimax"}:
             return settings.agent_default_model
         return settings.model_competitor
 

--- a/autocontext/tests/test_providers.py
+++ b/autocontext/tests/test_providers.py
@@ -123,6 +123,18 @@ class TestRegistry:
         p = create_provider("vllm", base_url="http://gpu-box:8000/v1", model="mistral-7b")
         assert p.default_model() == "mistral-7b"
 
+    @_skip_no_openai
+    def test_create_minimax_provider(self):
+        p = create_provider("minimax", api_key="minimax-test", model="MiniMax-M3")
+        assert p.default_model() == "MiniMax-M3"
+        assert "OpenAICompatibleProvider" in p.name  # may be wrapped in RetryProvider
+
+    @_skip_no_openai
+    def test_minimax_defaults_to_global_endpoint_and_m3(self):
+        p = create_provider("minimax", api_key="minimax-test")
+        assert p.default_model() == "MiniMax-M3"
+        assert "OpenAICompatibleProvider" in p.name  # may be wrapped in RetryProvider
+
     def test_unknown_provider_raises(self):
         with pytest.raises(ProviderError, match="Unknown provider type"):
             create_provider("magic-llm")

--- a/ts/README.md
+++ b/ts/README.md
@@ -51,7 +51,7 @@ AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_PI_COMMAND=pi autoctx solve "..." --it
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var; `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
 
-Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mistral`, `groq`, `openrouter`, `azure-openai`, `ollama`, `vllm`, `hermes`, `claude-cli`, `codex`, `pi`, `pi-rpc`, `deterministic`.
+Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mistral`, `groq`, `openrouter`, `azure-openai`, `minimax`, `ollama`, `vllm`, `hermes`, `claude-cli`, `codex`, `pi`, `pi-rpc`, `deterministic`.
 
 Provider routing details live in [../autocontext/docs/agent-integration.md](../autocontext/docs/agent-integration.md).
 

--- a/ts/src/config/credential-model-catalog.ts
+++ b/ts/src/config/credential-model-catalog.ts
@@ -46,6 +46,10 @@ export const PROVIDER_MODELS: Record<string, KnownModel[]> = {
     { id: "gpt-4o", displayName: "GPT-4o (Azure)" },
     { id: "gpt-4o-mini", displayName: "GPT-4o Mini (Azure)" },
   ],
+  minimax: [
+    { id: "MiniMax-M3", displayName: "MiniMax M3" },
+    { id: "MiniMax-M2.7", displayName: "MiniMax M2.7" },
+  ],
 };
 
 export function getModelsForProvider(provider: string): KnownModel[] {

--- a/ts/src/config/credential-provider-discovery.ts
+++ b/ts/src/config/credential-provider-discovery.ts
@@ -48,6 +48,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     envVar: "AZURE_OPENAI_API_KEY",
     requiresKey: true,
   },
+  { id: "minimax", displayName: "MiniMax", envVar: "MINIMAX_API_KEY", requiresKey: true },
   {
     id: "ollama",
     displayName: "Ollama",

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -154,6 +154,11 @@ export const OPENAI_COMPATIBLE_PROVIDER_DEFAULTS: Record<
     envVar: "AZURE_OPENAI_API_KEY",
     defaultModel: "gpt-4o",
   },
+  minimax: {
+    baseUrl: "https://api.minimax.io/v1",
+    envVar: "MINIMAX_API_KEY",
+    defaultModel: "MiniMax-M3",
+  },
 };
 
 export interface CreateProviderOpts {

--- a/ts/src/providers/supported-provider-types.ts
+++ b/ts/src/providers/supported-provider-types.ts
@@ -10,6 +10,7 @@ export const SUPPORTED_PROVIDER_TYPES = [
   "groq",
   "openrouter",
   "azure-openai",
+  "minimax",
   "claude-cli",
   "codex",
   "pi",

--- a/ts/tests/model-resolution.test.ts
+++ b/ts/tests/model-resolution.test.ts
@@ -214,6 +214,7 @@ describe("autoctx providers", () => {
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed.some((p) => p.id === "anthropic")).toBe(true);
     expect(parsed.some((p) => p.id === "gemini")).toBe(true);
+    expect(parsed.some((p) => p.id === "minimax")).toBe(true);
   });
 
   it("shows authenticated status for configured providers", async () => {

--- a/ts/tests/provider-factory-workflow.test.ts
+++ b/ts/tests/provider-factory-workflow.test.ts
@@ -15,6 +15,9 @@ describe("provider factory workflow", () => {
     expect(
       createProvider({ providerType: "openrouter", apiKey: "router-key" }).defaultModel(),
     ).toBe("anthropic/claude-sonnet-4");
+    expect(createProvider({ providerType: "minimax", apiKey: "minimax-key" }).defaultModel()).toBe(
+      "MiniMax-M3",
+    );
   });
 
   it("creates runtime-backed and renamed provider families", () => {

--- a/ts/tests/provider-routing.test.ts
+++ b/ts/tests/provider-routing.test.ts
@@ -154,6 +154,7 @@ describe("resolveProviderConfig env var alignment", () => {
       ["groq", "GROQ_API_KEY", "groq-key"],
       ["openrouter", "OPENROUTER_API_KEY", "openrouter-key"],
       ["azure-openai", "AZURE_OPENAI_API_KEY", "azure-key"],
+      ["minimax", "MINIMAX_API_KEY", "minimax-key"],
     ] as const;
 
     for (const [providerType, envVar, apiKey] of providerEnvPairs) {

--- a/ts/tests/provider-surface-consistency.test.ts
+++ b/ts/tests/provider-surface-consistency.test.ts
@@ -18,6 +18,7 @@ const EXPECTED_PROVIDER_IDS = [
   "groq",
   "openrouter",
   "azure-openai",
+  "minimax",
   "ollama",
   "vllm",
   "hermes",
@@ -86,6 +87,9 @@ describe("Provider surface consistency", () => {
         baseUrl: "https://azure.example.com/openai/v1",
       }).defaultModel(),
     ).toBe("gpt-4o");
+    expect(createProvider({ providerType: "minimax", apiKey: "minimax-key" }).defaultModel()).toBe(
+      "MiniMax-M3",
+    );
   });
 
   it("KNOWN_PROVIDERS has entries for subscription-backed CLI runtimes and gateway providers", async () => {

--- a/ts/tests/providers-registry.test.ts
+++ b/ts/tests/providers-registry.test.ts
@@ -26,7 +26,7 @@ describe("Known providers registry", () => {
     expect(KNOWN_PROVIDERS.length).toBeGreaterThanOrEqual(9);
   });
 
-  it("includes anthropic, openai, gemini, mistral, groq, openrouter, azure-openai, ollama, vllm", async () => {
+  it("includes anthropic, openai, gemini, mistral, groq, openrouter, azure-openai, minimax, ollama, vllm", async () => {
     const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
     const ids = KNOWN_PROVIDERS.map((p) => p.id);
     expect(ids).toContain("anthropic");
@@ -36,6 +36,7 @@ describe("Known providers registry", () => {
     expect(ids).toContain("groq");
     expect(ids).toContain("openrouter");
     expect(ids).toContain("azure-openai");
+    expect(ids).toContain("minimax");
     expect(ids).toContain("ollama");
     expect(ids).toContain("vllm");
   });


### PR DESCRIPTION
Reason: Add MiniMax as a first-class OpenAI-compatible provider with current M3 and M2.7 defaults, API-key discovery, and selectable global and China endpoints.

## Changes

Adds MiniMax to the Python and TypeScript OpenAI-compatible provider registries, following the existing gemini/mistral/groq/openrouter/azure-openai defaults pattern.

### Python (`autocontext/`)
- `providers/registry.py`: `create_provider("minimax", ...)` builds an `OpenAICompatibleProvider` with `MINIMAX_API_KEY` / `AUTOCONTEXT_MINIMAX_API_KEY` discovery, the global endpoint (`https://api.minimax.io/v1`), and `MiniMax-M3` as the default model. `get_provider()` applies the same env-var fallback on the judge path, and the supported-provider list now includes `minimax`.
- `agents/provider_bridge.py`: `_provider_api_key()` resolves the MiniMax key per role.
- `agents/llm_client.py` and `training/runner.py`: route `minimax` through the OpenAI-compatible bridge/model path.
- `.env.example` and `docs/agent-integration.md`: document `MINIMAX_API_KEY` and how to point the base URL at the China endpoint (`https://api.minimaxi.com/v1`).

### TypeScript (`ts/`)
- `SUPPORTED_PROVIDER_TYPES`, `OPENAI_COMPATIBLE_PROVIDER_DEFAULTS`, `KNOWN_PROVIDERS`, and `PROVIDER_MODELS` each gain a `minimax` entry (global endpoint, `MINIMAX_API_KEY`, `MiniMax-M3` default; models `MiniMax-M3` and `MiniMax-M2.7`).
- `ts/README.md` supported-providers line updated.

### Regional endpoints
The global endpoint (`https://api.minimax.io/v1`) is the default. The China endpoint (`https://api.minimaxi.com/v1`) is reachable through the existing OpenAI-compatible base-URL override (per-role `*_BASE_URL` or `AUTOCONTEXT_AGENT_BASE_URL`), so no new regional-switching code path is required.

## Checks run
- `npx tsc --noEmit` (TypeScript) — passed
- `npx vitest run` for the provider/credential/model-resolution test files — passed (54 + provider-routing 17)
- `npm run check:root-index` — passed
- `uv run ruff check` on changed Python files — passed
- `uv run mypy` on changed Python files — passed
- `uv run pytest tests/test_providers.py tests/test_provider_retry.py tests/test_per_role_provider.py tests/test_panel_runtime.py tests/test_hermes_runtime.py` — passed
