### PR TITLE
AC-907: rollback enforces the scope guardrail

### DIFF
--- a/autocontext/src/autocontext/knowledge/harness_entries.py
+++ b/autocontext/src/autocontext/knowledge/harness_entries.py
@@ -35,6 +35,19 @@ HarnessOutcome = Literal["pending", "confirmed", "refuted"]
 
 SCOPE_ORDER: dict[str, int] = {"run": 0, "scenario_family": 1, "global": 2}
 
+
+def _require_scope(scope: str) -> HarnessScope:
+    """Runtime backstop mirroring the TS ``requireScope`` (AC-907).
+
+    Typed callers are covered by mypy, but scope strings arriving from
+    dynamic boundaries (JSON, MCP) would otherwise surface as a raw
+    ``KeyError`` from the ``SCOPE_ORDER`` lookup.
+    """
+    if scope not in SCOPE_ORDER:
+        raise ValueError(f"unknown harness scope: {scope}")
+    return scope  # type: ignore[return-value]
+
+
 STATE_FILE_NAME = "harness_state.json"
 HISTORY_FILE_NAME = "harness_refinements.jsonl"
 
@@ -160,6 +173,7 @@ class HarnessEntryStore:
         An empty batch is a no-op: nothing is persisted and the returned
         refinement is not recorded in history.
         """
+        _require_scope(scope)
         state = self._load_state()
         applied = [self._apply_edit(state, edit, scope=scope, source=source) for edit in edits]
         refinement = HarnessRefinement(
@@ -219,6 +233,7 @@ class HarnessEntryStore:
         scope guardrail as ``apply`` holds: a narrower-scope caller cannot
         mark a broader-scope entry.
         """
+        _require_scope(scope)
         state = self._load_state()
         existing = state.get(entry_id)
         if existing is None:
@@ -265,10 +280,16 @@ class HarnessEntryStore:
 
         The same scope guardrail as ``apply`` and ``mark_outcome`` holds
         (AC-907): a narrower-scope caller cannot roll back a broader-scope
-        refinement. Checking the refinement's scope suffices because every
-        entry a refinement touched has scope at or below the refinement's
-        (``apply`` creates at caller scope and rejects broader updates).
+        refinement (whole-refinement check), and each restore additionally
+        verifies the CURRENT occupant of the entry id and the snapshot
+        being restored. The per-entry checks matter because entry ids can
+        be reused across scopes: an id deleted at run scope and recreated
+        at global scope must not be deletable or overwritable by a
+        run-scoped rollback. Blocked items are recorded with
+        ``error="scope_readonly"`` (the per-edit convention of ``apply``)
+        while the rest of the refinement still rolls back.
         """
+        _require_scope(scope)
         target = next((r for r in self.load_history() if r.id == refinement_id), None)
         if target is None:
             raise ValueError(f"unknown refinement: {refinement_id}")
@@ -280,6 +301,15 @@ class HarnessEntryStore:
             if not item.applied:
                 continue
             reason = f"rollback of {refinement_id}"
+            current = state.get(item.entry_id)
+            blocked = (current is not None and SCOPE_ORDER[current.scope] > SCOPE_ORDER[scope]) or (
+                item.before is not None and SCOPE_ORDER[item.before.scope] > SCOPE_ORDER[scope]
+            )
+            if blocked:
+                blocked_action: Literal["delete", "update"] = "delete" if item.before is None else "update"
+                edit = HarnessEdit(action=blocked_action, kind=item.edit.kind, id=item.entry_id, reason=reason)
+                applied.append(AppliedHarnessEdit(edit=edit, entry_id=item.entry_id, applied=False, error="scope_readonly"))
+                continue
             if item.before is None:
                 removed = state.pop(item.entry_id, None)
                 edit = HarnessEdit(action="delete", kind=item.edit.kind, id=item.entry_id, reason=reason)

--- a/autocontext/src/autocontext/knowledge/harness_entries.py
+++ b/autocontext/src/autocontext/knowledge/harness_entries.py
@@ -7,6 +7,10 @@ before/after snapshots, so any refinement can be rolled back. Modeled on
 prime-agent's continual-harness refinement store; adds outcome marking so
 verifier-scored runs can confirm or refute an entry's expected outcome.
 
+The scope guardrail (a narrower-scope caller cannot mutate broader-scope
+state) covers every write path: ``apply``, ``mark_outcome``, and
+``rollback`` (AC-907).
+
 The store assumes a single writer per root directory: writes are atomic
 but load-modify-save, so concurrent writers are last-writer-wins. State
 files are per-language (the TypeScript mirror writes camelCase fields)
@@ -251,17 +255,25 @@ class HarnessEntryStore:
             return ""
         return "## Harness Entries\n\n" + "\n\n".join(sections) + "\n"
 
-    def rollback(self, refinement_id: str) -> HarnessRefinement:
+    def rollback(self, refinement_id: str, *, scope: HarnessScope) -> HarnessRefinement:
         """Invert a recorded refinement by restoring its before-snapshots.
 
         One-step semantics: snapshots are restored blindly, so edits made
         to the same entries by later refinements are overwritten (lost
         update). Outcome marks are measurements, not refinement effects,
         so a current non-pending outcome survives the restore.
+
+        The same scope guardrail as ``apply`` and ``mark_outcome`` holds
+        (AC-907): a narrower-scope caller cannot roll back a broader-scope
+        refinement. Checking the refinement's scope suffices because every
+        entry a refinement touched has scope at or below the refinement's
+        (``apply`` creates at caller scope and rejects broader updates).
         """
         target = next((r for r in self.load_history() if r.id == refinement_id), None)
         if target is None:
             raise ValueError(f"unknown refinement: {refinement_id}")
+        if SCOPE_ORDER[target.scope] > SCOPE_ORDER[scope]:
+            raise ValueError(f"scope_readonly: {refinement_id} is {target.scope}-scoped")
         state = self._load_state()
         applied: list[AppliedHarnessEdit] = []
         for item in reversed(target.applied_edits):

--- a/autocontext/tests/test_agent_task_skill_promotion.py
+++ b/autocontext/tests/test_agent_task_skill_promotion.py
@@ -170,7 +170,7 @@ class TestReviewHardening:
             [HarnessEdit(action="delete", kind="procedure", id=batch.applied_edits[0].entry_id)],
             scope="scenario_family",
         )
-        store.rollback(removed.id)
+        store.rollback(removed.id, scope="scenario_family")
         entry = store.entries(kind="procedure")[0]
         assert entry.reference is not None and entry.reference.source == SLOT
 

--- a/autocontext/tests/test_harness_entries.py
+++ b/autocontext/tests/test_harness_entries.py
@@ -177,7 +177,7 @@ class TestRollback:
             ],
             scope="run",
         )
-        result = store.rollback(batch.id)
+        result = store.rollback(batch.id, scope="run")
         assert result.rollback_of == batch.id
         by_id = {entry.id: entry for entry in store.entries()}
         assert set(by_id) == {"harness_keep", "harness_gone"}
@@ -187,12 +187,12 @@ class TestRollback:
     def test_rollback_unknown_id_raises(self, tmp_path) -> None:
         store = HarnessEntryStore(tmp_path)
         with pytest.raises(ValueError, match="unknown refinement"):
-            store.rollback("refinement_nope")
+            store.rollback("refinement_nope", scope="run")
 
     def test_rollback_is_itself_recorded(self, tmp_path) -> None:
         store = HarnessEntryStore(tmp_path)
         batch = store.apply([HarnessEdit(action="create", kind="fact", title="t", content="c")], scope="run")
-        store.rollback(batch.id)
+        store.rollback(batch.id, scope="run")
         history = store.load_history()
         assert len(history) == 2 and history[1].rollback_of == batch.id
 
@@ -250,13 +250,35 @@ class TestReviewHardening:
         marked = store.mark_outcome(entry_id, "refuted", scope="global")
         assert marked.outcome == "refuted"
 
+    def test_rollback_respects_scope_guardrail(self, tmp_path) -> None:
+        store = HarnessEntryStore(tmp_path)
+        batch = store.apply(
+            [HarnessEdit(action="create", kind="fact", id="harness_g", title="g", content="v1")], scope="global"
+        )
+        with pytest.raises(ValueError, match="scope_readonly"):
+            store.rollback(batch.id, scope="run")
+        # The rejected rollback mutated nothing: entry intact, no rollback recorded.
+        assert store.entries()[0].content == "v1"
+        assert len(store.load_history()) == 1
+        undone = store.rollback(batch.id, scope="global")
+        assert undone.rollback_of == batch.id
+        assert store.entries() == []
+
+    def test_broader_caller_can_roll_back_narrower_refinement(self, tmp_path) -> None:
+        store = HarnessEntryStore(tmp_path)
+        batch = store.apply(
+            [HarnessEdit(action="create", kind="fact", id="harness_r", title="r", content="v1")], scope="run"
+        )
+        store.rollback(batch.id, scope="global")
+        assert store.entries() == []
+
     def test_rollback_of_rollback_restores_original(self, tmp_path) -> None:
         store = HarnessEntryStore(tmp_path)
         store.apply([HarnessEdit(action="create", kind="fact", id="harness_a", title="t", content="v1")], scope="run")
         batch = store.apply([HarnessEdit(action="update", kind="fact", id="harness_a", content="v2")], scope="run")
-        first = store.rollback(batch.id)
+        first = store.rollback(batch.id, scope="run")
         assert store.entries()[0].content == "v1"
-        store.rollback(first.id)
+        store.rollback(first.id, scope="run")
         assert store.entries()[0].content == "v2"
 
     def test_rollback_preserves_marked_outcome(self, tmp_path) -> None:
@@ -264,7 +286,7 @@ class TestReviewHardening:
         store.apply([HarnessEdit(action="create", kind="policy", id="harness_p", title="t", content="v1")], scope="run")
         batch = store.apply([HarnessEdit(action="update", kind="policy", id="harness_p", content="v2")], scope="run")
         store.mark_outcome("harness_p", "refuted", scope="run", evidence="did not deliver")
-        store.rollback(batch.id)
+        store.rollback(batch.id, scope="run")
         entry = store.entries()[0]
         assert entry.content == "v1"
         assert entry.outcome == "refuted" and entry.outcome_evidence == "did not deliver"
@@ -275,7 +297,7 @@ class TestReviewHardening:
         store.apply([HarnessEdit(action="create", kind="fact", id="harness_a", title="t", content="v1")], scope="run")
         mid = store.apply([HarnessEdit(action="update", kind="fact", id="harness_a", content="v2")], scope="run")
         store.apply([HarnessEdit(action="update", kind="fact", id="harness_a", content="v3")], scope="run")
-        store.rollback(mid.id)
+        store.rollback(mid.id, scope="run")
         assert store.entries()[0].content == "v1"
 
     def test_empty_apply_is_a_no_op(self, tmp_path) -> None:

--- a/autocontext/tests/test_harness_entries.py
+++ b/autocontext/tests/test_harness_entries.py
@@ -264,6 +264,43 @@ class TestReviewHardening:
         assert undone.rollback_of == batch.id
         assert store.entries() == []
 
+    def test_rollback_delete_path_cannot_remove_a_broader_current_occupant(self, tmp_path) -> None:
+        """Id reuse across scopes must not let a narrow rollback delete broad state."""
+        store = HarnessEntryStore(tmp_path)
+        created = store.apply(
+            [HarnessEdit(action="create", kind="fact", id="harness_x", title="t", content="run-v")], scope="run"
+        )
+        store.apply([HarnessEdit(action="delete", kind="fact", id="harness_x")], scope="run")
+        store.apply(
+            [HarnessEdit(action="create", kind="fact", id="harness_x", title="t", content="global-v")], scope="global"
+        )
+        result = store.rollback(created.id, scope="run")
+        blocked = result.applied_edits[0]
+        assert not blocked.applied and blocked.error == "scope_readonly"
+        entry = store.entries()[0]
+        assert entry.scope == "global" and entry.content == "global-v"
+
+    def test_rollback_restore_path_cannot_overwrite_a_broader_current_occupant(self, tmp_path) -> None:
+        store = HarnessEntryStore(tmp_path)
+        store.apply(
+            [HarnessEdit(action="create", kind="fact", id="harness_x", title="t", content="v1")], scope="run"
+        )
+        updated = store.apply([HarnessEdit(action="update", kind="fact", id="harness_x", content="v2")], scope="run")
+        store.apply([HarnessEdit(action="delete", kind="fact", id="harness_x")], scope="run")
+        store.apply(
+            [HarnessEdit(action="create", kind="fact", id="harness_x", title="t", content="global-v")], scope="global"
+        )
+        result = store.rollback(updated.id, scope="run")
+        blocked = result.applied_edits[0]
+        assert not blocked.applied and blocked.error == "scope_readonly"
+        entry = store.entries()[0]
+        assert entry.scope == "global" and entry.content == "global-v"
+
+    def test_rollback_rejects_unknown_scope_before_lookup(self, tmp_path) -> None:
+        store = HarnessEntryStore(tmp_path)
+        with pytest.raises(ValueError, match="unknown harness scope"):
+            store.rollback("refinement_whatever", scope="bogus")  # type: ignore[arg-type]
+
     def test_broader_caller_can_roll_back_narrower_refinement(self, tmp_path) -> None:
         store = HarnessEntryStore(tmp_path)
         batch = store.apply(

--- a/ts/src/knowledge/harness-entries.ts
+++ b/ts/src/knowledge/harness-entries.ts
@@ -9,6 +9,10 @@
  * outcome marking so verifier-scored runs can confirm or refute an entry's
  * expected outcome.
  *
+ * The scope guardrail (a narrower-scope caller cannot mutate broader-scope
+ * state) covers every write path: `apply`, `markOutcome`, and `rollback`
+ * (AC-907).
+ *
  * The store assumes a single writer per root directory: writes are atomic
  * but load-modify-save, so concurrent writers are last-writer-wins. State
  * files are per-language (Python writes snake_case fields) and are not
@@ -354,9 +358,15 @@ export class HarnessEntryStore {
    * non-pending outcome survives the restore.
    *
    * The same scope guardrail as `apply` and `markOutcome` holds (AC-907):
-   * a narrower-scope caller cannot roll back a broader-scope refinement.
-   * Checking the refinement's scope suffices because every entry a
-   * refinement touched has scope at or below the refinement's.
+   * a narrower-scope caller cannot roll back a broader-scope refinement
+   * (whole-refinement check), and each restore additionally verifies the
+   * CURRENT occupant of the entry id and the snapshot being restored.
+   * The per-entry checks matter because entry ids can be reused across
+   * scopes: an id deleted at run scope and recreated at global scope must
+   * not be deletable or overwritable by a run-scoped rollback. Blocked
+   * items are recorded with `error: "scope_readonly"` (the per-edit
+   * convention of `apply`) while the rest of the refinement still rolls
+   * back.
    */
   rollback(refinementId: string, opts: { scope: HarnessScope }): HarnessRefinement {
     const scope = requireScope(opts.scope);
@@ -372,6 +382,28 @@ export class HarnessEntryStore {
     const reason = `rollback of ${refinementId}`;
     for (const item of [...target.appliedEdits].reverse()) {
       if (!item.applied) continue;
+      const current = state.get(item.entryId);
+      const snapshot = item.before ?? undefined;
+      const blocked =
+        (current !== undefined && SCOPE_ORDER[current.scope] > SCOPE_ORDER[scope]) ||
+        (snapshot !== undefined && SCOPE_ORDER[snapshot.scope] > SCOPE_ORDER[scope]);
+      if (blocked) {
+        applied.push({
+          edit: {
+            action: snapshot === undefined ? "delete" : "update",
+            kind: item.edit.kind,
+            id: item.entryId,
+            title: "",
+            content: "",
+            expectedOutcome: "",
+            reason,
+          },
+          entryId: item.entryId,
+          applied: false,
+          error: "scope_readonly",
+        });
+        continue;
+      }
       if (item.before === undefined || item.before === null) {
         const removed = state.get(item.entryId);
         state.delete(item.entryId);

--- a/ts/src/knowledge/harness-entries.ts
+++ b/ts/src/knowledge/harness-entries.ts
@@ -352,11 +352,20 @@ export class HarnessEntryStore {
    * the same entries by later refinements are overwritten (lost update).
    * Outcome marks are measurements, not refinement effects, so a current
    * non-pending outcome survives the restore.
+   *
+   * The same scope guardrail as `apply` and `markOutcome` holds (AC-907):
+   * a narrower-scope caller cannot roll back a broader-scope refinement.
+   * Checking the refinement's scope suffices because every entry a
+   * refinement touched has scope at or below the refinement's.
    */
-  rollback(refinementId: string): HarnessRefinement {
+  rollback(refinementId: string, opts: { scope: HarnessScope }): HarnessRefinement {
+    const scope = requireScope(opts.scope);
     const target = this.loadHistory().find((r) => r.id === refinementId);
     if (!target) {
       throw new Error(`unknown refinement: ${refinementId}`);
+    }
+    if (SCOPE_ORDER[target.scope] > SCOPE_ORDER[scope]) {
+      throw new Error(`scope_readonly: ${refinementId} is ${target.scope}-scoped`);
     }
     const state = this.loadState();
     const applied: AppliedHarnessEdit[] = [];

--- a/ts/tests/harness-entries.test.ts
+++ b/ts/tests/harness-entries.test.ts
@@ -196,7 +196,7 @@ describe("rollback", () => {
       ],
       { scope: "run" },
     );
-    const result = store.rollback(batch.id);
+    const result = store.rollback(batch.id, { scope: "run" });
     expect(result.rollbackOf).toBe(batch.id);
     const byId = new Map(store.entries().map((entry) => [entry.id, entry]));
     expect([...byId.keys()].sort()).toEqual(["harness_gone", "harness_keep"]);
@@ -206,13 +206,13 @@ describe("rollback", () => {
 
   it("unknown id throws", () => {
     const store = new HarnessEntryStore(root);
-    expect(() => store.rollback("refinement_nope")).toThrow(/unknown refinement/);
+    expect(() => store.rollback("refinement_nope", { scope: "run" })).toThrow(/unknown refinement/);
   });
 
   it("rollback is itself recorded", () => {
     const store = new HarnessEntryStore(root);
     const batch = store.apply([createEdit()], { scope: "run" });
-    store.rollback(batch.id);
+    store.rollback(batch.id, { scope: "run" });
     const history = store.loadHistory();
     expect(history).toHaveLength(2);
     expect(history[1].rollbackOf).toBe(batch.id);
@@ -273,6 +273,36 @@ describe("outcome and render", () => {
 });
 
 describe("review hardening (parity with Python TestReviewHardening)", () => {
+  it("rollback respects scope guardrail", () => {
+    const store = new HarnessEntryStore(root);
+    const batch = store.apply([createEdit({ id: "harness_g", title: "g", content: "v1" })], {
+      scope: "global",
+    });
+    expect(() => store.rollback(batch.id, { scope: "run" })).toThrow(/scope_readonly/);
+    // The rejected rollback mutated nothing: entry intact, no rollback recorded.
+    expect(store.entries()[0].content).toBe("v1");
+    expect(store.loadHistory()).toHaveLength(1);
+    const undone = store.rollback(batch.id, { scope: "global" });
+    expect(undone.rollbackOf).toBe(batch.id);
+    expect(store.entries()).toHaveLength(0);
+  });
+
+  it("broader caller can roll back a narrower refinement", () => {
+    const store = new HarnessEntryStore(root);
+    const batch = store.apply([createEdit({ id: "harness_r", title: "r", content: "v1" })], {
+      scope: "run",
+    });
+    store.rollback(batch.id, { scope: "global" });
+    expect(store.entries()).toHaveLength(0);
+  });
+
+  it("rollback rejects a missing scope at runtime", () => {
+    const store = new HarnessEntryStore(root);
+    const batch = store.apply([createEdit()], { scope: "run" });
+    const opts: { scope?: "run" } = {};
+    expect(() => store.rollback(batch.id, opts as { scope: "run" })).toThrow(/scope/);
+  });
+
   it("markOutcome respects scope guardrail", () => {
     const store = new HarnessEntryStore(root);
     const created = store.apply([createEdit({ kind: "policy", title: "g" })], { scope: "global" });
@@ -314,9 +344,9 @@ describe("review hardening (parity with Python TestReviewHardening)", () => {
     const batch = store.apply([createEdit({ action: "update", id: "harness_a", content: "v2" })], {
       scope: "run",
     });
-    const first = store.rollback(batch.id);
+    const first = store.rollback(batch.id, { scope: "run" });
     expect(store.entries()[0].content).toBe("v1");
-    store.rollback(first.id);
+    store.rollback(first.id, { scope: "run" });
     expect(store.entries()[0].content).toBe("v2");
   });
 
@@ -328,7 +358,7 @@ describe("review hardening (parity with Python TestReviewHardening)", () => {
       { scope: "run" },
     );
     store.markOutcome("harness_p", "refuted", { scope: "run", evidence: "did not deliver" });
-    store.rollback(batch.id);
+    store.rollback(batch.id, { scope: "run" });
     const entry = store.entries()[0];
     expect(entry.content).toBe("v1");
     expect(entry.outcome).toBe("refuted");
@@ -345,7 +375,7 @@ describe("review hardening (parity with Python TestReviewHardening)", () => {
     store.apply([createEdit({ action: "update", id: "harness_a", content: "v3" })], {
       scope: "run",
     });
-    store.rollback(mid.id);
+    store.rollback(mid.id, { scope: "run" });
     expect(store.entries()[0].content).toBe("v1");
   });
 

--- a/ts/tests/harness-entries.test.ts
+++ b/ts/tests/harness-entries.test.ts
@@ -287,6 +287,38 @@ describe("review hardening (parity with Python TestReviewHardening)", () => {
     expect(store.entries()).toHaveLength(0);
   });
 
+  it("rollback delete path cannot remove a broader current occupant", () => {
+    // Id reuse across scopes must not let a narrow rollback delete broad state.
+    const store = new HarnessEntryStore(root);
+    const created = store.apply([createEdit({ id: "harness_x", content: "run-v" })], {
+      scope: "run",
+    });
+    store.apply([createEdit({ action: "delete", id: "harness_x" })], { scope: "run" });
+    store.apply([createEdit({ id: "harness_x", content: "global-v" })], { scope: "global" });
+    const result = store.rollback(created.id, { scope: "run" });
+    expect(result.appliedEdits[0].applied).toBe(false);
+    expect(result.appliedEdits[0].error).toBe("scope_readonly");
+    const entry = store.entries()[0];
+    expect(entry.scope).toBe("global");
+    expect(entry.content).toBe("global-v");
+  });
+
+  it("rollback restore path cannot overwrite a broader current occupant", () => {
+    const store = new HarnessEntryStore(root);
+    store.apply([createEdit({ id: "harness_x", content: "v1" })], { scope: "run" });
+    const updated = store.apply([createEdit({ action: "update", id: "harness_x", content: "v2" })], {
+      scope: "run",
+    });
+    store.apply([createEdit({ action: "delete", id: "harness_x" })], { scope: "run" });
+    store.apply([createEdit({ id: "harness_x", content: "global-v" })], { scope: "global" });
+    const result = store.rollback(updated.id, { scope: "run" });
+    expect(result.appliedEdits[0].applied).toBe(false);
+    expect(result.appliedEdits[0].error).toBe("scope_readonly");
+    const entry = store.entries()[0];
+    expect(entry.scope).toBe("global");
+    expect(entry.content).toBe("global-v");
+  });
+
   it("broader caller can roll back a narrower refinement", () => {
     const store = new HarnessEntryStore(root);
     const batch = store.apply([createEdit({ id: "harness_r", title: "r", content: "v1" })], {

--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -156,7 +156,9 @@ describe("TaskRunner", () => {
       },
     };
 
-    const runner = new TaskRunner({ store, provider: failProvider });
+    // maxAttempts: 1 pins the permanent-failure surface this test is about;
+    // with the AC-906 default (3) a first failure re-queues as pending.
+    const runner = new TaskRunner({ store, provider: failProvider, maxAttempts: 1 });
     const result = await runner.runOnce();
     expect(result).not.toBeNull();
     expect(result!.status).toBe("failed");
@@ -165,12 +167,29 @@ describe("TaskRunner", () => {
     expect(result!.error).not.toContain("\n    at ");
   });
 
+  it("retries a provider error as pending under the default attempt budget", async () => {
+    const store = createStore();
+    enqueueTask(store, "retry-spec", { initialOutput: "test" });
+    const failProvider: LLMProvider = {
+      name: "fail",
+      defaultModel: () => "m",
+      complete: async () => {
+        throw new Error("API down");
+      },
+    };
+    const runner = new TaskRunner({ store, provider: failProvider });
+    const result = await runner.runOnce();
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("pending");
+    expect(result!.error).toContain("API down");
+  });
+
   it("rejects invalid config via Zod validation", async () => {
     const store = createStore();
     const provider = makeMockProvider();
     // max_rounds must be a positive integer, not a string
     store.enqueueTask("bad", "test_spec", 0, { max_rounds: "not_a_number" });
-    const runner = new TaskRunner({ store, provider });
+    const runner = new TaskRunner({ store, provider, maxAttempts: 1 });
     const result = await runner.runOnce();
     expect(result!.status).toBe("failed");
     expect(result!.error).toContain("Expected number");


### PR DESCRIPTION
## Summary

Closes [AC-907](https://linear.app/greyhaven/issue/AC-907): `HarnessEntryStore.rollback` previously took no caller scope, so a run-scoped caller could roll back a global refinement and rewrite global entries, the exact write the scope guardrail on `apply` and `mark_outcome` exists to prevent. Decision taken: enforce (option 2 on the issue), not document an exemption; an operator who legitimately needs a global rollback passes `scope="global"`.

- `rollback(refinement_id, *, scope)` in Python, `rollback(refinementId, { scope })` in TS (routed through the `requireScope` runtime backstop so untyped callers cannot omit it).
- Whole-refinement check: rejects with `scope_readonly` before any state or history mutation when the target refinement is broader-scoped than the caller.
- Per-entry checks in the restore loop (both languages): each item also verifies the CURRENT occupant of the entry id and the snapshot being restored, blocking with `applied=False, error="scope_readonly"` per apply's per-edit convention. This closes a real bypass the review found: entry ids can be reused across scopes (deleted at run scope, recreated at global scope), and a blind restore would let a run-scoped rollback delete or overwrite the global entry.
- Python gains `_require_scope` mirroring TS `requireScope`, called first in all three write paths, so a dynamic-boundary scope string fails with `ValueError: unknown harness scope: ...` instead of a raw `KeyError`, with the same check ordering as TS.
- Module and method docs updated in both languages: the guardrail now explicitly covers `apply`, `mark_outcome`, and `rollback`.

## Review

Independent review: 1 Critical (a missed rollback call site in the skill-promotion tests, shipped failing), 1 Important (the id-reuse bypass, reproduced live in both languages including a compounding rollback-of-rollback scope-laundering variant), 3 Minor. All fixed in 00269c20 and re-verified by the reviewer re-running their reproductions against the fixed code: all blocked, global state intact.

## Testing

- Python: `tests/test_harness_entries.py` + `tests/test_agent_task_skill_promotion.py` 60/60; ruff + mypy clean.
- TS: `tests/harness-entries.test.ts` 37/37 (both files are in the `check:test-types` allowlist); `npm run lint`, `check:schemas`, package-boundaries green.
- Parity pinned: identical `scope_readonly` message shape, identical check ordering, both bypass variants tested in both languages.