### PR TITLE
AC-901: persistent interpreter workspace for multi-generation runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ All config via `AUTOCONTEXT_*` env vars, loaded in `config/settings.py` as Pydan
 - **Knowledge**: `AUTOCONTEXT_CROSS_RUN_INHERITANCE`, `AUTOCONTEXT_PLAYBOOK_MAX_VERSIONS`, `AUTOCONTEXT_ABLATION_NO_FEEDBACK`
 - **RLM**: `AUTOCONTEXT_RLM_ENABLED`, `AUTOCONTEXT_RLM_BACKEND`, `AUTOCONTEXT_RLM_MAX_TURNS`, `AUTOCONTEXT_RLM_SUB_MODEL`
 - **Output budgets**: `AUTOCONTEXT_<ROLE>_MAX_TOKENS` per-role output-token budgets (competitor/translator/analyst/coach/architect/curator/skeptic + designer/codegen variants; see `config/output_budgets.py`)
+- **Workspace interpreter**: `AUTOCONTEXT_WORKSPACE_INTERPRETER_ENABLED` (opt-in persistent interpreter workspace for multi-generation runs; lifecycle isolation, not a security sandbox), `AUTOCONTEXT_WORKSPACE_INTERPRETER_TIMEOUT_SECONDS` (see `config/workspace_interpreter.py`)
 - **Judge**: `AUTOCONTEXT_JUDGE_PROVIDER`, `AUTOCONTEXT_JUDGE_MODEL`, `AUTOCONTEXT_JUDGE_SAMPLES`, `AUTOCONTEXT_JUDGE_TEMPERATURE`, `AUTOCONTEXT_JUDGE_MAX_TOKENS`, `AUTOCONTEXT_JUDGE_BASE_URL`, `AUTOCONTEXT_JUDGE_API_KEY`
 - **Pi**: `AUTOCONTEXT_PI_COMMAND`, `AUTOCONTEXT_PI_TIMEOUT`, `AUTOCONTEXT_PI_WORKSPACE`, `AUTOCONTEXT_PI_MODEL`
 - **Pi RPC**: `AUTOCONTEXT_PI_RPC_ENDPOINT`, `AUTOCONTEXT_PI_RPC_API_KEY`, `AUTOCONTEXT_PI_RPC_SESSION_PERSISTENCE`

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator  # type: ignore[import-no
 
 from autocontext.config.output_budgets import OutputBudgetFields
 from autocontext.config.presets import apply_preset
+from autocontext.config.workspace_interpreter import WorkspaceInterpreterFields
 from autocontext.runtimes.pi_defaults import PI_DEFAULT_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ class HarnessProfile(StrEnum):
     LEAN = "lean"
 
 
-class AppSettings(OutputBudgetFields, BaseModel):
+class AppSettings(WorkspaceInterpreterFields, OutputBudgetFields, BaseModel):
     db_path: Path = Field(default=Path("runs/autocontext.sqlite3"))
     runs_root: Path = Field(default=Path("runs"))
     knowledge_root: Path = Field(default=Path("knowledge"))

--- a/autocontext/src/autocontext/config/workspace_interpreter.py
+++ b/autocontext/src/autocontext/config/workspace_interpreter.py
@@ -1,0 +1,22 @@
+"""Persistent interpreter workspace fields (AC-901).
+
+Extracted from AppSettings to keep config/settings.py under the module
+size limit (AC-905 pattern). The workspace is opt-in and off by default:
+the serialize-everything path remains the baseline until benchmarked per
+scenario. Lifecycle isolation only, not a security sandbox; see
+autocontext.execution.interpreter_workspace.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class WorkspaceInterpreterFields(BaseModel):
+    """Mixin holding the persistent interpreter workspace settings."""
+
+    workspace_interpreter_enabled: bool = Field(
+        default=False,
+        description="Opt-in persistent interpreter workspace for multi-generation runs",
+    )
+    workspace_interpreter_timeout_seconds: float = Field(default=10.0, gt=0)

--- a/autocontext/src/autocontext/execution/agent_task_evolution.py
+++ b/autocontext/src/autocontext/execution/agent_task_evolution.py
@@ -343,6 +343,8 @@ def migrate_workspaces(
     """
     if not states or not workspaces:
         return
+    if len(workspaces) != len(states):
+        raise ValueError(f"expected {len(states)} workspaces, got {len(workspaces)}")
     champion_index = max(range(len(states)), key=lambda i: states[i].best_score)
     snapshot = workspaces[champion_index].snapshot()
     for i, (before, after) in enumerate(zip(states, migrated, strict=True)):
@@ -636,12 +638,17 @@ class AgentTaskEvolutionRunner:
             for _ in range(num_islands)
         ]
 
+        # Created inside the try so a factory failure mid-list still closes
+        # the workspaces already created.
+        created_workspaces: list[InterpreterWorkspace] = []
         workspaces: list[InterpreterWorkspace] | None = None
-        if self._workspace_factory is not None:
-            workspaces = [self._workspace_factory() for _ in range(num_islands)]
 
         best_per_gen: list[float] = []
         try:
+            if self._workspace_factory is not None:
+                for _ in range(num_islands):
+                    created_workspaces.append(self._workspace_factory())
+                workspaces = created_workspaces
             for gen in range(num_generations):
                 if workspaces is None:
                     states = [self.run_generation(s) for s in states]
@@ -654,9 +661,8 @@ class AgentTaskEvolutionRunner:
                         migrate_workspaces(states, migrated, workspaces)
                     states = migrated
         finally:
-            if workspaces is not None:
-                for ws in workspaces:
-                    ws.close()
+            for ws in created_workspaces:
+                ws.close()
 
         champion = max(states, key=lambda s: s.best_score)
         return AgentTaskTrajectory(

--- a/autocontext/src/autocontext/execution/agent_task_evolution.py
+++ b/autocontext/src/autocontext/execution/agent_task_evolution.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from autocontext.execution.interpreter_workspace import InterpreterWorkspace
 from autocontext.knowledge.compaction import compact_prompt_component
 from autocontext.knowledge.harness_entries import HarnessEdit, HarnessEntry, SkillReference
 from autocontext.scenarios.agent_task import AgentTaskResult
@@ -227,12 +228,16 @@ def build_enriched_prompt(
     best_score: float,
     harness: str = "",
     skills: Sequence[HarnessEntry] = (),
+    workspace_summary: str = "",
 ) -> str:
     """Enrich a task prompt with cross-generation context.
 
     In function-slot mode (``harness`` provided), the fixed harness is shown
     once as stable context so the model knows the contract it writes the slot
     against. The evolved slot itself is carried via ``best_output``.
+
+    ``workspace_summary`` describes persistent interpreter variables by name
+    (AC-901); contents stay in the workspace, never in the prompt.
     """
     playbook = compact_prompt_component("agent_task_playbook", playbook)
     best_output = compact_prompt_component("agent_task_best_output", best_output)
@@ -258,8 +263,12 @@ def build_enriched_prompt(
         if entry.reference is not None
     ]
     if skill_lines:
+        sections.append("\n\n## Available Skills (call them; do not reimplement)\n" + "\n".join(skill_lines))
+
+    if workspace_summary:
         sections.append(
-            "\n\n## Available Skills (call them; do not reimplement)\n" + "\n".join(skill_lines)
+            "\n\n## Workspace (persistent interpreter variables; reference them by name, "
+            "contents are not inlined)\n" + workspace_summary
         )
 
     if playbook or best_output:
@@ -318,6 +327,27 @@ def migrate_states(
         else:
             migrated.append(s)
     return migrated
+
+
+def migrate_workspaces(
+    states: list[AgentTaskGenerationState],
+    migrated: list[AgentTaskGenerationState],
+    workspaces: Sequence[InterpreterWorkspace],
+) -> None:
+    """Carry the champion's workspace into islands that adopted its output.
+
+    ``states``/``migrated`` are the before/after of :func:`migrate_states`;
+    an island whose best score rose during migration adopted the champion's
+    output, so it also adopts a deep copy of the champion's variables. The
+    champion (and any tied island) keeps its own workspace untouched.
+    """
+    if not states or not workspaces:
+        return
+    champion_index = max(range(len(states)), key=lambda i: states[i].best_score)
+    snapshot = workspaces[champion_index].snapshot()
+    for i, (before, after) in enumerate(zip(states, migrated, strict=True)):
+        if after.best_score > before.best_score:
+            workspaces[i].restore(snapshot)
 
 
 class AgentTaskTrajectory(BaseModel):
@@ -407,6 +437,7 @@ class ScenarioFamilyGuide:
 
 GenerateFn = Callable[[str, int], str]
 EvaluateFn = Callable[[str, int], AgentTaskGenerationEvaluation]
+WorkspaceEvaluateFn = Callable[[str, int, InterpreterWorkspace], AgentTaskGenerationEvaluation]
 
 
 class AgentTaskEvolutionRunner:
@@ -420,19 +451,31 @@ class AgentTaskEvolutionRunner:
         initial_output: str = "",
         task_name: str = "agent_task",
         slot: FunctionSlot | None = None,
+        workspace_factory: Callable[[], InterpreterWorkspace] | None = None,
+        workspace_evaluate_fn: WorkspaceEvaluateFn | None = None,
     ) -> None:
+        if workspace_evaluate_fn is not None and workspace_factory is None:
+            raise ValueError("workspace_evaluate_fn requires a workspace_factory")
         self._task_prompt = task_prompt
         self._generate_fn = generate_fn
         self._evaluate_fn = evaluate_fn
         self._initial_output = initial_output
         self._task_name = task_name
         self._slot = slot
+        self._workspace_factory = workspace_factory
+        self._workspace_evaluate_fn = workspace_evaluate_fn
 
     def run_generation(
         self,
         state: AgentTaskGenerationState,
+        workspace: InterpreterWorkspace | None = None,
     ) -> AgentTaskGenerationState:
-        """Run one generation: generate, evaluate, accumulate lessons, advance state."""
+        """Run one generation: generate, evaluate, accumulate lessons, advance state.
+
+        When a ``workspace`` is provided its variable listing (names, never
+        contents) is rendered into the prompt, and evaluation goes through
+        ``workspace_evaluate_fn`` when one was configured (AC-901).
+        """
         prompt = build_enriched_prompt(
             task_prompt=self._task_prompt,
             playbook=state.playbook,
@@ -440,6 +483,7 @@ class AgentTaskEvolutionRunner:
             best_output=state.best_output,
             best_score=state.best_score,
             harness=self._slot.harness if self._slot else "",
+            workspace_summary=workspace.render_markdown() if workspace is not None else "",
         )
 
         if state.generation == 0 and self._initial_output:
@@ -452,11 +496,18 @@ class AgentTaskEvolutionRunner:
         if self._slot is not None:
             # Function-slot mode: evaluate the assembled harness+slot, but
             # carry only the small slot forward (no whole-program bloat).
-            assembled = self._slot.assemble(candidate_output)
-            evaluation = self._evaluate_fn(assembled, state.generation)
+            program = self._slot.assemble(candidate_output)
+        else:
+            program = candidate_output
+
+        if workspace is not None and self._workspace_evaluate_fn is not None:
+            evaluation = self._workspace_evaluate_fn(program, state.generation, workspace)
+        else:
+            evaluation = self._evaluate_fn(program, state.generation)
+
+        if self._slot is not None:
             evaluated_output = candidate_output
         else:
-            evaluation = self._evaluate_fn(candidate_output, state.generation)
             evaluated_output = evaluation.output.strip() or candidate_output
 
         judge_result = AgentTaskResult(
@@ -492,6 +543,11 @@ class AgentTaskEvolutionRunner:
         metadata["generation_round_counts"] = generation_round_counts
         metadata["met_threshold_history"] = met_threshold_history
 
+        if workspace is not None:
+            workspace_variables = list(metadata.get("workspace_variables", []))
+            workspace_variables.append([f"{v.name}:{v.type_name}" for v in workspace.variables()])
+            metadata["workspace_variables"] = workspace_variables
+
         return AgentTaskGenerationState(
             generation=state.generation + 1,
             best_output=new_best_output,
@@ -517,8 +573,13 @@ class AgentTaskEvolutionRunner:
             metadata={},
         )
 
-        for _ in range(num_generations):
-            state = self.run_generation(state)
+        workspace = self._workspace_factory() if self._workspace_factory is not None else None
+        try:
+            for _ in range(num_generations):
+                state = self.run_generation(state, workspace=workspace)
+        finally:
+            if workspace is not None:
+                workspace.close()
 
         trajectory = AgentTaskTrajectory(
             task_name=self._task_name,
@@ -575,12 +636,27 @@ class AgentTaskEvolutionRunner:
             for _ in range(num_islands)
         ]
 
+        workspaces: list[InterpreterWorkspace] | None = None
+        if self._workspace_factory is not None:
+            workspaces = [self._workspace_factory() for _ in range(num_islands)]
+
         best_per_gen: list[float] = []
-        for gen in range(num_generations):
-            states = [self.run_generation(s) for s in states]
-            best_per_gen.append(max(s.best_score for s in states))
-            if migrate_every and (gen + 1) % migrate_every == 0:
-                states = migrate_states(states)
+        try:
+            for gen in range(num_generations):
+                if workspaces is None:
+                    states = [self.run_generation(s) for s in states]
+                else:
+                    states = [self.run_generation(s, workspace=ws) for s, ws in zip(states, workspaces, strict=True)]
+                best_per_gen.append(max(s.best_score for s in states))
+                if migrate_every and (gen + 1) % migrate_every == 0:
+                    migrated = migrate_states(states)
+                    if workspaces is not None:
+                        migrate_workspaces(states, migrated, workspaces)
+                    states = migrated
+        finally:
+            if workspaces is not None:
+                for ws in workspaces:
+                    ws.close()
 
         champion = max(states, key=lambda s: s.best_score)
         return AgentTaskTrajectory(

--- a/autocontext/src/autocontext/execution/interpreter_workspace.py
+++ b/autocontext/src/autocontext/execution/interpreter_workspace.py
@@ -54,6 +54,11 @@ class InterpreterWorkspace:
     across :meth:`run` calls until :meth:`close`. Names starting with an
     underscore are treated as private scratch and excluded from
     :meth:`variables`, snapshots, and prompt rendering.
+
+    Caveat: off the main thread, ReplWorker enforces timeouts by abandoning
+    the executing daemon thread; a timed-out candidate may keep mutating
+    the persistent namespace in the background. On the main thread (the
+    normal runner path) timeouts are signal-based and this does not apply.
     """
 
     def __init__(
@@ -68,7 +73,20 @@ class InterpreterWorkspace:
         # (builtins, safe modules, text helpers, answer) is infrastructure.
         self._infra_keys = frozenset(self._worker.namespace)
         if seed:
-            self._worker.namespace.update(seed)
+            for name in seed:
+                if name in self._infra_keys or name.startswith("_"):
+                    raise ValueError(
+                        f"seed key {name!r} collides with workspace infrastructure or is private; "
+                        "choose a different variable name"
+                    )
+            # Deep-copied so candidate mutations never leak back into caller
+            # state; uncopyable values fall back to the shared reference
+            # (dropping an explicitly provided seed would be worse).
+            for name, value in seed.items():
+                try:
+                    self._worker.namespace[name] = copy.deepcopy(value)
+                except Exception:
+                    self._worker.namespace[name] = value
         self._closed = False
 
     def _ensure_open(self) -> None:
@@ -93,9 +111,17 @@ class InterpreterWorkspace:
             return self._worker.run_code(ReplCommand(code=code))
         except CodeTimeout as exc:
             return ReplResult(stdout="", error=f"CodeTimeout: {exc}", answer={})
+        except SystemExit as exc:
+            # ReplWorker's inner handler catches only Exception, so a
+            # candidate's `raise SystemExit(...)` would otherwise escape and
+            # kill the owning process (TaskRunner catches Exception only).
+            # KeyboardInterrupt is deliberately NOT contained: that is a
+            # genuine operator signal, not candidate behavior.
+            return ReplResult(stdout="", error=f"SystemExit: {exc}", answer={})
 
     def variables(self) -> list[WorkspaceVariable]:
         """Describe user variables (never their full contents), sorted by name."""
+        self._ensure_open()
         described: list[WorkspaceVariable] = []
         for name, value in self._user_items():
             try:
@@ -139,12 +165,20 @@ class InterpreterWorkspace:
 
         The second copy keeps lineages independent: restoring the same
         snapshot into several islands must never share mutable objects.
+        Copies are staged before any existing variable is deleted, so a
+        value whose deepcopy fails at restore time degrades to omission
+        instead of leaving a half-restored namespace.
         """
         self._ensure_open()
+        staged: dict[str, Any] = {}
+        for name, value in snap.variables.items():
+            try:
+                staged[name] = copy.deepcopy(value)
+            except Exception:
+                continue
         for name, _ in self._user_items():
             del self._worker.namespace[name]
-        for name, value in snap.variables.items():
-            self._worker.namespace[name] = copy.deepcopy(value)
+        self._worker.namespace.update(staged)
 
     def close(self) -> None:
         """Deterministic teardown: drop all namespace references. Idempotent."""

--- a/autocontext/src/autocontext/execution/interpreter_workspace.py
+++ b/autocontext/src/autocontext/execution/interpreter_workspace.py
@@ -1,0 +1,154 @@
+"""Persistent interpreter workspace for multi-generation runs (AC-901).
+
+Working state (candidate pools, seeds, helper data) lives in a persistent
+Python namespace that survives generation boundaries; enriched prompts
+describe the variables (name, type, size, summary) instead of inlining
+their contents, so prompt size stays flat as the working set grows.
+
+Trust model: this is lifecycle isolation, NOT a security sandbox. The
+underlying :class:`~autocontext.harness.repl.worker.ReplWorker` restricts
+builtins (no file I/O, os, subprocess, or import machinery), but candidate
+code still runs in-process; treat the workspace as a scoped scratch
+environment for run-owned code, not as a boundary against hostile input.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.harness.repl.types import ReplCommand, ReplResult
+from autocontext.harness.repl.worker import CodeTimeout, ReplWorker
+
+_SUMMARY_MAX_CHARS = 120
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceVariable:
+    """Prompt-facing description of one workspace variable."""
+
+    name: str
+    type_name: str
+    size: int | None
+    summary: str
+
+
+@dataclass(slots=True)
+class WorkspaceSnapshot:
+    """Deep-copied user variables captured for migration or inspection.
+
+    ``skipped`` records variables whose values could not be deep-copied
+    (generators, open handles, ...); they degrade to omission, never to a
+    crash, so migration always proceeds with what is copyable.
+    """
+
+    variables: dict[str, Any]
+    skipped: tuple[str, ...] = ()
+
+
+class InterpreterWorkspace:
+    """A persistent, restricted Python namespace owned by a runner lineage.
+
+    Variables assigned by executed code (and any ``seed`` values) persist
+    across :meth:`run` calls until :meth:`close`. Names starting with an
+    underscore are treated as private scratch and excluded from
+    :meth:`variables`, snapshots, and prompt rendering.
+    """
+
+    def __init__(
+        self,
+        seed: dict[str, Any] | None = None,
+        *,
+        timeout_seconds: float = 10.0,
+        max_stdout_chars: int = 8192,
+    ) -> None:
+        self._worker = ReplWorker(timeout_seconds=timeout_seconds, max_stdout_chars=max_stdout_chars)
+        # Captured before seeding: everything ReplWorker pre-installs
+        # (builtins, safe modules, text helpers, answer) is infrastructure.
+        self._infra_keys = frozenset(self._worker.namespace)
+        if seed:
+            self._worker.namespace.update(seed)
+        self._closed = False
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("workspace is closed")
+
+    def _user_items(self) -> list[tuple[str, Any]]:
+        return sorted(
+            (name, value)
+            for name, value in self._worker.namespace.items()
+            if name not in self._infra_keys and not name.startswith("_")
+        )
+
+    def run(self, code: str) -> ReplResult:
+        """Execute ``code`` in the persistent namespace.
+
+        Timeouts are converted into an error result rather than raised, so a
+        runaway candidate never tears down the owning generation loop.
+        """
+        self._ensure_open()
+        try:
+            return self._worker.run_code(ReplCommand(code=code))
+        except CodeTimeout as exc:
+            return ReplResult(stdout="", error=f"CodeTimeout: {exc}", answer={})
+
+    def variables(self) -> list[WorkspaceVariable]:
+        """Describe user variables (never their full contents), sorted by name."""
+        described: list[WorkspaceVariable] = []
+        for name, value in self._user_items():
+            try:
+                size: int | None = len(value)
+            except TypeError:
+                size = None
+            try:
+                summary = repr(value)
+            except Exception:
+                summary = f"<{type(value).__name__}>"
+            if len(summary) > _SUMMARY_MAX_CHARS:
+                summary = summary[: _SUMMARY_MAX_CHARS - 3] + "..."
+            described.append(WorkspaceVariable(name=name, type_name=type(value).__name__, size=size, summary=summary))
+        return described
+
+    def render_markdown(self, max_vars: int = 20) -> str:
+        """Render the variable listing as prompt-ready markdown lines."""
+        listed = self.variables()
+        lines = []
+        for var in listed[:max_vars]:
+            size_part = f", size {var.size}" if var.size is not None else ""
+            lines.append(f"- {var.name} ({var.type_name}{size_part}): {var.summary}")
+        if len(listed) > max_vars:
+            lines.append(f"... and {len(listed) - max_vars} more")
+        return "\n".join(lines)
+
+    def snapshot(self) -> WorkspaceSnapshot:
+        """Deep-copy user variables; non-copyable values are skipped, not fatal."""
+        self._ensure_open()
+        variables: dict[str, Any] = {}
+        skipped: list[str] = []
+        for name, value in self._user_items():
+            try:
+                variables[name] = copy.deepcopy(value)
+            except Exception:
+                skipped.append(name)
+        return WorkspaceSnapshot(variables=variables, skipped=tuple(skipped))
+
+    def restore(self, snap: WorkspaceSnapshot) -> None:
+        """Replace user variables with a deep copy of the snapshot's.
+
+        The second copy keeps lineages independent: restoring the same
+        snapshot into several islands must never share mutable objects.
+        """
+        self._ensure_open()
+        for name, _ in self._user_items():
+            del self._worker.namespace[name]
+        for name, value in snap.variables.items():
+            self._worker.namespace[name] = copy.deepcopy(value)
+
+    def close(self) -> None:
+        """Deterministic teardown: drop all namespace references. Idempotent."""
+        if self._closed:
+            return
+        self._worker.namespace.clear()
+        self._closed = True

--- a/autocontext/src/autocontext/execution/interpreter_workspace.py
+++ b/autocontext/src/autocontext/execution/interpreter_workspace.py
@@ -111,13 +111,17 @@ class InterpreterWorkspace:
             return self._worker.run_code(ReplCommand(code=code))
         except CodeTimeout as exc:
             return ReplResult(stdout="", error=f"CodeTimeout: {exc}", answer={})
-        except SystemExit as exc:
+        except KeyboardInterrupt:
+            # Deliberately NOT contained: a genuine operator signal, not
+            # candidate behavior.
+            raise
+        except BaseException as exc:  # noqa: BLE001
             # ReplWorker's inner handler catches only Exception, so a
-            # candidate's `raise SystemExit(...)` would otherwise escape and
-            # kill the owning process (TaskRunner catches Exception only).
-            # KeyboardInterrupt is deliberately NOT contained: that is a
-            # genuine operator signal, not candidate behavior.
-            return ReplResult(stdout="", error=f"SystemExit: {exc}", answer={})
+            # candidate's `raise SystemExit(...)` or `raise BaseException(...)`
+            # would otherwise escape and kill the owning process (TaskRunner
+            # catches Exception only). Containment of every non-operator
+            # escape is the point of this handler.
+            return ReplResult(stdout="", error=f"{type(exc).__name__}: {exc}", answer={})
 
     def variables(self) -> list[WorkspaceVariable]:
         """Describe user variables (never their full contents), sorted by name."""

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -109,7 +109,16 @@ def _serialize_result(
 def _workspace_factory_from_settings(
     settings: AppSettings | None,
 ) -> Callable[[], InterpreterWorkspace] | None:
-    """Build a workspace factory when the opt-in flag is set (AC-901)."""
+    """Build a workspace factory when the opt-in flag is set (AC-901).
+
+    Substrate-only wiring: the queued-task evaluate path (ImprovementLoop +
+    LLM judge) does not execute candidate code, so it passes no
+    workspace_evaluate_fn and the workspace stays empty there. Code-mode
+    consumers construct AgentTaskEvolutionRunner directly with a
+    workspace_evaluate_fn (see tests/test_workspace_benchmark.py and
+    examples/workspace_benchmark.py); wiring a code-executing queued-task
+    path is deferred follow-up work, noted on the Linear issue.
+    """
     if settings is None or not settings.workspace_interpreter_enabled:
         return None
     timeout = settings.workspace_interpreter_timeout_seconds

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -13,6 +13,7 @@ import signal
 import time
 import traceback
 import uuid
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -36,6 +37,7 @@ from autocontext.execution.agent_task_evolution import (
 from autocontext.execution.evaluator_epoch_registry import observe_epoch_quarantined
 from autocontext.execution.evaluator_guardrail import evaluate_evaluator_guardrail
 from autocontext.execution.improvement_loop import ImprovementLoop, ImprovementResult
+from autocontext.execution.interpreter_workspace import InterpreterWorkspace
 from autocontext.execution.judge import LLMJudge
 from autocontext.execution.queued_task_browser_context import (
     QueuedTaskBrowserContextService,
@@ -102,6 +104,16 @@ def _serialize_result(
     if result.metadata:
         data["optimizer_metadata"] = result.metadata
     return json.dumps(data)
+
+
+def _workspace_factory_from_settings(
+    settings: AppSettings | None,
+) -> Callable[[], InterpreterWorkspace] | None:
+    """Build a workspace factory when the opt-in flag is set (AC-901)."""
+    if settings is None or not settings.workspace_interpreter_enabled:
+        return None
+    timeout = settings.workspace_interpreter_timeout_seconds
+    return lambda: InterpreterWorkspace(timeout_seconds=timeout)
 
 
 def _serialize_evolution_result(
@@ -620,6 +632,7 @@ class TaskRunner:
             evaluate_fn=evaluate_fn,
             initial_output=initial_output,
             task_name=spec_name,
+            workspace_factory=_workspace_factory_from_settings(self.settings),
         )
         trajectory, state = evolution.run_with_state(config.generations)
 

--- a/autocontext/tests/test_agent_task_workspace.py
+++ b/autocontext/tests/test_agent_task_workspace.py
@@ -1,0 +1,262 @@
+"""Workspace integration for the agent task evolution runner (AC-901)."""
+
+from __future__ import annotations
+
+import pytest
+
+from autocontext.execution.agent_task_evolution import (
+    AgentTaskEvolutionRunner,
+    AgentTaskGenerationEvaluation,
+    AgentTaskGenerationState,
+    FunctionSlot,
+    build_enriched_prompt,
+    migrate_states,
+    migrate_workspaces,
+)
+from autocontext.execution.interpreter_workspace import InterpreterWorkspace
+
+
+def _evaluation(score: float, output: str = "out") -> AgentTaskGenerationEvaluation:
+    return AgentTaskGenerationEvaluation(output=output, score=score, reasoning="r")
+
+
+def _state() -> AgentTaskGenerationState:
+    return AgentTaskGenerationState(
+        generation=0,
+        best_output="",
+        best_score=0.0,
+        playbook="",
+        score_history=[],
+        lesson_history=[],
+        metadata={},
+    )
+
+
+class TrackingWorkspaceFactory:
+    """Factory that records every workspace it creates."""
+
+    def __init__(self, seed: dict | None = None) -> None:
+        self.created: list[InterpreterWorkspace] = []
+        self._seed = seed
+
+    def __call__(self) -> InterpreterWorkspace:
+        ws = InterpreterWorkspace(seed=dict(self._seed) if self._seed else None)
+        self.created.append(ws)
+        return ws
+
+
+def test_prompt_without_workspace_summary_is_unchanged() -> None:
+    baseline = build_enriched_prompt(
+        task_prompt="Task",
+        playbook="notes",
+        generation=2,
+        best_output="prev",
+        best_score=0.5,
+    )
+    explicit = build_enriched_prompt(
+        task_prompt="Task",
+        playbook="notes",
+        generation=2,
+        best_output="prev",
+        best_score=0.5,
+        workspace_summary="",
+    )
+    assert explicit == baseline
+    assert "## Workspace" not in baseline
+
+
+def test_prompt_with_workspace_summary_adds_section() -> None:
+    prompt = build_enriched_prompt(
+        task_prompt="Task",
+        playbook="",
+        generation=1,
+        best_output="",
+        best_score=0.0,
+        workspace_summary="- pool (list, size 3): [1, 2, 3]",
+    )
+    assert "## Workspace (persistent interpreter variables; reference them by name, contents are not inlined)" in prompt
+    assert "- pool (list, size 3): [1, 2, 3]" in prompt
+
+
+def test_workspace_evaluate_fn_requires_factory() -> None:
+    with pytest.raises(ValueError, match="workspace_factory"):
+        AgentTaskEvolutionRunner(
+            task_prompt="Task",
+            generate_fn=lambda prompt, gen: "code",
+            evaluate_fn=lambda output, gen: _evaluation(0.5),
+            workspace_evaluate_fn=lambda output, gen, ws: _evaluation(0.5),
+        )
+
+
+def test_run_generation_uses_workspace_evaluate_fn_with_assembled_program() -> None:
+    seen: list[tuple[str, int, InterpreterWorkspace]] = []
+
+    def workspace_evaluate(output: str, gen: int, ws: InterpreterWorkspace) -> AgentTaskGenerationEvaluation:
+        seen.append((output, gen, ws))
+        return _evaluation(0.7, output="slot_code")
+
+    factory = TrackingWorkspaceFactory()
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Task",
+        generate_fn=lambda prompt, gen: "slot_code",
+        evaluate_fn=lambda output, gen: _evaluation(0.1),
+        slot=FunctionSlot(harness="harness_code"),
+        workspace_factory=factory,
+        workspace_evaluate_fn=workspace_evaluate,
+    )
+    ws = factory()
+    state = runner.run_generation(_state(), workspace=ws)
+    assert len(seen) == 1
+    program, gen, seen_ws = seen[0]
+    assert program == "slot_code\n\nharness_code"
+    assert gen == 0
+    assert seen_ws is ws
+    # Slot mode still carries only the slot forward.
+    assert state.best_output == "slot_code"
+
+
+def test_run_generation_without_workspace_falls_back_to_evaluate_fn() -> None:
+    calls: list[str] = []
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Task",
+        generate_fn=lambda prompt, gen: "code",
+        evaluate_fn=lambda output, gen: (calls.append(output), _evaluation(0.4))[1],
+        workspace_factory=TrackingWorkspaceFactory(),
+        workspace_evaluate_fn=lambda output, gen, ws: _evaluation(0.9),
+    )
+    state = runner.run_generation(_state())
+    assert calls == ["code"]
+    assert state.best_score == 0.4
+
+
+def test_run_generation_renders_workspace_into_prompt_and_metadata() -> None:
+    ws = InterpreterWorkspace(seed={"pool": [1, 2, 3]})
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Task",
+        generate_fn=lambda prompt, gen: "code",
+        evaluate_fn=lambda output, gen: _evaluation(0.4),
+    )
+    state = runner.run_generation(_state(), workspace=ws)
+    prompt = state.metadata["generation_prompts"][0]
+    assert "## Workspace" in prompt
+    assert "- pool (list, size 3): [1, 2, 3]" in prompt
+    assert state.metadata["workspace_variables"] == [["pool:list"]]
+
+
+def test_run_with_state_persists_workspace_and_closes_it() -> None:
+    factory = TrackingWorkspaceFactory(seed={"pool": [1, 2, 3]})
+
+    def workspace_evaluate(output: str, gen: int, ws: InterpreterWorkspace) -> AgentTaskGenerationEvaluation:
+        ws.run(f"progress_{gen} = {gen}")
+        return _evaluation(0.5 + gen / 10, output=output)
+
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Task",
+        generate_fn=lambda prompt, gen: "code",
+        evaluate_fn=lambda output, gen: _evaluation(0.0),
+        workspace_factory=factory,
+        workspace_evaluate_fn=workspace_evaluate,
+    )
+    _, state = runner.run_with_state(num_generations=2)
+
+    assert len(factory.created) == 1
+    ws = factory.created[0]
+    # Variables written in generation 0 appear in generation 1's prompt.
+    second_prompt = state.metadata["generation_prompts"][1]
+    assert "progress_0" in second_prompt
+    # Deterministic teardown after the run.
+    with pytest.raises(RuntimeError, match="closed"):
+        ws.run("1")
+
+
+def test_run_with_state_closes_workspace_on_evaluate_exception() -> None:
+    factory = TrackingWorkspaceFactory()
+
+    def exploding_evaluate(output: str, gen: int, ws: InterpreterWorkspace) -> AgentTaskGenerationEvaluation:
+        raise RuntimeError("boom")
+
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Task",
+        generate_fn=lambda prompt, gen: "code",
+        evaluate_fn=lambda output, gen: _evaluation(0.0),
+        workspace_factory=factory,
+        workspace_evaluate_fn=exploding_evaluate,
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        runner.run_with_state(num_generations=1)
+    assert len(factory.created) == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        factory.created[0].run("1")
+
+
+def test_run_islands_one_workspace_per_island_all_closed() -> None:
+    factory = TrackingWorkspaceFactory()
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Task",
+        generate_fn=lambda prompt, gen: "code",
+        evaluate_fn=lambda output, gen: _evaluation(0.0),
+        workspace_factory=factory,
+        workspace_evaluate_fn=lambda output, gen, ws: _evaluation(0.5),
+    )
+    runner.run_islands(num_islands=3, num_generations=2)
+    assert len(factory.created) == 3
+    for ws in factory.created:
+        with pytest.raises(RuntimeError, match="closed"):
+            ws.run("1")
+
+
+def test_migrate_workspaces_adopts_champion_state_in_laggards_only() -> None:
+    champion_ws = InterpreterWorkspace(seed={"data": [1, 2, 3]})
+    laggard_ws = InterpreterWorkspace(seed={"data": [9]})
+    tied_ws = InterpreterWorkspace(seed={"data": [7]})
+
+    def state_with(score: float) -> AgentTaskGenerationState:
+        return AgentTaskGenerationState(
+            generation=1,
+            best_output=f"out_{score}",
+            best_score=score,
+            playbook="",
+            score_history=[score],
+            lesson_history=[],
+            metadata={},
+        )
+
+    states = [state_with(0.9), state_with(0.2), state_with(0.9)]
+    migrated = migrate_states(states)
+    migrate_workspaces(states, migrated, [champion_ws, laggard_ws, tied_ws])
+
+    adopted = laggard_ws.run("data")
+    assert "[1, 2, 3]" in adopted.stdout
+    untouched = tied_ws.run("data")
+    assert "[7]" in untouched.stdout
+    # Deep independence: mutating the laggard's copy leaves the champion intact.
+    laggard_ws.run("data[0] = 99")
+    original = champion_ws.run("data")
+    assert "[1, 2, 3]" in original.stdout
+
+
+def test_run_islands_migration_carries_workspace_variables() -> None:
+    factory = TrackingWorkspaceFactory()
+    scores = {0: [0.9, 0.9], 1: [0.1, 0.1]}
+    observed: dict[int, str] = {}
+
+    def workspace_evaluate(output: str, gen: int, ws: InterpreterWorkspace) -> AgentTaskGenerationEvaluation:
+        island = factory.created.index(ws)
+        if gen == 0:
+            ws.run(f"marker = {island}")
+        else:
+            observed[island] = ws.run("marker").stdout.strip()
+        return _evaluation(scores[island][gen])
+
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Task",
+        generate_fn=lambda prompt, gen: "code",
+        evaluate_fn=lambda output, gen: _evaluation(0.0),
+        workspace_factory=factory,
+        workspace_evaluate_fn=workspace_evaluate,
+    )
+    runner.run_islands(num_islands=2, num_generations=2, migrate_every=1)
+    # After the first migration the laggard island's workspace carries the
+    # champion's marker (island 0), observed during its second generation.
+    assert observed[0] == "0"
+    assert observed[1] == "0"

--- a/autocontext/tests/test_interpreter_workspace.py
+++ b/autocontext/tests/test_interpreter_workspace.py
@@ -1,0 +1,134 @@
+"""Tests for the persistent interpreter workspace (AC-901)."""
+
+from __future__ import annotations
+
+import pytest
+
+from autocontext.execution.interpreter_workspace import (
+    InterpreterWorkspace,
+    WorkspaceSnapshot,
+    WorkspaceVariable,
+)
+
+
+def test_state_persists_across_run_calls() -> None:
+    ws = InterpreterWorkspace()
+    first = ws.run("x = 5")
+    assert first.error is None
+    second = ws.run("x + 1")
+    assert second.error is None
+    assert "6" in second.stdout
+
+
+def test_variables_lists_seeded_and_assigned_only() -> None:
+    ws = InterpreterWorkspace(seed={"pool": [1, 2, 3]})
+    ws.run("best = 'abc'")
+    ws.run("_scratch = 1")
+    names = {v.name for v in ws.variables()}
+    assert names == {"pool", "best"}
+    # ReplWorker infrastructure never leaks into the listing.
+    assert "answer" not in names
+    assert "json" not in names
+    assert "peek" not in names
+
+
+def test_variables_metadata_fields() -> None:
+    ws = InterpreterWorkspace(seed={"pool": [1, 2, 3]})
+    ws.run("count = 7")
+    by_name = {v.name: v for v in ws.variables()}
+    pool = by_name["pool"]
+    assert isinstance(pool, WorkspaceVariable)
+    assert pool.type_name == "list"
+    assert pool.size == 3
+    assert pool.summary == "[1, 2, 3]"
+    count = by_name["count"]
+    assert count.type_name == "int"
+    assert count.size is None
+    assert count.summary == "7"
+
+
+def test_variables_sorted_and_summary_truncated() -> None:
+    ws = InterpreterWorkspace()
+    ws.run("zeta = 1")
+    ws.run(f"alpha = {'x' * 500!r}")
+    listed = ws.variables()
+    assert [v.name for v in listed] == ["alpha", "zeta"]
+    assert len(listed[0].summary) <= 120
+
+
+def test_render_markdown_bounded() -> None:
+    ws = InterpreterWorkspace()
+    for i in range(25):
+        ws.run(f"var_{i:02d} = {i}")
+    rendered = ws.render_markdown(max_vars=20)
+    assert "- var_00 (int): 0" in rendered
+    assert "var_19" in rendered
+    assert "- var_20" not in rendered
+    assert "... and 5 more" in rendered
+
+
+def test_render_markdown_empty_workspace() -> None:
+    ws = InterpreterWorkspace()
+    assert ws.render_markdown() == ""
+
+
+def test_snapshot_restore_round_trip_is_deep() -> None:
+    ws = InterpreterWorkspace(seed={"pool": [[1], [2]]})
+    snap = ws.snapshot()
+
+    fresh = InterpreterWorkspace()
+    fresh.restore(snap)
+    result = fresh.run("pool[0][0]")
+    assert "1" in result.stdout
+
+    # Mutating the restored copy touches neither the snapshot nor the source.
+    fresh.run("pool[0][0] = 99")
+    assert snap.variables["pool"][0][0] == 1
+    source = ws.run("pool[0][0]")
+    assert "1" in source.stdout
+
+
+def test_snapshot_skips_non_copyable_values() -> None:
+    ws = InterpreterWorkspace()
+    ws.run("gen = (i for i in range(3))")
+    ws.run("ok = [1, 2]")
+    snap = ws.snapshot()
+    assert isinstance(snap, WorkspaceSnapshot)
+    assert "gen" in snap.skipped
+    assert snap.variables["ok"] == [1, 2]
+    assert "gen" not in snap.variables
+
+
+def test_restore_replaces_existing_user_variables() -> None:
+    ws = InterpreterWorkspace(seed={"stale": 1})
+    ws.restore(WorkspaceSnapshot(variables={"fresh": 2}, skipped=()))
+    names = {v.name for v in ws.variables()}
+    assert names == {"fresh"}
+
+
+def test_error_result_keeps_workspace_usable() -> None:
+    ws = InterpreterWorkspace()
+    result = ws.run("1/0")
+    assert result.error is not None and "ZeroDivisionError" in result.error
+    after = ws.run("2 + 2")
+    assert after.error is None
+    assert "4" in after.stdout
+
+
+def test_close_is_deterministic_teardown() -> None:
+    ws = InterpreterWorkspace(seed={"pool": [1]})
+    ws.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        ws.run("1 + 1")
+    with pytest.raises(RuntimeError, match="closed"):
+        ws.snapshot()
+    with pytest.raises(RuntimeError, match="closed"):
+        ws.restore(WorkspaceSnapshot(variables={}, skipped=()))
+    # Idempotent close.
+    ws.close()
+
+
+def test_timeout_configured_through_worker() -> None:
+    ws = InterpreterWorkspace(timeout_seconds=0.2)
+    result = ws.run("while True:\n    pass")
+    assert result.error is not None

--- a/autocontext/tests/test_interpreter_workspace.py
+++ b/autocontext/tests/test_interpreter_workspace.py
@@ -142,6 +142,17 @@ def test_system_exit_from_candidate_is_contained() -> None:
     assert after.error is None and "2" in after.stdout
 
 
+def test_base_exception_from_candidate_is_contained() -> None:
+    """`raise BaseException` needs no builtins and previously escaped run(),
+    the same daemon-killing path as the SystemExit case (TaskRunner catches
+    Exception only)."""
+    ws = InterpreterWorkspace()
+    result = ws.run("raise BaseException('boom')")
+    assert result.error is not None and "BaseException" in result.error
+    after = ws.run("1 + 1")
+    assert after.error is None and "2" in after.stdout
+
+
 def test_seed_values_do_not_alias_caller_state() -> None:
     caller_pool = [1, 2, 3]
     ws = InterpreterWorkspace(seed={"pool": caller_pool})

--- a/autocontext/tests/test_interpreter_workspace.py
+++ b/autocontext/tests/test_interpreter_workspace.py
@@ -132,3 +132,55 @@ def test_timeout_configured_through_worker() -> None:
     ws = InterpreterWorkspace(timeout_seconds=0.2)
     result = ws.run("while True:\n    pass")
     assert result.error is not None
+
+
+def test_system_exit_from_candidate_is_contained() -> None:
+    ws = InterpreterWorkspace()
+    result = ws.run("raise SystemExit(3)")
+    assert result.error is not None and "SystemExit" in result.error
+    after = ws.run("1 + 1")
+    assert after.error is None and "2" in after.stdout
+
+
+def test_seed_values_do_not_alias_caller_state() -> None:
+    caller_pool = [1, 2, 3]
+    ws = InterpreterWorkspace(seed={"pool": caller_pool})
+    ws.run("pool.append(99)")
+    assert caller_pool == [1, 2, 3]
+
+
+def test_seed_keys_may_not_collide_with_infrastructure() -> None:
+    with pytest.raises(ValueError, match="answer"):
+        InterpreterWorkspace(seed={"answer": {}})
+    with pytest.raises(ValueError, match="_private"):
+        InterpreterWorkspace(seed={"_private": 1})
+
+
+def test_variables_and_render_raise_after_close() -> None:
+    ws = InterpreterWorkspace(seed={"pool": [1]})
+    ws.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        ws.variables()
+    with pytest.raises(RuntimeError, match="closed"):
+        ws.render_markdown()
+
+
+def test_restore_is_two_phase_and_skips_uncopyable_values() -> None:
+    class ExplodesOnSecondDeepcopy:
+        def __init__(self) -> None:
+            self.copies = 0
+
+        def __deepcopy__(self, memo):
+            self.copies += 1
+            if self.copies > 1:
+                raise RuntimeError("stateful deepcopy")
+            return self
+
+    ws = InterpreterWorkspace(seed={"keep": [1]})
+    snap = WorkspaceSnapshot(variables={"bad": ExplodesOnSecondDeepcopy(), "good": [2]}, skipped=())
+    # First deepcopy of "bad" happens here and succeeds; the restore-time
+    # copy raises and must degrade to omission, not a partial namespace.
+    snap.variables["bad"].__deepcopy__({})
+    ws.restore(snap)
+    names = {v.name for v in ws.variables()}
+    assert names == {"good"}

--- a/autocontext/tests/test_workspace_benchmark.py
+++ b/autocontext/tests/test_workspace_benchmark.py
@@ -1,0 +1,145 @@
+"""Workspace vs serialize-everything baseline (AC-901 acceptance benchmark).
+
+Cap-sets-style deterministic comparison: the working state is a pool of
+F_3^dim vectors, candidates are priority functions for a fixed greedy
+harness. Baseline mode carries the pool inside the whole-program
+``best_output`` (re-serialized into every enriched prompt); workspace mode
+keeps the pool as a persistent interpreter variable referenced by name.
+Both must reach the same score; workspace prompts must be far smaller.
+"""
+
+from __future__ import annotations
+
+import random
+
+from autocontext.execution.agent_task_evolution import (
+    AgentTaskEvolutionRunner,
+    AgentTaskGenerationEvaluation,
+    FunctionSlot,
+)
+from autocontext.execution.interpreter_workspace import InterpreterWorkspace
+
+GREEDY_HARNESS = """\
+def _is_line(a, b, c):
+    return all((x + y + z) % 3 == 0 for x, y, z in zip(a, b, c))
+
+def build_cap(pool, priority):
+    chosen = []
+    for v in sorted(pool, key=priority, reverse=True):
+        if all(not _is_line(v, a, b) for i, a in enumerate(chosen) for b in chosen[:i]):
+            chosen.append(v)
+    return chosen
+
+cap = build_cap(pool, priority)
+answer["content"] = str(len(cap))
+answer["ready"] = True
+"""
+
+SLOTS = [
+    "def priority(v):\n    return 0",
+    "def priority(v):\n    return sum(v)",
+    "def priority(v):\n    return -sum(v)",
+    "def priority(v):\n    return v.count(0)",
+    "def priority(v):\n    return sum(x * x for x in v)",
+]
+
+
+def make_pool(n: int = 250, dim: int = 7, seed: int = 7) -> list[tuple[int, ...]]:
+    rng = random.Random(seed)
+    vectors = {tuple(rng.randrange(3) for _ in range(dim)) for _ in range(n)}
+    return sorted(vectors)
+
+
+def _score(size: int) -> float:
+    return size / 100.0
+
+
+def run_workspace_mode(pool: list[tuple[int, ...]], generations: int) -> tuple[float, list[str], list[int]]:
+    """Returns (best_score, generation_prompts, history_lengths_seen)."""
+    history_lengths: list[int] = []
+
+    def factory() -> InterpreterWorkspace:
+        return InterpreterWorkspace(seed={"pool": list(pool), "history": []})
+
+    def workspace_evaluate(program: str, gen: int, ws: InterpreterWorkspace) -> AgentTaskGenerationEvaluation:
+        result = ws.run(program)
+        size = int(result.answer["content"]) if result.error is None and result.answer.get("content") else 0
+        history_result = ws.run(f"history.append({size})\nlen(history)")
+        history_lengths.append(int(history_result.stdout.strip()))
+        return AgentTaskGenerationEvaluation(output=program, score=_score(size), reasoning="deterministic")
+
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Find a large cap set from the workspace variable `pool`.",
+        generate_fn=lambda prompt, gen: SLOTS[gen % len(SLOTS)],
+        evaluate_fn=lambda output, gen: AgentTaskGenerationEvaluation(output=output, score=0.0, reasoning=""),
+        slot=FunctionSlot(harness=GREEDY_HARNESS),
+        workspace_factory=factory,
+        workspace_evaluate_fn=workspace_evaluate,
+    )
+    _, state = runner.run_with_state(generations)
+    return state.best_score, list(state.metadata["generation_prompts"]), history_lengths
+
+
+def run_baseline_mode(pool: list[tuple[int, ...]], generations: int) -> tuple[float, list[str]]:
+    """Whole-program mode: the pool is serialized into every candidate program."""
+
+    def generate_fn(prompt: str, gen: int) -> str:
+        return f"pool = {pool!r}\n\n{SLOTS[gen % len(SLOTS)]}\n\n{GREEDY_HARNESS}"
+
+    def evaluate_fn(program: str, gen: int) -> AgentTaskGenerationEvaluation:
+        scratch = InterpreterWorkspace()
+        try:
+            result = scratch.run(program)
+            size = int(result.answer["content"]) if result.error is None and result.answer.get("content") else 0
+        finally:
+            scratch.close()
+        return AgentTaskGenerationEvaluation(output=program, score=_score(size), reasoning="deterministic")
+
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Find a large cap set from the pool defined in the program.",
+        generate_fn=generate_fn,
+        evaluate_fn=evaluate_fn,
+    )
+    _, state = runner.run_with_state(generations)
+    return state.best_score, list(state.metadata["generation_prompts"])
+
+
+def test_workspace_matches_baseline_score_with_far_smaller_prompts() -> None:
+    pool = make_pool()
+    generations = 5
+
+    ws_best, ws_prompts, history_lengths = run_workspace_mode(pool, generations)
+    base_best, base_prompts = run_baseline_mode(pool, generations)
+
+    assert ws_best > 0
+    assert ws_best == base_best
+
+    # The pool never leaks into workspace prompts; the baseline re-serializes
+    # it (until semantic compaction caps the carried output, an orthogonal
+    # mitigation that shrinks but does not remove the serialized state).
+    mean_ws = sum(len(p) for p in ws_prompts) / len(ws_prompts)
+    mean_base = sum(len(p) for p in base_prompts) / len(base_prompts)
+    assert mean_ws < 0.5 * mean_base
+
+    # Content check: a pool vector's serialization appears in baseline
+    # prompts from generation 2 onward (carried best_output) but never in
+    # any workspace prompt. The workspace section shows only a truncated
+    # 120-char summary (roughly the first five vectors), so an element
+    # deeper in the pool can never appear there; it is still early enough
+    # to survive compaction's head-keeping truncation in the baseline.
+    marker = repr(pool[10])
+    assert marker in base_prompts[1]
+    assert all(marker not in prompt for prompt in ws_prompts)
+
+    # Persistence: the history variable accumulated one entry per generation
+    # inside the same interpreter (state written in generation N is visible
+    # in generation N+1).
+    assert history_lengths == list(range(1, generations + 1))
+
+
+def test_workspace_prompts_stay_flat_as_generations_accumulate() -> None:
+    pool = make_pool()
+    _, ws_prompts, _ = run_workspace_mode(pool, 5)
+    # Prompt size stays flat (workspace section lists names, not contents):
+    # later generations may add lessons but never the serialized pool.
+    assert max(len(p) for p in ws_prompts) < 3000

--- a/autocontext/tests/test_workspace_interpreter_settings.py
+++ b/autocontext/tests/test_workspace_interpreter_settings.py
@@ -1,0 +1,91 @@
+"""Workspace interpreter opt-in configuration (AC-901)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.config.settings import AppSettings, load_settings
+from autocontext.execution.interpreter_workspace import InterpreterWorkspace
+from autocontext.execution.task_runner import (
+    SimpleAgentTask,
+    TaskConfig,
+    TaskRunner,
+    _workspace_factory_from_settings,
+)
+from autocontext.providers.base import CompletionResult, LLMProvider
+from autocontext.storage.sqlite_store import SQLiteStore
+
+
+class _Provider(LLMProvider):
+    def complete(self, system_prompt, user_prompt, model=None, temperature=0.0, max_tokens=4096):
+        return CompletionResult(text="output", model=model or "mock")
+
+    def default_model(self):
+        return "mock-v1"
+
+
+def test_defaults_are_off() -> None:
+    settings = AppSettings()
+    assert settings.workspace_interpreter_enabled is False
+    assert settings.workspace_interpreter_timeout_seconds == 10.0
+
+
+def test_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_WORKSPACE_INTERPRETER_ENABLED", "true")
+    monkeypatch.setenv("AUTOCONTEXT_WORKSPACE_INTERPRETER_TIMEOUT_SECONDS", "2.5")
+    settings = load_settings()
+    assert settings.workspace_interpreter_enabled is True
+    assert settings.workspace_interpreter_timeout_seconds == 2.5
+
+
+def test_factory_helper_respects_flag_and_timeout() -> None:
+    factory = _workspace_factory_from_settings(
+        AppSettings(workspace_interpreter_enabled=True, workspace_interpreter_timeout_seconds=3.0)
+    )
+    assert factory is not None
+    ws = factory()
+    assert isinstance(ws, InterpreterWorkspace)
+    assert ws._worker._timeout == 3.0  # noqa: SLF001
+    ws.close()
+
+    assert _workspace_factory_from_settings(AppSettings()) is None
+    assert _workspace_factory_from_settings(None) is None
+
+
+def test_multi_generation_passes_workspace_factory_when_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from autocontext.execution import task_runner as task_runner_module
+
+    store = SQLiteStore(tmp_path / "test.db")
+    store.migrate(Path(__file__).parent.parent / "migrations")
+
+    captured: dict[str, object] = {}
+
+    class FakeRunner:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def run_with_state(self, generations: int) -> tuple[None, None]:
+            raise RuntimeError("stop before persistence")
+
+    monkeypatch.setattr(task_runner_module, "AgentTaskEvolutionRunner", FakeRunner)
+
+    provider = _Provider()
+    runner = TaskRunner(
+        store=store,
+        provider=provider,
+        settings=AppSettings(workspace_interpreter_enabled=True),
+    )
+    agent_task = SimpleAgentTask(task_prompt="Do the thing", rubric="Be accurate", provider=provider)
+
+    with pytest.raises(RuntimeError, match="stop before persistence"):
+        runner._run_task_multi_generation("task-1", agent_task, "spec-1", "initial", TaskConfig())
+
+    assert callable(captured["workspace_factory"])
+
+    captured.clear()
+    disabled_runner = TaskRunner(store=store, provider=provider, settings=AppSettings())
+    with pytest.raises(RuntimeError, match="stop before persistence"):
+        disabled_runner._run_task_multi_generation("task-2", agent_task, "spec-2", "initial", TaskConfig())
+    assert captured["workspace_factory"] is None

--- a/examples/workspace_benchmark.py
+++ b/examples/workspace_benchmark.py
@@ -1,0 +1,129 @@
+"""AC-901 benchmark: persistent interpreter workspace vs serialize-everything.
+
+Deterministic (no LLM, no network): a fixed slate of priority-function
+candidates runs against a cap-sets-style greedy harness over a pool of
+F_3^7 vectors. Baseline mode carries the pool inside the whole-program
+best_output, re-serialized into every enriched prompt; workspace mode
+keeps the pool as a persistent interpreter variable referenced by name.
+
+Run from the ``autocontext/`` package directory:
+
+    uv run --frozen python ../examples/workspace_benchmark.py
+"""
+
+from __future__ import annotations
+
+import random
+import time
+
+from autocontext.execution.agent_task_evolution import (
+    AgentTaskEvolutionRunner,
+    AgentTaskGenerationEvaluation,
+    FunctionSlot,
+)
+from autocontext.execution.interpreter_workspace import InterpreterWorkspace
+
+GREEDY_HARNESS = """\
+def _is_line(a, b, c):
+    return all((x + y + z) % 3 == 0 for x, y, z in zip(a, b, c))
+
+def build_cap(pool, priority):
+    chosen = []
+    for v in sorted(pool, key=priority, reverse=True):
+        if all(not _is_line(v, a, b) for i, a in enumerate(chosen) for b in chosen[:i]):
+            chosen.append(v)
+    return chosen
+
+cap = build_cap(pool, priority)
+answer["content"] = str(len(cap))
+answer["ready"] = True
+"""
+
+SLOTS = [
+    "def priority(v):\n    return 0",
+    "def priority(v):\n    return sum(v)",
+    "def priority(v):\n    return -sum(v)",
+    "def priority(v):\n    return v.count(0)",
+    "def priority(v):\n    return sum(x * x for x in v)",
+]
+
+GENERATIONS = 5
+
+
+def make_pool(n: int = 250, dim: int = 7, seed: int = 7) -> list[tuple[int, ...]]:
+    rng = random.Random(seed)
+    return sorted({tuple(rng.randrange(3) for _ in range(dim)) for _ in range(n)})
+
+
+def _parse_size(result) -> int:
+    if result.error is None and result.answer.get("content"):
+        return int(result.answer["content"])
+    return 0
+
+
+def run_workspace(pool: list[tuple[int, ...]]) -> tuple[float, list[int], float]:
+    def factory() -> InterpreterWorkspace:
+        return InterpreterWorkspace(seed={"pool": list(pool)})
+
+    def workspace_evaluate(program: str, gen: int, ws: InterpreterWorkspace) -> AgentTaskGenerationEvaluation:
+        size = _parse_size(ws.run(program))
+        return AgentTaskGenerationEvaluation(output=program, score=size / 100.0, reasoning="deterministic")
+
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Find a large cap set from the workspace variable `pool`.",
+        generate_fn=lambda prompt, gen: SLOTS[gen % len(SLOTS)],
+        evaluate_fn=lambda output, gen: AgentTaskGenerationEvaluation(output=output, score=0.0, reasoning=""),
+        slot=FunctionSlot(harness=GREEDY_HARNESS),
+        workspace_factory=factory,
+        workspace_evaluate_fn=workspace_evaluate,
+    )
+    start = time.perf_counter()
+    _, state = runner.run_with_state(GENERATIONS)
+    elapsed = time.perf_counter() - start
+    return state.best_score, [len(p) for p in state.metadata["generation_prompts"]], elapsed
+
+
+def run_baseline(pool: list[tuple[int, ...]]) -> tuple[float, list[int], float]:
+    def generate_fn(prompt: str, gen: int) -> str:
+        return f"pool = {pool!r}\n\n{SLOTS[gen % len(SLOTS)]}\n\n{GREEDY_HARNESS}"
+
+    def evaluate_fn(program: str, gen: int) -> AgentTaskGenerationEvaluation:
+        scratch = InterpreterWorkspace()
+        try:
+            size = _parse_size(scratch.run(program))
+        finally:
+            scratch.close()
+        return AgentTaskGenerationEvaluation(output=program, score=size / 100.0, reasoning="deterministic")
+
+    runner = AgentTaskEvolutionRunner(
+        task_prompt="Find a large cap set from the pool defined in the program.",
+        generate_fn=generate_fn,
+        evaluate_fn=evaluate_fn,
+    )
+    start = time.perf_counter()
+    _, state = runner.run_with_state(GENERATIONS)
+    elapsed = time.perf_counter() - start
+    return state.best_score, [len(p) for p in state.metadata["generation_prompts"]], elapsed
+
+
+def main() -> None:
+    pool = make_pool()
+    ws_score, ws_prompts, ws_time = run_workspace(pool)
+    base_score, base_prompts, base_time = run_baseline(pool)
+
+    print(f"pool: {len(pool)} vectors in F_3^7, {GENERATIONS} generations, deterministic slate")
+    print()
+    print(f"{'generation':>10} | {'baseline prompt chars':>22} | {'workspace prompt chars':>23}")
+    for i, (b, w) in enumerate(zip(base_prompts, ws_prompts, strict=True), start=1):
+        print(f"{i:>10} | {b:>22} | {w:>23}")
+    mean_base = sum(base_prompts) / len(base_prompts)
+    mean_ws = sum(ws_prompts) / len(ws_prompts)
+    print(f"{'mean':>10} | {mean_base:>22.0f} | {mean_ws:>23.0f}")
+    print()
+    print(f"best score: baseline {base_score:.2f}, workspace {ws_score:.2f} (must match)")
+    print(f"wall time:  baseline {base_time:.3f}s, workspace {ws_time:.3f}s")
+    print(f"prompt compression: workspace mean is {mean_ws / mean_base:.1%} of baseline mean")
+
+
+if __name__ == "__main__":
+    main()

--- a/ts/src/execution/agent-task-evolution.ts
+++ b/ts/src/execution/agent-task-evolution.ts
@@ -5,6 +5,12 @@
  * maintained at behavioral parity with the Python module. The framework's
  * native multi-generation loop for agent tasks: lesson accumulation,
  * best-tracking, and enriched prompts carried across generations.
+ *
+ * AC-901 note: the persistent interpreter workspace substrate
+ * (`autocontext/execution/interpreter_workspace.py`) is Python-only runner
+ * infrastructure; ts/src has no code-execution engine. This module mirrors
+ * only the prompt/data layer (workspace variable descriptions and the
+ * workspace prompt section) so cross-language artifacts stay consistent.
  */
 
 import { compactPromptComponent } from "../knowledge/semantic-compaction.js";
@@ -265,7 +271,9 @@ export function proposeSkillPromotion(
 export async function validateSkillPromotion(
   edit: HarnessEdit,
   slotHarness: FunctionSlot,
-  evaluate: (program: string) => AgentTaskGenerationEvaluation | Promise<AgentTaskGenerationEvaluation>,
+  evaluate: (
+    program: string,
+  ) => AgentTaskGenerationEvaluation | Promise<AgentTaskGenerationEvaluation>,
   opts: { bestScore: number; skills?: string[]; epsilon?: number },
 ): Promise<boolean> {
   if (!edit.reference) return false;
@@ -274,12 +282,35 @@ export async function validateSkillPromotion(
   return evaluation.score >= opts.bestScore - (opts.epsilon ?? 1e-9);
 }
 
+/** Prompt-facing description of one workspace variable (AC-901). */
+export interface WorkspaceVariable {
+  name: string;
+  typeName: string;
+  size: number | null;
+  summary: string;
+}
+
+/** Render workspace variables as prompt-ready markdown lines (AC-901). */
+export function renderWorkspaceSummary(vars: WorkspaceVariable[], maxVars = 20): string {
+  const lines = vars.slice(0, maxVars).map((v) => {
+    const sizePart = v.size !== null ? `, size ${v.size}` : "";
+    return `- ${v.name} (${v.typeName}${sizePart}): ${v.summary}`;
+  });
+  if (vars.length > maxVars) {
+    lines.push(`... and ${vars.length - maxVars} more`);
+  }
+  return lines.join("\n");
+}
+
 /**
  * Enrich a task prompt with cross-generation context.
  *
  * In function-slot mode (`harness` provided), the fixed harness is shown once
  * as stable context so the model knows the contract it writes the slot
  * against. The evolved slot itself is carried via `bestOutput`.
+ *
+ * `workspaceSummary` describes persistent interpreter variables by name
+ * (AC-901); contents stay in the workspace, never in the prompt.
  */
 export function buildEnrichedPrompt(args: {
   taskPrompt: string;
@@ -289,6 +320,7 @@ export function buildEnrichedPrompt(args: {
   bestScore: number;
   harness?: string;
   skills?: HarnessEntry[];
+  workspaceSummary?: string;
 }): string {
   const playbook = compactPromptComponent("agent_task_playbook", args.playbook);
   const bestOutput = compactPromptComponent("agent_task_best_output", args.bestOutput);
@@ -320,7 +352,17 @@ export function buildEnrichedPrompt(args: {
     return [`- \`${pattern}\`: ${entry.title.replace(/\n/g, " ")}`];
   });
   if (skillLines.length > 0) {
-    sections.push("\n\n## Available Skills (call them; do not reimplement)\n" + skillLines.join("\n"));
+    sections.push(
+      "\n\n## Available Skills (call them; do not reimplement)\n" + skillLines.join("\n"),
+    );
+  }
+
+  if (args.workspaceSummary) {
+    sections.push(
+      "\n\n## Workspace (persistent interpreter variables; reference them by name, " +
+        "contents are not inlined)\n" +
+        args.workspaceSummary,
+    );
   }
 
   if (playbook || bestOutput) {

--- a/ts/tests/agent-task-evolution.test.ts
+++ b/ts/tests/agent-task-evolution.test.ts
@@ -8,6 +8,7 @@ import {
   lessonEdit,
   migrateStates,
   proposeSkillPromotion,
+  renderWorkspaceSummary,
   validateSkillPromotion,
   type AgentTaskGenerationEvaluation,
   type AgentTaskGenerationState,
@@ -415,5 +416,50 @@ describe("skill promotion (parity with Python, AC-899)", () => {
       reasoning: "regressed",
     }), { bestScore: 0.949 });
     expect(bad).toBe(false);
+  });
+});
+
+describe("workspace prompt section (AC-901 parity with Python)", () => {
+  it("renderWorkspaceSummary formats variables and bounds the listing", () => {
+    const vars = Array.from({ length: 25 }, (_, i) => ({
+      name: `var_${String(i).padStart(2, "0")}`,
+      typeName: "int",
+      size: null,
+      summary: String(i),
+    }));
+    const rendered = renderWorkspaceSummary(vars, 20);
+    expect(rendered).toContain("- var_00 (int): 0");
+    expect(rendered).toContain("- var_19 (int): 19");
+    expect(rendered).not.toContain("- var_20");
+    expect(rendered).toContain("... and 5 more");
+  });
+
+  it("renderWorkspaceSummary includes size when present and returns empty for no vars", () => {
+    const rendered = renderWorkspaceSummary([
+      { name: "pool", typeName: "list", size: 3, summary: "[1, 2, 3]" },
+    ]);
+    expect(rendered).toBe("- pool (list, size 3): [1, 2, 3]");
+    expect(renderWorkspaceSummary([])).toBe("");
+  });
+
+  it("buildEnrichedPrompt appends the workspace section only when a summary is given", () => {
+    const base = {
+      taskPrompt: "TASK",
+      playbook: "",
+      generation: 1,
+      bestOutput: "",
+      bestScore: 0,
+    };
+    expect(buildEnrichedPrompt(base)).toBe("TASK");
+    expect(buildEnrichedPrompt({ ...base, workspaceSummary: "" })).toBe("TASK");
+    const withWorkspace = buildEnrichedPrompt({
+      ...base,
+      workspaceSummary: "- pool (list, size 3): [1, 2, 3]",
+    });
+    // Section text pinned to the exact Python literal.
+    expect(withWorkspace).toContain(
+      "## Workspace (persistent interpreter variables; reference them by name, contents are not inlined)",
+    );
+    expect(withWorkspace).toContain("- pool (list, size 3): [1, 2, 3]");
   });
 });


### PR DESCRIPTION
## Summary

Implements [AC-901](https://linear.app/greyhaven/issue/AC-901): carry working state across generations as persistent interpreter variables referenced by name, instead of re-serializing contents into every enriched prompt (prime-agent RLM lesson, pinned be9e2fa).

- **`execution/interpreter_workspace.py`**: `InterpreterWorkspace` wraps the existing `harness/repl` `ReplWorker` (persistent restricted namespace, timeouts). API: `run`, `variables()` (name/type/size/120-char summary), `render_markdown`, `snapshot`/`restore` (deep copy both ways; uncopyable values degrade to `skipped`), `close()` (deterministic teardown; later use raises). Documented as lifecycle isolation, not a security sandbox.
- **Evolution runner integration**: `build_enriched_prompt` gains a Workspace section (names only, never contents); `AgentTaskEvolutionRunner` gains `workspace_factory` + `workspace_evaluate_fn`; one workspace per lineage (per island in `run_islands`) with try/finally teardown; `migrate_workspaces` carries a champion snapshot into islands that adopted its output during migration, deep-copied so lineages never share objects.
- **Opt-in config**: `AUTOCONTEXT_WORKSPACE_INTERPRETER_ENABLED` (default off; the non-workspace path is byte-identical) + `AUTOCONTEXT_WORKSPACE_INTERPRETER_TIMEOUT_SECONDS`, in a `config/workspace_interpreter.py` mixin (settings.py stays at 848/850 lines). Task-runner wiring is substrate-only (documented): the LLM-judge queued-task path executes no candidate code; code-mode consumers pass `workspace_evaluate_fn` directly.
- **TS parity (prompt layer)**: `WorkspaceVariable`, `renderWorkspaceSummary`, `workspaceSummary` on `buildEnrichedPrompt`, section literal pinned to the Python string by test. The interpreter substrate itself is Python-only runner infrastructure (ts/src has no code-execution engine), documented in the module header.

## Benchmark (deterministic, no LLM)

Cap-sets-style greedy over 238 F_3^7 vectors, 5 generations, fixed candidate slate (`examples/workspace_benchmark.py`):

```
generation |  baseline prompt chars |  workspace prompt chars
         1 |                     58 |                     780
         2 |                   3993 |                    1369
         3 |                   4047 |                    1423
         4 |                   4101 |                    1477
         5 |                   4155 |                    1531
      mean |                   3271 |                    1316

best score: baseline 0.95, workspace 0.95 (must match)
prompt compression: workspace mean is 40.2% of baseline mean
```

The baseline is already capped by semantic compaction (~900 tokens of carried output); without it the gap widens. `tests/test_workspace_benchmark.py` pins equal scores, <50% mean prompt size, pool serialization never appearing in workspace prompts, and cross-generation persistence.

## Review

Independent review found 0 Critical / 3 Important / 6 Minor; all fixed and test-pinned in 89f29bcc, notably: SystemExit from candidate code is now contained (it previously escaped ReplWorker's Exception-only handler and would have killed the TaskRunner daemon), seed values are deep-copied so candidate mutations cannot alias caller state, and `restore()` stages copies before deleting so a failing deepcopy cannot leave a half-restored namespace.

## Testing

- Full Python suite green (`uv run --frozen pytest`), ruff + mypy clean.
- TS: targeted vitest (30/30), `npm run lint` (tsc + test-types), `check:schemas`, no new type assertions.