### PR TITLE
fix: task-runner permanent-failure tests pin maxAttempts=1 (AC-906 fallout)

### DIFF
--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -156,7 +156,9 @@ describe("TaskRunner", () => {
       },
     };
 
-    const runner = new TaskRunner({ store, provider: failProvider });
+    // maxAttempts: 1 pins the permanent-failure surface this test is about;
+    // with the AC-906 default (3) a first failure re-queues as pending.
+    const runner = new TaskRunner({ store, provider: failProvider, maxAttempts: 1 });
     const result = await runner.runOnce();
     expect(result).not.toBeNull();
     expect(result!.status).toBe("failed");
@@ -165,12 +167,29 @@ describe("TaskRunner", () => {
     expect(result!.error).not.toContain("\n    at ");
   });
 
+  it("retries a provider error as pending under the default attempt budget", async () => {
+    const store = createStore();
+    enqueueTask(store, "retry-spec", { initialOutput: "test" });
+    const failProvider: LLMProvider = {
+      name: "fail",
+      defaultModel: () => "m",
+      complete: async () => {
+        throw new Error("API down");
+      },
+    };
+    const runner = new TaskRunner({ store, provider: failProvider });
+    const result = await runner.runOnce();
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("pending");
+    expect(result!.error).toContain("API down");
+  });
+
   it("rejects invalid config via Zod validation", async () => {
     const store = createStore();
     const provider = makeMockProvider();
     // max_rounds must be a positive integer, not a string
     store.enqueueTask("bad", "test_spec", 0, { max_rounds: "not_a_number" });
-    const runner = new TaskRunner({ store, provider });
+    const runner = new TaskRunner({ store, provider, maxAttempts: 1 });
     const result = await runner.runOnce();
     expect(result!.status).toBe("failed");
     expect(result!.error).toContain("Expected number");


### PR DESCRIPTION
## Summary

Main's first post-outage CI run (31127300042 on d80c751d) failed on two `ts/tests/task-runner.test.ts` tests that assert a single provider failure marks a task `failed`. Under AC-906's retry semantics (default `maxAttempts: 3`, claim burns an attempt, linear backoff) a first failure correctly re-queues the task as `pending`, so the tests were asserting pre-AC-906 behavior. The AC-906 PR (#1239) was admin-merged during the GitHub Actions outage, so its own CI never executed and this slipped through; local branch health was judged by targeted suites that did not include this file.

- The two permanent-failure tests now construct `TaskRunner` with `maxAttempts: 1` (immediate dead-letter), preserving their intent: a provider error surfaces as `failed` with a clean, stack-trace-free error.
- A new companion test pins the default-budget behavior: first failure returns `pending` with the error recorded.

The same run's `openai-sdk-matrix-python (1.84.0)` failure has zero recorded steps and no retrievable logs (45-minute zombie job): outage-aftermath infra, and the same matrix cell passed on every prior run today. A rerun on this merge should settle it.

## Testing

`tests/task-runner.test.ts` 25/25; adjacent queue suites (task-processing-workflow, storage-task-queue-facade, task-queue-store-workflow) 15/15; `npm run lint` clean.