### PR TITLE
AC-910: pin cross-language role-routing parity before the capability refactor

### DIFF
--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -128,3 +128,61 @@ def test_cost_estimation_parity(case_name: str, case: dict[str, Any]) -> None:
     expected = case["expected"]
     for key in ("total_per_1k_tokens", "all_frontier_per_1k_tokens", "savings_vs_all_frontier"):
         assert estimate[key] == pytest.approx(expected[key]), key
+
+
+# Every group the fixture is expected to contain, including groups that are not in
+# ROUTE_GROUPS (cost_estimation has its own replay; a "divergent" group, if Task 2
+# created one, is data only). If you add a group, add it here too, or the guard
+# stops guarding.
+_EXPECTED_GROUPS = {
+    "auto_mode",
+    "explicit_override",
+    "routing_off",
+    "local_artifacts",
+    "cost_estimation",
+}
+
+
+def test_every_expected_fixture_group_is_present() -> None:
+    """A deleted group would otherwise make both suites pass with less coverage."""
+    assert set(_load()["fixtures"]) == _EXPECTED_GROUPS
+
+
+def test_no_expected_group_is_empty() -> None:
+    """Emptying a group is the silent failure the present-check does not catch.
+
+    `"auto_mode": {}` keeps the key, so the presence check still passes, but
+    `_cases()` returns [] and pytest reports an empty parametrize list as
+    "1 skipped" with exit code 0: a green CI run that asserted nothing.
+    The TypeScript replay already guards this per group via its
+    "has cases to replay" test; this is the Python counterpart.
+    """
+    fixtures = _load()["fixtures"]
+    empty = sorted(name for name in _EXPECTED_GROUPS if not fixtures.get(name))
+    assert not empty, f"fixture groups present but empty: {empty}"
+
+
+def test_known_divergences_are_fully_described() -> None:
+    """A divergence recorded without a resolution is an untracked bug."""
+    divergences = _load()["known_divergences"]
+    assert divergences, "expected at least the mixed-case provider divergence from Task 3"
+    required = {"case", "python", "typescript", "reason", "resolution"}
+    for entry in divergences:
+        missing = required - set(entry)
+        assert not missing, f"divergence entry missing keys: {sorted(missing)}"
+
+
+def test_fixture_typo_guards_actually_raise() -> None:
+    """The harness's own typo guards are otherwise never executed.
+
+    `_settings_from_fixture` and `_context_from_fixture` raise on unknown keys
+    so that a misspelled fixture key fails loudly. If those guards were broken,
+    a typo would be silently ignored, the case would run against default
+    settings, and it could pass while testing something other than what it
+    claims. That is the same silent-green failure this whole fixture exists to
+    prevent, so the guards themselves get a test.
+    """
+    with pytest.raises(AssertionError, match="unknown settings keys"):
+        _settings_from_fixture({"not_a_real_setting": "x"})
+    with pytest.raises(AssertionError, match="unknown context key"):
+        _context_from_fixture({"notARealContextKey": []})

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -21,7 +21,12 @@ FIXTURE_PATH = Path(__file__).resolve().parents[2] / "docs" / "role-routing-pari
 
 # Fixture groups whose cases are single route() calls compared field by field.
 # Groups with a different shape (cost estimation) get their own replay test.
-ROUTE_GROUPS: tuple[str, ...] = ("auto_mode", "explicit_override")
+ROUTE_GROUPS: tuple[str, ...] = (
+    "auto_mode",
+    "explicit_override",
+    "routing_off",
+    "local_artifacts",
+)
 
 # Every settings key a fixture case may set, with the value used when a case omits it.
 # Mirrors the TypeScript baseSettings() helper so both languages start from identical state.

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -21,7 +21,7 @@ FIXTURE_PATH = Path(__file__).resolve().parents[2] / "docs" / "role-routing-pari
 
 # Fixture groups whose cases are single route() calls compared field by field.
 # Groups with a different shape (cost estimation) get their own replay test.
-ROUTE_GROUPS: tuple[str, ...] = ("auto_mode",)
+ROUTE_GROUPS: tuple[str, ...] = ("auto_mode", "explicit_override")
 
 # Every settings key a fixture case may set, with the value used when a case omits it.
 # Mirrors the TypeScript baseSettings() helper so both languages start from identical state.

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -113,3 +113,18 @@ def test_route_parity(group: str, case_name: str, case: dict[str, Any]) -> None:
     router = RoleRouter(_settings_from_fixture(case.get("settings", {})))
     context = RoutingContext(**_context_from_fixture(case.get("context", {})))
     _assert_route_matches(router.route(case["role"], context=context), case["expected"])
+
+
+@pytest.mark.parametrize("case_name,case", _cases("cost_estimation"))
+def test_cost_estimation_parity(case_name: str, case: dict[str, Any]) -> None:
+    """Cost totals must match TypeScript's estimateRoleRoutingCost()."""
+    from autocontext.agents.role_router import RoleRouter, RoutingContext
+
+    del case_name
+    router = RoleRouter(_settings_from_fixture(case.get("settings", {})))
+    context = RoutingContext(**_context_from_fixture(case.get("context", {})))
+    estimate = router.estimate_run_cost(context=context)
+
+    expected = case["expected"]
+    for key in ("total_per_1k_tokens", "all_frontier_per_1k_tokens", "savings_vs_all_frontier"):
+        assert estimate[key] == pytest.approx(expected[key]), key

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -1,0 +1,110 @@
+"""AC-910 step 1: cross-language routing parity.
+
+Replays docs/role-routing-parity-fixtures.json through the Python RoleRouter.
+ts/tests/role-routing-parity.test.ts replays the identical file through the
+TypeScript routeRoleProvider. Both must agree exactly.
+
+To add a scenario group: add it to the fixture, then add its name to
+ROUTE_GROUPS here and to ROUTE_GROUPS in the TypeScript replay.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+FIXTURE_PATH = Path(__file__).resolve().parents[2] / "docs" / "role-routing-parity-fixtures.json"
+
+# Fixture groups whose cases are single route() calls compared field by field.
+# Groups with a different shape (cost estimation) get their own replay test.
+ROUTE_GROUPS: tuple[str, ...] = ("auto_mode",)
+
+# Every settings key a fixture case may set, with the value used when a case omits it.
+# Mirrors the TypeScript baseSettings() helper so both languages start from identical state.
+# The placeholder model names are deliberately not real Claude ids: they make it obvious
+# which settings field a returned model came from.
+_SETTINGS_DEFAULTS: dict[str, str] = {
+    "role_routing": "auto",
+    "agent_provider": "anthropic",
+    "competitor_provider": "",
+    "analyst_provider": "",
+    "coach_provider": "",
+    "architect_provider": "",
+    "model_competitor": "competitor-role-model",
+    "model_analyst": "analyst-role-model",
+    "model_coach": "coach-role-model",
+    "model_architect": "architect-role-model",
+    "model_curator": "curator-role-model",
+    "model_translator": "translator-role-model",
+    "tier_opus_model": "opus-tier-model",
+    "tier_sonnet_model": "sonnet-tier-model",
+    "tier_haiku_model": "haiku-tier-model",
+    "mlx_model_path": "/models/default-local",
+}
+
+# The fixture uses the TypeScript spelling for context fields so one file drives
+# both languages. Python's RoutingContext uses snake_case.
+_CONTEXT_KEY_MAP: dict[str, str] = {
+    "availableLocalModels": "available_local_models",
+}
+
+
+def _load() -> dict[str, Any]:
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError("parity fixture must be a JSON object")
+    return cast(dict[str, Any], payload)
+
+
+def _cases(group: str) -> list[tuple[str, dict[str, Any]]]:
+    fixtures = _load()["fixtures"]
+    if group not in fixtures:
+        raise AssertionError(f"fixture group {group!r} missing")
+    return sorted(fixtures[group].items())
+
+
+def _route_cases() -> list[tuple[str, str, dict[str, Any]]]:
+    return [(group, name, case) for group in ROUTE_GROUPS for name, case in _cases(group)]
+
+
+def _settings_from_fixture(overrides: dict[str, Any]) -> MagicMock:
+    """Build a settings double from fixture overrides layered on shared defaults."""
+    unknown = set(overrides) - set(_SETTINGS_DEFAULTS)
+    if unknown:
+        raise AssertionError(f"fixture sets unknown settings keys: {sorted(unknown)}")
+    settings = MagicMock()
+    for key, default in _SETTINGS_DEFAULTS.items():
+        setattr(settings, key, overrides.get(key, default))
+    return settings
+
+
+def _context_from_fixture(raw: dict[str, Any]) -> dict[str, Any]:
+    converted: dict[str, Any] = {}
+    for key, value in raw.items():
+        mapped = _CONTEXT_KEY_MAP.get(key)
+        if mapped is None:
+            raise AssertionError(f"fixture sets unknown context key: {key}")
+        converted[mapped] = value
+    return converted
+
+
+def _assert_route_matches(result: Any, expected: dict[str, Any]) -> None:
+    assert result.provider_type == expected["provider_type"]
+    assert result.model == expected["model"]
+    assert result.provider_class.value == expected["provider_class"]
+    assert result.estimated_cost_per_1k_tokens == pytest.approx(expected["cost_per_1k_tokens"])
+
+
+@pytest.mark.parametrize("group,case_name,case", _route_cases())
+def test_route_parity(group: str, case_name: str, case: dict[str, Any]) -> None:
+    """Every registered group's cases must match the values TypeScript produces."""
+    from autocontext.agents.role_router import RoleRouter, RoutingContext
+
+    del group, case_name  # surfaced by the parametrize id on failure
+    router = RoleRouter(_settings_from_fixture(case.get("settings", {})))
+    context = RoutingContext(**_context_from_fixture(case.get("context", {})))
+    _assert_route_matches(router.route(case["role"], context=context), case["expected"])

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -144,8 +144,17 @@ _EXPECTED_GROUPS = {
 
 
 def test_every_expected_fixture_group_is_present() -> None:
-    """A deleted group would otherwise make both suites pass with less coverage."""
+    """A deleted group would otherwise make both suites pass with less coverage.
+
+    Also couples ROUTE_GROUPS (the replay registry) to _EXPECTED_GROUPS: they are
+    otherwise independent literals, so dropping a name from ROUTE_GROUPS leaves
+    the fixture-key check untouched (the fixture still has the group, this
+    assertion above still passes) and this language silently stops replaying
+    it. The fixture-key check alone cannot catch a dropped replay registration —
+    only comparing the registry itself against the expected set can.
+    """
     assert set(_load()["fixtures"]) == _EXPECTED_GROUPS
+    assert set(ROUTE_GROUPS) | {"cost_estimation"} == _EXPECTED_GROUPS
 
 
 def test_no_expected_group_is_empty() -> None:

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -4,8 +4,8 @@ Replays docs/role-routing-parity-fixtures.json through the Python RoleRouter.
 ts/tests/role-routing-parity.test.ts replays the identical file through the
 TypeScript routeRoleProvider. Both must agree exactly.
 
-To add a scenario group: add it to the fixture, then add its name to
-ROUTE_GROUPS here and to ROUTE_GROUPS in the TypeScript replay.
+To add a scenario: add it to the fixture, then add its case id to
+_EXPECTED_CASE_IDS here and EXPECTED_CASE_IDS in the TypeScript replay.
 """
 
 from __future__ import annotations
@@ -19,14 +19,75 @@ import pytest
 
 FIXTURE_PATH = Path(__file__).resolve().parents[2] / "docs" / "role-routing-parity-fixtures.json"
 
+# The fixture is the behavioral contract, but the expected case ids live outside
+# it so deleting or replacing a critical scenario cannot silently reduce coverage.
+_EXPECTED_CASE_IDS: dict[str, frozenset[str]] = {
+    "auto_mode": frozenset(
+        {
+            "competitor_frontier",
+            "analyst_mid_tier",
+            "coach_mid_tier",
+            "architect_frontier_no_local_fallback",
+            "curator_fast",
+            "translator_fast",
+            "unknown_role_falls_back_to_mid_tier",
+            "self_hosted_default_provider_is_frontier_via_table",
+        },
+    ),
+    "explicit_override": frozenset(
+        {
+            "competitor_override_to_ollama_is_mid_tier",
+            "architect_override_to_vllm_is_mid_tier",
+            "unknown_override_provider_defaults_to_frontier",
+            "override_to_mlx_uses_mlx_model_path",
+            "override_wins_over_role_routing_off",
+        },
+    ),
+    "routing_off": frozenset(
+        {
+            "off_uses_default_provider_and_role_model",
+            "off_with_ollama_default_is_mid_tier",
+            "off_with_unknown_default_provider_is_mid_tier",
+            "off_uses_coach_role_model",
+            "off_uses_curator_role_model",
+            "off_uses_translator_role_model",
+            "off_with_mlx_default_uses_mlx_model_path",
+        },
+    ),
+    "local_artifacts": frozenset(
+        {
+            "eligible_role_prefers_local_artifact",
+            "architect_ignores_local_artifact",
+            "curator_ignores_local_artifact",
+            "local_artifact_ignored_when_routing_off",
+        },
+    ),
+    "cost_estimation": frozenset(
+        {
+            "default_auto_mode_totals",
+            "with_local_artifacts_totals",
+        },
+    ),
+}
+
+_EXPECTED_DIVERGENCE_CASE_IDS = {
+    "explicit_override.mixed_case_provider_name",
+    "explicit_override.whitespace_only_provider_name",
+    "routing_off.unknown_role_model",
+}
+
 # Fixture groups whose cases are single route() calls compared field by field.
 # Groups with a different shape (cost estimation) get their own replay test.
-ROUTE_GROUPS: tuple[str, ...] = (
-    "auto_mode",
-    "explicit_override",
-    "routing_off",
-    "local_artifacts",
+ROUTE_GROUPS: tuple[str, ...] = tuple(
+    group for group in _EXPECTED_CASE_IDS if group != "cost_estimation"
 )
+_EXPECTED_GROUPS = set(_EXPECTED_CASE_IDS)
+_EXPECTED_ASSIGNMENT_KEYS = {
+    "provider_type",
+    "model",
+    "provider_class",
+    "cost_per_1k_tokens",
+}
 
 # Every settings key a fixture case may set, with the value used when a case omits it.
 # Mirrors the TypeScript baseSettings() helper so both languages start from identical state.
@@ -74,6 +135,10 @@ def _cases(group: str) -> list[tuple[str, dict[str, Any]]]:
 
 def _route_cases() -> list[tuple[str, str, dict[str, Any]]]:
     return [(group, name, case) for group in ROUTE_GROUPS for name, case in _cases(group)]
+
+
+def _divergence_cases() -> list[tuple[str, dict[str, Any]]]:
+    return sorted((entry["case"], entry) for entry in _load()["known_divergences"])
 
 
 def _settings_from_fixture(overrides: dict[str, Any]) -> MagicMock:
@@ -130,31 +195,30 @@ def test_cost_estimation_parity(case_name: str, case: dict[str, Any]) -> None:
         assert estimate[key] == pytest.approx(expected[key]), key
 
 
-# Every group the fixture is expected to contain, including groups that are not in
-# ROUTE_GROUPS (cost_estimation has its own replay; a "divergent" group, if Task 2
-# created one, is data only). If you add a group, add it here too, or the guard
-# stops guarding.
-_EXPECTED_GROUPS = {
-    "auto_mode",
-    "explicit_override",
-    "routing_off",
-    "local_artifacts",
-    "cost_estimation",
-}
+@pytest.mark.parametrize("case_name,case", _divergence_cases())
+def test_python_known_divergence_output(case_name: str, case: dict[str, Any]) -> None:
+    """Known disagreements remain executable until AC-911 resolves them."""
+    from autocontext.agents.role_router import RoleRouter, RoutingContext
+
+    del case_name
+    router = RoleRouter(_settings_from_fixture(case.get("settings", {})))
+    context = RoutingContext(**_context_from_fixture(case.get("context", {})))
+    _assert_route_matches(router.route(case["role"], context=context), case["python"])
+    assert case["python"] != case["typescript"]
 
 
 def test_every_expected_fixture_group_is_present() -> None:
-    """A deleted group would otherwise make both suites pass with less coverage.
-
-    Also couples ROUTE_GROUPS (the replay registry) to _EXPECTED_GROUPS: they are
-    otherwise independent literals, so dropping a name from ROUTE_GROUPS leaves
-    the fixture-key check untouched (the fixture still has the group, this
-    assertion above still passes) and this language silently stops replaying
-    it. The fixture-key check alone cannot catch a dropped replay registration —
-    only comparing the registry itself against the expected set can.
-    """
+    """The external inventory pins both fixture groups and replay registration."""
     assert set(_load()["fixtures"]) == _EXPECTED_GROUPS
     assert set(ROUTE_GROUPS) | {"cost_estimation"} == _EXPECTED_GROUPS
+
+
+def test_every_expected_fixture_case_is_present() -> None:
+    """Deleting or replacing one scenario must not silently reduce coverage."""
+    fixtures = _load()["fixtures"]
+    actual = {group: set(cases) for group, cases in fixtures.items()}
+    expected = {group: set(case_ids) for group, case_ids in _EXPECTED_CASE_IDS.items()}
+    assert actual == expected
 
 
 def test_no_expected_group_is_empty() -> None:
@@ -172,13 +236,30 @@ def test_no_expected_group_is_empty() -> None:
 
 
 def test_known_divergences_are_fully_described() -> None:
-    """A divergence recorded without a resolution is an untracked bug."""
+    """Divergences must have runnable inputs, exact outputs, and a resolution."""
     divergences = _load()["known_divergences"]
-    assert divergences, "expected at least the mixed-case provider divergence from Task 3"
-    required = {"case", "python", "typescript", "reason", "resolution"}
+    case_ids = [entry["case"] for entry in divergences]
+    assert len(case_ids) == len(set(case_ids)), "duplicate known-divergence case ids"
+    assert set(case_ids) == _EXPECTED_DIVERGENCE_CASE_IDS
+
+    required = {
+        "case",
+        "role",
+        "settings",
+        "context",
+        "python",
+        "typescript",
+        "reason",
+        "resolution",
+    }
     for entry in divergences:
         missing = required - set(entry)
         assert not missing, f"divergence entry missing keys: {sorted(missing)}"
+        assert set(entry["python"]) == _EXPECTED_ASSIGNMENT_KEYS
+        assert set(entry["typescript"]) == _EXPECTED_ASSIGNMENT_KEYS
+        assert entry["python"] != entry["typescript"]
+        assert entry["reason"].strip()
+        assert entry["resolution"].strip()
 
 
 def test_fixture_typo_guards_actually_raise() -> None:

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -218,6 +218,26 @@
           "cost_per_1k_tokens": 0.015
         }
       }
+    },
+    "cost_estimation": {
+      "default_auto_mode_totals": {
+        "settings": {},
+        "context": {},
+        "expected": {
+          "total_per_1k_tokens": 0.038,
+          "all_frontier_per_1k_tokens": 0.09,
+          "savings_vs_all_frontier": 0.052
+        }
+      },
+      "with_local_artifacts_totals": {
+        "settings": {},
+        "context": { "availableLocalModels": ["/models/distilled"] },
+        "expected": {
+          "total_per_1k_tokens": 0.016,
+          "all_frontier_per_1k_tokens": 0.09,
+          "savings_vs_all_frontier": 0.074
+        }
+      }
     }
   },
   "known_divergences": [

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -79,6 +79,17 @@
           "provider_class": "mid_tier",
           "cost_per_1k_tokens": 0.003
         }
+      },
+      "self_hosted_default_provider_is_frontier_via_table": {
+        "role": "competitor",
+        "settings": { "agent_provider": "vllm" },
+        "context": {},
+        "expected": {
+          "provider_type": "vllm",
+          "model": "opus-tier-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
       }
     },
     "explicit_override": {
@@ -243,10 +254,17 @@
   "known_divergences": [
     {
       "case": "explicit_override.mixed_case_provider_name",
-      "python": "returns the raw settings value, e.g. 'Ollama'",
-      "typescript": "returns normalizeProvider(value), e.g. 'ollama'",
-      "reason": "Python's _config_for_explicit lowercases only for the _EXPLICIT_PROVIDER_CLASS lookup and returns provider_type verbatim; TypeScript's routeRoleProvider returns the normalized value. The provider_class agrees; only the reported provider string differs.",
-      "resolution": "AC-911: normalize once when Endpoint replaces the bare provider string, so both packages report the canonical transport name."
+      "python": "returns the raw settings value verbatim at all three sites that build a ProviderConfig from a provider string (_config_for_class, _config_for_explicit, _config_for_default), e.g. 'Ollama'. It also never trims: a whitespace-only provider value (e.g. competitor_provider = \"  \") is still truthy, so Python takes the EXPLICIT-override path with provider_type '  ' and model from the role's explicit-model setting.",
+      "typescript": "returns normalizeProvider(value), which both lowercases AND trims via clean(), e.g. 'ollama'. For a whitespace-only provider value, clean() reduces it to undefined, so TypeScript takes the AUTO path instead (provider_type 'anthropic', tier-derived model) rather than the explicit path.",
+      "reason": "For an ordinary mixed-case value (e.g. 'Ollama') both languages resolve the same provider_class and only the reported provider string differs, as originally recorded. But for a whitespace-only value the divergence is not cosmetic: normalizeProvider's trim makes TypeScript treat the setting as unset and take a different route (auto vs. explicit) with a different model, not merely a different provider spelling.",
+      "resolution": "AC-911: normalize once when Endpoint replaces the bare provider string, so both packages report the canonical transport name. That normalization must also decide, once, whether a whitespace-only override counts as 'set' — right now Python says yes (explicit) and TypeScript says no (auto)."
+    },
+    {
+      "case": "routing_off.unknown_role_model",
+      "python": "returns model=None (role_router.py _config_for_default: self._role_models.get(role) misses for an unregistered role, e.g. 'skeptic', and there is no fallback default)",
+      "typescript": "returns \"sonnet-tier-model\" (role-routing.ts roleSpecificModel falls through to a tier default for any role outside its switch statement)",
+      "reason": "Python has no fallback for an unregistered role under routing_off and returns None for the model, while TypeScript's roleSpecificModel falls back to the sonnet tier model. provider_type ('anthropic') and provider_class ('frontier') agree in both; only model differs.",
+      "resolution": "AC-911: the RoleAssignment work must decide one behavior for an unregistered role under routing_off, rather than inheriting Python's None and TypeScript's tier-default fallback as two separate defaults."
     }
   ]
 }

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -137,6 +137,87 @@
           "cost_per_1k_tokens": 0.003
         }
       }
+    },
+    "routing_off": {
+      "off_uses_default_provider_and_role_model": {
+        "role": "competitor",
+        "settings": { "role_routing": "off" },
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "competitor-role-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "off_with_ollama_default_is_mid_tier": {
+        "role": "architect",
+        "settings": { "role_routing": "off", "agent_provider": "ollama" },
+        "context": {},
+        "expected": {
+          "provider_type": "ollama",
+          "model": "architect-role-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      },
+      "off_with_unknown_default_provider_is_mid_tier": {
+        "role": "analyst",
+        "settings": { "role_routing": "off", "agent_provider": "some-unknown-provider" },
+        "context": {},
+        "expected": {
+          "provider_type": "some-unknown-provider",
+          "model": "analyst-role-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      }
+    },
+    "local_artifacts": {
+      "eligible_role_prefers_local_artifact": {
+        "role": "competitor",
+        "settings": {},
+        "context": { "availableLocalModels": ["/models/distilled-competitor"] },
+        "expected": {
+          "provider_type": "mlx",
+          "model": "/models/distilled-competitor",
+          "provider_class": "local",
+          "cost_per_1k_tokens": 0.0
+        }
+      },
+      "architect_ignores_local_artifact": {
+        "role": "architect",
+        "settings": {},
+        "context": { "availableLocalModels": ["/models/distilled-architect"] },
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "opus-tier-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "curator_ignores_local_artifact": {
+        "role": "curator",
+        "settings": {},
+        "context": { "availableLocalModels": ["/models/distilled-curator"] },
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "haiku-tier-model",
+          "provider_class": "fast",
+          "cost_per_1k_tokens": 0.001
+        }
+      },
+      "local_artifact_ignored_when_routing_off": {
+        "role": "competitor",
+        "settings": { "role_routing": "off" },
+        "context": { "availableLocalModels": ["/models/distilled-competitor"] },
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "competitor-role-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      }
     }
   },
   "known_divergences": [

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": 1,
+  "contract": "cross-language role routing behavior; replayed by autocontext/tests/test_role_routing_parity.py and ts/tests/role-routing-parity.test.ts",
+  "fixtures": {
+    "auto_mode": {
+      "competitor_frontier": {
+        "role": "competitor",
+        "settings": {},
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "opus-tier-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "analyst_mid_tier": {
+        "role": "analyst",
+        "settings": {},
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "sonnet-tier-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      },
+      "coach_mid_tier": {
+        "role": "coach",
+        "settings": {},
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "sonnet-tier-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      },
+      "architect_frontier_no_local_fallback": {
+        "role": "architect",
+        "settings": {},
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "opus-tier-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "curator_fast": {
+        "role": "curator",
+        "settings": {},
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "haiku-tier-model",
+          "provider_class": "fast",
+          "cost_per_1k_tokens": 0.001
+        }
+      },
+      "translator_fast": {
+        "role": "translator",
+        "settings": {},
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "haiku-tier-model",
+          "provider_class": "fast",
+          "cost_per_1k_tokens": 0.001
+        }
+      },
+      "unknown_role_falls_back_to_mid_tier": {
+        "role": "skeptic",
+        "settings": {},
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "sonnet-tier-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      }
+    }
+  },
+  "known_divergences": []
+}

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -80,7 +80,72 @@
           "cost_per_1k_tokens": 0.003
         }
       }
+    },
+    "explicit_override": {
+      "competitor_override_to_ollama_is_mid_tier": {
+        "role": "competitor",
+        "settings": { "competitor_provider": "ollama" },
+        "context": {},
+        "expected": {
+          "provider_type": "ollama",
+          "model": "competitor-role-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      },
+      "architect_override_to_vllm_is_mid_tier": {
+        "role": "architect",
+        "settings": { "architect_provider": "vllm" },
+        "context": {},
+        "expected": {
+          "provider_type": "vllm",
+          "model": "architect-role-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      },
+      "unknown_override_provider_defaults_to_frontier": {
+        "role": "analyst",
+        "settings": { "analyst_provider": "some-unknown-provider" },
+        "context": {},
+        "expected": {
+          "provider_type": "some-unknown-provider",
+          "model": "analyst-role-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "override_to_mlx_uses_mlx_model_path": {
+        "role": "coach",
+        "settings": { "coach_provider": "mlx" },
+        "context": {},
+        "expected": {
+          "provider_type": "mlx",
+          "model": "/models/default-local",
+          "provider_class": "local",
+          "cost_per_1k_tokens": 0.0
+        }
+      },
+      "override_wins_over_role_routing_off": {
+        "role": "competitor",
+        "settings": { "competitor_provider": "ollama", "role_routing": "off" },
+        "context": {},
+        "expected": {
+          "provider_type": "ollama",
+          "model": "competitor-role-model",
+          "provider_class": "mid_tier",
+          "cost_per_1k_tokens": 0.003
+        }
+      }
     }
   },
-  "known_divergences": []
+  "known_divergences": [
+    {
+      "case": "explicit_override.mixed_case_provider_name",
+      "python": "returns the raw settings value, e.g. 'Ollama'",
+      "typescript": "returns normalizeProvider(value), e.g. 'ollama'",
+      "reason": "Python's _config_for_explicit lowercases only for the _EXPLICIT_PROVIDER_CLASS lookup and returns provider_type verbatim; TypeScript's routeRoleProvider returns the normalized value. The provider_class agrees; only the reported provider string differs.",
+      "resolution": "AC-911: normalize once when Endpoint replaces the bare provider string, so both packages report the canonical transport name."
+    }
+  ]
 }

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -182,6 +182,50 @@
           "provider_class": "mid_tier",
           "cost_per_1k_tokens": 0.003
         }
+      },
+      "off_uses_coach_role_model": {
+        "role": "coach",
+        "settings": { "role_routing": "off" },
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "coach-role-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "off_uses_curator_role_model": {
+        "role": "curator",
+        "settings": { "role_routing": "off" },
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "curator-role-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "off_uses_translator_role_model": {
+        "role": "translator",
+        "settings": { "role_routing": "off" },
+        "context": {},
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "translator-role-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "off_with_mlx_default_uses_mlx_model_path": {
+        "role": "coach",
+        "settings": { "role_routing": "off", "agent_provider": "mlx" },
+        "context": {},
+        "expected": {
+          "provider_type": "mlx",
+          "model": "/models/default-local",
+          "provider_class": "local",
+          "cost_per_1k_tokens": 0.0
+        }
       }
     },
     "local_artifacts": {
@@ -254,15 +298,61 @@
   "known_divergences": [
     {
       "case": "explicit_override.mixed_case_provider_name",
-      "python": "returns the raw settings value verbatim at all three sites that build a ProviderConfig from a provider string (_config_for_class, _config_for_explicit, _config_for_default), e.g. 'Ollama'. It also never trims: a whitespace-only provider value (e.g. competitor_provider = \"  \") is still truthy, so Python takes the EXPLICIT-override path with provider_type '  ' and model from the role's explicit-model setting.",
-      "typescript": "returns normalizeProvider(value), which both lowercases AND trims via clean(), e.g. 'ollama'. For a whitespace-only provider value, clean() reduces it to undefined, so TypeScript takes the AUTO path instead (provider_type 'anthropic', tier-derived model) rather than the explicit path.",
-      "reason": "For an ordinary mixed-case value (e.g. 'Ollama') both languages resolve the same provider_class and only the reported provider string differs, as originally recorded. But for a whitespace-only value the divergence is not cosmetic: normalizeProvider's trim makes TypeScript treat the setting as unset and take a different route (auto vs. explicit) with a different model, not merely a different provider spelling.",
-      "resolution": "AC-911: normalize once when Endpoint replaces the bare provider string, so both packages report the canonical transport name. That normalization must also decide, once, whether a whitespace-only override counts as 'set' — right now Python says yes (explicit) and TypeScript says no (auto)."
+      "role": "competitor",
+      "settings": { "competitor_provider": "Ollama" },
+      "context": {},
+      "python": {
+        "provider_type": "Ollama",
+        "model": "competitor-role-model",
+        "provider_class": "mid_tier",
+        "cost_per_1k_tokens": 0.003
+      },
+      "typescript": {
+        "provider_type": "ollama",
+        "model": "competitor-role-model",
+        "provider_class": "mid_tier",
+        "cost_per_1k_tokens": 0.003
+      },
+      "reason": "Python returns the raw per-role provider string while TypeScript normalizes it to lowercase.",
+      "resolution": "AC-911: normalize once when Endpoint replaces the bare provider string, so both packages report the canonical transport name."
+    },
+    {
+      "case": "explicit_override.whitespace_only_provider_name",
+      "role": "competitor",
+      "settings": { "competitor_provider": "  " },
+      "context": {},
+      "python": {
+        "provider_type": "  ",
+        "model": "competitor-role-model",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "typescript": {
+        "provider_type": "anthropic",
+        "model": "opus-tier-model",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "reason": "Python treats a whitespace-only provider as a truthy explicit override; TypeScript trims it to undefined and takes the auto route.",
+      "resolution": "AC-911: decide once whether a whitespace-only override counts as set when Endpoint replaces the bare provider string."
     },
     {
       "case": "routing_off.unknown_role_model",
-      "python": "returns model=None (role_router.py _config_for_default: self._role_models.get(role) misses for an unregistered role, e.g. 'skeptic', and there is no fallback default)",
-      "typescript": "returns \"sonnet-tier-model\" (role-routing.ts roleSpecificModel falls through to a tier default for any role outside its switch statement)",
+      "role": "skeptic",
+      "settings": { "role_routing": "off" },
+      "context": {},
+      "python": {
+        "provider_type": "anthropic",
+        "model": null,
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "typescript": {
+        "provider_type": "anthropic",
+        "model": "sonnet-tier-model",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
       "reason": "Python has no fallback for an unregistered role under routing_off and returns None for the model, while TypeScript's roleSpecificModel falls back to the sonnet tier model. provider_type ('anthropic') and provider_class ('frontier') agree in both; only model differs.",
       "resolution": "AC-911: the RoleAssignment work must decide one behavior for an unregistered role under routing_off, rather than inheriting Python's None and TypeScript's tier-default fallback as two separate defaults."
     }

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -43,7 +43,7 @@ const FIXTURES = JSON.parse(
 
 // Fixture groups whose cases are single routeRoleProvider() calls compared field by
 // field. Must stay in sync with ROUTE_GROUPS in the Python replay.
-const ROUTE_GROUPS = ["auto_mode"] as const;
+const ROUTE_GROUPS = ["auto_mode", "explicit_override"] as const;
 
 // The fixture uses Python snake_case settings keys. Map them to the camelCase
 // fields RoleRoutingSettings expects, so one fixture drives both languages.

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -1,0 +1,159 @@
+/**
+ * AC-910 step 1: cross-language routing parity.
+ *
+ * Replays docs/role-routing-parity-fixtures.json through routeRoleProvider().
+ * autocontext/tests/test_role_routing_parity.py replays the identical file
+ * through the Python RoleRouter. Both must agree exactly.
+ *
+ * To add a scenario group: add it to the fixture, then add its name to
+ * ROUTE_GROUPS here and to ROUTE_GROUPS in the Python replay.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { routeRoleProvider, type RoleRoutingSettings } from "../src/providers/index.js";
+
+type ExpectedAssignment = {
+  cost_per_1k_tokens: number;
+  model: string;
+  provider_class: string;
+  provider_type: string;
+};
+
+type ParityCase = {
+  context?: { availableLocalModels?: string[] };
+  expected: ExpectedAssignment;
+  role: string;
+  settings?: Record<string, string>;
+};
+
+type ParityFixtures = {
+  fixtures: Record<string, Record<string, ParityCase>>;
+  known_divergences: unknown[];
+  schema_version: number;
+};
+
+const FIXTURES = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "role-routing-parity-fixtures.json"),
+    "utf-8",
+  ),
+) as ParityFixtures;
+
+// Fixture groups whose cases are single routeRoleProvider() calls compared field by
+// field. Must stay in sync with ROUTE_GROUPS in the Python replay.
+const ROUTE_GROUPS = ["auto_mode"] as const;
+
+// The fixture uses Python snake_case settings keys. Map them to the camelCase
+// fields RoleRoutingSettings expects, so one fixture drives both languages.
+const SETTINGS_KEY_MAP: Record<string, keyof RoleRoutingSettings> = {
+  role_routing: "roleRouting",
+  agent_provider: "agentProvider",
+  competitor_provider: "competitorProvider",
+  analyst_provider: "analystProvider",
+  coach_provider: "coachProvider",
+  architect_provider: "architectProvider",
+  model_competitor: "modelCompetitor",
+  model_analyst: "modelAnalyst",
+  model_coach: "modelCoach",
+  model_architect: "modelArchitect",
+  model_curator: "modelCurator",
+  model_translator: "modelTranslator",
+  tier_opus_model: "tierOpusModel",
+  tier_sonnet_model: "tierSonnetModel",
+  tier_haiku_model: "tierHaikuModel",
+  mlx_model_path: "mlxModelPath",
+};
+
+// Must match _SETTINGS_DEFAULTS in the Python replay exactly.
+function baseSettings(): RoleRoutingSettings {
+  return {
+    agentProvider: "anthropic",
+    roleRouting: "auto",
+    competitorProvider: "",
+    analystProvider: "",
+    coachProvider: "",
+    architectProvider: "",
+    modelCompetitor: "competitor-role-model",
+    modelAnalyst: "analyst-role-model",
+    modelCoach: "coach-role-model",
+    modelArchitect: "architect-role-model",
+    modelCurator: "curator-role-model",
+    modelTranslator: "translator-role-model",
+    tierOpusModel: "opus-tier-model",
+    tierSonnetModel: "sonnet-tier-model",
+    tierHaikuModel: "haiku-tier-model",
+    mlxModelPath: "/models/default-local",
+  };
+}
+
+function settingsFromFixture(overrides: Record<string, string> = {}): RoleRoutingSettings {
+  const settings = baseSettings();
+  for (const [pythonKey, value] of Object.entries(overrides)) {
+    const camelKey = SETTINGS_KEY_MAP[pythonKey];
+    if (!camelKey) {
+      throw new Error(`fixture sets unknown settings key: ${pythonKey}`);
+    }
+    (settings as Record<string, string>)[camelKey] = value;
+  }
+  return settings;
+}
+
+function assertRouteMatches(
+  result: {
+    estimatedCostPer1kTokens: number;
+    model: string;
+    providerClass: string;
+    providerType: string;
+  },
+  expected: ExpectedAssignment,
+): void {
+  expect(result.providerType).toBe(expected.provider_type);
+  expect(result.model).toBe(expected.model);
+  expect(result.providerClass).toBe(expected.provider_class);
+  expect(result.estimatedCostPer1kTokens).toBeCloseTo(expected.cost_per_1k_tokens);
+}
+
+/**
+ * routeRoleProvider() reads AUTOCONTEXT_AGENT_PROVIDER / AUTOCONTEXT_PROVIDER live from
+ * process.env and lets them outrank the passed settings. Python does not read env at all.
+ * Without this isolation the suite passes or fails based on the runner's environment.
+ */
+let savedAgentProvider: string | undefined;
+let savedProvider: string | undefined;
+
+beforeEach(() => {
+  savedAgentProvider = process.env.AUTOCONTEXT_AGENT_PROVIDER;
+  savedProvider = process.env.AUTOCONTEXT_PROVIDER;
+  delete process.env.AUTOCONTEXT_AGENT_PROVIDER;
+  delete process.env.AUTOCONTEXT_PROVIDER;
+});
+
+afterEach(() => {
+  if (savedAgentProvider === undefined) delete process.env.AUTOCONTEXT_AGENT_PROVIDER;
+  else process.env.AUTOCONTEXT_AGENT_PROVIDER = savedAgentProvider;
+  if (savedProvider === undefined) delete process.env.AUTOCONTEXT_PROVIDER;
+  else process.env.AUTOCONTEXT_PROVIDER = savedProvider;
+});
+
+for (const group of ROUTE_GROUPS) {
+  describe(`${group} parity`, () => {
+    const cases = Object.entries(FIXTURES.fixtures[group] ?? {});
+
+    it("has cases to replay", () => {
+      expect(cases.length).toBeGreaterThan(0);
+    });
+
+    for (const [name, testCase] of cases) {
+      it(`matches Python for ${name}`, () => {
+        const result = routeRoleProvider(
+          settingsFromFixture(testCase.settings),
+          testCase.role,
+          testCase.context ?? {},
+        );
+        assertRouteMatches(result, testCase.expected);
+      });
+    }
+  });
+}

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -43,7 +43,7 @@ const FIXTURES = JSON.parse(
 
 // Fixture groups whose cases are single routeRoleProvider() calls compared field by
 // field. Must stay in sync with ROUTE_GROUPS in the Python replay.
-const ROUTE_GROUPS = ["auto_mode", "explicit_override"] as const;
+const ROUTE_GROUPS = ["auto_mode", "explicit_override", "routing_off", "local_artifacts"] as const;
 
 // The fixture uses Python snake_case settings keys. Map them to the camelCase
 // fields RoleRoutingSettings expects, so one fixture drives both languages.

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -99,7 +99,7 @@ function settingsFromFixture(overrides: Record<string, string> = {}): RoleRoutin
     if (!camelKey) {
       throw new Error(`fixture sets unknown settings key: ${pythonKey}`);
     }
-    (settings as Record<string, string>)[camelKey] = value;
+    settings[camelKey] = value;
   }
   return settings;
 }

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -104,6 +104,10 @@ function settingsFromFixture(overrides: Record<string, string> = {}): RoleRoutin
   return settings;
 }
 
+// toBeCloseTo defaults to precision 2 (tolerance 0.005); the cost classes here are
+// 0.015 / 0.003 / 0.001 / 0.0, so a default-precision check cannot distinguish
+// most of them from each other. Pin to precision 6 so this assertion is at least
+// as strict as Python's pytest.approx (relative tolerance 1e-6) on the same fields.
 function assertRouteMatches(
   result: {
     estimatedCostPer1kTokens: number;
@@ -116,7 +120,7 @@ function assertRouteMatches(
   expect(result.providerType).toBe(expected.provider_type);
   expect(result.model).toBe(expected.model);
   expect(result.providerClass).toBe(expected.provider_class);
-  expect(result.estimatedCostPer1kTokens).toBeCloseTo(expected.cost_per_1k_tokens);
+  expect(result.estimatedCostPer1kTokens).toBeCloseTo(expected.cost_per_1k_tokens, 6);
 }
 
 /**
@@ -187,11 +191,15 @@ describe("cost_estimation parity", () => {
         settingsFromFixture(testCase.settings),
         testCase.context ?? {},
       );
-      expect(estimate.totalPer1kTokens).toBeCloseTo(testCase.expected.total_per_1k_tokens);
+      expect(estimate.totalPer1kTokens).toBeCloseTo(testCase.expected.total_per_1k_tokens, 6);
       expect(estimate.allFrontierPer1kTokens).toBeCloseTo(
         testCase.expected.all_frontier_per_1k_tokens,
+        6,
       );
-      expect(estimate.savingsVsAllFrontier).toBeCloseTo(testCase.expected.savings_vs_all_frontier);
+      expect(estimate.savingsVsAllFrontier).toBeCloseTo(
+        testCase.expected.savings_vs_all_frontier,
+        6,
+      );
     });
   }
 });
@@ -208,6 +216,14 @@ describe("fixture completeness", () => {
 
   it("replays every expected fixture group", () => {
     expect(Object.keys(FIXTURES.fixtures).sort()).toEqual(EXPECTED_GROUPS);
+
+    // ROUTE_GROUPS and EXPECTED_GROUPS are independent literals, so dropping a
+    // name from ROUTE_GROUPS (the replay registry) leaves the assertion above
+    // untouched: the fixture still has the group, that check still passes, and
+    // this language silently stops replaying it. The fixture-key check alone
+    // cannot catch a dropped replay registration — only comparing the registry
+    // itself against the expected set can.
+    expect([...ROUTE_GROUPS, "cost_estimation"].sort()).toEqual(EXPECTED_GROUPS);
   });
 
   it("has no empty group", () => {

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -12,7 +12,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { routeRoleProvider, type RoleRoutingSettings } from "../src/providers/index.js";
+import {
+  estimateRoleRoutingCost,
+  routeRoleProvider,
+  type RoleRoutingSettings,
+} from "../src/providers/index.js";
 
 type ExpectedAssignment = {
   cost_per_1k_tokens: number;
@@ -157,3 +161,37 @@ for (const group of ROUTE_GROUPS) {
     }
   });
 }
+
+type CostCase = {
+  context?: { availableLocalModels?: string[] };
+  expected: {
+    all_frontier_per_1k_tokens: number;
+    savings_vs_all_frontier: number;
+    total_per_1k_tokens: number;
+  };
+  settings?: Record<string, string>;
+};
+
+describe("cost_estimation parity", () => {
+  const cases = Object.entries(
+    (FIXTURES.fixtures.cost_estimation ?? {}) as unknown as Record<string, CostCase>,
+  );
+
+  it("has cases to replay", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  for (const [name, testCase] of cases) {
+    it(`matches Python for ${name}`, () => {
+      const estimate = estimateRoleRoutingCost(
+        settingsFromFixture(testCase.settings),
+        testCase.context ?? {},
+      );
+      expect(estimate.totalPer1kTokens).toBeCloseTo(testCase.expected.total_per_1k_tokens);
+      expect(estimate.allFrontierPer1kTokens).toBeCloseTo(
+        testCase.expected.all_frontier_per_1k_tokens,
+      );
+      expect(estimate.savingsVsAllFrontier).toBeCloseTo(testCase.expected.savings_vs_all_frontier);
+    });
+  }
+});

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -5,8 +5,8 @@
  * autocontext/tests/test_role_routing_parity.py replays the identical file
  * through the Python RoleRouter. Both must agree exactly.
  *
- * To add a scenario group: add it to the fixture, then add its name to
- * ROUTE_GROUPS here and to ROUTE_GROUPS in the Python replay.
+ * To add a scenario: add it to the fixture, then add its case id to
+ * EXPECTED_CASE_IDS here and _EXPECTED_CASE_IDS in the Python replay.
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -20,7 +20,7 @@ import {
 
 type ExpectedAssignment = {
   cost_per_1k_tokens: number;
-  model: string;
+  model: string | null;
   provider_class: string;
   provider_type: string;
 };
@@ -32,9 +32,20 @@ type ParityCase = {
   settings?: Record<string, string>;
 };
 
+type DivergenceCase = {
+  case: string;
+  context?: { availableLocalModels?: string[] };
+  python: ExpectedAssignment;
+  reason: string;
+  resolution: string;
+  role: string;
+  settings?: Record<string, string>;
+  typescript: ExpectedAssignment;
+};
+
 type ParityFixtures = {
   fixtures: Record<string, Record<string, ParityCase>>;
-  known_divergences: unknown[];
+  known_divergences: DivergenceCase[];
   schema_version: number;
 };
 
@@ -45,9 +56,61 @@ const FIXTURES = JSON.parse(
   ),
 ) as ParityFixtures;
 
-// Fixture groups whose cases are single routeRoleProvider() calls compared field by
-// field. Must stay in sync with ROUTE_GROUPS in the Python replay.
-const ROUTE_GROUPS = ["auto_mode", "explicit_override", "routing_off", "local_artifacts"] as const;
+// The fixture is the behavioral contract, but the expected case ids live outside
+// it so deleting or replacing a critical scenario cannot silently reduce coverage.
+const EXPECTED_CASE_IDS = {
+  auto_mode: [
+    "competitor_frontier",
+    "analyst_mid_tier",
+    "coach_mid_tier",
+    "architect_frontier_no_local_fallback",
+    "curator_fast",
+    "translator_fast",
+    "unknown_role_falls_back_to_mid_tier",
+    "self_hosted_default_provider_is_frontier_via_table",
+  ],
+  explicit_override: [
+    "competitor_override_to_ollama_is_mid_tier",
+    "architect_override_to_vllm_is_mid_tier",
+    "unknown_override_provider_defaults_to_frontier",
+    "override_to_mlx_uses_mlx_model_path",
+    "override_wins_over_role_routing_off",
+  ],
+  routing_off: [
+    "off_uses_default_provider_and_role_model",
+    "off_with_ollama_default_is_mid_tier",
+    "off_with_unknown_default_provider_is_mid_tier",
+    "off_uses_coach_role_model",
+    "off_uses_curator_role_model",
+    "off_uses_translator_role_model",
+    "off_with_mlx_default_uses_mlx_model_path",
+  ],
+  local_artifacts: [
+    "eligible_role_prefers_local_artifact",
+    "architect_ignores_local_artifact",
+    "curator_ignores_local_artifact",
+    "local_artifact_ignored_when_routing_off",
+  ],
+  cost_estimation: ["default_auto_mode_totals", "with_local_artifacts_totals"],
+} as const satisfies Record<string, readonly string[]>;
+
+const EXPECTED_DIVERGENCE_CASE_IDS = [
+  "explicit_override.mixed_case_provider_name",
+  "explicit_override.whitespace_only_provider_name",
+  "routing_off.unknown_role_model",
+];
+
+const EXPECTED_ASSIGNMENT_KEYS = [
+  "cost_per_1k_tokens",
+  "model",
+  "provider_class",
+  "provider_type",
+];
+
+const EXPECTED_GROUPS = Object.keys(EXPECTED_CASE_IDS).sort();
+
+// Fixture groups whose cases are single routeRoleProvider() calls compared field by field.
+const ROUTE_GROUPS = Object.keys(EXPECTED_CASE_IDS).filter((group) => group !== "cost_estimation");
 
 // The fixture uses Python snake_case settings keys. Map them to the camelCase
 // fields RoleRoutingSettings expects, so one fixture drives both languages.
@@ -166,6 +229,31 @@ for (const group of ROUTE_GROUPS) {
   });
 }
 
+describe("known divergences", () => {
+  it("contains every expected divergence exactly once", () => {
+    const caseIds = FIXTURES.known_divergences.map((testCase) => testCase.case);
+    expect(new Set(caseIds).size).toBe(caseIds.length);
+    expect(caseIds.sort()).toEqual(EXPECTED_DIVERGENCE_CASE_IDS);
+  });
+
+  for (const testCase of FIXTURES.known_divergences) {
+    it(`pins the TypeScript output for ${testCase.case}`, () => {
+      expect(Object.keys(testCase.python).sort()).toEqual(EXPECTED_ASSIGNMENT_KEYS);
+      expect(Object.keys(testCase.typescript).sort()).toEqual(EXPECTED_ASSIGNMENT_KEYS);
+      expect(testCase.typescript).not.toEqual(testCase.python);
+      expect(testCase.reason.trim()).not.toBe("");
+      expect(testCase.resolution.trim()).not.toBe("");
+
+      const result = routeRoleProvider(
+        settingsFromFixture(testCase.settings),
+        testCase.role,
+        testCase.context ?? {},
+      );
+      assertRouteMatches(result, testCase.typescript);
+    });
+  }
+});
+
 type CostCase = {
   context?: { availableLocalModels?: string[] };
   expected: {
@@ -205,25 +293,19 @@ describe("cost_estimation parity", () => {
 });
 
 describe("fixture completeness", () => {
-  // Must match _EXPECTED_GROUPS in the Python replay.
-  const EXPECTED_GROUPS = [
-    "auto_mode",
-    "cost_estimation",
-    "explicit_override",
-    "local_artifacts",
-    "routing_off",
-  ];
-
   it("replays every expected fixture group", () => {
     expect(Object.keys(FIXTURES.fixtures).sort()).toEqual(EXPECTED_GROUPS);
-
-    // ROUTE_GROUPS and EXPECTED_GROUPS are independent literals, so dropping a
-    // name from ROUTE_GROUPS (the replay registry) leaves the assertion above
-    // untouched: the fixture still has the group, that check still passes, and
-    // this language silently stops replaying it. The fixture-key check alone
-    // cannot catch a dropped replay registration — only comparing the registry
-    // itself against the expected set can.
     expect([...ROUTE_GROUPS, "cost_estimation"].sort()).toEqual(EXPECTED_GROUPS);
+  });
+
+  it("replays every expected fixture case", () => {
+    const actual = Object.fromEntries(
+      Object.entries(FIXTURES.fixtures).map(([group, cases]) => [group, Object.keys(cases).sort()]),
+    );
+    const expected = Object.fromEntries(
+      Object.entries(EXPECTED_CASE_IDS).map(([group, caseIds]) => [group, [...caseIds].sort()]),
+    );
+    expect(actual).toEqual(expected);
   });
 
   it("has no empty group", () => {

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -195,3 +195,31 @@ describe("cost_estimation parity", () => {
     });
   }
 });
+
+describe("fixture completeness", () => {
+  // Must match _EXPECTED_GROUPS in the Python replay.
+  const EXPECTED_GROUPS = [
+    "auto_mode",
+    "cost_estimation",
+    "explicit_override",
+    "local_artifacts",
+    "routing_off",
+  ];
+
+  it("replays every expected fixture group", () => {
+    expect(Object.keys(FIXTURES.fixtures).sort()).toEqual(EXPECTED_GROUPS);
+  });
+
+  it("has no empty group", () => {
+    const empty = EXPECTED_GROUPS.filter(
+      (g) => Object.keys(FIXTURES.fixtures[g] ?? {}).length === 0,
+    );
+    expect(empty).toEqual([]);
+  });
+
+  // The unknown-key guard exists so a misspelled fixture key fails loudly instead
+  // of silently falling back to defaults. Untested, it could rot into a no-op.
+  it("rejects an unknown settings key", () => {
+    expect(() => settingsFromFixture({ not_a_real_setting: "x" })).toThrow(/unknown settings key/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `docs/role-routing-parity-fixtures.json`, a shared fixture pinning **22 cross-language routing cases** across 5 groups, replayed by a new test in each package. Test-only: **zero production code changes.**
- AC-910 is about to separate model *capability* (frontier/mid/fast) from *hosting* (local/remote), which the codebase currently collapses into one `ProviderClass` axis. That refactor touches both `agents/role_router.py` and `ts/src/providers/role-routing.ts`. Nothing today asserts the two produce the same answer for the same input, so they could drift apart during the refactor while both suites stayed green.
- `docs/role-routing-contract.json` already pins shared *constants*; this pins shared *behavior*. Complementary, not a replacement.

**Two live divergences found and recorded** (verified by executing both routers, not inferred):

| Input | Python | TypeScript |
| --- | --- | --- |
| Mixed-case provider (`"Ollama"`) | returns raw string | normalizes (and trims) |
| Routing-off + unregistered role | `model=None` | `model="sonnet-tier-model"` |

Both are recorded in `known_divergences` with a resolution pointing at AC-911, rather than fixed here.

The fixture deliberately pins behavior the team considers wrong, so AC-911 changing it is a visible fixture edit rather than an accident. Most notably `self_hosted_default_provider_is_frontier_via_table`: a self-hosted vLLM endpoint gets an Anthropic tier model id and is billed at frontier rates, because auto-mode takes its class from the role table rather than from the provider.

## Surfaces Touched

- [x] Parity decision: cross-runtime parity is user-visible and required now — this PR *is* the parity mechanism
- [x] Python package (test only)
- [x] TypeScript package (test only)
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run --frozen ruff check src tests` — passed
- [x] `cd autocontext && uv run --frozen mypy src` — no issues, 738 files
- [x] `cd autocontext && uv run --frozen pytest tests/` — exit 0
- [x] `cd ts && npm run lint` — exit 0 (includes the AC-909 `check:test-types` gate)
- [x] `cd ts && npm test` — 834 files / 6040 tests passed
- [x] additional manual verification described below

**Every guard was observed failing before being trusted.** Three deliberate-corruption experiments, fixture restored byte-identical after each:

| Experiment | Python | TypeScript |
| --- | --- | --- |
| A — deleted fixture group | collection error | 3 tests fail |
| B — emptied fixture group | `test_no_expected_group_is_empty`, exit 1 | `has cases to replay` |
| C — extra untracked group | `test_every_expected_fixture_group_is_present` | `replays every expected fixture group` |

Experiment B exists because of a real hole: without that guard, an emptied group makes pytest report **`1 skipped` with exit code 0** — a green run asserting nothing. Verified directly.

Experiment C exists because Experiment A never actually isolated the presence guard: `_cases()` runs inside the `@parametrize` decorator, so a missing group aborts collection before the guard executes.

A final whole-branch review also caught that `ROUTE_GROUPS` (the replay registry) and `EXPECTED_GROUPS` (the completeness guard) were independent literals, so dropping a group from one language's registry left the fixture untouched, passed every guard, and silently halved that language's coverage. Now coupled, and that coupling was proven to fail before being accepted.

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

Test-only internal change; nothing user-facing to document or release.

## Notes

- **No behavior change.** No production file is touched. The fixture encodes current behavior exactly as it is today, including behavior we intend to change.
- **Follow-up:** AC-919 records the findings deliberately deferred from this branch — five more verified divergences in the unset/empty-settings layer, unenforced divergence records, and the observation that `docs/role-routing-contract.json` already carries both languages' field spellings, so the hand-mirrored key map can be *deleted* rather than test-guarded.
- **Known limitation:** the registry-coupling assertion lives inside the existing completeness test, so a bare CI summary line will not distinguish "fixture lost a group" from "registry lost a group". Both languages print the actual diff on failure and carry an explanatory comment; splitting it into its own test was judged not worth an extra test whose only benefit is a nicer summary line.

Part of AC-910.
