### PR TITLE
fix(AC-910): consolidate seven model-JSON extractors onto one parser

### DIFF
--- a/autocontext/src/autocontext/agents/architect.py
+++ b/autocontext/src/autocontext/agents/architect.py
@@ -8,22 +8,15 @@ from typing import Any
 
 from autocontext.agents.subagent_runtime import SubagentRuntime, SubagentTask
 from autocontext.agents.types import RoleExecution
-from autocontext.harness.core.output_parser import extract_delimited_section
+from autocontext.harness.core.output_parser import extract_delimited_section, extract_json
 
 logger = logging.getLogger(__name__)
 
+
 def parse_architect_tool_specs(content: str) -> list[dict[str, Any]]:
-    start = content.find("```json")
-    end = content.rfind("```")
-    if start == -1 or end == -1 or end <= start:
-        return []
-    body = content[start + 7 : end].strip()
-    try:
-        decoded = json.loads(body)
-    except json.JSONDecodeError:
+    decoded = extract_json(content, on_failure="none")
+    if decoded is None:
         logger.warning("architect output JSON block unparseable (possibly truncated); treating as no proposal")
-        return []
-    if not isinstance(decoded, Mapping):
         return []
     tools = decoded.get("tools")
     if not isinstance(tools, list):

--- a/autocontext/src/autocontext/agents/architect.py
+++ b/autocontext/src/autocontext/agents/architect.py
@@ -16,7 +16,17 @@ logger = logging.getLogger(__name__)
 def parse_architect_tool_specs(content: str) -> list[dict[str, Any]]:
     decoded = extract_json(content, on_failure="none")
     if decoded is None:
-        logger.warning("architect output JSON block unparseable (possibly truncated); treating as no proposal")
+        # Warn only when there was something object-shaped to fail ON. Before
+        # this site was migrated onto extract_json it looked for a literal
+        # "```json" and returned [] SILENTLY when there wasn't one, so an empty
+        # string, bare prose, or an array-shaped answer produced no log line at
+        # all; warning on those now would be pure added volume with nothing
+        # actionable in it. extract_json can only ever succeed by returning a
+        # Mapping, so with no "{" anywhere the failure was a foregone
+        # conclusion rather than a truncated proposal -- which is exactly what
+        # this message claims it is.
+        if "{" in content:
+            logger.warning("architect output JSON block unparseable (possibly truncated); treating as no proposal")
         return []
     tools = decoded.get("tools")
     if not isinstance(tools, list):

--- a/autocontext/src/autocontext/agents/curator.py
+++ b/autocontext/src/autocontext/agents/curator.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from importlib import import_module
 from typing import Any
 
+from pydantic import ValidationError
+
 from autocontext.agents.feedback_loops import AnalystRating
 from autocontext.agents.subagent_runtime import SubagentRuntime, SubagentTask
 from autocontext.agents.types import RoleExecution
@@ -212,11 +214,39 @@ class KnowledgeCurator:
         )
         decoded = extract_json(exec_result.content, on_failure="none")
         if decoded is None:
+            # No exc_info here, unlike the ValidationError branch below and
+            # unlike this line before the migration. It used to sit inside
+            # `except json.JSONDecodeError`, where there was a live exception
+            # to attach; extract_json(on_failure="none") swallows that
+            # exception internally and reports failure as a None return, so
+            # there is no active exception at this point and exc_info=True
+            # would append a bare "NoneType: None" to every such warning.
             logger.warning("curator analyst-rating parse failed; using default scores")
             payload: dict[str, Any] = {}
         else:
             payload = decoded
-        rating = AnalystRating.from_dict({"generation": generation, **payload})
+        try:
+            rating = AnalystRating.from_dict({"generation": generation, **payload})
+        except ValidationError:
+            # This site's contract is fail-soft, and it has to be: the rating is
+            # FEEDBACK routed into the next generation's analyst prompt, not the
+            # artifact the loop scores. Its caller
+            # (loop.stage_helpers.persistence_helpers._maybe_rate_analyst_output)
+            # runs mid-generation with no handler, so raising here would abort a
+            # whole generation over a cosmetic score. Contrast translator.translate,
+            # which deliberately uses on_failure="raise" because the strategy it
+            # parses IS the scored artifact.
+            #
+            # A payload that PARSES as JSON but not as a rating (e.g.
+            # {"actionability": "not-a-number"}) has always been able to reach
+            # from_dict and raise; what widened it was migrating this site onto
+            # extract_json, which recovers unfenced prose JSON the old
+            # json.loads(strip_json_fences(...)) could not, so inputs that used
+            # to fail closed at the JSONDecodeError now arrive here with a
+            # non-default payload. Degrade to defaults instead, which is what
+            # every other malformed-output path at this site already does.
+            logger.warning("curator analyst-rating payload failed schema validation; using default scores", exc_info=True)
+            rating = AnalystRating.from_dict({"generation": generation})
         return rating, exec_result
 
     def consolidate_lessons(

--- a/autocontext/src/autocontext/agents/curator.py
+++ b/autocontext/src/autocontext/agents/curator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import re
 from dataclasses import dataclass
@@ -10,7 +9,7 @@ from typing import Any
 from autocontext.agents.feedback_loops import AnalystRating
 from autocontext.agents.subagent_runtime import SubagentRuntime, SubagentTask
 from autocontext.agents.types import RoleExecution
-from autocontext.harness.core.output_parser import strip_json_fences
+from autocontext.harness.core.output_parser import extract_json
 
 _DECISION_RE = re.compile(r"<!--\s*CURATOR_DECISION:\s*(accept|reject|merge)\s*-->", re.IGNORECASE)
 _PLAYBOOK_RE = re.compile(
@@ -102,6 +101,7 @@ _CURATOR_CONSOLIDATION_CONSTRAINT = (
     "- Do NOT keep lessons that directly contradict each other without resolution\n\n"
 )
 
+
 def _structural_hint_prompt(hint_style: str) -> str:
     return str(import_module("autocontext.knowledge.soft_hints").structural_hint_prompt(hint_style))
 
@@ -191,8 +191,7 @@ class KnowledgeCurator:
         """Rate analyst quality so the next analyst prompt gets concrete curator feedback."""
         constraint_preamble = _CURATOR_ANALYST_RATING_CONSTRAINT if constraint_mode else ""
         prompt = (
-            constraint_preamble
-            + "You are a curator rating the quality of the analyst's report.\n\n"
+            constraint_preamble + "You are a curator rating the quality of the analyst's report.\n\n"
             "Score the report from 1-5 on:\n"
             "- actionability: how directly the recommendations can be used\n"
             "- specificity: how concrete and evidence-backed the findings are\n"
@@ -211,14 +210,12 @@ class KnowledgeCurator:
                 temperature=0.2,
             )
         )
-        payload: dict[str, Any] = {}
-        try:
-            decoded = json.loads(strip_json_fences(exec_result.content))
-            if isinstance(decoded, dict):
-                payload = decoded
-        except json.JSONDecodeError:
-            logger.warning("curator analyst-rating parse failed; using default scores", exc_info=True)
-            payload = {}
+        decoded = extract_json(exec_result.content, on_failure="none")
+        if decoded is None:
+            logger.warning("curator analyst-rating parse failed; using default scores")
+            payload: dict[str, Any] = {}
+        else:
+            payload = decoded
         rating = AnalystRating.from_dict({"generation": generation, **payload})
         return rating, exec_result
 
@@ -233,8 +230,7 @@ class KnowledgeCurator:
         lessons_text = "\n".join(existing_lessons)
         constraint_preamble = _CURATOR_CONSOLIDATION_CONSTRAINT if constraint_mode else ""
         prompt = (
-            constraint_preamble
-            + "You are a curator consolidating operational lessons. "
+            constraint_preamble + "You are a curator consolidating operational lessons. "
             f"Reduce {len(existing_lessons)} lessons to at most {max_lessons}.\n\n"
             "Deduplicate semantically similar lessons. Rank by evidence strength.\n"
             "Remove outdated or contradicted lessons.\n\n"

--- a/autocontext/src/autocontext/agents/hint_feedback.py
+++ b/autocontext/src/autocontext/agents/hint_feedback.py
@@ -13,12 +13,13 @@ Key types:
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
+
+from autocontext.harness.core.output_parser import extract_json
 
 logger = logging.getLogger(__name__)
 
@@ -139,9 +140,6 @@ def build_hint_reflection_prompt(
     )
 
 
-_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
-
-
 def _normalize_feedback_list(value: Any) -> list[str]:
     if isinstance(value, str):
         item = value.strip()
@@ -189,48 +187,45 @@ def parse_hint_feedback(
     hint_items: list[str] | None = None,
 ) -> HintFeedback:
     """Parse competitor's hint feedback response."""
-    text = raw_text.strip()
+    # AC-910 Task 5: delegates to the shared extract_json(..., on_failure="none")
+    # instead of its own newline-required fence regex + json.loads. Both a
+    # JSONDecodeError and a successful-but-non-dict parse (e.g. a bare array)
+    # collapse to None here, matching this function's original "fall through
+    # to all-empty defaults on any parse failure" policy exactly -- neither
+    # case ever raised before, and neither does now.
+    data = extract_json(raw_text, on_failure="none")
+    if data is None:
+        logger.debug("agents.hint_feedback: no parseable JSON object found in competitor response")
+        return HintFeedback(helpful=[], misleading=[], missing=[], generation=generation)
 
-    # Try fenced JSON first
-    match = _JSON_FENCE_RE.search(text)
-    if match:
-        text = match.group(1).strip()
+    helpful: list[str]
+    misleading: list[str]
+    if hint_items:
+        helpful_indexes = _normalize_feedback_index_list(
+            data.get("helpful_hint_numbers"),
+            max_index=len(hint_items),
+        )
+        misleading_indexes = _normalize_feedback_index_list(
+            data.get("misleading_hint_numbers"),
+            max_index=len(hint_items),
+        )
+        helpful = [hint_items[index - 1] for index in helpful_indexes]
+        misleading = [hint_items[index - 1] for index in misleading_indexes]
+    else:
+        helpful = []
+        misleading = []
 
-    try:
-        data = json.loads(text)
-        if isinstance(data, dict):
-            helpful: list[str]
-            misleading: list[str]
-            if hint_items:
-                helpful_indexes = _normalize_feedback_index_list(
-                    data.get("helpful_hint_numbers"),
-                    max_index=len(hint_items),
-                )
-                misleading_indexes = _normalize_feedback_index_list(
-                    data.get("misleading_hint_numbers"),
-                    max_index=len(hint_items),
-                )
-                helpful = [hint_items[index - 1] for index in helpful_indexes]
-                misleading = [hint_items[index - 1] for index in misleading_indexes]
-            else:
-                helpful = []
-                misleading = []
+    if not helpful:
+        helpful = _normalize_feedback_list(data.get("helpful"))
+    if not misleading:
+        misleading = _normalize_feedback_list(data.get("misleading"))
 
-            if not helpful:
-                helpful = _normalize_feedback_list(data.get("helpful"))
-            if not misleading:
-                misleading = _normalize_feedback_list(data.get("misleading"))
-
-            return HintFeedback(
-                helpful=helpful,
-                misleading=misleading,
-                missing=_normalize_feedback_list(data.get("missing")),
-                generation=generation,
-            )
-    except (json.JSONDecodeError, TypeError):
-        logger.debug("agents.hint_feedback: suppressed json.JSONDecodeError), TypeError", exc_info=True)
-
-    return HintFeedback(helpful=[], misleading=[], missing=[], generation=generation)
+    return HintFeedback(
+        helpful=helpful,
+        misleading=misleading,
+        missing=_normalize_feedback_list(data.get("missing")),
+        generation=generation,
+    )
 
 
 def format_hint_feedback_for_coach(feedback: HintFeedback | None) -> str:

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -678,15 +678,36 @@ class AgentOrchestrator:
         # then gets executed and scored as a legitimate result. extract_json's
         # default on_failure="raise" matches the direct (non-pipeline) path's
         # StrategyTranslator.translate, which already raises on the same
-        # failure; this used to diverge and fail soft instead. This also
-        # closes a second, separate defect: the old `json.loads(...)` call had
-        # no type check at all, so a translator response shaped as a JSON
-        # array (not an object) was assigned to `strategy` as-is -- a list
-        # silently violating the `dict[str, Any]` every downstream consumer
-        # (AgentOutputs, CompetitorOutput) declares and expects. extract_json
-        # treats a successful parse to a non-object as terminal and raises,
-        # so that shape is now rejected here instead of failing later, less
-        # legibly, downstream.
+        # failure; this used to diverge and fail soft instead. It also type-
+        # checks, which the old `json.loads(...)` here did not: a translator
+        # response shaped as a JSON array (not an object) used to be assigned
+        # to `strategy` as-is -- a list silently violating the
+        # `dict[str, Any]` every downstream consumer (AgentOutputs,
+        # CompetitorOutput) declares and expects.
+        #
+        # Be clear about what this line can and cannot catch as currently
+        # wired, though, because an earlier version of this comment read as
+        # if both changes were live here and neither is. pipeline_adapter's
+        # translator branch calls `orch.translator.translate(...)`, DISCARDS
+        # the strategy it returns, and hands back only the RoleExecution --
+        # whose `.content` is either `json.dumps(...)` (always valid) or the
+        # very string `translate` just parsed successfully. extract_json is
+        # deterministic, so this second parse cannot disagree with the first:
+        # any input bad enough to fail here fails inside `translate` one frame
+        # earlier and never reaches this line. Through that path neither
+        # fail-hard nor the array rejection can actually fire.
+        #
+        # So this is defense-in-depth, kept deliberately rather than deleted.
+        # The adapter's discard-and-re-parse is an implementation detail, not
+        # a contract: an adapter that sourced the translator RoleExecution
+        # from anywhere other than `translate`'s own return (a cached
+        # execution, a retry, a streaming/partial-result path) would put
+        # un-vetted content in front of this line, and `use_pipeline_engine`
+        # flipping default-on is when that stops being hypothetical. Both
+        # behaviors ARE pinned, by tests that stub the role handler to reach
+        # this parse for real -- see, in tests/test_pipeline_adapter.py,
+        # test_orchestrator_parses_translator_content_and_raises_on_malformed
+        # and test_orchestrator_rejects_array_shaped_translator_content.
         from autocontext.harness.core.output_parser import extract_json
 
         strategy = extract_json(results["translator"].content)

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json as _json
 import logging
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager
@@ -673,13 +672,17 @@ class AgentOrchestrator:
         engine = PipelineEngine(dag, handler, max_workers=2)
         results = engine.execute(prompt_map, on_role_event=on_role_event)
 
-        # Extract strategy from translator result
-        from autocontext.harness.core.output_parser import strip_json_fences
+        # Extract strategy from translator result. This is the strategy being
+        # evaluated -- the artifact the whole generation loop scores -- so a
+        # parse failure must raise, not silently become an empty dict that
+        # then gets executed and scored as a legitimate result. extract_json's
+        # default on_failure="raise" matches the direct (non-pipeline) path's
+        # StrategyTranslator.translate, which already raises on the same
+        # failure; this used to diverge and fail soft instead.
+        from autocontext.harness.core.output_parser import extract_json
 
-        try:
-            strategy = _json.loads(strip_json_fences(results["translator"].content))
-        except (_json.JSONDecodeError, TypeError):
-            strategy = {}
+        strategy = extract_json(results["translator"].content)
+        assert strategy is not None  # on_failure="raise" never returns None
 
         tools = parse_architect_tool_specs(results["architect"].content)
         harness_specs = parse_architect_harness_specs(results["architect"].content)

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -678,7 +678,15 @@ class AgentOrchestrator:
         # then gets executed and scored as a legitimate result. extract_json's
         # default on_failure="raise" matches the direct (non-pipeline) path's
         # StrategyTranslator.translate, which already raises on the same
-        # failure; this used to diverge and fail soft instead.
+        # failure; this used to diverge and fail soft instead. This also
+        # closes a second, separate defect: the old `json.loads(...)` call had
+        # no type check at all, so a translator response shaped as a JSON
+        # array (not an object) was assigned to `strategy` as-is -- a list
+        # silently violating the `dict[str, Any]` every downstream consumer
+        # (AgentOutputs, CompetitorOutput) declares and expects. extract_json
+        # treats a successful parse to a non-object as terminal and raises,
+        # so that shape is now rejected here instead of failing later, less
+        # legibly, downstream.
         from autocontext.harness.core.output_parser import extract_json
 
         strategy = extract_json(results["translator"].content)

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -711,7 +711,12 @@ class AgentOrchestrator:
         from autocontext.harness.core.output_parser import extract_json
 
         strategy = extract_json(results["translator"].content)
-        assert strategy is not None  # on_failure="raise" never returns None
+        # Type narrowing for mypy ONLY, not a runtime guard: extract_json is
+        # declared `-> dict[str, Any] | None` because of the on_failure="none"
+        # variant, but on the default "raise" path it either returns a dict or
+        # raises, so the None arm is unreachable here. Asserts are stripped
+        # under `python -O`; nothing below depends on this one executing.
+        assert strategy is not None
 
         tools = parse_architect_tool_specs(results["architect"].content)
         harness_specs = parse_architect_harness_specs(results["architect"].content)

--- a/autocontext/src/autocontext/agents/pipeline_adapter.py
+++ b/autocontext/src/autocontext/agents/pipeline_adapter.py
@@ -92,6 +92,13 @@ def build_role_handler(
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
             ):
+                # The parsed strategy is discarded here and `_run_via_pipeline`
+                # re-parses `exec_result.content` itself. Worth knowing when
+                # reading that site: the content it re-parses is either
+                # `json.dumps(...)` or the exact string `translate` just parsed
+                # successfully, so its extract_json call cannot fail while this
+                # is the only way a translator RoleExecution is produced. See
+                # the comment at that call for why it is kept anyway.
                 _strategy, exec_result = orch.translator.translate(raw_text, strategy_interface)
                 return exec_result
         elif name == "analyst":

--- a/autocontext/src/autocontext/agents/translator.py
+++ b/autocontext/src/autocontext/agents/translator.py
@@ -72,7 +72,12 @@ class StrategyTranslator:
             raise
         except ValueError as exc:
             raise ValueError("translator did not return a JSON object") from exc
-        assert decoded is not None  # on_failure="raise" never returns None
+        # Type narrowing for mypy ONLY, not a runtime guard: extract_json is
+        # declared `-> dict[str, Any] | None` because of the on_failure="none"
+        # variant, but on the default "raise" path it either returns a dict or
+        # raises, so the None arm is unreachable here. Asserts are stripped
+        # under `python -O`; nothing below depends on this one executing.
+        assert decoded is not None
         return decoded, execution
 
     @staticmethod

--- a/autocontext/src/autocontext/agents/translator.py
+++ b/autocontext/src/autocontext/agents/translator.py
@@ -10,7 +10,7 @@ from typing import Any
 from autocontext.agents.subagent_runtime import SubagentRuntime, SubagentTask
 from autocontext.agents.translator_simplification import extract_strategy_deterministic
 from autocontext.agents.types import RoleExecution
-from autocontext.harness.core.output_parser import strip_json_fences as _harness_strip_fences
+from autocontext.harness.core.output_parser import extract_json
 from autocontext.harness.core.types import RoleUsage
 from autocontext.strategy_interface import is_action_plan_interface
 
@@ -24,11 +24,6 @@ class StrategyTranslator:
         # AC-905: the old 400/200 budgets were the tightest in the codebase
         # and routinely truncated strategy JSON; the floor is now 1024.
         self.max_tokens = max_tokens
-
-    @staticmethod
-    def _strip_fences(text: str) -> str:
-        """Strip markdown code fences if present, returning the inner content."""
-        return _harness_strip_fences(text)
 
     def translate(self, raw_output: str, strategy_interface: str) -> tuple[dict[str, Any], RoleExecution]:
         deterministic = extract_strategy_deterministic(raw_output)
@@ -64,11 +59,21 @@ class StrategyTranslator:
                 temperature=0.0,
             )
         )
-        cleaned = self._strip_fences(execution.content)
-        decoded = json.loads(cleaned)
-        if not isinstance(decoded, Mapping):
-            raise ValueError("translator did not return a JSON object")
-        return dict(decoded), execution
+        # extract_json defaults to on_failure="raise": a strategy that fails
+        # to parse must surface as an error, never as a silently-substituted
+        # empty dict that then gets executed and scored as a legitimate
+        # result. A JSONDecodeError (nothing parsed at all) is re-raised
+        # as-is; a successful parse to a non-object (e.g. a bare array) is
+        # reported with this method's own, more specific message instead of
+        # the parser's generic one.
+        try:
+            decoded = extract_json(execution.content)
+        except json.JSONDecodeError:
+            raise
+        except ValueError as exc:
+            raise ValueError("translator did not return a JSON object") from exc
+        assert decoded is not None  # on_failure="raise" never returns None
+        return decoded, execution
 
     @staticmethod
     def _matches_strategy_interface(strategy: Mapping[str, Any], strategy_interface: str) -> bool:

--- a/autocontext/src/autocontext/agents/translator_simplification.py
+++ b/autocontext/src/autocontext/agents/translator_simplification.py
@@ -10,12 +10,13 @@ Track 2: Consolidated analyst+coach output model and benchmark harness
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+from autocontext.harness.core.output_parser import extract_json
 
 logger = logging.getLogger(__name__)
 
@@ -23,44 +24,17 @@ logger = logging.getLogger(__name__)
 # Track 1: Deterministic strategy extraction
 # ---------------------------------------------------------------------------
 
-_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
-_JSON_OBJECT_RE = re.compile(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}")
-
 
 def extract_strategy_deterministic(raw_text: str) -> dict[str, Any] | None:
     """Try to extract a JSON strategy dict from raw competitor output without an LLM.
 
     Returns the parsed dict if successful, None if no valid JSON object found.
-    Tries in order: fenced code blocks, then bare JSON objects in the text.
     """
-    if not raw_text or not raw_text.strip():
+    decoded = extract_json(raw_text, on_failure="none")
+    if decoded is None:
+        logger.debug("agents.translator_simplification: no parseable JSON object found in competitor output")
         return None
-
-    # Try fenced code blocks first
-    for match in _JSON_FENCE_RE.finditer(raw_text):
-        result = _try_parse_object(match.group(1).strip())
-        if result is not None:
-            return result
-
-    # Try bare JSON objects in text
-    for match in _JSON_OBJECT_RE.finditer(raw_text):
-        result = _try_parse_object(match.group(0))
-        if result is not None:
-            return result
-
-    # Last resort: try the whole text as JSON
-    return _try_parse_object(raw_text.strip())
-
-
-def _try_parse_object(text: str) -> dict[str, Any] | None:
-    """Attempt to parse text as a JSON object. Returns None on failure or if not a dict."""
-    try:
-        parsed = json.loads(text)
-        if isinstance(parsed, dict):
-            return parsed
-    except (json.JSONDecodeError, ValueError):
-        logger.debug("agents.translator_simplification: suppressed json.JSONDecodeError), ValueError", exc_info=True)
-    return None
+    return decoded
 
 
 # ---------------------------------------------------------------------------
@@ -89,7 +63,7 @@ def _extract_section_bullets(markdown: str, heading: str) -> list[str]:
     if not match:
         return bullets
 
-    after = markdown[match.end():]
+    after = markdown[match.end() :]
     for line in after.splitlines():
         stripped = line.strip()
         if stripped.startswith("#") or stripped.startswith("<!--"):

--- a/autocontext/src/autocontext/execution/action_filter.py
+++ b/autocontext/src/autocontext/execution/action_filter.py
@@ -14,6 +14,7 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
+from autocontext.harness.core.output_parser import extract_json
 from autocontext.scenarios.base import ScenarioInterface
 
 logger = logging.getLogger(__name__)
@@ -205,19 +206,4 @@ class ActionFilterHarness:
 
     @staticmethod
     def _extract_json_object(response: str) -> dict[str, Any] | None:
-        candidates: list[str] = []
-        fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", response, flags=re.IGNORECASE)
-        if fenced:
-            candidates.append(fenced.group(1))
-        start = response.find("{")
-        end = response.rfind("}")
-        if start != -1 and end > start:
-            candidates.append(response[start : end + 1])
-        for candidate in candidates:
-            try:
-                parsed = json.loads(candidate)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(parsed, dict):
-                return parsed
-        return None
+        return extract_json(response, on_failure="none")

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -8,9 +8,9 @@ from collections.abc import Mapping
 from typing import Any
 
 # The `tag` group is what makes a ```json fence distinguishable from a bare
-# ``` or a ```python one. It is a named group so that adding it cannot silently
-# renumber `body` out from under strip_json_fences, which captured group(1)
-# before this group existed.
+# ``` or a ```python one. Both groups are named rather than positional so that
+# adding or reordering one cannot silently renumber `body` out from under a
+# reader of this regex.
 _JSON_FENCE_RE = re.compile(r"```(?P<tag>json)?\s*\n?(?P<body>.*?)\n?\s*```", re.DOTALL)
 
 # U+FEFF (BOM / zero-width no-break space). `str.strip()` does NOT remove it
@@ -41,20 +41,6 @@ def _scope_text(raw: str) -> str:
 # hand-rolled version was tried and worked, but it cannot help disagreeing
 # with json.loads at the margins (that disagreement is exactly how the two
 # holes this function now closes got in) where the real parser can't.
-
-
-def strip_json_fences(text: str) -> str:
-    """Strip markdown code fences, returning inner content.
-
-    Takes the FIRST fence of any language, unlike extract_json below, which
-    prefers a ```json-tagged one. That difference is deliberate and pinned:
-    this is a general-purpose fence stripper with callers that are not
-    extracting JSON at all, so it has no basis for preferring a json tag.
-    Do not "fix" it to match extract_json -- if a caller of this function
-    wants JSON, it should call extract_json.
-    """
-    match = _JSON_FENCE_RE.search(text)
-    return match.group("body").strip() if match else text.strip()
 
 
 def _top_level_object_spans(text: str) -> list[str]:

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -9,6 +9,26 @@ from typing import Any
 
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
 
+# U+FEFF (BOM / zero-width no-break space). `str.strip()` does NOT remove it
+# -- it is a format character, not whitespace, so `.isspace()` on it is False
+# -- and neither does the fence regex's `\s*`, so a BOM survives both ways of
+# producing a scope in extract_json. That matters because the array-shape
+# check there is a `startswith("[")` on the scope: a leading BOM shifts the
+# "[" off index 0, the check reads False, and a truncated array falls through
+# to the rescue candidates it is supposed to be exempt from. Spelled with
+# chr() rather than pasted in, so it is visible in a diff and in an editor.
+_BOM = chr(0xFEFF)
+
+
+def _scope_text(raw: str) -> str:
+    """Normalize a candidate scope: strip surrounding whitespace and any leading BOM.
+
+    The trailing `.strip()` handles a BOM followed by whitespace, which the
+    leading one stops at.
+    """
+    return raw.strip().lstrip(_BOM).strip()
+
+
 # A plain json.JSONDecoder (no object_hook etc) exposes raw_decode: given a
 # starting index, it parses exactly one JSON value from there using the real
 # parser and reports where that value ended. _top_level_object_spans uses it
@@ -111,7 +131,7 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     """
     fence_match = _JSON_FENCE_RE.search(text)
     has_fence = fence_match is not None
-    scope = fence_match.group(1).strip() if fence_match else text.strip()
+    scope = _scope_text(fence_match.group(1) if fence_match else text)
 
     candidates = [scope]
     # scope opening with `[` means the model was producing an array, and this
@@ -129,7 +149,9 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     # reached through malformed syntax instead of a successful parse.
     # Skipping the rescue candidates entirely means an array-shaped scope is
     # terminal whether it parses or not, regardless of which branch below
-    # would otherwise have produced them.
+    # would otherwise have produced them. `scope` is BOM-normalized by
+    # _scope_text above precisely so this check cannot be walked past by a
+    # leading U+FEFF -- see that constant's comment.
     if not scope.startswith("["):
         if has_fence:
             start, end = scope.find("{"), scope.rfind("}")

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -8,19 +8,24 @@ from collections.abc import Mapping
 from typing import Any
 
 # The `tag` group is what makes a ```json fence distinguishable from a bare
-# ``` or a ```python one. Both groups are named rather than positional so that
-# adding or reordering one cannot silently renumber `body` out from under a
-# reader of this regex.
-_JSON_FENCE_RE = re.compile(r"```(?P<tag>json)?\s*\n?(?P<body>.*?)\n?\s*```", re.DOTALL)
+# ``` or a ```python one. JSON is case-insensitive, but it must be the complete
+# tag: jsonl/json5/jsonnet are different info strings and must not gain JSON's
+# priority merely because they share its prefix. ``{``/``[`` in the lookahead
+# preserves the supported single-line form (```json{"a": 1}```), while U+FEFF
+# lets the normal scope cleanup handle a BOM between the tag and payload.
+_JSON_FENCE_RE = re.compile(
+    r"```(?P<tag>json(?=\s|[\[{\ufeff]))?\s*\n?(?P<body>.*?)\n?\s*```",
+    re.DOTALL | re.IGNORECASE,
+)
 
 # U+FEFF (BOM / zero-width no-break space). `str.strip()` does NOT remove it
 # -- it is a format character, not whitespace, so `.isspace()` on it is False
 # -- and neither does the fence regex's `\s*`, so a BOM survives both ways of
-# producing a scope in extract_json. That matters because the array-shape
-# check there is a `startswith("[")` on the scope: a leading BOM shifts the
-# "[" off index 0, the check reads False, and a truncated array falls through
-# to the rescue candidates it is supposed to be exempt from. Spelled with
-# chr() rather than pasted in, so it is visible in a diff and in an editor.
+# producing a scope in extract_json. Normalizing it here keeps structural
+# checks and direct parsing aligned, rather than making the same payload take
+# a recovery path solely because an invisible format character precedes it.
+# Spelled with chr() rather than pasted in, so it is visible in a diff and in
+# an editor.
 _BOM = chr(0xFEFF)
 
 
@@ -41,6 +46,17 @@ def _scope_text(raw: str) -> str:
 # hand-rolled version was tried and worked, but it cannot help disagreeing
 # with json.loads at the margins (that disagreement is exactly how the two
 # holes this function now closes got in) where the real parser can't.
+
+
+def strip_json_fences(text: str) -> str:
+    """Strip the first markdown code fence, returning its inner content.
+
+    This compatibility wrapper intentionally keeps the historical first-fence
+    behavior. JSON-parsing callers should use :func:`extract_json`, which can
+    distinguish a designated JSON answer from an earlier reasoning fence.
+    """
+    match = _JSON_FENCE_RE.search(text)
+    return match.group("body").strip() if match else text.strip()
 
 
 def _top_level_object_spans(text: str) -> list[str]:
@@ -65,10 +81,12 @@ def _top_level_object_spans(text: str) -> list[str]:
     only looked at whether the scope *starts* with ``[`` would miss the
     latter.
 
-    A location where raw_decode can't produce a full value (e.g. a stray
-    ``{`` that never closes) is skipped and scanning resumes one character
-    later, so side-by-side top-level values are still returned as separate
-    spans rather than one merged, invalid span.
+    A malformed object start is skipped and scanning resumes one character
+    later, so side-by-side top-level objects are still returned separately.
+    A malformed array start is different: scanning into it could expose a
+    complete nested object and silently unwrap that object as the answer. Its
+    remaining text is therefore returned as one terminal failing candidate,
+    and scanning stops.
     """
     spans: list[str] = []
     decoder = json.JSONDecoder()
@@ -81,6 +99,12 @@ def _top_level_object_spans(text: str) -> list[str]:
         try:
             _value, end = decoder.raw_decode(text, start)
         except ValueError:
+            if text[start] == "[":
+                # A truncated array can still contain complete object values.
+                # Treat the whole remainder as one failing candidate instead
+                # of walking into it and promoting one of those nested values.
+                spans.append(text[start:])
+                return spans
             # AC-922: retrying one character later is O(n^2) on degenerate
             # repetitive input (e.g. '{"a": ' * n); load-bearing for
             # correctness (it's what lets side-by-side spans still separate
@@ -185,13 +209,11 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     valid one is the closest match to what a human reader would take as the
     answer.
 
-    A scope that opens with ``[`` -- fenced or not -- is exempt from any
-    rescue attempt: if it parses, it's a decisive, terminal answer about the
-    model's output shape (see the wrong-type note below), not a detour on
-    the way to finding an object; if it fails to parse (e.g. a truncated
-    array cut off mid-token), that failure is terminal too, rather than a
-    cue to brace-scan or span-scan into the array's interior and unwrap
-    whatever complete object happens to be sitting inside it.
+    A scope whose first JSON container is ``[`` -- fenced or not, and even
+    when prose precedes it -- is exempt from object rescue. If it parses, it
+    is a decisive answer about the model's output shape (see the wrong-type
+    note below); if it is truncated, that parse failure is terminal too,
+    rather than a cue to scan into the array and unwrap a nested object.
 
     ``on_failure`` controls what happens when no JSON object is found:
     ``"raise"`` (default) re-raises the underlying parse error; ``"none"``
@@ -209,26 +231,24 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     candidates: list[str] = []
     for scope in scopes:
         candidates.append(scope)
-        # scope opening with `[` means the model was producing an array, and
-        # this check must run BEFORE looking at has_fence (not nested inside a
-        # fenced `elif`, the way an earlier version of this had it), because a
-        # fenced scope can open with `[` too, and the fenced branch's
-        # brace-scan below is just as able to reach into a truncated array's
-        # interior as the no-fence span scan is. A complete array is caught by
-        # the wrong-type-terminal rule further down once it parses, but a
-        # TRUNCATED array (no closing bracket) never reaches that rule:
-        # json.loads(scope) raises JSONDecodeError instead of returning a
-        # list, so without this check the loop would fall through to a rescue
-        # candidate below and unwrap whatever complete object happens to sit
-        # inside the unterminated array -- the same silent-unwrap shape the
-        # wrong-type rule exists to prevent, reached through malformed syntax
-        # instead of a successful parse.
-        # Skipping the rescue candidates entirely means an array-shaped scope
-        # is terminal whether it parses or not, regardless of which branch
-        # below would otherwise have produced them. `scope` is BOM-normalized
-        # by _scope_text precisely so this check cannot be walked past by a
-        # leading U+FEFF -- see that constant's comment.
-        if scope.startswith("["):
+        # The first structural JSON token, not scope[0], decides whether the
+        # model is producing an array: prose and non-JSON fence info can sit in
+        # front of it. Parse a complete array as its own candidate so the
+        # wrong-type rule below remains decisive; for a truncated array,
+        # _top_level_object_spans returns its whole remainder as one failing
+        # candidate. Either way, do not add any object-rescue candidates from
+        # inside or after that array.
+        array_start = scope.find("[")
+        object_start = scope.find("{")
+        if array_start != -1 and (object_start == -1 or array_start < object_start):
+            # Keep the established direct-array behavior: the whole scope is
+            # already the exact candidate, including any trailing material
+            # whose Extra-data JSONDecodeError is part of the public outcome.
+            if array_start == 0:
+                continue
+            array_candidate = _top_level_object_spans(scope)[0]
+            if array_candidate != scope:
+                candidates.append(array_candidate)
             continue
         if has_fence:
             # NOTE: this crude first-`{`-to-last-`}` rescue is weaker than the

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -53,7 +53,17 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
             continue
         if isinstance(decoded, Mapping):
             return dict(decoded)
+        # A candidate that PARSES but isn't a Mapping (e.g. a JSON array) is a
+        # decisive answer about what the model produced, not a parse failure
+        # to recover from. Stop here rather than falling through to the next
+        # candidate (the first-"{"-to-last-"}" brace scan): that scan would
+        # then grab whatever object-shaped fragment happens to be nested
+        # inside the array and silently return it, which is the same
+        # substitute-something-plausible-nearby failure as AC-921, just one
+        # level of nesting inward instead of outward. Only a JSONDecodeError
+        # above (candidate didn't parse at all) is a reason to keep scanning.
         last_exc = ValueError("Expected JSON object, got " + type(decoded).__name__)
+        break
 
     assert last_exc is not None
     if on_failure == "none":

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -9,6 +9,15 @@ from typing import Any
 
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
 
+# A plain json.JSONDecoder (no object_hook etc) exposes raw_decode: given a
+# starting index, it parses exactly one JSON value from there using the real
+# parser and reports where that value ended. _top_level_object_spans uses it
+# to find top-level value boundaries instead of hand-rolling a brace counter
+# that reimplements JSON string-quoting/escaping rules on its own -- a
+# hand-rolled version was tried and worked, but it cannot help disagreeing
+# with json.loads at the margins (that disagreement is exactly how the two
+# holes this function now closes got in) where the real parser can't.
+
 
 def strip_json_fences(text: str) -> str:
     """Strip markdown code fences, returning inner content."""
@@ -17,30 +26,47 @@ def strip_json_fences(text: str) -> str:
 
 
 def _top_level_object_spans(text: str) -> list[str]:
-    """Find each top-level, brace-balanced ``{...}`` span in ``text``, in order.
+    """Find each top-level JSON value span (``{...}`` or ``[...]``) in ``text``, in order.
 
-    A plain depth counter over ``{``/``}`` characters -- it does not
-    understand JSON string quoting, so a literal brace inside a string value
-    can still throw off the count (this matches the naive scanning the old
-    per-site extractors did; it is not meant to be a real JSON tokenizer).
-    Once a span closes (depth returns to 0), scanning resumes for the next
-    ``{`` after it, so side-by-side objects are returned as separate spans
-    rather than merged into one.
+    Scans for the next ``{`` or ``[`` -- whichever comes first -- and asks
+    ``json.JSONDecoder.raw_decode`` to parse one full value starting there.
+    Deferring to the real parser for where a value ends means a literal
+    brace inside a string value can never be mistaken for a structural one:
+    raw_decode understands JSON string quoting and backslash escapes
+    natively, so it can't fragment a well-formed object the way a naive
+    ``{``/``}`` counter can.
+
+    Searching for ``[`` as well as ``{`` (not just ``{``) matters: when
+    raw_decode is asked to parse starting at a ``[``, it consumes the
+    ENTIRE array, including anything nested inside it, and scanning resumes
+    only after the array's end. That means a ``{`` nested inside a
+    top-level array is never independently found and unwrapped into its
+    own object candidate -- the array always comes back as one whole span.
+    This holds no matter where the array sits in the text (leading, or
+    buried in prose), not only when it opens the whole scope; a check that
+    only looked at whether the scope *starts* with ``[`` would miss the
+    latter.
+
+    A location where raw_decode can't produce a full value (e.g. a stray
+    ``{`` that never closes) is skipped and scanning resumes one character
+    later, so side-by-side top-level values are still returned as separate
+    spans rather than one merged, invalid span.
     """
     spans: list[str] = []
-    depth = 0
-    start = -1
-    for i, ch in enumerate(text):
-        if ch == "{":
-            if depth == 0:
-                start = i
-            depth += 1
-        elif ch == "}" and depth > 0:
-            depth -= 1
-            if depth == 0 and start != -1:
-                spans.append(text[start : i + 1])
-                start = -1
-    return spans
+    decoder = json.JSONDecoder()
+    i = 0
+    while True:
+        starts = [p for p in (text.find("{", i), text.find("[", i)) if p != -1]
+        if not starts:
+            return spans
+        start = min(starts)
+        try:
+            _value, end = decoder.raw_decode(text, start)
+        except ValueError:
+            i = start + 1
+            continue
+        spans.append(text[start:end])
+        i = end
 
 
 def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | None:
@@ -58,13 +84,19 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     guess through.
 
     Only when there is no fenced block at all does the scan fall back to the
-    whole text. There, unlike the fenced case, multiple candidate objects are
-    tried in the order they appear, returning the first one that parses --
-    this is what lets bare, unfenced JSON embedded in prose still be
-    recovered, including when a competitor lists more than one option (e.g.
-    "Option A: {...} Option B: {...}"): loose prose makes no claim to a
-    single payload the way a fence does, so picking the first valid one is
-    the closest match to what a human reader would take as the answer.
+    whole text. There, unlike the fenced case, multiple candidate top-level
+    values are tried in the order they appear, returning the first Mapping
+    that parses -- this is what lets bare, unfenced JSON embedded in prose
+    still be recovered, including when a competitor lists more than one
+    option (e.g. "Option A: {...} Option B: {...}"): loose prose makes no
+    claim to a single payload the way a fence does, so picking the first
+    valid one is the closest match to what a human reader would take as the
+    answer. A top-level ``[...]`` array candidate is exempt from this
+    "keep trying" behavior: if one parses successfully, it is terminal (see
+    the wrong-type note below) rather than a cue to keep scanning for an
+    object nested inside it or sitting elsewhere in the text -- an array the
+    model produced is a decisive answer about its shape, not a detour on the
+    way to finding an object.
 
     ``on_failure`` controls what happens when no JSON object is found:
     ``"raise"`` (default) re-raises the underlying parse error; ``"none"``

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -7,7 +7,11 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
-_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
+# The `tag` group is what makes a ```json fence distinguishable from a bare
+# ``` or a ```python one. It is a named group so that adding it cannot silently
+# renumber `body` out from under strip_json_fences, which captured group(1)
+# before this group existed.
+_JSON_FENCE_RE = re.compile(r"```(?P<tag>json)?\s*\n?(?P<body>.*?)\n?\s*```", re.DOTALL)
 
 # U+FEFF (BOM / zero-width no-break space). `str.strip()` does NOT remove it
 # -- it is a format character, not whitespace, so `.isspace()` on it is False
@@ -40,9 +44,17 @@ def _scope_text(raw: str) -> str:
 
 
 def strip_json_fences(text: str) -> str:
-    """Strip markdown code fences, returning inner content."""
+    """Strip markdown code fences, returning inner content.
+
+    Takes the FIRST fence of any language, unlike extract_json below, which
+    prefers a ```json-tagged one. That difference is deliberate and pinned:
+    this is a general-purpose fence stripper with callers that are not
+    extracting JSON at all, so it has no basis for preferring a json tag.
+    Do not "fix" it to match extract_json -- if a caller of this function
+    wants JSON, it should call extract_json.
+    """
     match = _JSON_FENCE_RE.search(text)
-    return match.group(1).strip() if match else text.strip()
+    return match.group("body").strip() if match else text.strip()
 
 
 def _top_level_object_spans(text: str) -> list[str]:
@@ -93,22 +105,92 @@ def _top_level_object_spans(text: str) -> list[str]:
         i = end
 
 
+def _fenced_payload_scopes(text: str) -> list[str] | None:
+    """Return the fenced scopes to search, or None to search the whole text.
+
+    Picking the right fence is the whole job here, and committing to
+    ``_JSON_FENCE_RE.search(text)``'s first hit -- the first fence of ANY
+    language -- was a regression (C1). A model that emits a reasoning block
+    before its answer:
+
+        Let me think.
+        ```
+        reasoning scratch
+        ```
+        Here is the tool:
+        ```json
+        {"tools": [...]}
+        ```
+
+    put the scratch block in front of the payload, and `search` handed that
+    scratch block over as THE scope. Every recovery path is confined to the
+    scope, so the real payload became unreachable: architect returned [] and
+    logged "possibly truncated", which is AC-920's exact user-visible symptom
+    reintroduced at AC-920's own call site. The pre-consolidation architect
+    searched for the literal "```json" and skipped a preceding fence
+    harmlessly; the migration lost that. Worse, when the preamble was a
+    ```python block whose code happened to contain a dict literal, the scope
+    PARSED and extract_json returned the model's scratch work as the answer --
+    a silent wrong answer, not a missing one.
+
+    The tag is the model's own designation, so it decides:
+
+    1. Any ```json-tagged fence -> the FIRST one is the sole scope, and it is
+       terminal. This is what makes the preamble cases work regardless of what
+       the preamble contains (prose, code, braces, valid JSON), and it keeps
+       both existing fence rules intact: first block wins when there are two
+       (AC-920), and a corrupt tagged block fails closed rather than
+       substituting JSON found elsewhere in the text (AC-921).
+    2. Otherwise, untagged fences that could plausibly hold an object -- ones
+       containing a ``{`` or a ``[`` -- are tried in order. An untagged fence
+       is a weaker claim than a tagged one, but it is still a claim, so this
+       stays confined to the fences and does NOT fall back to the surrounding
+       prose; that fallback is precisely AC-921's failure shape.
+    3. If every fence is brace-free (pure prose or code -- the reasoning-
+       scratch shape with no json block after it), there is no fenced payload
+       at all. Return None so the caller scans the whole text, which is what
+       recovers an object sitting in the prose outside those fences.
+
+    The brace test in 2/3 is deliberately crude, and it is a fallback for
+    untagged fences only -- rule 1 short-circuits before it whenever a tag is
+    present, so a ```python block containing a dict literal cannot capture the
+    scan away from a real ```json block. It only decides between untagged
+    fences, where there is no better signal available.
+    """
+    matches = list(_JSON_FENCE_RE.finditer(text))
+    if not matches:
+        return None
+    tagged = [m for m in matches if m.group("tag")]
+    if tagged:
+        return [_scope_text(tagged[0].group("body"))]
+    scopes = [_scope_text(m.group("body")) for m in matches]
+    plausible = [scope for scope in scopes if "{" in scope or "[" in scope]
+    return plausible or None
+
+
 def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | None:
     """Extract a JSON object from LLM text.
 
-    Tries a fenced code block first. If a fence is present but its captured
-    content does not parse directly, this scans for a ``{...}`` span WITHIN
-    that fenced content only -- never the surrounding prose. A broken fence
-    is evidence the model intended that block to be the payload; silently
-    substituting unrelated JSON found elsewhere in the text would return a
-    wrong answer instead of no answer (see AC-921), so it is never attempted.
-    A fence containing more than one object side by side still fails outright
-    for the same reason: the fence is the model's claim about its payload,
-    and more than one object inside it is a real conflict, not something to
-    guess through.
+    Tries fenced code blocks first. WHICH fence is not "the first one":
+    ``_fenced_payload_scopes`` picks it, preferring a ```json-tagged block
+    over any untagged block that precedes it, so a reasoning or code block
+    emitted before the answer cannot capture the scan. See that function --
+    reading the wrong fence was a real regression (C1) with a silent
+    wrong-answer mode, and the rule is stated there once rather than twice.
 
-    Only when there is no fenced block at all does the scan fall back to the
-    whole text. There, unlike the fenced case, multiple candidate top-level
+    If the chosen fence's content does not parse directly, this scans for a
+    ``{...}`` span WITHIN that fenced content only -- never the surrounding
+    prose. A broken fence is evidence the model intended that block to be the
+    payload; silently substituting unrelated JSON found elsewhere in the text
+    would return a wrong answer instead of no answer (see AC-921), so it is
+    never attempted. A fence containing more than one object side by side
+    still fails outright for the same reason: the fence is the model's claim
+    about its payload, and more than one object inside it is a real conflict,
+    not something to guess through.
+
+    Only when there is no fenced payload at all -- no fences, or only
+    brace-free ones that cannot be holding an object -- does the scan fall
+    back to the whole text. There, unlike the fenced case, multiple candidate top-level
     values are tried in the order they appear, returning the first Mapping
     that parses -- this is what lets bare, unfenced JSON embedded in prose
     still be recovered, including when a competitor lists more than one
@@ -129,31 +211,47 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     ``"raise"`` (default) re-raises the underlying parse error; ``"none"``
     returns ``None`` instead.
     """
-    fence_match = _JSON_FENCE_RE.search(text)
-    has_fence = fence_match is not None
-    scope = _scope_text(fence_match.group(1) if fence_match else text)
+    fenced_scopes = _fenced_payload_scopes(text)
+    has_fence = fenced_scopes is not None
+    scopes = fenced_scopes if fenced_scopes is not None else [_scope_text(text)]
 
-    candidates = [scope]
-    # scope opening with `[` means the model was producing an array, and this
-    # check must run BEFORE looking at has_fence (not nested inside a fenced
-    # `elif`, the way an earlier version of this had it), because a fenced
-    # scope can open with `[` too, and the fenced branch's brace-scan below
-    # is just as able to reach into a truncated array's interior as the
-    # no-fence span scan is. A complete array is caught by the wrong-type-
-    # terminal rule further down once it parses, but a TRUNCATED array (no
-    # closing bracket) never reaches that rule: json.loads(scope) raises
-    # JSONDecodeError instead of returning a list, so without this check the
-    # loop would fall through to a rescue candidate below and unwrap
-    # whatever complete object happens to sit inside the unterminated array
-    # -- the same silent-unwrap shape the wrong-type rule exists to prevent,
-    # reached through malformed syntax instead of a successful parse.
-    # Skipping the rescue candidates entirely means an array-shaped scope is
-    # terminal whether it parses or not, regardless of which branch below
-    # would otherwise have produced them. `scope` is BOM-normalized by
-    # _scope_text above precisely so this check cannot be walked past by a
-    # leading U+FEFF -- see that constant's comment.
-    if not scope.startswith("["):
+    # One flat candidate list across every scope, in scope order and, within a
+    # scope, whole-scope before recovered sub-span. Flat rather than a loop per
+    # scope because the wrong-type rule below stops the ENTIRE scan, not just
+    # the current scope: a candidate that parses to a non-Mapping settles what
+    # the model produced no matter which fence it came from.
+    candidates: list[str] = []
+    for scope in scopes:
+        candidates.append(scope)
+        # scope opening with `[` means the model was producing an array, and
+        # this check must run BEFORE looking at has_fence (not nested inside a
+        # fenced `elif`, the way an earlier version of this had it), because a
+        # fenced scope can open with `[` too, and the fenced branch's
+        # brace-scan below is just as able to reach into a truncated array's
+        # interior as the no-fence span scan is. A complete array is caught by
+        # the wrong-type-terminal rule further down once it parses, but a
+        # TRUNCATED array (no closing bracket) never reaches that rule:
+        # json.loads(scope) raises JSONDecodeError instead of returning a
+        # list, so without this check the loop would fall through to a rescue
+        # candidate below and unwrap whatever complete object happens to sit
+        # inside the unterminated array -- the same silent-unwrap shape the
+        # wrong-type rule exists to prevent, reached through malformed syntax
+        # instead of a successful parse.
+        # Skipping the rescue candidates entirely means an array-shaped scope
+        # is terminal whether it parses or not, regardless of which branch
+        # below would otherwise have produced them. `scope` is BOM-normalized
+        # by _scope_text precisely so this check cannot be walked past by a
+        # leading U+FEFF -- see that constant's comment.
+        if scope.startswith("["):
+            continue
         if has_fence:
+            # NOTE: this crude first-`{`-to-last-`}` rescue is weaker than the
+            # string-aware span scan the no-fence branch uses below, so
+            # 'blah {oops} and {"a": 1}' recovers unfenced but not fenced.
+            # That divergence predates C1 and is left alone here rather than
+            # widened: unifying it would also change the deliberate rule that
+            # a fence holding two side-by-side objects is a conflict, which is
+            # a separate decision from which fence to read.
             start, end = scope.find("{"), scope.rfind("}")
             if start != -1 and end > start:
                 brace_candidate = scope[start : end + 1]

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -16,13 +16,49 @@ def strip_json_fences(text: str) -> str:
     return match.group(1).strip() if match else text.strip()
 
 
-def extract_json(text: str) -> dict[str, Any]:
-    """Strip fences and parse as JSON object. Raises ValueError on failure."""
-    cleaned = strip_json_fences(text)
-    decoded = json.loads(cleaned)
-    if not isinstance(decoded, Mapping):
-        raise ValueError("Expected JSON object, got " + type(decoded).__name__)
-    return dict(decoded)
+def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | None:
+    """Extract a JSON object from LLM text.
+
+    Tries a fenced code block first. If a fence is present but its captured
+    content does not parse directly, this scans for a ``{...}`` span WITHIN
+    that fenced content only -- never the surrounding prose. A broken fence
+    is evidence the model intended that block to be the payload; silently
+    substituting unrelated JSON found elsewhere in the text would return a
+    wrong answer instead of no answer (see AC-921), so it is never attempted.
+
+    Only when there is no fenced block at all does the ``{...}`` scan fall
+    back to the whole text -- this is what lets bare, unfenced JSON embedded
+    in prose still be recovered.
+
+    ``on_failure`` controls what happens when no JSON object is found:
+    ``"raise"`` (default) re-raises the underlying parse error; ``"none"``
+    returns ``None`` instead.
+    """
+    fence_match = _JSON_FENCE_RE.search(text)
+    scope = fence_match.group(1).strip() if fence_match else text.strip()
+
+    candidates = [scope]
+    start, end = scope.find("{"), scope.rfind("}")
+    if start != -1 and end > start:
+        brace_candidate = scope[start : end + 1]
+        if brace_candidate != scope:
+            candidates.append(brace_candidate)
+
+    last_exc: Exception | None = None
+    for candidate in candidates:
+        try:
+            decoded = json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            last_exc = exc
+            continue
+        if isinstance(decoded, Mapping):
+            return dict(decoded)
+        last_exc = ValueError("Expected JSON object, got " + type(decoded).__name__)
+
+    assert last_exc is not None
+    if on_failure == "none":
+        return None
+    raise last_exc
 
 
 def extract_tagged_content(text: str, tag: str) -> str | None:

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -63,6 +63,10 @@ def _top_level_object_spans(text: str) -> list[str]:
         try:
             _value, end = decoder.raw_decode(text, start)
         except ValueError:
+            # AC-922: retrying one character later is O(n^2) on degenerate
+            # repetitive input (e.g. '{"a": ' * n); load-bearing for
+            # correctness (it's what lets side-by-side spans still separate
+            # after a stray unclosed brace), so don't "optimize" it away here.
             i = start + 1
             continue
         spans.append(text[start:end])
@@ -113,10 +117,21 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
             brace_candidate = scope[start : end + 1]
             if brace_candidate != scope:
                 candidates.append(brace_candidate)
-    else:
+    elif not scope.startswith("["):
         for span in _top_level_object_spans(scope):
             if span != scope:
                 candidates.append(span)
+    # else: scope opens with `[` -- the model was producing an array. A
+    # complete array is caught by the wrong-type-terminal rule below once it
+    # parses, but a TRUNCATED array (no closing bracket) never reaches that
+    # rule: json.loads(scope) raises JSONDecodeError instead of returning a
+    # list, so without this branch the loop would fall through to
+    # _top_level_object_spans and unwrap whatever complete object happens to
+    # sit inside the unterminated array -- the same silent-unwrap shape as
+    # the wrong-type rule exists to prevent, reached through malformed
+    # syntax instead of a successful parse. Skipping the rescue candidates
+    # entirely here means an array-shaped scope is terminal whether it
+    # parses or not.
 
     last_exc: Exception | None = None
     for candidate in candidates:

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -16,6 +16,33 @@ def strip_json_fences(text: str) -> str:
     return match.group(1).strip() if match else text.strip()
 
 
+def _top_level_object_spans(text: str) -> list[str]:
+    """Find each top-level, brace-balanced ``{...}`` span in ``text``, in order.
+
+    A plain depth counter over ``{``/``}`` characters -- it does not
+    understand JSON string quoting, so a literal brace inside a string value
+    can still throw off the count (this matches the naive scanning the old
+    per-site extractors did; it is not meant to be a real JSON tokenizer).
+    Once a span closes (depth returns to 0), scanning resumes for the next
+    ``{`` after it, so side-by-side objects are returned as separate spans
+    rather than merged into one.
+    """
+    spans: list[str] = []
+    depth = 0
+    start = -1
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}" and depth > 0:
+            depth -= 1
+            if depth == 0 and start != -1:
+                spans.append(text[start : i + 1])
+                start = -1
+    return spans
+
+
 def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | None:
     """Extract a JSON object from LLM text.
 
@@ -25,24 +52,39 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     is evidence the model intended that block to be the payload; silently
     substituting unrelated JSON found elsewhere in the text would return a
     wrong answer instead of no answer (see AC-921), so it is never attempted.
+    A fence containing more than one object side by side still fails outright
+    for the same reason: the fence is the model's claim about its payload,
+    and more than one object inside it is a real conflict, not something to
+    guess through.
 
-    Only when there is no fenced block at all does the ``{...}`` scan fall
-    back to the whole text -- this is what lets bare, unfenced JSON embedded
-    in prose still be recovered.
+    Only when there is no fenced block at all does the scan fall back to the
+    whole text. There, unlike the fenced case, multiple candidate objects are
+    tried in the order they appear, returning the first one that parses --
+    this is what lets bare, unfenced JSON embedded in prose still be
+    recovered, including when a competitor lists more than one option (e.g.
+    "Option A: {...} Option B: {...}"): loose prose makes no claim to a
+    single payload the way a fence does, so picking the first valid one is
+    the closest match to what a human reader would take as the answer.
 
     ``on_failure`` controls what happens when no JSON object is found:
     ``"raise"`` (default) re-raises the underlying parse error; ``"none"``
     returns ``None`` instead.
     """
     fence_match = _JSON_FENCE_RE.search(text)
+    has_fence = fence_match is not None
     scope = fence_match.group(1).strip() if fence_match else text.strip()
 
     candidates = [scope]
-    start, end = scope.find("{"), scope.rfind("}")
-    if start != -1 and end > start:
-        brace_candidate = scope[start : end + 1]
-        if brace_candidate != scope:
-            candidates.append(brace_candidate)
+    if has_fence:
+        start, end = scope.find("{"), scope.rfind("}")
+        if start != -1 and end > start:
+            brace_candidate = scope[start : end + 1]
+            if brace_candidate != scope:
+                candidates.append(brace_candidate)
+    else:
+        for span in _top_level_object_spans(scope):
+            if span != scope:
+                candidates.append(span)
 
     last_exc: Exception | None = None
     for candidate in candidates:
@@ -55,13 +97,15 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
             return dict(decoded)
         # A candidate that PARSES but isn't a Mapping (e.g. a JSON array) is a
         # decisive answer about what the model produced, not a parse failure
-        # to recover from. Stop here rather than falling through to the next
-        # candidate (the first-"{"-to-last-"}" brace scan): that scan would
-        # then grab whatever object-shaped fragment happens to be nested
-        # inside the array and silently return it, which is the same
-        # substitute-something-plausible-nearby failure as AC-921, just one
-        # level of nesting inward instead of outward. Only a JSONDecodeError
-        # above (candidate didn't parse at all) is a reason to keep scanning.
+        # to recover from. Stop here rather than falling through to later
+        # candidates (the fenced brace scan, or the no-fence multi-object
+        # scan): either would then grab whatever object-shaped fragment
+        # happens to be nested inside the array and silently return it,
+        # which is the same substitute-something-plausible-nearby failure as
+        # AC-921, just one level of nesting inward instead of outward. Only
+        # a JSONDecodeError above (candidate didn't parse at all) is a
+        # reason to keep scanning -- this is also why `candidates` always
+        # tries `scope` itself first, before any recovered sub-span.
         last_exc = ValueError("Expected JSON object, got " + type(decoded).__name__)
         break
 

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -95,12 +95,15 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     option (e.g. "Option A: {...} Option B: {...}"): loose prose makes no
     claim to a single payload the way a fence does, so picking the first
     valid one is the closest match to what a human reader would take as the
-    answer. A top-level ``[...]`` array candidate is exempt from this
-    "keep trying" behavior: if one parses successfully, it is terminal (see
-    the wrong-type note below) rather than a cue to keep scanning for an
-    object nested inside it or sitting elsewhere in the text -- an array the
-    model produced is a decisive answer about its shape, not a detour on the
-    way to finding an object.
+    answer.
+
+    A scope that opens with ``[`` -- fenced or not -- is exempt from any
+    rescue attempt: if it parses, it's a decisive, terminal answer about the
+    model's output shape (see the wrong-type note below), not a detour on
+    the way to finding an object; if it fails to parse (e.g. a truncated
+    array cut off mid-token), that failure is terminal too, rather than a
+    cue to brace-scan or span-scan into the array's interior and unwrap
+    whatever complete object happens to be sitting inside it.
 
     ``on_failure`` controls what happens when no JSON object is found:
     ``"raise"`` (default) re-raises the underlying parse error; ``"none"``
@@ -111,27 +114,33 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     scope = fence_match.group(1).strip() if fence_match else text.strip()
 
     candidates = [scope]
-    if has_fence:
-        start, end = scope.find("{"), scope.rfind("}")
-        if start != -1 and end > start:
-            brace_candidate = scope[start : end + 1]
-            if brace_candidate != scope:
-                candidates.append(brace_candidate)
-    elif not scope.startswith("["):
-        for span in _top_level_object_spans(scope):
-            if span != scope:
-                candidates.append(span)
-    # else: scope opens with `[` -- the model was producing an array. A
-    # complete array is caught by the wrong-type-terminal rule below once it
-    # parses, but a TRUNCATED array (no closing bracket) never reaches that
-    # rule: json.loads(scope) raises JSONDecodeError instead of returning a
-    # list, so without this branch the loop would fall through to
-    # _top_level_object_spans and unwrap whatever complete object happens to
-    # sit inside the unterminated array -- the same silent-unwrap shape as
-    # the wrong-type rule exists to prevent, reached through malformed
-    # syntax instead of a successful parse. Skipping the rescue candidates
-    # entirely here means an array-shaped scope is terminal whether it
-    # parses or not.
+    # scope opening with `[` means the model was producing an array, and this
+    # check must run BEFORE looking at has_fence (not nested inside a fenced
+    # `elif`, the way an earlier version of this had it), because a fenced
+    # scope can open with `[` too, and the fenced branch's brace-scan below
+    # is just as able to reach into a truncated array's interior as the
+    # no-fence span scan is. A complete array is caught by the wrong-type-
+    # terminal rule further down once it parses, but a TRUNCATED array (no
+    # closing bracket) never reaches that rule: json.loads(scope) raises
+    # JSONDecodeError instead of returning a list, so without this check the
+    # loop would fall through to a rescue candidate below and unwrap
+    # whatever complete object happens to sit inside the unterminated array
+    # -- the same silent-unwrap shape the wrong-type rule exists to prevent,
+    # reached through malformed syntax instead of a successful parse.
+    # Skipping the rescue candidates entirely means an array-shaped scope is
+    # terminal whether it parses or not, regardless of which branch below
+    # would otherwise have produced them.
+    if not scope.startswith("["):
+        if has_fence:
+            start, end = scope.find("{"), scope.rfind("}")
+            if start != -1 and end > start:
+                brace_candidate = scope[start : end + 1]
+                if brace_candidate != scope:
+                    candidates.append(brace_candidate)
+        else:
+            for span in _top_level_object_spans(scope):
+                if span != scope:
+                    candidates.append(span)
 
     last_exc: Exception | None = None
     for candidate in candidates:

--- a/autocontext/tests/test_harness/test_harness_output_parser.py
+++ b/autocontext/tests/test_harness/test_harness_output_parser.py
@@ -8,6 +8,7 @@ from autocontext.harness.core.output_parser import (
     extract_delimited_section,
     extract_json,
     extract_tagged_content,
+    strip_json_fences,
 )
 
 
@@ -26,6 +27,15 @@ class TestExtractJson:
         text = "```json\n[1, 2, 3]\n```"
         with pytest.raises(ValueError, match="Expected JSON object"):
             extract_json(text)
+
+
+class TestStripJsonFences:
+    def test_strips_first_fenced_payload(self) -> None:
+        text = 'before\n```JSON\n{"name": "test"}\n```\nafter'
+        assert strip_json_fences(text) == '{"name": "test"}'
+
+    def test_unfenced_text_is_stripped_and_returned(self) -> None:
+        assert strip_json_fences('  {"name": "test"}\n') == '{"name": "test"}'
 
 
 class TestExtractTaggedContent:

--- a/autocontext/tests/test_harness/test_harness_output_parser.py
+++ b/autocontext/tests/test_harness/test_harness_output_parser.py
@@ -8,22 +8,7 @@ from autocontext.harness.core.output_parser import (
     extract_delimited_section,
     extract_json,
     extract_tagged_content,
-    strip_json_fences,
 )
-
-
-class TestStripJsonFences:
-    def test_strip_json_fences_with_json_tag(self) -> None:
-        text = '```json\n{"key": "value"}\n```'
-        assert strip_json_fences(text) == '{"key": "value"}'
-
-    def test_strip_json_fences_plain(self) -> None:
-        text = '```\n{"key": "value"}\n```'
-        assert strip_json_fences(text) == '{"key": "value"}'
-
-    def test_strip_json_fences_no_fences(self) -> None:
-        text = '{"key": "value"}'
-        assert strip_json_fences(text) == '{"key": "value"}'
 
 
 class TestExtractJson:
@@ -33,12 +18,12 @@ class TestExtractJson:
         assert result == {"name": "test", "count": 42}
 
     def test_extract_json_invalid(self) -> None:
-        text = '```json\nnot valid json\n```'
+        text = "```json\nnot valid json\n```"
         with pytest.raises(ValueError):
             extract_json(text)
 
     def test_extract_json_not_object(self) -> None:
-        text = '```json\n[1, 2, 3]\n```'
+        text = "```json\n[1, 2, 3]\n```"
         with pytest.raises(ValueError, match="Expected JSON object"):
             extract_json(text)
 
@@ -62,13 +47,7 @@ class TestExtractTaggedContent:
 
 class TestExtractDelimitedSection:
     def test_extract_delimited_section(self) -> None:
-        text = (
-            "preamble\n"
-            "<!-- PLAYBOOK_START -->\n"
-            "Strategy content here\n"
-            "<!-- PLAYBOOK_END -->\n"
-            "postamble"
-        )
+        text = "preamble\n<!-- PLAYBOOK_START -->\nStrategy content here\n<!-- PLAYBOOK_END -->\npostamble"
         result = extract_delimited_section(text, "<!-- PLAYBOOK_START -->", "<!-- PLAYBOOK_END -->")
         assert result == "Strategy content here"
 

--- a/autocontext/tests/test_harness/test_output_parser_adoption.py
+++ b/autocontext/tests/test_harness/test_output_parser_adoption.py
@@ -1,7 +1,8 @@
 """Equivalence tests: output_parser functions match existing inline parsing."""
+
 from __future__ import annotations
 
-from autocontext.harness.core.output_parser import extract_delimited_section, extract_json, strip_json_fences
+from autocontext.harness.core.output_parser import extract_delimited_section, extract_json
 
 
 class TestCoachParsingEquivalence:
@@ -21,12 +22,7 @@ class TestCoachParsingEquivalence:
         assert lessons == "- Lesson 1"
 
     def test_hints_extraction(self) -> None:
-        text = (
-            "Coach output\n"
-            "<!-- COMPETITOR_HINTS_START -->\n"
-            "Try higher aggression\n"
-            "<!-- COMPETITOR_HINTS_END -->\n"
-        )
+        text = "Coach output\n<!-- COMPETITOR_HINTS_START -->\nTry higher aggression\n<!-- COMPETITOR_HINTS_END -->\n"
         hints = extract_delimited_section(text, "<!-- COMPETITOR_HINTS_START -->", "<!-- COMPETITOR_HINTS_END -->")
         assert hints == "Try higher aggression"
 
@@ -36,17 +32,21 @@ class TestCoachParsingEquivalence:
 
 
 class TestTranslatorParsingEquivalence:
-    def test_strip_fences_json_tag(self) -> None:
+    # These three shapes used to be pinned against strip_json_fences, which is
+    # what the translator called before AC-910 Task 4 migrated it. They are
+    # pinned against extract_json now so they still cover the parser this site
+    # actually runs.
+    def test_fenced_with_json_tag(self) -> None:
         text = '```json\n{"aggression": 0.8}\n```'
-        assert strip_json_fences(text) == '{"aggression": 0.8}'
+        assert extract_json(text) == {"aggression": 0.8}
 
-    def test_strip_fences_no_tag(self) -> None:
+    def test_fenced_without_tag(self) -> None:
         text = '```\n{"aggression": 0.8}\n```'
-        assert strip_json_fences(text) == '{"aggression": 0.8}'
+        assert extract_json(text) == {"aggression": 0.8}
 
-    def test_strip_fences_passthrough(self) -> None:
+    def test_unfenced_passthrough(self) -> None:
         text = '{"aggression": 0.8}'
-        assert strip_json_fences(text) == '{"aggression": 0.8}'
+        assert extract_json(text) == {"aggression": 0.8}
 
     def test_extract_json_full_pipeline(self) -> None:
         text = 'Here is the strategy:\n```json\n{"aggression": 0.8, "defense": 0.3}\n```'

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -311,6 +311,55 @@ CORPUS: list[tuple[str, str]] = [
         "bom_object_no_fence",
         _BOM + '{"a": 1}',
     ),
+    (
+        # C1, a REGRESSION this branch introduced and these three rows pin.
+        # extract_json committed to `_JSON_FENCE_RE.search(text)`'s first hit
+        # -- the first fence of ANY language -- and confined every recovery
+        # path to it. A model that reasons in a plain ``` block before
+        # answering therefore had its answer made unreachable: architect
+        # returned [] and logged "possibly truncated", which is AC-920's exact
+        # user-visible symptom reintroduced at AC-920's own call site. The
+        # pre-consolidation architect matched the literal "```json" and
+        # skipped a preceding fence harmlessly; the migration lost that.
+        #
+        # Unpinned in BOTH directions before this: `two_fenced_blocks` uses
+        # two ```json blocks, so it structurally cannot see which fence is
+        # chosen, and no corpus row had a non-JSON fence at all.
+        "plain_fence_preamble_then_json_fence",
+        (
+            "Let me think about this.\n```\nreasoning scratch\n```\n"
+            'Here is the tool:\n```json\n{"tools": [{"name": "n", "description": "d", "code": "c"}]}\n```'
+        ),
+    ),
+    (
+        # Same defect, and the shape that made it a SILENT WRONG ANSWER rather
+        # than a missing one. The preamble is a ```python block whose code
+        # contains a dict literal, so the wrong scope PARSED: extract_json
+        # returned {"draft": 1} -- the model's scratch work -- as the payload.
+        # At the migrated sites that meant extract_strategy_deterministic and
+        # action_filter handing scratch work back as a strategy, which is
+        # worse than the [] the architect row above produced.
+        #
+        # This is also why the fence choice keys on the `json` TAG and not on
+        # "does the block contain a brace": the brace test alone would pick
+        # this python block. The tag is the model's own designation.
+        "python_fence_preamble_then_json_fence",
+        (
+            'Let me think.\n```python\nplan = {"draft": 1}\n```\n'
+            'Here is the tool:\n```json\n{"tools": [{"name": "n", "description": "d", "code": "c"}]}\n```'
+        ),
+    ),
+    (
+        # The third C1 shape: a brace-free reasoning fence and NO json-tagged
+        # block at all, with the payload bare in the prose after it. Nothing
+        # fenced can be holding an object here, so there is no fenced payload
+        # to be confined to and the whole-text span scan runs. Distinct from
+        # ac_921_corrupt_fence_with_decoy_json, where the fence DOES contain a
+        # brace and so is a payload claim whose failure must stay terminal --
+        # that row is what stops this fallback from being widened into AC-921.
+        "braceless_fence_preamble_then_bare_json",
+        'Thinking:\n```\nscratch\n```\nResult: {"a": 1}',
+    ),
 ]
 
 CORPUS_IDS = [name for name, _ in CORPUS]
@@ -462,6 +511,16 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     "bom_truncated_array_no_fence": _BOM + '[{"a": 1}',
     "bom_fenced_truncated_array": _BOM + '[{"a": 1}',
     "bom_object_no_fence": _BOM + '{"a": 1}',
+    # C1: strip_json_fences is UNCHANGED and still takes the FIRST fence of any
+    # language, so it returns the reasoning/code preamble on all three. Only
+    # extract_json learned to prefer the ```json block. That divergence is
+    # deliberate -- this is a general fence stripper with callers that aren't
+    # extracting JSON, so it has no basis for preferring a json tag -- and
+    # these rows exist to say so out loud, since "why didn't the C1 fix touch
+    # strip_json_fences too" is the obvious next question.
+    "plain_fence_preamble_then_json_fence": "reasoning scratch",
+    "python_fence_preamble_then_json_fence": 'python\nplan = {"draft": 1}',
+    "braceless_fence_preamble_then_bare_json": "scratch",
 }
 
 
@@ -578,6 +637,16 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     "bom_fenced_truncated_array": _Raises(json.JSONDecodeError),
     # Control: same normalization, opposite direction -- still parses.
     "bom_object_no_fence": {"a": 1},
+    # C1 fix: the ```json-tagged block is preferred over the preamble fence,
+    # so the real payload is recovered instead of the reasoning scratch.
+    # Before the fix: row 1 raised JSONDecodeError (scope was "reasoning
+    # scratch"), and row 2 returned {"draft": 1} -- the scratch dict, silently
+    # substituted for the answer.
+    "plain_fence_preamble_then_json_fence": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "python_fence_preamble_then_json_fence": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    # No json-tagged block and the only fence is brace-free, so there is no
+    # fenced payload at all and the whole-text span scan recovers the object.
+    "braceless_fence_preamble_then_bare_json": {"a": 1},
 }
 
 
@@ -719,6 +788,76 @@ def test_extract_json_unfenced_earlier_malformed_candidate_is_skipped() -> None:
     recovered one (AC-921). Without a fence, no such designation exists.
     """
     assert extract_json('first: {bad json,} then: {"x": 2}') == {"x": 2}
+
+
+def test_extract_json_prefers_json_tagged_fence_over_preceding_fence() -> None:
+    """C1: a reasoning or code block before the answer must not capture the scan.
+
+    extract_json used to commit to `_JSON_FENCE_RE.search(text)`'s first hit --
+    the first fence of ANY language -- and confine every recovery path to it,
+    so a model that thinks out loud in a ``` block before emitting its
+    ```json block had its answer made unreachable. The pre-consolidation
+    architect matched the literal "```json" and skipped a preceding fence
+    harmlessly; the migration lost that, reintroducing AC-920's user-visible
+    symptom (proposal dropped, warning blaming truncation) at AC-920's own
+    call site.
+
+    Three preamble shapes, because they failed differently:
+    - plain ``` prose -> the wrong scope did not parse -> raised.
+    - ```python containing a dict literal -> the wrong scope DID parse ->
+      returned the scratch dict, a silent wrong answer.
+    - a fence with a brace-free body and no ```json block after it -> nothing
+      fenced can hold an object, so the whole-text scan must run.
+
+    See test_parse_architect_tool_specs_c1_preamble_fence_does_not_drop_tools
+    for the same defect at the call site whose symptom it reproduced.
+    """
+    payload = '{"tools": [{"name": "n", "description": "d", "code": "c"}]}'
+    expected = {"tools": [{"name": "n", "description": "d", "code": "c"}]}
+
+    plain_preamble = f"Let me think about this.\n```\nreasoning scratch\n```\nHere is the tool:\n```json\n{payload}\n```"
+    assert extract_json(plain_preamble) == expected
+
+    # The ```python body contains a dict literal, so a "does this fence hold a
+    # brace" heuristic alone would still pick it. The `json` TAG is what
+    # decides, which is the point of this case.
+    code_preamble = f'Let me think.\n```python\nplan = {{"draft": 1}}\n```\nHere is the tool:\n```json\n{payload}\n```'
+    assert extract_json(code_preamble) == expected
+
+    # No json-tagged block anywhere and the only fence is brace-free: there is
+    # no fenced payload to be confined to, so the whole-text span scan runs.
+    assert extract_json('Thinking:\n```\nscratch\n```\nResult: {"a": 1}') == {"a": 1}
+
+    # Controls, so preferring the tagged fence cannot be over-read.
+    # 1. AC-921 is untouched: a corrupt TAGGED fence still fails closed rather
+    #    than reaching the decoy in the trailing prose.
+    assert extract_json('```json\n{a: 1, "b":}\n```  also see config: {"x": 2}', on_failure="none") is None
+    # 2. An untagged fence that DOES hold a brace is still a payload claim, so
+    #    its failure stays terminal too -- this is what stops the brace-free
+    #    fallback above from widening into AC-921.
+    assert extract_json('```\n{a: 1, "b":}\n```  also see config: {"x": 2}', on_failure="none") is None
+    # 3. AC-920 still holds: with two tagged fences the FIRST one wins.
+    assert extract_json('```json\n{"a": 1}\n```\n```json\n{"b": 2}\n```') == {"a": 1}
+
+
+def test_parse_architect_tool_specs_c1_preamble_fence_does_not_drop_tools() -> None:
+    """C1 at the call site whose symptom it reproduced.
+
+    A reasoning block before the ```json block made this return [] and log
+    "possibly truncated" -- a real architect proposal silently discarded, with
+    the warning pointing at the wrong cause. Byte-for-byte AC-920's symptom,
+    reintroduced through a different door at AC-920's own call site.
+    """
+    payload = '{"tools": [{"name": "n", "description": "d", "code": "c"}]}'
+    expected = [{"name": "n", "description": "d", "code": "c"}]
+
+    assert parse_architect_tool_specs(f"Let me think.\n```\nscratch\n```\nHere:\n```json\n{payload}\n```") == expected
+    assert (
+        parse_architect_tool_specs(f'Thinking.\n```python\nx = {{"draft": 1}}\n```\nHere:\n```json\n{payload}\n```') == expected
+    )
+    # Control: the same payload with no preamble worked throughout, so the
+    # rows above isolate the preamble as the cause.
+    assert parse_architect_tool_specs(f"```json\n{payload}\n```") == expected
 
 
 def test_extract_json_wrong_type_candidate_is_terminal() -> None:
@@ -872,6 +1011,14 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "bom_truncated_array_no_fence": [],  # extract_json now raises (BOM fix) -> None -> []
     "bom_fenced_truncated_array": [],  # same
     "bom_object_no_fence": [],  # valid dict recovered, but no "tools" key
+    # C1 fix, and THIS is the row that matters most in this table: the
+    # regression's user-visible symptom was exactly an architect proposal
+    # being silently dropped ([] plus a "possibly truncated" warning) because
+    # a reasoning block preceded the ```json block. Both now recover the spec,
+    # matching the pre-consolidation find("```json") behavior.
+    "plain_fence_preamble_then_json_fence": [{"name": "n", "description": "d", "code": "c"}],
+    "python_fence_preamble_then_json_fence": [{"name": "n", "description": "d", "code": "c"}],
+    "braceless_fence_preamble_then_bare_json": [],  # recovers {"a": 1}, but no "tools" key
 }
 
 
@@ -1006,6 +1153,13 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "bom_truncated_array_no_fence": _CURATOR_DEFAULT,  # extract_json raises (BOM fix) -> None -> default
     "bom_fenced_truncated_array": _CURATOR_DEFAULT,  # same
     "bom_object_no_fence": _CURATOR_DEFAULT,  # parses fine, no matching rating keys
+    # C1 fix: recovers the right dict now, but none of these payloads carry
+    # rating keys, so this table cannot observe the fix. Pinned for
+    # completeness -- EXTRACT_JSON_EXPECTED and the architect table are where
+    # the C1 rows discriminate.
+    "plain_fence_preamble_then_json_fence": _CURATOR_DEFAULT,
+    "python_fence_preamble_then_json_fence": _CURATOR_DEFAULT,
+    "braceless_fence_preamble_then_bare_json": _CURATOR_DEFAULT,
 }
 
 
@@ -1091,6 +1245,13 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "bom_truncated_array_no_fence": None,
     "bom_fenced_truncated_array": None,
     "bom_object_no_fence": {"a": 1},
+    # C1 fix: the ```json block is preferred over the preamble fence. Row 2 is
+    # the one that mattered at THIS site -- before the fix it returned
+    # {"draft": 1}, the model's python scratch dict, as a strategy/selection.
+    # A lost recovery is bad; returning scratch work as the answer is worse.
+    "plain_fence_preamble_then_json_fence": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "python_fence_preamble_then_json_fence": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "braceless_fence_preamble_then_bare_json": {"a": 1},
 }
 
 
@@ -1210,6 +1371,13 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "bom_truncated_array_no_fence": None,
     "bom_fenced_truncated_array": None,
     "bom_object_no_fence": {"a": 1},
+    # C1 fix: the ```json block is preferred over the preamble fence. Row 2 is
+    # the one that mattered at THIS site -- before the fix it returned
+    # {"draft": 1}, the model's python scratch dict, as a strategy/selection.
+    # A lost recovery is bad; returning scratch work as the answer is worse.
+    "plain_fence_preamble_then_json_fence": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "python_fence_preamble_then_json_fence": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "braceless_fence_preamble_then_bare_json": {"a": 1},
 }
 
 

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -105,6 +105,22 @@ CORPUS: list[tuple[str, str]] = [
         "hint_feedback_shape",
         '```json\n{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}\n```',
     ),
+    (
+        # AC-921: a corrupt fenced block followed by unrelated JSON in the
+        # trailing prose. extract_strategy_deterministic's bare-object
+        # fallback finds the decoy {"x": 2} and returns it -- silently wrong,
+        # not safe. This case guards the strengthened extract_json against
+        # reintroducing that behavior.
+        "ac_921_corrupt_fence_with_decoy_json",
+        '```json\n{a: 1, "b":}\n```  also see config: {"x": 2}',
+    ),
+    (
+        # strip_json_fences is case-sensitive: the "(?:json)?" tag group
+        # only matches lowercase, so an uppercase ```JSON tag isn't consumed
+        # as a tag and leaks into the "stripped" content instead.
+        "uppercase_json_fence_tag",
+        '```JSON\n{"a": 1}\n```',
+    ),
 ]
 
 CORPUS_IDS = [name for name, _ in CORPUS]
@@ -202,6 +218,8 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     "fenced_with_leading_prose_and_trailing_prose": '{"a": 1}',
     "curator_rating_shape": '{"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"}',
     "hint_feedback_shape": '{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}',
+    "ac_921_corrupt_fence_with_decoy_json": '{a: 1, "b":}',
+    "uppercase_json_fence_tag": 'JSON\n{"a": 1}',
 }
 
 
@@ -231,6 +249,8 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
     "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+    "ac_921_corrupt_fence_with_decoy_json": _Raises(json.JSONDecodeError),
+    "uppercase_json_fence_tag": _Raises(json.JSONDecodeError),
 }
 
 
@@ -265,6 +285,8 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "fenced_with_leading_prose_and_trailing_prose": [],
     "curator_rating_shape": [],
     "hint_feedback_shape": [],
+    "ac_921_corrupt_fence_with_decoy_json": [],  # body between the tag and last ``` is invalid JSON -> JSONDecodeError -> []
+    "uppercase_json_fence_tag": [],  # requires the literal "```json" tag; uppercase never matches find("```json")
 }
 
 
@@ -311,6 +333,8 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "fenced_with_leading_prose_and_trailing_prose": _CURATOR_DEFAULT,
     "curator_rating_shape": _CuratorRatingShape(actionability=4, specificity=5, correctness=2, rationale="solid"),
     "hint_feedback_shape": _CURATOR_DEFAULT,
+    "ac_921_corrupt_fence_with_decoy_json": _CURATOR_DEFAULT,  # JSONDecodeError swallowed
+    "uppercase_json_fence_tag": _CURATOR_DEFAULT,  # leaky "JSON\n{...}" content isn't valid JSON; swallowed
 }
 
 
@@ -340,6 +364,8 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
     "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+    "ac_921_corrupt_fence_with_decoy_json": {"x": 2},  # AC-921: decoy bare-object fallback picks up unrelated JSON
+    "uppercase_json_fence_tag": {"a": 1},  # bare-object regex fallback still finds it despite the leaky tag
 }
 
 
@@ -387,6 +413,8 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
     "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+    "ac_921_corrupt_fence_with_decoy_json": None,  # fenced candidate invalid; naive first-{-to-last-} scan also invalid
+    "uppercase_json_fence_tag": {"a": 1},  # fenced regex is case-insensitive, unlike strip_json_fences
 }
 
 

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -76,6 +76,12 @@ from autocontext.harness.core.types import RoleExecution, RoleUsage
 # and by later AC-910 tasks that build the consolidated parser against it.
 # ---------------------------------------------------------------------------
 
+# U+FEFF, spelled with chr() and concatenated into the corpus rows below
+# rather than pasted in as a literal, because a pasted BOM is invisible in
+# an editor and in a diff -- the corpus rows it appears in would read as
+# duplicates of the plain ones they exist to contrast with.
+_BOM = chr(0xFEFF)
+
 CORPUS: list[tuple[str, str]] = [
     ("normal_fenced_block", '```json\n{"a": 1}\n```'),
     ("fence_no_language", '```\n{"a": 1}\n```'),
@@ -247,6 +253,38 @@ CORPUS: list[tuple[str, str]] = [
         "hint_feedback_shape_single_line_fence",
         '```json{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}```',
     ),
+    (
+        # BOM + truncated array, UNFENCED. `truncated_array_one_object`
+        # above is the same payload without the BOM, and it is terminal
+        # because extract_json's array-shape check sees scope[0] == "[".
+        # U+FEFF is not whitespace, so `.strip()` leaves it in place, the
+        # "[" lands at index 1, the check reads False, and before the fix
+        # this fell through to the span scan and unwrapped the inner
+        # {"a": 1} -- the exact silent-wrong-answer shape that check exists
+        # to prevent, reached by one invisible character.
+        "bom_truncated_array_no_fence",
+        _BOM + '[{"a": 1}',
+    ),
+    (
+        # Same defect through the FENCED path. The fence regex's `\s*` does
+        # not consume U+FEFF either, so the BOM survives into the captured
+        # group and the fenced brace scan reaches into the array's interior
+        # just as the unfenced span scan did. Both shapes are pinned because
+        # the two scopes are produced by different code (`fence_match.group(1)`
+        # vs `text`) and an earlier round of this work fixed one path and
+        # left the other.
+        "bom_fenced_truncated_array",
+        "```json\n" + _BOM + '[{"a": 1}\n```',
+    ),
+    (
+        # Control for the two above: the BOM fix must not turn a BOM-prefixed
+        # ORDINARY object into a failure. This parsed before the fix too, but
+        # only by accident -- json.loads choked on the BOM and the span-scan
+        # rescue recovered the object. Now the normalized scope parses
+        # directly, first candidate, no rescue involved.
+        "bom_object_no_fence",
+        _BOM + '{"a": 1}',
+    ),
 ]
 
 CORPUS_IDS = [name for name, _ in CORPUS]
@@ -376,6 +414,14 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     "truncated_array_two_objects": '[{"a": 1}, {"b": 2}',
     "unfenced_earlier_malformed_then_valid": 'first: {bad json,} then: {"x": 2}',
     "hint_feedback_shape_single_line_fence": '{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}',
+    # strip_json_fences is UNCHANGED by the BOM fix -- it strips fences, and
+    # its `.strip()` cannot remove a U+FEFF any more than extract_json's
+    # could. The BOM is pinned as surviving all three of these on purpose:
+    # the fix lives in extract_json's scope normalization, not here, and if
+    # someone later moves it into strip_json_fences these rows say so.
+    "bom_truncated_array_no_fence": _BOM + '[{"a": 1}',
+    "bom_fenced_truncated_array": _BOM + '[{"a": 1}',
+    "bom_object_no_fence": _BOM + '{"a": 1}',
 }
 
 
@@ -462,6 +508,14 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # (extract_json's own regex already had the optional-newline form) --
     # this row's significance is only visible at the hint_feedback site.
     "hint_feedback_shape_single_line_fence": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+    # BOM fix: the scope is BOM-normalized before the array-shape check, so
+    # these two now behave exactly like their BOM-less twins
+    # (truncated_array_one_object / the fenced case) instead of returning the
+    # unwrapped inner {"a": 1}.
+    "bom_truncated_array_no_fence": _Raises(json.JSONDecodeError),
+    "bom_fenced_truncated_array": _Raises(json.JSONDecodeError),
+    # Control: same normalization, opposite direction -- still parses.
+    "bom_object_no_fence": {"a": 1},
 }
 
 
@@ -603,6 +657,34 @@ def test_extract_json_unfenced_earlier_malformed_candidate_is_skipped() -> None:
     assert extract_json('first: {bad json,} then: {"x": 2}') == {"x": 2}
 
 
+def test_extract_json_bom_does_not_walk_past_the_array_shape_check() -> None:
+    """A leading U+FEFF must not defeat the truncated-array rule.
+
+    The rule two tests above is a `scope.startswith("[")` check, and the
+    scope is produced with `.strip()`, which does NOT remove U+FEFF -- it is
+    a format character, not whitespace. So a BOM shifted the "[" to index 1,
+    the check read False, and the rescue candidates the rule exists to skip
+    ran anyway, unwrapping the inner object and returning a plausible wrong
+    answer. One invisible character was enough to undo the fix.
+
+    Both scope-producing paths are pinned, not just one: the fenced scope
+    (`fence_match.group(1)`) and the unfenced one (`text`) are separate
+    expressions, the fence regex's `\\s*` does not consume U+FEFF either, and
+    an earlier round of this work fixed one path while leaving the other --
+    so a single-shape test here would repeat that mistake.
+    """
+    with pytest.raises(json.JSONDecodeError):
+        extract_json(_BOM + '[{"a": 1}')
+    with pytest.raises(json.JSONDecodeError):
+        extract_json("```json\n" + _BOM + '[{"a": 1}\n```')
+    # Control: normalizing the BOM away must not newly reject a BOM-prefixed
+    # ordinary object. This one succeeded before the fix too, but only via
+    # the span-scan rescue (json.loads rejects the BOM); now the first
+    # candidate parses directly.
+    assert extract_json(_BOM + '{"a": 1}') == {"a": 1}
+    assert extract_json("```json\n" + _BOM + '{"a": 1}\n```') == {"a": 1}
+
+
 # ---------------------------------------------------------------------------
 # Extractor 3: agents.architect.parse_architect_tool_specs
 # ---------------------------------------------------------------------------
@@ -655,6 +737,9 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "truncated_array_two_objects": [],  # same
     "unfenced_earlier_malformed_then_valid": [],  # extract_json recovers {"x": 2}, but no "tools" key
     "hint_feedback_shape_single_line_fence": [],  # recovers the dict, but no "tools" key
+    "bom_truncated_array_no_fence": [],  # extract_json now raises (BOM fix) -> None -> []
+    "bom_fenced_truncated_array": [],  # same
+    "bom_object_no_fence": [],  # valid dict recovered, but no "tools" key
 }
 
 
@@ -777,6 +862,9 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "truncated_array_two_objects": _CURATOR_DEFAULT,  # same
     "unfenced_earlier_malformed_then_valid": _CURATOR_DEFAULT,  # recovers {"x": 2}, but no matching rating keys
     "hint_feedback_shape_single_line_fence": _CURATOR_DEFAULT,  # recovers the dict, no matching rating keys
+    "bom_truncated_array_no_fence": _CURATOR_DEFAULT,  # extract_json raises (BOM fix) -> None -> default
+    "bom_fenced_truncated_array": _CURATOR_DEFAULT,  # same
+    "bom_object_no_fence": _CURATOR_DEFAULT,  # parses fine, no matching rating keys
 }
 
 
@@ -853,6 +941,11 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     # Step 1c(iv) accepted residual: recovers the later well-formed candidate.
     "unfenced_earlier_malformed_then_valid": {"x": 2},
     "hint_feedback_shape_single_line_fence": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+    # BOM fix (see EXTRACT_JSON_EXPECTED): a BOM no longer walks past
+    # extract_json's array-shape check, so these fail closed -> None.
+    "bom_truncated_array_no_fence": None,
+    "bom_fenced_truncated_array": None,
+    "bom_object_no_fence": {"a": 1},
 }
 
 
@@ -953,6 +1046,11 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     # Step 1c(iv) accepted residual: recovers the later well-formed candidate.
     "unfenced_earlier_malformed_then_valid": {"x": 2},
     "hint_feedback_shape_single_line_fence": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+    # BOM fix (see EXTRACT_JSON_EXPECTED): a BOM no longer walks past
+    # extract_json's array-shape check, so these fail closed -> None.
+    "bom_truncated_array_no_fence": None,
+    "bom_fenced_truncated_array": None,
+    "bom_object_no_fence": {"a": 1},
 }
 
 
@@ -970,14 +1068,22 @@ def test_action_filter_extract_json_object(name: str, text: str) -> None:
 _GUARDED_SRC_DIRS = ("agents", "execution")
 _ALLOWED_FENCE_REGEX_FILE = "output_parser.py"
 
-# The four regex call sites this guard is aware of today, one per line,
-# collapsed to three files below because two of them (translator.py's
+# The five regex call sites this guard is aware of today, one per line,
+# collapsed to four files below because two of them (translator.py's
 # python-fence and generic-fence searches) live in the same module:
 #
-#   agents/translator.py:118            re.search  -- python code block
-#   agents/translator.py:121            re.search  -- generic fence
+#   agents/translator.py:118             re.search  -- python code block
+#   agents/translator.py:121             re.search  -- generic fence
 #   execution/harness_synthesizer.py:233 re.search  -- python code block
-#   execution/judge.py:555              re.compile -- JSON (AC-924)
+#   execution/policy_refinement.py:71    re.findall -- python code block
+#   execution/judge.py:555               re.compile -- JSON (AC-924)
+#
+# policy_refinement.py was MISSED by the first version of this guard, and by
+# two independent evasions at once, either of which alone would have hidden
+# it: `findall` was not in the constructor set below, and its pattern is a
+# function-local variable passed by name rather than an inline literal. Both
+# holes are closed now (see `_fence_regex_offenders`), which is the only
+# reason this comment can claim five sites rather than four.
 #
 # judge.py is tracked, unmigrated JSON extraction: `_try_code_block_parse`
 # is one of FOUR ordered parsing strategies (marker-delimited, raw-JSON-
@@ -986,12 +1092,12 @@ _ALLOWED_FENCE_REGEX_FILE = "output_parser.py"
 # be exactly the mistake this plan keeps proving is wrong -- characterize
 # before you change. Tracked in AC-924, not fixed here.
 #
-# translator.py and harness_synthesizer.py are a DIFFERENT kind of
-# exemption, not a to-do: both regexes extract PYTHON source code from a
-# fence, not JSON. extract_json is a JSON parser (it feeds candidates to
-# json.loads); forcing a Python-code extraction onto it would be wrong, not
-# incomplete, so these are deliberately and permanently out of scope for
-# migration, unlike judge.py's AC-924 debt.
+# translator.py, harness_synthesizer.py and policy_refinement.py are a
+# DIFFERENT kind of exemption, not a to-do: all three regexes extract PYTHON
+# source code from a fence, not JSON. extract_json is a JSON parser (it feeds
+# candidates to json.loads); forcing a Python-code extraction onto it would be
+# wrong, not incomplete, so these are deliberately and permanently out of
+# scope for migration, unlike judge.py's AC-924 debt.
 #
 # This is EXACT-SET equality, not an allow-list: it fails both when a NEW
 # offender appears (someone adds a fence regex) and when a known one
@@ -1000,21 +1106,31 @@ _ALLOWED_FENCE_REGEX_FILE = "output_parser.py"
 # permissive allow-list would let it.
 _KNOWN_OFFENDERS = frozenset(
     {
+        # Tracked, unmigrated JSON extraction (AC-924).
         "execution/judge.py",
+        # Python code extraction, not JSON -- permanently out of scope.
         "agents/translator.py",
         "execution/harness_synthesizer.py",
+        # Python code extraction, not JSON -- same permanent exemption as the
+        # two above. Missed by the original guard (re.findall + a pattern
+        # bound to a function-local variable); listed here only once the
+        # guard below could actually see it.
+        "execution/policy_refinement.py",
     }
 )
 
-# re.* callables whose first positional argument, if a string literal
+# re.* callables whose first positional argument, if it resolves to a string
 # containing a markdown fence, marks the call as a fence-regex offender.
 # "compile" catches the pattern this guard was originally written for
 # (`_JSON_FENCE_RE = re.compile(...)`, reused across multiple calls); the
-# other three catch a pattern built inline at each call site instead
+# rest catch a pattern built inline at each call site instead
 # (`re.search(r"```...", text)`), which is exactly the shape translator.py
 # and harness_synthesizer.py use and the original "compile"-only check
-# missed entirely.
-_FENCE_REGEX_CONSTRUCTORS = frozenset({"compile", "search", "match", "finditer"})
+# missed entirely. "findall"/"split"/"sub" were added after `findall`'s
+# absence turned out to be one of the two reasons policy_refinement.py went
+# undetected; they are the remaining module-level re.* functions that take a
+# pattern first and are plausible ways to pull content out of a fence.
+_FENCE_REGEX_CONSTRUCTORS = frozenset({"compile", "search", "match", "finditer", "findall", "split", "sub"})
 
 
 def _guarded_python_files() -> list[Path]:
@@ -1025,30 +1141,84 @@ def _guarded_python_files() -> list[Path]:
     return files
 
 
+def _string_literal_bindings(tree: ast.Module) -> dict[str, list[str]]:
+    """Map each name bound to a plain string literal anywhere in ``tree``.
+
+    Collected by walking the WHOLE module, so function-local bindings count
+    the same as module-level ones. That is load-bearing rather than
+    thorough-for-its-own-sake: execution/policy_refinement.py's offender is a
+    function-local ``pattern = r"```(?:python)?\\s*\\n(.*?)```"`` handed to
+    ``re.findall(pattern, ...)`` on the next line, and a module-level-only
+    scan cannot see it.
+
+    Scope is deliberately ignored and no reachability is computed -- this is
+    a name-to-literal lookup, not dataflow. Consequences, both accepted:
+    a name bound in one function and a same-named binding in another are
+    conflated (over-approximating, which for a guard means a spurious
+    failure someone must look at, never a silent miss), and a name rebound
+    several times maps to every literal it took, any one of which containing
+    a fence is enough to flag the call site.
+    """
+    bindings: dict[str, list[str]] = {}
+    for node in ast.walk(tree):
+        target_names: list[str] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            target_names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            # `pattern: str = r"```..."` -- same shape, different node type.
+            target_names = [node.target.id]
+            value = node.value
+        if value is None or not (isinstance(value, ast.Constant) and isinstance(value.value, str)):
+            continue
+        for name in target_names:
+            bindings.setdefault(name, []).append(value.value)
+    return bindings
+
+
 def _fence_regex_offenders() -> set[str]:
     """Return the set of guarded-directory-relative paths (e.g.
-    "agents/hint_feedback.py") containing a `re.compile(...)`, `re.search(...)`,
-    `re.match(...)`, or `re.finditer(...)` call whose first positional
-    argument is a string literal containing three backticks.
+    "agents/hint_feedback.py") that call one of ``re.compile``, ``re.search``,
+    ``re.match``, ``re.finditer``, ``re.findall``, ``re.split`` or ``re.sub``
+    with a first positional argument that resolves to a string containing
+    three backticks.
 
-    What this DOES catch: a fence pattern passed directly as a string
-    literal to one of those four `re` module functions, e.g.
-    ``re.compile(r"```(?:json)?...")`` or ``re.search(r"```python\\s*\\n(.*?)```", text)``,
-    however many are in one file (a file with two such calls is still one
-    entry in the returned set).
+    What this DOES catch:
+    - A fence pattern passed inline as a string literal to any of those seven
+      `re` module functions, e.g. ``re.compile(r"```(?:json)?...")`` or
+      ``re.search(r"```python\\s*\\n(.*?)```", text)``.
+    - A fence pattern bound to a NAME anywhere in the same module (any scope,
+      module-level or function-local) and passed by that name, e.g.
+      ``pattern = r"```(?:python)?..."`` then ``re.findall(pattern, text)``
+      -- which is exactly the shape execution/policy_refinement.py uses, and
+      which this guard used to miss for two independent reasons at once
+      (``findall`` was not in the constructor set, and the pattern was not
+      inline). Resolution is by name only, via `_string_literal_bindings`;
+      see that function for what "resolves" does and does not mean.
 
-    What this does NOT catch, by construction of the AST check below --
-    each of these is a real, demonstrated way to defeat it, not a
-    theoretical gap:
-    - A pattern assigned to a module-level variable and passed by name
-      (``_P = re.compile(...)`` then ``_P.search(text)`` elsewhere) --
-      idiomatic Python, not evasion; a routine refactor would silently slip
-      past this guard exactly the way a deliberate bypass would.
-    - A pattern built by string concatenation or an f-string instead of a
-      single literal.
-    - ``from re import compile as _c`` (or any aliased import) followed by
-      ``_c(...)`` -- the check requires the call's object to be the bare
-      name ``re``.
+    Either way, however many such calls are in one file, the file is one
+    entry in the returned set.
+
+    What this still does NOT catch, by construction of the AST check below.
+    The first two were demonstrated live against this guard; all are real
+    holes, not theoretical ones:
+    - ``import re as _r`` / ``from re import compile as _c`` (any aliased
+      import) followed by ``_r.compile(...)`` / ``_c(...)`` -- the check
+      requires the call's object to be the bare name ``re``.
+    - A pattern built by string concatenation or an f-string rather than
+      being a single literal: neither the inline check nor the name
+      resolution above looks at anything but ``ast.Constant`` strings, so
+      ``re.search("`" * 3 + "(.*?)", text)`` or an f-string pattern passes
+      straight through.
+    - A pattern reached through anything other than a direct name: an
+      attribute (``_PATTERNS.fence``), a subscript (``_PATTERNS["fence"]``),
+      a function's return value, or a name bound from another module's
+      constant.
+    - The compiled-object call shape ``_P = re.compile(r"```...")`` followed
+      by ``_P.search(text)`` IS caught, but only because of the
+      ``re.compile`` call itself -- the ``_P.search`` site is invisible, so
+      a pattern compiled in a different module and imported is not seen.
     - A fence string embedded in ordinary text that is never passed to a
       `re.*` call at all (e.g. a prompt telling the model to emit fenced
       output, as in agents/llm_client.py) -- deliberately not flagged,
@@ -1061,6 +1231,7 @@ def _fence_regex_offenders() -> set[str]:
         if path.name == _ALLOWED_FENCE_REGEX_FILE:
             continue
         tree = ast.parse(path.read_text(), filename=str(path))
+        bindings = _string_literal_bindings(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -1072,9 +1243,13 @@ def _fence_regex_offenders() -> set[str]:
             if not node.args:
                 continue
             first_arg = node.args[0]
-            if not (isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str)):
+            if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+                candidates = [first_arg.value]
+            elif isinstance(first_arg, ast.Name):
+                candidates = bindings.get(first_arg.id, [])
+            else:
                 continue
-            if "```" in first_arg.value:
+            if any("```" in candidate for candidate in candidates):
                 offenders.add(str(path.relative_to(src_root)))
     return offenders
 
@@ -1088,17 +1263,30 @@ def test_no_new_markdown_fence_regex_outside_output_parser() -> None:
     name is defense-in-depth rather than load-bearing, in case it ever moves.
 
     This enforces exactly what `_fence_regex_offenders`' docstring says it
-    detects -- a fence pattern passed as a string literal directly to
-    `re.compile` / `re.search` / `re.match` / `re.finditer` -- and nothing
-    more. It does NOT catch a pattern assigned to a module-level variable
-    and reused, built by concatenation or an f-string, or reached through
-    an aliased `re` import; see that docstring for why each of those is
-    deliberately out of scope rather than an oversight. A guard that
-    implied broader coverage than that would be worse than one whose limits
-    are written down, because the false confidence is what lets a routine
-    refactor (moving a pattern to a module-level constant, which is
-    idiomatic, not evasive) slip a new duplicate fence extractor past it
-    unnoticed.
+    detects, and nothing more: a fence pattern reaching `re.compile` /
+    `re.search` / `re.match` / `re.finditer` / `re.findall` / `re.split` /
+    `re.sub` either as an inline string literal, or as a name bound to a
+    string literal somewhere in the same module (any scope -- module-level
+    or function-local).
+
+    It still does NOT catch a pattern reached through an aliased `re` import
+    (`import re as _r`, `from re import compile as _c`), one built by
+    concatenation or an f-string rather than being a single literal, or one
+    reached by anything other than a bare name (an attribute, a subscript, a
+    call's return value, a constant imported from another module). See that
+    docstring for why each is out of scope rather than an oversight. A guard
+    that implied broader coverage than it has would be worse than one whose
+    limits are written down: the false confidence is what let
+    execution/policy_refinement.py sit undetected while an earlier version
+    of this docstring claimed the coverage was complete for what it
+    described.
+
+    That miss is the reason for the current wording. The first version of
+    this guard checked four `re.*` functions and inline literals only, and
+    policy_refinement.py evaded it twice over -- `re.findall` was not in the
+    set, AND its pattern is a function-local variable passed by name. Either
+    hole alone would have hidden it. Both are closed now; the remaining
+    holes listed above are not.
 
     Exact-set equality against `_KNOWN_OFFENDERS`, not a plain "no offenders"
     assertion and not a permissive allow-list: a NEW offender fails it (the
@@ -1107,26 +1295,17 @@ def test_no_new_markdown_fence_regex_outside_output_parser() -> None:
     expected set to be updated deliberately, rather than carrying a stale
     exemption forever).
 
-    Proven to fire in all three directions this guard cares about (see
-    task-5-fix-report.md for the pasted output):
-    1. The current tree passes with exactly `_KNOWN_OFFENDERS`.
+    Proven to fire in all three directions this guard cares about:
+    1. The current tree passes with exactly `_KNOWN_OFFENDERS` (four files).
     2. A deliberately reintroduced fence regex added to an agents/ module
-       that already imports `re` (e.g. `_BYPASS = re.compile(r"```...")` in
-       agents/curator.py) -> fails, naming that file. Removed -> passes.
+       that already imports `re` -- specifically the shape that used to slip
+       through, `pattern = r"```...(.*?)```"` then `re.findall(pattern, ...)`
+       in agents/curator.py -> fails, naming that file. Removed -> passes.
        (A module that does NOT already import `re`, e.g. agents/coach.py,
        fails at import instead of tripping the guard -- that failure looks
        like a passing proof but tests the wrong thing, so the file used for
        this check must already import `re`.)
-    3. `_KNOWN_OFFENDERS` missing one of the three tracked files while that
+    3. `_KNOWN_OFFENDERS` missing one of the four tracked files while that
        file still offends -> fails. Restored -> passes.
-
-    A module-level-variable bypass (`_BYPASS = re.compile(...)` assigned in
-    one place, called via `_BYPASS.search(...)` elsewhere) and an aliased-
-    import bypass (`from re import compile as _c`) were both demonstrated
-    live against this guard and neither is caught -- see this function's
-    docstring and `_fence_regex_offenders`' docstring for why: closing them
-    would require tracing assignments and import aliases, not just call
-    shapes, which is a bigger change than this guard's AST walk is designed
-    to do. Documented here rather than silently accepted.
     """
     assert _fence_regex_offenders() == _KNOWN_OFFENDERS

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -143,6 +143,17 @@ CORPUS: list[tuple[str, str]] = [
         "fenced_mixed_array_with_object",
         '```json\n[1, {"a": 1}, 2]\n```',
     ),
+    (
+        # AC-910 Task 3 regression case: two separate bare (unfenced) JSON
+        # objects in prose, e.g. a competitor listing two strategy options.
+        # extract_json's no-fence fallback must try each top-level candidate
+        # in order and return the first that parses, not build one
+        # first-"{"-to-last-"}" span (which would cross both objects and
+        # fail). Also pinned directly against the real production path in
+        # tests/test_translator_simplification.py::test_multiple_json_objects_extracts_first.
+        "two_bare_json_objects_no_fence",
+        'Option A: {"aggression": 0.9, "defense": 0.1}\nOption B: {"aggression": 0.5, "defense": 0.5}',
+    ),
 ]
 
 CORPUS_IDS = [name for name, _ in CORPUS]
@@ -245,6 +256,10 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     "bare_array_of_objects": '[{"a": 1}]',
     "fenced_array_of_objects": '[{"a": 1}]',
     "fenced_mixed_array_with_object": '[1, {"a": 1}, 2]',
+    # No fence present -> passthrough unchanged, same as any other no-fence case.
+    "two_bare_json_objects_no_fence": (
+        'Option A: {"aggression": 0.9, "defense": 0.1}\nOption B: {"aggression": 0.5, "defense": 0.5}'
+    ),
 }
 
 
@@ -292,6 +307,11 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     "bare_array_of_objects": _Raises(ValueError),
     "fenced_array_of_objects": _Raises(ValueError),
     "fenced_mixed_array_with_object": _Raises(ValueError),
+    # AC-910 Task 3 fix: no fence, so multiple top-level candidates are tried
+    # in order; Option A's object parses first and wins. Before the fix this
+    # raised JSONDecodeError (the single first-"{"-to-last-"}" span crossed
+    # both objects and the "Option B:" prose between them).
+    "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
 }
 
 
@@ -398,6 +418,7 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "bare_array_of_objects": [],
     "fenced_array_of_objects": [],  # same terminal-list rule -> None -> [] with a warning
     "fenced_mixed_array_with_object": [],  # same terminal-list rule -> None -> [] with a warning
+    "two_bare_json_objects_no_fence": [],  # extract_json recovers Option A's dict, but it has no "tools" key
 }
 
 
@@ -467,6 +488,7 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "bare_array_of_objects": _CURATOR_DEFAULT,  # parses to a list; isinstance(decoded, dict) is False -> discarded silently
     "fenced_array_of_objects": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
     "fenced_mixed_array_with_object": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
+    "two_bare_json_objects_no_fence": _CURATOR_DEFAULT,  # recovers Option A's dict, but no matching rating keys
 }
 
 
@@ -523,6 +545,11 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "bare_array_of_objects": None,
     "fenced_array_of_objects": None,
     "fenced_mixed_array_with_object": None,
+    # Multi-object regression FIX (Task 3, output_parser.py): before the fix
+    # this was None (the whole point of the regression report); now recovers
+    # Option A, matching the old three-layer fallback chain this extractor
+    # used to have. Net unchanged from the pre-migration baseline.
+    "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
 }
 
 
@@ -592,6 +619,11 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "bare_array_of_objects": None,
     "fenced_array_of_objects": None,
     "fenced_mixed_array_with_object": None,
+    # Multi-object regression FIX (Task 3, output_parser.py): this extractor
+    # used to have its own two-stage candidate approach and would have
+    # recovered Option A too before the extract_json migration; the parser
+    # fix restores that.
+    "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
 }
 
 

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -121,6 +121,28 @@ CORPUS: list[tuple[str, str]] = [
         "uppercase_json_fence_tag",
         '```JSON\n{"a": 1}\n```',
     ),
+    (
+        # AC-910 Task 2 defect: a bare (unfenced) array of OBJECTS, not
+        # scalars. json_array_not_object above ([1, 2, 3]) contains no
+        # braces at all, so it never exercised the brace-scan fallback; this
+        # one does, and used to have the fallback silently return the
+        # array's first element instead of raising.
+        "bare_array_of_objects",
+        '[{"a": 1}]',
+    ),
+    (
+        # Same defect, fenced: the scope itself parses successfully to a
+        # list, which must be terminal -- not a cue to fall through to the
+        # brace-scan candidate and grab the nested {"a": 1}.
+        "fenced_array_of_objects",
+        '```json\n[{"a": 1}]\n```',
+    ),
+    (
+        # Same defect, mixed array: scalars AND an object. Confirms the fix
+        # isn't specific to all-object arrays.
+        "fenced_mixed_array_with_object",
+        '```json\n[1, {"a": 1}, 2]\n```',
+    ),
 ]
 
 CORPUS_IDS = [name for name, _ in CORPUS]
@@ -220,6 +242,9 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     "hint_feedback_shape": '{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}',
     "ac_921_corrupt_fence_with_decoy_json": '{a: 1, "b":}',
     "uppercase_json_fence_tag": 'JSON\n{"a": 1}',
+    "bare_array_of_objects": '[{"a": 1}]',
+    "fenced_array_of_objects": '[{"a": 1}]',
+    "fenced_mixed_array_with_object": '[1, {"a": 1}, 2]',
 }
 
 
@@ -261,6 +286,12 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # contains a recoverable {...} span once the leaked tag is scanned past.
     # This never reaches outside the fence, so it doesn't reintroduce AC-921.
     "uppercase_json_fence_tag": {"a": 1},
+    # Defect fix (AC-910 Task 2 review): the scope parses successfully to a
+    # list. That is now terminal -- raise -- rather than falling through to
+    # the brace-scan candidate and silently returning the nested {"a": 1}.
+    "bare_array_of_objects": _Raises(ValueError),
+    "fenced_array_of_objects": _Raises(ValueError),
+    "fenced_mixed_array_with_object": _Raises(ValueError),
 }
 
 
@@ -347,6 +378,9 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "hint_feedback_shape": [],
     "ac_921_corrupt_fence_with_decoy_json": [],  # body between the tag and last ``` is invalid JSON -> JSONDecodeError -> []
     "uppercase_json_fence_tag": [],  # requires the literal "```json" tag; uppercase never matches find("```json")
+    "bare_array_of_objects": [],  # no "```json" tag at all
+    "fenced_array_of_objects": [],  # parses to a list, not a dict with a "tools" key
+    "fenced_mixed_array_with_object": [],  # same: parses to a list, not a dict with a "tools" key
 }
 
 
@@ -395,6 +429,9 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "hint_feedback_shape": _CURATOR_DEFAULT,
     "ac_921_corrupt_fence_with_decoy_json": _CURATOR_DEFAULT,  # JSONDecodeError swallowed
     "uppercase_json_fence_tag": _CURATOR_DEFAULT,  # leaky "JSON\n{...}" content isn't valid JSON; swallowed
+    "bare_array_of_objects": _CURATOR_DEFAULT,  # parses to a list; isinstance(decoded, dict) is False -> discarded silently
+    "fenced_array_of_objects": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
+    "fenced_mixed_array_with_object": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
 }
 
 
@@ -426,6 +463,14 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
     "ac_921_corrupt_fence_with_decoy_json": {"x": 2},  # AC-921: decoy bare-object fallback picks up unrelated JSON
     "uppercase_json_fence_tag": {"a": 1},  # bare-object regex fallback still finds it despite the leaky tag
+    # This extractor's own bare-object regex has the same array-coercion
+    # defect that AC-910 Task 2 fixed in extract_json: it finds the nested
+    # {"a": 1} inside the array and returns it instead of rejecting the
+    # array. Out of scope for this task (no call sites may change here) --
+    # pinned as-is per the characterization-suite mandate.
+    "bare_array_of_objects": {"a": 1},
+    "fenced_array_of_objects": {"a": 1},
+    "fenced_mixed_array_with_object": {"a": 1},
 }
 
 
@@ -475,6 +520,13 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
     "ac_921_corrupt_fence_with_decoy_json": None,  # fenced candidate invalid; naive first-{-to-last-} scan also invalid
     "uppercase_json_fence_tag": {"a": 1},  # fenced regex is case-insensitive, unlike strip_json_fences
+    # Same pre-existing array-coercion defect as extract_strategy_deterministic
+    # above: this extractor's naive first-"{"-to-last-"}" fallback has no type
+    # check at all, so it happily returns the nested object from an array.
+    # Out of scope here (no call sites may change); pinned as-is.
+    "bare_array_of_objects": {"a": 1},
+    "fenced_array_of_objects": {"a": 1},
+    "fenced_mixed_array_with_object": {"a": 1},
 }
 
 

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -13,11 +13,9 @@ same input, that disagreement is the point -- see the report at
 ``.superpowers/sdd/2026-08-08-ac-910-plan3-model-json-consolidation/task-1-report.md``
 for the full disagreement table.
 
-The call sites characterized here. There were eight when this file was written;
-``strip_json_fences`` was the ninth and is gone -- it was a generic fence
-stripper that ended the consolidation with zero production callers, so AC-910
-deleted it rather than leave behind the same uncalled-public-extractor shape
-the plan set out to remove:
+The call sites characterized here. ``strip_json_fences`` is retained as a
+compatibility wrapper for external imports, but has zero production callers;
+all production JSON parsing routes through the seven sites below:
 
 1. ``harness.core.output_parser.extract_json`` -- the consolidation target.
    It had zero callers when this file was written; every site below that
@@ -141,9 +139,9 @@ CORPUS: list[tuple[str, str]] = [
         '```json\n{a: 1, "b":}\n```  also see config: {"x": 2}',
     ),
     (
-        # strip_json_fences is case-sensitive: the "(?:json)?" tag group
-        # only matches lowercase, so an uppercase ```JSON tag isn't consumed
-        # as a tag and leaks into the "stripped" content instead.
+        # JSON fence tags are case-insensitive. This corpus row is the simple
+        # control; a separate priority test below proves an uppercase tag is
+        # recognized rather than merely recovered by a brace scan.
         "uppercase_json_fence_tag",
         '```JSON\n{"a": 1}\n```',
     ),
@@ -510,10 +508,8 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # scan is confined to the fence's own captured content, so it never
     # reaches the decoy -- this is the AC-921 guard.
     "ac_921_corrupt_fence_with_decoy_json": _Raises(json.JSONDecodeError),
-    # CHANGED by the Step 2 strengthening: a fence IS present, so the fallback
-    # stays confined to its captured content ('JSON\n{"a": 1}'), which itself
-    # contains a recoverable {...} span once the leaked tag is scanned past.
-    # This never reaches outside the fence, so it doesn't reintroduce AC-921.
+    # JSON tags are now matched case-insensitively, so this parses directly
+    # from the designated fence rather than succeeding through brace recovery.
     "uppercase_json_fence_tag": {"a": 1},
     # Defect fix (AC-910 Task 2 review): the scope parses successfully to a
     # list. That is now terminal -- raise -- rather than falling through to
@@ -531,7 +527,7 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # instead of falling through to the unrelated "stale" decoy object.
     "critical1_brace_in_string_with_decoy": {"score": 5, "rationale": "matches rubric step 3}"},
     # AC-910 Task 3 review Critical 2 fix: the scope OPENS with "[", so the
-    # `scope.startswith("[")` check skips the rescue candidates entirely and
+    # direct-array check skips the rescue candidates entirely and
     # the only candidate left is the whole scope -- which json.loads rejects
     # with "Extra data" at the trailing `, {"b": 2}`. So this is terminal via
     # the array-SHAPED-SCOPE rule and a JSONDecodeError, NOT via the
@@ -546,9 +542,9 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # `array_span_then_later_object_no_fence` after it (which additionally
     # pins that the scan STOPS there).
     "array_then_separate_object_no_fence": _Raises(json.JSONDecodeError),
-    # Same Critical 2 fix, array embedded in prose rather than leading: the
-    # scope does not open with "[", so the span scan runs, offers the array as
-    # a rescue candidate, and it parses to a list -> wrong-type ValueError.
+    # Same Critical 2 fix, array embedded in prose rather than leading: it is
+    # isolated as the first container candidate and parses to a list ->
+    # wrong-type ValueError.
     "array_of_objects_in_prose_no_fence": _Raises(ValueError),
     # Wrong-type TERMINALITY (the `break`, not merely the raise): an array
     # span with a well-formed object span AFTER it. See CORPUS.
@@ -558,10 +554,10 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # the whole-scope candidate -- pinned as the no-decoy companion to
     # critical1 above.
     "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
-    # AC-910 Task 5 Step 1c(i) fix: the scope opens with "[", so a failed
-    # parse (JSONDecodeError, since the array is unterminated) is now
-    # terminal -- no rescue candidates are tried -- instead of falling
-    # through to _top_level_object_spans and unwrapping the inner {"a": 1}.
+    # AC-910 Task 5 Step 1c(i) fix: the first container is "[", so a failed
+    # parse (JSONDecodeError, since the array is unterminated) is terminal --
+    # no object-rescue candidates are tried -- instead of unwrapping the inner
+    # {"a": 1}.
     "truncated_array_one_object": _Raises(json.JSONDecodeError),
     "truncated_array_two_objects": _Raises(json.JSONDecodeError),
     # Step 1c(iv) accepted residual: no fence, so each malformed candidate is
@@ -619,11 +615,24 @@ def test_extract_json_prose_wrapped_bare_json_parses_via_brace_scan() -> None:
     assert extract_json('Here is the result: {"a": 1} -- hope that helps!') == {"a": 1}
 
 
-def test_extract_json_broken_fence_tag_recovers_via_brace_scan_within_fence() -> None:
-    # The fenced content itself ('JSON\n{"a": 1}') doesn't parse directly
-    # because of the leaked uppercase tag, but brace-scanning WITHIN that
-    # captured span (not the wider text) recovers the object.
+def test_extract_json_uppercase_json_fence_tag_is_recognized() -> None:
     assert extract_json('```JSON\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_extract_json_matches_json_fence_tag_exactly_case_insensitively() -> None:
+    expected = {"answer": 2}
+
+    # If the uppercase tag leaked into its body, both fences would look
+    # untagged and the earlier python dict would win.
+    uppercase_answer = '```python\nscratch = {"draft": 1}\n```\n```JsOn\n{"answer": 2}\n```'
+    assert extract_json(uppercase_answer) == expected
+    assert ActionFilterHarness._extract_json_object(uppercase_answer) == expected
+
+    # Prefixes are not tags. If any of these gained JSON priority, its scratch
+    # object would beat the later, genuinely JSON-tagged answer.
+    for info_string in ("jsonl", "json5", "jsonnet"):
+        response = f'```{info_string}\n{{"draft": 1}}\n```\n```json\n{{"answer": 2}}\n```'
+        assert extract_json(response) == expected
 
 
 def test_extract_json_json_array_raises_instead_of_being_coerced() -> None:
@@ -714,8 +723,31 @@ def test_extract_json_fenced_truncated_array_does_not_unwrap_inner_object() -> N
         extract_json('```json\n[{"a": 1}]\n```')
     # Plain object control, fenced: proves the array-only check doesn't
     # over-tighten and start blocking the ordinary fenced brace-scan rescue
-    # path (see test_extract_json_broken_fence_tag_recovers_via_brace_scan_within_fence).
+    # path.
     assert extract_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        'Final: [{"aggression": 0.7}',
+        '```\nFinal: [{"aggression": 0.7}\n```',
+        '```JSON\n[{"aggression": 0.7}\n```',
+        '```jsonnet\n[{"aggression": 0.7}\n```',
+    ],
+)
+def test_extract_json_prefixed_truncated_array_is_terminal(text: str) -> None:
+    """Prose or fence info before ``[`` must not expose an inner object."""
+    with pytest.raises(json.JSONDecodeError):
+        extract_json(text)
+    assert extract_json(text, on_failure="none") is None
+    assert ActionFilterHarness._extract_json_object(text) is None
+
+
+def test_translator_rejects_prefixed_truncated_array() -> None:
+    """The fail-hard production translator must reject, not score, the fragment."""
+    with pytest.raises(json.JSONDecodeError):
+        _translate('Final: [{"aggression": 0.7}')
 
 
 def test_extract_json_unfenced_earlier_malformed_candidate_is_skipped() -> None:
@@ -809,13 +841,12 @@ def test_extract_json_wrong_type_candidate_is_terminal() -> None:
 
     This pins the `break` (not `continue`) at output_parser.py:188 -- the
     plan's strongest structural claim about extract_json, and until now
-    entirely untested. Every corpus row that reaches that line has the
-    wrong-type candidate as the LAST candidate, where breaking and continuing
-    are indistinguishable; the `scope.startswith("[")` check is what makes
-    those rows terminal, not the break. Flipping `break` to `continue` left
-    the whole targeted suite green (292/292). These three inputs are the ones
-    that tell the two apart -- each has a well-formed OBJECT candidate sitting
-    after the wrong-type one, so `continue` returns it instead of raising:
+    entirely untested. Every earlier corpus row that reached that line had the
+    wrong-type candidate LAST, where breaking and continuing were
+    indistinguishable; direct-array rows skipped rescue candidates before
+    reaching it. These inputs tell the two apart -- each has a well-formed
+    OBJECT candidate after the wrong-type one, so `continue` would return it
+    instead of raising:
 
         'Tools: [{"a": 1}] and {"b": 2}'                    -> would return {"b": 2}
         'garbage: {not valid json,} [{"mid": 1}] {"c": 3}'  -> would return {"c": 3}
@@ -874,12 +905,10 @@ def test_extract_json_wrong_type_candidate_is_terminal() -> None:
 def test_extract_json_bom_does_not_walk_past_the_array_shape_check() -> None:
     """A leading U+FEFF must not defeat the truncated-array rule.
 
-    The rule two tests above is a `scope.startswith("[")` check, and the
-    scope is produced with `.strip()`, which does NOT remove U+FEFF -- it is
-    a format character, not whitespace. So a BOM shifted the "[" to index 1,
-    the check read False, and the rescue candidates the rule exists to skip
-    ran anyway, unwrapping the inner object and returning a plausible wrong
-    answer. One invisible character was enough to undo the fix.
+    The original rule used `scope.startswith("[")`, while `.strip()` does not
+    remove U+FEFF. A BOM therefore shifted the "[" to index 1 and exposed the
+    inner object to rescue. Scope normalization and first-container detection
+    now make the BOM-prefixed payload follow the same path as its plain twin.
 
     Both scope-producing paths are pinned, not just one: the fenced scope
     (`fence_match.group(1)`) and the unfenced one (`text`) are separate
@@ -936,7 +965,7 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     # still fails within the fenced scope (decoy sits outside it) -> None ->
     # [] with a warning, as before
     "ac_921_corrupt_fence_with_decoy_json": [],
-    "uppercase_json_fence_tag": [],  # recovered via the within-scope brace scan despite the leaked tag; still no "tools" key
+    "uppercase_json_fence_tag": [],  # parses directly; still no "tools" key
     # scope parses to a list -> terminal ValueError -> None -> [] with a
     # warning (previously [] via no "```json" tag found at all, no warning)
     "bare_array_of_objects": [],
@@ -1111,7 +1140,7 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "curator_rating_shape": _CuratorRatingShape(actionability=4, specificity=5, correctness=2, rationale="solid"),
     "hint_feedback_shape": _CURATOR_DEFAULT,
     "ac_921_corrupt_fence_with_decoy_json": _CURATOR_DEFAULT,  # JSONDecodeError swallowed
-    "uppercase_json_fence_tag": _CURATOR_DEFAULT,  # leaky "JSON\n{...}" content isn't valid JSON; swallowed
+    "uppercase_json_fence_tag": _CURATOR_DEFAULT,  # parses directly, but has no rating keys
     "bare_array_of_objects": _CURATOR_DEFAULT,  # parses to a list; isinstance(decoded, dict) is False -> discarded silently
     "fenced_array_of_objects": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
     "fenced_mixed_array_with_object": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
@@ -1229,7 +1258,7 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
     # AC-921 FIX (see comment above the table): was {"x": 2}, now None.
     "ac_921_corrupt_fence_with_decoy_json": None,
-    "uppercase_json_fence_tag": {"a": 1},  # recovered via the within-scope brace scan on the leaked tag, not a bare-object regex
+    "uppercase_json_fence_tag": {"a": 1},  # exact case-insensitive JSON tag
     # Array-coercion FIX (see comment above the table): were all {"a": 1}, now None.
     "bare_array_of_objects": None,
     "fenced_array_of_objects": None,
@@ -1353,9 +1382,7 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
     "ac_921_corrupt_fence_with_decoy_json": None,  # unchanged: fails within scope, decoy never reached, as before
-    "uppercase_json_fence_tag": {
-        "a": 1
-    },  # recovered via the within-scope brace scan on the leaked tag now, not case-insensitive tag matching
+    "uppercase_json_fence_tag": {"a": 1},  # exact case-insensitive JSON tag
     # Array-coercion FIX (see comment above the table): were all {"a": 1}, now None.
     "bare_array_of_objects": None,
     "fenced_array_of_objects": None,

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -154,6 +154,40 @@ CORPUS: list[tuple[str, str]] = [
         "two_bare_json_objects_no_fence",
         'Option A: {"aggression": 0.9, "defense": 0.1}\nOption B: {"aggression": 0.5, "defense": 0.5}',
     ),
+    (
+        # AC-910 Task 3 review Critical 1: a literal "}" inside a JSON string
+        # value used to fragment this well-formed object into an invalid
+        # prefix, letting the naive scan fall through to the unrelated decoy
+        # object below and silently return it. The string-aware span scan
+        # must keep the whole first object intact and return it, never the
+        # decoy.
+        "critical1_brace_in_string_with_decoy",
+        ('My rating: {"score": 5, "rationale": "matches rubric step 3}"} Ignore stale: {"score": 1, "rationale": "stale"}'),
+    ),
+    (
+        # AC-910 Task 3 review Critical 2: a bare array followed by a
+        # separate bare object, no fence. The array is a decisive answer
+        # about what the model produced; the naive scan used to reach past
+        # it and adopt the object dangling after it.
+        "array_then_separate_object_no_fence",
+        '[{"a": 1}], {"b": 2}',
+    ),
+    (
+        # Same defect as above, realistic shape: array of objects embedded in
+        # prose rather than at the very start of the text. This is the case
+        # that a plain `scope.lstrip().startswith("[")` check would miss,
+        # since the array isn't the first token in the scope.
+        "array_of_objects_in_prose_no_fence",
+        'Available tools: [{"name": "n1"}] let me know.',
+    ),
+    (
+        # Companion to critical1: a brace inside a string value with NO decoy
+        # after it. This must still parse successfully -- confirms the
+        # string-aware fix isn't just failing safe on brace-in-string inputs,
+        # it's recovering the correct object.
+        "brace_in_string_value_no_fence_no_decoy",
+        '{"note": "step 3} done", "a": 1}',
+    ),
 ]
 
 CORPUS_IDS = [name for name, _ in CORPUS]
@@ -260,6 +294,12 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     "two_bare_json_objects_no_fence": (
         'Option A: {"aggression": 0.9, "defense": 0.1}\nOption B: {"aggression": 0.5, "defense": 0.5}'
     ),
+    "critical1_brace_in_string_with_decoy": (
+        'My rating: {"score": 5, "rationale": "matches rubric step 3}"} Ignore stale: {"score": 1, "rationale": "stale"}'
+    ),
+    "array_then_separate_object_no_fence": '[{"a": 1}], {"b": 2}',
+    "array_of_objects_in_prose_no_fence": 'Available tools: [{"name": "n1"}] let me know.',
+    "brace_in_string_value_no_fence_no_decoy": '{"note": "step 3} done", "a": 1}',
 }
 
 
@@ -286,7 +326,13 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     "empty_string": _Raises(json.JSONDecodeError),
     "invalid_json_in_fence": _Raises(json.JSONDecodeError),
     "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},
-    "trailing_stray_brace_no_fence": _Raises(json.JSONDecodeError),
+    # CHANGED by the AC-910 Task 3 review fix (Critical 1, string-aware
+    # spans): the naive brace counter used to see the "}" inside the
+    # "value } here" string as closing the object, leaving an invalid
+    # `{"text": "value }` fragment and a dangling `{2}` decoy, neither of
+    # which parses -> raise. The string-aware scan now sees the real,
+    # well-formed `{"text": "value } here"}` object and recovers it.
+    "trailing_stray_brace_no_fence": {"text": "value } here"},
     "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
     "whitespace_only": _Raises(json.JSONDecodeError),
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
@@ -312,6 +358,21 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # raised JSONDecodeError (the single first-"{"-to-last-"}" span crossed
     # both objects and the "Option B:" prose between them).
     "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
+    # AC-910 Task 3 review Critical 1 fix: the brace inside the "rationale"
+    # string no longer fragments the first object, so it recovers correctly
+    # instead of falling through to the unrelated "stale" decoy object.
+    "critical1_brace_in_string_with_decoy": {"score": 5, "rationale": "matches rubric step 3}"},
+    # AC-910 Task 3 review Critical 2 fix: a top-level array candidate is
+    # terminal even when it isn't the whole scope, so this no longer
+    # unwraps {"a": 1} out of the array and ignores the trailing {"b": 2}.
+    "array_then_separate_object_no_fence": _Raises(ValueError),
+    # Same Critical 2 fix, array embedded in prose rather than leading.
+    "array_of_objects_in_prose_no_fence": _Raises(ValueError),
+    # String-aware span scan recovers this whole, valid object; there's no
+    # decoy here to fall through to, so this also passed before the fix via
+    # the whole-scope candidate -- pinned as the no-decoy companion to
+    # critical1 above.
+    "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
 }
 
 
@@ -419,6 +480,10 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "fenced_array_of_objects": [],  # same terminal-list rule -> None -> [] with a warning
     "fenced_mixed_array_with_object": [],  # same terminal-list rule -> None -> [] with a warning
     "two_bare_json_objects_no_fence": [],  # extract_json recovers Option A's dict, but it has no "tools" key
+    "critical1_brace_in_string_with_decoy": [],  # extract_json recovers the correct object, but no "tools" key
+    "array_then_separate_object_no_fence": [],  # extract_json now raises (Critical 2 fix) -> None -> []
+    "array_of_objects_in_prose_no_fence": [],  # same Critical 2 fix -> None -> []
+    "brace_in_string_value_no_fence_no_decoy": [],  # valid dict recovered, but no "tools" key
 }
 
 
@@ -489,6 +554,16 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "fenced_array_of_objects": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
     "fenced_mixed_array_with_object": _CURATOR_DEFAULT,  # same: parses to a list, not a dict
     "two_bare_json_objects_no_fence": _CURATOR_DEFAULT,  # recovers Option A's dict, but no matching rating keys
+    # extract_json recovers {"score": 5, "rationale": "matches rubric step 3}"}.
+    # "score" isn't a rating field and is ignored, but "rationale" IS a
+    # rating field, so it flows through where the other rows' recovered
+    # dicts have no field overlap at all.
+    "critical1_brace_in_string_with_decoy": _CuratorRatingShape(
+        actionability=3, specificity=3, correctness=3, rationale="matches rubric step 3}"
+    ),
+    "array_then_separate_object_no_fence": _CURATOR_DEFAULT,  # extract_json raises -> None -> default
+    "array_of_objects_in_prose_no_fence": _CURATOR_DEFAULT,  # same
+    "brace_in_string_value_no_fence_no_decoy": _CURATOR_DEFAULT,  # parses fine, no matching keys
 }
 
 
@@ -532,7 +607,9 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "empty_string": None,
     "invalid_json_in_fence": None,
     "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},
-    "trailing_stray_brace_no_fence": None,
+    # CHANGED by the AC-910 Task 3 review fix (Critical 1, string-aware
+    # spans): see the matching comment on EXTRACT_JSON_EXPECTED above.
+    "trailing_stray_brace_no_fence": {"text": "value } here"},
     "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
     "whitespace_only": None,
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
@@ -550,6 +627,12 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     # Option A, matching the old three-layer fallback chain this extractor
     # used to have. Net unchanged from the pre-migration baseline.
     "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
+    # Critical 1 fix: recovers the correct first object, not the decoy.
+    "critical1_brace_in_string_with_decoy": {"score": 5, "rationale": "matches rubric step 3}"},
+    # Critical 2 fix: extract_json now raises on the array candidate -> None.
+    "array_then_separate_object_no_fence": None,
+    "array_of_objects_in_prose_no_fence": None,
+    "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
 }
 
 
@@ -605,7 +688,9 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "empty_string": None,
     "invalid_json_in_fence": None,
     "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},
-    "trailing_stray_brace_no_fence": None,
+    # CHANGED by the AC-910 Task 3 review fix (Critical 1, string-aware
+    # spans): see the matching comment on EXTRACT_JSON_EXPECTED above.
+    "trailing_stray_brace_no_fence": {"text": "value } here"},
     "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
     "whitespace_only": None,
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
@@ -624,6 +709,12 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     # recovered Option A too before the extract_json migration; the parser
     # fix restores that.
     "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
+    # Critical 1 fix: recovers the correct first object, not the decoy.
+    "critical1_brace_in_string_with_decoy": {"score": 5, "rationale": "matches rubric step 3}"},
+    # Critical 2 fix: extract_json now raises on the array candidate -> None.
+    "array_then_separate_object_no_fence": None,
+    "array_of_objects_in_prose_no_fence": None,
+    "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
 }
 
 

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -184,6 +184,12 @@ CORPUS: list[tuple[str, str]] = [
         # separate bare object, no fence. The array is a decisive answer
         # about what the model produced; the naive scan used to reach past
         # it and adopt the object dangling after it.
+        #
+        # NOTE what this row does and does not reach today: the scope opens
+        # with "[", so the array-shaped-scope check skips the rescue
+        # candidates and json.loads rejects the whole scope with "Extra data".
+        # It is terminal via THAT rule, not via the wrong-type rule -- see
+        # EXTRACT_JSON_EXPECTED's comment on this row.
         "array_then_separate_object_no_fence",
         '[{"a": 1}], {"b": 2}',
     ),
@@ -194,6 +200,24 @@ CORPUS: list[tuple[str, str]] = [
         # since the array isn't the first token in the scope.
         "array_of_objects_in_prose_no_fence",
         'Available tools: [{"name": "n1"}] let me know.',
+    ),
+    (
+        # The wrong-type rule's TERMINALITY, which nothing else here pinned.
+        # `array_of_objects_in_prose_no_fence` above reaches the wrong-type
+        # rule, but its array is the LAST candidate, so stopping there and
+        # continuing past it are indistinguishable -- and every other row
+        # that reaches the rule has the same shape. Changing the `break` at
+        # output_parser.py:188 to `continue` left the entire suite green.
+        #
+        # Here the array span is followed by a LATER, well-formed object
+        # span, so the two differ: `break` raises (the array settles what the
+        # model produced), `continue` reaches past it and returns {"b": 2} --
+        # the same silently-plausible wrong answer as AC-921, one nesting
+        # level inward. See test_extract_json_wrong_type_candidate_is_terminal
+        # for the two other discriminating shapes (an array reached after an
+        # earlier malformed span, and a non-array wrong type).
+        "array_span_then_later_object_no_fence",
+        'Tools: [{"a": 1}] and {"b": 2}',
     ),
     (
         # Companion to critical1: a brace inside a string value with NO decoy
@@ -248,8 +272,10 @@ CORPUS: list[tuple[str, str]] = [
         # input, so a corpus case with no matching keys can't observe this
         # site's behavior change -- this one can. Before the migration,
         # hint_feedback's own fence regex required a literal newline after
-        # the fence tag and silently missed this (falling to all-empty
-        # defaults); extract_json's optional-newline regex recovers it.
+        # the fence tag and, matching nothing, gave up entirely -- falling to
+        # all-empty defaults. What recovers it now is not extract_json's
+        # optional newline but the fact that extract_json has a fallback at
+        # all; see HINT_FEEDBACK_EXPECTED's comment below.
         "hint_feedback_shape_single_line_fence",
         '```json{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}```',
     ),
@@ -291,7 +317,20 @@ CORPUS_IDS = [name for name, _ in CORPUS]
 
 
 class _Raises:
-    """Sentinel marking that an extractor is pinned to raise on this case."""
+    """Sentinel marking that an extractor is pinned to raise on this case.
+
+    The pinned type is matched EXACTLY (``type(exc) is exc_type``), not by
+    ``isinstance``. ``json.JSONDecodeError`` subclasses ``ValueError``, so an
+    ``isinstance`` check cannot tell "nothing parsed at all" from "parsed
+    fine, but to the wrong type" -- and those are two different outcomes of
+    two different rules in extract_json, reached through different branches.
+    A row that silently swapped one for the other would still pass a loose
+    check. That is not hypothetical: ``array_then_separate_object_no_fence``
+    below was pinned to ``ValueError`` and documented as covering the
+    wrong-type rule, while it actually raises ``JSONDecodeError`` and never
+    reaches that rule at all. The subclass relationship is the only reason
+    the mislabel survived.
+    """
 
     def __init__(self, exc_type: type[BaseException]) -> None:
         self.exc_type = exc_type
@@ -409,6 +448,7 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     ),
     "array_then_separate_object_no_fence": '[{"a": 1}], {"b": 2}',
     "array_of_objects_in_prose_no_fence": 'Available tools: [{"name": "n1"}] let me know.',
+    "array_span_then_later_object_no_fence": 'Tools: [{"a": 1}] and {"b": 2}',
     "brace_in_string_value_no_fence_no_decoy": '{"note": "step 3} done", "a": 1}',
     "truncated_array_one_object": '[{"a": 1}',
     "truncated_array_two_objects": '[{"a": 1}, {"b": 2}',
@@ -440,9 +480,12 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     "fence_single_line": {"a": 1},
     "two_fenced_blocks": {"a": 1},
     "truncated_block": _Raises(json.JSONDecodeError),
-    # CHANGED by the Step 2 strengthening: no fence is present (the fence is
-    # unterminated), so extract_json now brace-scans the bare text -- same
-    # fallback action_filter already uses -- and recovers the object.
+    # CHANGED by the Step 2 strengthening: this row has no fence at all, just
+    # an object in prose, so extract_json now span-scans the bare text -- same
+    # fallback action_filter already uses -- and recovers the object. (The
+    # "no fence because the fence is unterminated" case is `truncated_block`
+    # directly above; it reaches the same no-fence branch by a different
+    # route and still fails, since there's nothing complete to recover.)
     "bare_json_with_prose": {"a": 1},
     "json_array_not_object": _Raises(ValueError),
     "empty_string": _Raises(json.JSONDecodeError),
@@ -484,12 +527,29 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # string no longer fragments the first object, so it recovers correctly
     # instead of falling through to the unrelated "stale" decoy object.
     "critical1_brace_in_string_with_decoy": {"score": 5, "rationale": "matches rubric step 3}"},
-    # AC-910 Task 3 review Critical 2 fix: a top-level array candidate is
-    # terminal even when it isn't the whole scope, so this no longer
-    # unwraps {"a": 1} out of the array and ignores the trailing {"b": 2}.
-    "array_then_separate_object_no_fence": _Raises(ValueError),
-    # Same Critical 2 fix, array embedded in prose rather than leading.
+    # AC-910 Task 3 review Critical 2 fix: the scope OPENS with "[", so the
+    # `scope.startswith("[")` check skips the rescue candidates entirely and
+    # the only candidate left is the whole scope -- which json.loads rejects
+    # with "Extra data" at the trailing `, {"b": 2}`. So this is terminal via
+    # the array-SHAPED-SCOPE rule and a JSONDecodeError, NOT via the
+    # wrong-type rule; the wrong-type `break` at output_parser.py:188 is never
+    # reached on this input. It was pinned to `_Raises(ValueError)` and
+    # commented as covering "a top-level array candidate is terminal even
+    # when it isn't the whole scope" -- neither claim is true of this row, and
+    # it only passed because JSONDecodeError subclasses ValueError. The row
+    # that actually covers a terminal array candidate mid-scope is
+    # `array_of_objects_in_prose_no_fence` just below (array not at index 0,
+    # so the rescue candidates DO run and the array parses to a list), and
+    # `array_span_then_later_object_no_fence` after it (which additionally
+    # pins that the scan STOPS there).
+    "array_then_separate_object_no_fence": _Raises(json.JSONDecodeError),
+    # Same Critical 2 fix, array embedded in prose rather than leading: the
+    # scope does not open with "[", so the span scan runs, offers the array as
+    # a rescue candidate, and it parses to a list -> wrong-type ValueError.
     "array_of_objects_in_prose_no_fence": _Raises(ValueError),
+    # Wrong-type TERMINALITY (the `break`, not merely the raise): an array
+    # span with a well-formed object span AFTER it. See CORPUS.
+    "array_span_then_later_object_no_fence": _Raises(ValueError),
     # String-aware span scan recovers this whole, valid object; there's no
     # decoy here to fall through to, so this also passed before the fix via
     # the whole-scope candidate -- pinned as the no-decoy companion to
@@ -504,9 +564,11 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # Step 1c(iv) accepted residual: no fence, so each malformed candidate is
     # skipped in favor of the next one that parses. See the CORPUS comment.
     "unfenced_earlier_malformed_then_valid": {"x": 2},
-    # hint_feedback.py migration: a single-line fence recovers fine here too
-    # (extract_json's own regex already had the optional-newline form) --
-    # this row's significance is only visible at the hint_feedback site.
+    # hint_feedback.py migration: a single-line fence recovers fine here --
+    # via the fence regex's optional newline, and, were that newline
+    # required, via the unfenced span scan instead (verified by requiring it
+    # and re-running). This row's significance is only visible at the
+    # hint_feedback site.
     "hint_feedback_shape_single_line_fence": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
     # BOM fix: the scope is BOM-normalized before the array-shape check, so
     # these two now behave exactly like their BOM-less twins
@@ -523,8 +585,10 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
 def test_extract_json(name: str, text: str) -> None:
     expected = EXTRACT_JSON_EXPECTED[name]
     if isinstance(expected, _Raises):
-        with pytest.raises(expected.exc_type):
+        with pytest.raises(expected.exc_type) as excinfo:
             extract_json(text)
+        # Exact type, not isinstance -- see _Raises' docstring.
+        assert type(excinfo.value) is expected.exc_type
     else:
         assert extract_json(text) == expected
 
@@ -657,6 +721,73 @@ def test_extract_json_unfenced_earlier_malformed_candidate_is_skipped() -> None:
     assert extract_json('first: {bad json,} then: {"x": 2}') == {"x": 2}
 
 
+def test_extract_json_wrong_type_candidate_is_terminal() -> None:
+    """A candidate that PARSES to a non-Mapping stops the whole scan.
+
+    This pins the `break` (not `continue`) at output_parser.py:188 -- the
+    plan's strongest structural claim about extract_json, and until now
+    entirely untested. Every corpus row that reaches that line has the
+    wrong-type candidate as the LAST candidate, where breaking and continuing
+    are indistinguishable; the `scope.startswith("[")` check is what makes
+    those rows terminal, not the break. Flipping `break` to `continue` left
+    the whole targeted suite green (292/292). These three inputs are the ones
+    that tell the two apart -- each has a well-formed OBJECT candidate sitting
+    after the wrong-type one, so `continue` returns it instead of raising:
+
+        'Tools: [{"a": 1}] and {"b": 2}'                    -> would return {"b": 2}
+        'garbage: {not valid json,} [{"mid": 1}] {"c": 3}'  -> would return {"c": 3}
+        '"empty {} here"'                                   -> would return {}
+
+    Returning any of those would be the AC-921 failure shape one nesting
+    level inward: a plausible object lifted from somewhere the model never
+    designated, substituted for an answer the parser already had. The array
+    (or, in the third case, the string) IS the model's answer about what it
+    produced; the fact that an object-shaped fragment sits nearby is not a
+    reason to keep looking.
+
+    The three shapes are deliberately different, since they enter the
+    wrong-type branch by different routes: an array reached as the first
+    rescue candidate; an array reached only AFTER an earlier malformed span
+    was skipped (proving the break isn't an artifact of being the first
+    rescue tried); and a non-array wrong type (a bare JSON string as the
+    whole scope, terminal from the scope candidate itself, with the object
+    fragment found by the span scan behind it).
+    """
+    # 1. Array span, then a later object span. Terminal at the array.
+    with pytest.raises(ValueError) as excinfo:
+        extract_json('Tools: [{"a": 1}] and {"b": 2}')
+    assert type(excinfo.value) is ValueError  # not JSONDecodeError; see _Raises
+    assert "got list" in str(excinfo.value)
+
+    # 2. Same, but the array is only reached after an earlier candidate fails
+    #    to parse -- so the scan is demonstrably still running when it hits
+    #    the wrong type, and still stops there.
+    with pytest.raises(ValueError) as excinfo:
+        extract_json('garbage: {not valid json,} [{"mid": 1}] {"c": 3}')
+    assert type(excinfo.value) is ValueError
+    assert "got list" in str(excinfo.value)
+
+    # 3. Non-array wrong type: the scope is a bare JSON string, which parses
+    #    (to `str`) as the FIRST candidate. The span scan still found a `{}`
+    #    inside it, so a `continue` would return that empty dict.
+    with pytest.raises(ValueError) as excinfo:
+        extract_json('"empty {} here"')
+    assert type(excinfo.value) is ValueError
+    assert "got str" in str(excinfo.value)
+
+    # on_failure="none" must fail closed on all three too, not fall through to
+    # the trailing object -- this is the shape the migrated call sites use.
+    assert extract_json('Tools: [{"a": 1}] and {"b": 2}', on_failure="none") is None
+    assert extract_json('garbage: {not valid json,} [{"mid": 1}] {"c": 3}', on_failure="none") is None
+    assert extract_json('"empty {} here"', on_failure="none") is None
+
+    # Control: an earlier candidate that FAILS to parse is still a reason to
+    # keep scanning (the Step 1c(iv) residual). Only a successful parse to a
+    # wrong type is terminal, so the break must not be over-read as "stop on
+    # any bad candidate".
+    assert extract_json('first: {bad json,} then: {"x": 2}') == {"x": 2}
+
+
 def test_extract_json_bom_does_not_walk_past_the_array_shape_check() -> None:
     """A leading U+FEFF must not defeat the truncated-array rule.
 
@@ -732,6 +863,7 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "critical1_brace_in_string_with_decoy": [],  # extract_json recovers the correct object, but no "tools" key
     "array_then_separate_object_no_fence": [],  # extract_json now raises (Critical 2 fix) -> None -> []
     "array_of_objects_in_prose_no_fence": [],  # same Critical 2 fix -> None -> []
+    "array_span_then_later_object_no_fence": [],  # wrong-type rule is terminal -> raises -> None -> []
     "brace_in_string_value_no_fence_no_decoy": [],  # valid dict recovered, but no "tools" key
     "truncated_array_one_object": [],  # extract_json now raises (Step 1c(i) fix) -> None -> []
     "truncated_array_two_objects": [],  # same
@@ -792,8 +924,13 @@ def test_parse_architect_tool_specs_ac_920_two_tools_blocks_uses_first_block() -
 def test_translator_translate(name: str, text: str) -> None:
     expected = EXTRACT_JSON_EXPECTED[name]
     if isinstance(expected, _Raises):
-        with pytest.raises(expected.exc_type):
+        with pytest.raises(expected.exc_type) as excinfo:
             _translate(text)
+        # Exact type, not isinstance -- see _Raises' docstring. translate()
+        # re-raises the wrong-type case as its own bare ValueError and lets a
+        # JSONDecodeError through untouched, so the exact types match
+        # extract_json's row for row.
+        assert type(excinfo.value) is expected.exc_type
     else:
         assert _translate(text) == expected
 
@@ -857,6 +994,10 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     ),
     "array_then_separate_object_no_fence": _CURATOR_DEFAULT,  # extract_json raises -> None -> default
     "array_of_objects_in_prose_no_fence": _CURATOR_DEFAULT,  # same
+    # extract_json raises (wrong-type rule is terminal) -> None -> default.
+    # The {"b": 2} a `continue` would reach has no rating keys either, so this
+    # row cannot discriminate the break -- only EXTRACT_JSON_EXPECTED's can.
+    "array_span_then_later_object_no_fence": _CURATOR_DEFAULT,
     "brace_in_string_value_no_fence_no_decoy": _CURATOR_DEFAULT,  # parses fine, no matching keys
     "truncated_array_one_object": _CURATOR_DEFAULT,  # extract_json raises -> None -> default
     "truncated_array_two_objects": _CURATOR_DEFAULT,  # same
@@ -930,9 +1071,13 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
     # Critical 1 fix: recovers the correct first object, not the decoy.
     "critical1_brace_in_string_with_decoy": {"score": 5, "rationale": "matches rubric step 3}"},
-    # Critical 2 fix: extract_json now raises on the array candidate -> None.
+    # Critical 2 fix: extract_json now raises -> None. Via the array-shaped-
+    # scope rule for the first (JSONDecodeError on the whole scope), the
+    # wrong-type rule for the second and third; the third additionally pins
+    # that the scan stops rather than adopting the later {"b": 2}.
     "array_then_separate_object_no_fence": None,
     "array_of_objects_in_prose_no_fence": None,
+    "array_span_then_later_object_no_fence": None,
     "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
     # Step 1c(i) fix (see EXTRACT_JSON_EXPECTED comment): truncated array
     # scopes are now terminal on failure, not a cue to unwrap a nested object.
@@ -969,10 +1114,20 @@ HINT_FEEDBACK_EXPECTED["hint_feedback_shape"] = _HintFeedbackShape(helpful=("h1"
 # own fence regex required a literal newline after the fence tag and missed
 # this single-line fence, silently falling through to the all-empty default
 # (identical to `_HINT_FEEDBACK_DEFAULT` above, so pre-migration this row
-# would have been indistinguishable from the base case). extract_json's
-# regex has always accepted the newline as optional, so migrating recovers
-# the payload -- the intended union-of-behaviors direction this whole plan
-# has been strengthening extract_json toward, not a regression.
+# would have been indistinguishable from the base case).
+#
+# What recovers it is NOT, as an earlier version of this comment claimed,
+# extract_json's optional-newline fence regex. Requiring the newline there
+# and re-running leaves this row passing: with no fence matched, the scope
+# becomes the whole text and the unfenced span scan finds the payload
+# anyway. The optional newline is one of two independent routes; the real
+# difference is that extract_json has a fallback at all, where
+# hint_feedback's single regex either matched or gave up. That distinction
+# matters because it says what would actually regress this row -- removing
+# the fallback scan, not tightening the fence pattern.
+#
+# Either way this is the intended union-of-behaviors direction this whole
+# plan has been strengthening extract_json toward, not a regression.
 HINT_FEEDBACK_EXPECTED["hint_feedback_shape_single_line_fence"] = _HintFeedbackShape(
     helpful=("h1",), misleading=("m1",), missing=("mi1",)
 )
@@ -1035,9 +1190,13 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "two_bare_json_objects_no_fence": {"aggression": 0.9, "defense": 0.1},
     # Critical 1 fix: recovers the correct first object, not the decoy.
     "critical1_brace_in_string_with_decoy": {"score": 5, "rationale": "matches rubric step 3}"},
-    # Critical 2 fix: extract_json now raises on the array candidate -> None.
+    # Critical 2 fix: extract_json now raises -> None. Via the array-shaped-
+    # scope rule for the first (JSONDecodeError on the whole scope), the
+    # wrong-type rule for the second and third; the third additionally pins
+    # that the scan stops rather than adopting the later {"b": 2}.
     "array_then_separate_object_no_fence": None,
     "array_of_objects_in_prose_no_fence": None,
+    "array_span_then_later_object_no_fence": None,
     "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
     # Step 1c(i) fix (see EXTRACT_JSON_EXPECTED comment): truncated array
     # scopes are now terminal on failure, not a cue to unwrap a nested object.

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -34,8 +34,11 @@ The seven call sites characterized here:
    own fence regex (this one requires a literal newline after the fence,
    unlike (1)'s optional-newline regex) with a bare-JSON-object regex
    fallback and a whole-text last resort.
-7. ``agents.hint_feedback.parse_hint_feedback`` -- another private fence
-   regex requiring a literal newline, feeding a schema-specific payload.
+7. ``agents.hint_feedback.parse_hint_feedback`` -- feeds a schema-specific
+   payload. Originally its own private fence regex requiring a literal
+   newline; AC-910 Task 5 migrated it onto (2), which recovers a single-line
+   fence this site used to silently miss (see
+   ``hint_feedback_shape_single_line_fence`` below).
 8. ``execution.action_filter.ActionFilterHarness._extract_json_object`` --
    tries a fenced-and-anchored regex, then falls back to naive
    first-``{``-to-last-``}`` scanning.
@@ -51,8 +54,10 @@ rather than indistinguishable from the various failure paths.
 
 from __future__ import annotations
 
+import ast
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -192,6 +197,56 @@ CORPUS: list[tuple[str, str]] = [
         "brace_in_string_value_no_fence_no_decoy",
         '{"note": "step 3} done", "a": 1}',
     ),
+    (
+        # AC-910 Task 5 Step 1c(i): a TRUNCATED array (no closing bracket)
+        # containing exactly one complete object. `bare_array_of_objects`
+        # above ('[{"a": 1}]', complete) is already terminal via the
+        # successful-list-parse rule; this one is the residual the F1/Critical
+        # 2 fixes didn't cover, because json.loads(scope) raises
+        # JSONDecodeError on truncated input instead of returning a list, so
+        # the terminal rule never got a chance to engage and the scan used to
+        # unwrap the inner {"a": 1}. Must now raise, same as the complete case.
+        "truncated_array_one_object",
+        '[{"a": 1}',
+    ),
+    (
+        # Same defect, two complete objects inside the truncated array. Both
+        # are individually well-formed, which is exactly what let the old
+        # no-fence multi-candidate scan find and adopt the first one.
+        "truncated_array_two_objects",
+        '[{"a": 1}, {"b": 2}',
+    ),
+    (
+        # AC-910 Task 5 Step 1c(iv): the accepted residual. No fence is
+        # present, so there is no designated payload -- unlike
+        # ac_921_corrupt_fence_with_decoy_json above, where a fence exists
+        # and a broken fence is evidence the model claimed that block as its
+        # answer, so substituting a decoy found elsewhere would be a silent
+        # wrong-answer (AC-921's failure shape). Here, with no fence, the
+        # first candidate ("first: {bad json,}...") is malformed and the
+        # scan tries the next top-level candidate in appearance order,
+        # recovering {"x": 2}. This is DELIBERATE: try-each-candidate is the
+        # only sensible policy for unfenced prose, and it matches
+        # pre-consolidation behavior (see EXTRACT_JSON_EXPECTED's comment on
+        # two_bare_json_objects_no_fence for the same policy applied to two
+        # well-formed candidates instead of one malformed + one valid).
+        "unfenced_earlier_malformed_then_valid",
+        'first: {bad json,} then: {"x": 2}',
+    ),
+    (
+        # AC-910 Task 5 hint_feedback.py migration: a single-line fence with
+        # a payload matching HintFeedback's own schema (helpful/misleading/
+        # missing), unlike `fence_single_line` above ({"a": 1}, no matching
+        # keys). hint_feedback's own extraction step routes through a domain
+        # type (HintFeedback) that masks parse success on schema-mismatched
+        # input, so a corpus case with no matching keys can't observe this
+        # site's behavior change -- this one can. Before the migration,
+        # hint_feedback's own fence regex required a literal newline after
+        # the fence tag and silently missed this (falling to all-empty
+        # defaults); extract_json's optional-newline regex recovers it.
+        "hint_feedback_shape_single_line_fence",
+        '```json{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}```',
+    ),
 ]
 
 CORPUS_IDS = [name for name, _ in CORPUS]
@@ -317,6 +372,10 @@ STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
     "array_then_separate_object_no_fence": '[{"a": 1}], {"b": 2}',
     "array_of_objects_in_prose_no_fence": 'Available tools: [{"name": "n1"}] let me know.',
     "brace_in_string_value_no_fence_no_decoy": '{"note": "step 3} done", "a": 1}',
+    "truncated_array_one_object": '[{"a": 1}',
+    "truncated_array_two_objects": '[{"a": 1}, {"b": 2}',
+    "unfenced_earlier_malformed_then_valid": 'first: {bad json,} then: {"x": 2}',
+    "hint_feedback_shape_single_line_fence": '{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}',
 }
 
 
@@ -390,6 +449,19 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     # the whole-scope candidate -- pinned as the no-decoy companion to
     # critical1 above.
     "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
+    # AC-910 Task 5 Step 1c(i) fix: the scope opens with "[", so a failed
+    # parse (JSONDecodeError, since the array is unterminated) is now
+    # terminal -- no rescue candidates are tried -- instead of falling
+    # through to _top_level_object_spans and unwrapping the inner {"a": 1}.
+    "truncated_array_one_object": _Raises(json.JSONDecodeError),
+    "truncated_array_two_objects": _Raises(json.JSONDecodeError),
+    # Step 1c(iv) accepted residual: no fence, so each malformed candidate is
+    # skipped in favor of the next one that parses. See the CORPUS comment.
+    "unfenced_earlier_malformed_then_valid": {"x": 2},
+    # hint_feedback.py migration: a single-line fence recovers fine here too
+    # (extract_json's own regex already had the optional-newline form) --
+    # this row's significance is only visible at the hint_feedback site.
+    "hint_feedback_shape_single_line_fence": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
 }
 
 
@@ -453,6 +525,43 @@ def test_extract_json_ac_921_decoy_does_not_return_the_decoy_object() -> None:
         extract_json(decoy_text)
 
 
+def test_extract_json_truncated_array_does_not_unwrap_inner_object() -> None:
+    """AC-910 Task 5 Step 1c(i): a truncated (unterminated) array must fail
+    the same way a complete one does, not silently unwrap its inner object.
+
+    Before this fix: candidate 1 (the whole scope) raised JSONDecodeError
+    because the array never closes, so the loop continued to
+    _top_level_object_spans, which found the complete {"a": 1} sitting
+    inside the unterminated array and returned it. A model hitting its
+    token budget mid-array is a realistic truncation, not an exotic input
+    (see AC-904/AC-905), so this silent unwrap mattered.
+    """
+    with pytest.raises(json.JSONDecodeError):
+        extract_json('[{"a": 1}')
+    with pytest.raises(json.JSONDecodeError):
+        extract_json('[{"a": 1}, {"b": 2}')
+    # Complete array: already terminal via the successful-list-parse rule,
+    # pinned here as the control case this fix must not disturb.
+    with pytest.raises(ValueError):
+        extract_json('[{"a": 1}]')
+
+
+def test_extract_json_unfenced_earlier_malformed_candidate_is_skipped() -> None:
+    """AC-910 Task 5 Step 1c(iv): the accepted residual, pinned deliberately.
+
+    With no fence, there is no designated payload, so trying each top-level
+    candidate in order and returning the first that parses is the only
+    sensible policy -- it is what recovers legitimate prose-plus-noise (see
+    two_bare_json_objects_no_fence in the corpus) and it matches
+    pre-consolidation behavior. This differs from the FENCED case
+    (ac_921_corrupt_fence_with_decoy_json): there, a broken fence is
+    evidence the model designated that block as its answer, so silently
+    substituting a decoy found elsewhere would be a wrong answer, not a
+    recovered one (AC-921). Without a fence, no such designation exists.
+    """
+    assert extract_json('first: {bad json,} then: {"x": 2}') == {"x": 2}
+
+
 # ---------------------------------------------------------------------------
 # Extractor 3: agents.architect.parse_architect_tool_specs
 # ---------------------------------------------------------------------------
@@ -501,6 +610,10 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "array_then_separate_object_no_fence": [],  # extract_json now raises (Critical 2 fix) -> None -> []
     "array_of_objects_in_prose_no_fence": [],  # same Critical 2 fix -> None -> []
     "brace_in_string_value_no_fence_no_decoy": [],  # valid dict recovered, but no "tools" key
+    "truncated_array_one_object": [],  # extract_json now raises (Step 1c(i) fix) -> None -> []
+    "truncated_array_two_objects": [],  # same
+    "unfenced_earlier_malformed_then_valid": [],  # extract_json recovers {"x": 2}, but no "tools" key
+    "hint_feedback_shape_single_line_fence": [],  # recovers the dict, but no "tools" key
 }
 
 
@@ -619,6 +732,10 @@ CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
     "array_then_separate_object_no_fence": _CURATOR_DEFAULT,  # extract_json raises -> None -> default
     "array_of_objects_in_prose_no_fence": _CURATOR_DEFAULT,  # same
     "brace_in_string_value_no_fence_no_decoy": _CURATOR_DEFAULT,  # parses fine, no matching keys
+    "truncated_array_one_object": _CURATOR_DEFAULT,  # extract_json raises -> None -> default
+    "truncated_array_two_objects": _CURATOR_DEFAULT,  # same
+    "unfenced_earlier_malformed_then_valid": _CURATOR_DEFAULT,  # recovers {"x": 2}, but no matching rating keys
+    "hint_feedback_shape_single_line_fence": _CURATOR_DEFAULT,  # recovers the dict, no matching rating keys
 }
 
 
@@ -688,6 +805,13 @@ EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "array_then_separate_object_no_fence": None,
     "array_of_objects_in_prose_no_fence": None,
     "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
+    # Step 1c(i) fix (see EXTRACT_JSON_EXPECTED comment): truncated array
+    # scopes are now terminal on failure, not a cue to unwrap a nested object.
+    "truncated_array_one_object": None,
+    "truncated_array_two_objects": None,
+    # Step 1c(iv) accepted residual: recovers the later well-formed candidate.
+    "unfenced_earlier_malformed_then_valid": {"x": 2},
+    "hint_feedback_shape_single_line_fence": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
 }
 
 
@@ -707,6 +831,17 @@ _HINT_FEEDBACK_DEFAULT = _HintFeedbackShape(helpful=(), misleading=(), missing=(
 
 HINT_FEEDBACK_EXPECTED: dict[str, _HintFeedbackShape] = {name: _HINT_FEEDBACK_DEFAULT for name, _ in CORPUS}
 HINT_FEEDBACK_EXPECTED["hint_feedback_shape"] = _HintFeedbackShape(helpful=("h1",), misleading=("m1",), missing=("mi1",))
+# AC-910 Task 5: CHANGED by the migration to extract_json. hint_feedback's
+# own fence regex required a literal newline after the fence tag and missed
+# this single-line fence, silently falling through to the all-empty default
+# (identical to `_HINT_FEEDBACK_DEFAULT` above, so pre-migration this row
+# would have been indistinguishable from the base case). extract_json's
+# regex has always accepted the newline as optional, so migrating recovers
+# the payload -- the intended union-of-behaviors direction this whole plan
+# has been strengthening extract_json toward, not a regression.
+HINT_FEEDBACK_EXPECTED["hint_feedback_shape_single_line_fence"] = _HintFeedbackShape(
+    helpful=("h1",), misleading=("m1",), missing=("mi1",)
+)
 
 
 @pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
@@ -770,9 +905,101 @@ EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "array_then_separate_object_no_fence": None,
     "array_of_objects_in_prose_no_fence": None,
     "brace_in_string_value_no_fence_no_decoy": {"note": "step 3} done", "a": 1},
+    # Step 1c(i) fix (see EXTRACT_JSON_EXPECTED comment): truncated array
+    # scopes are now terminal on failure, not a cue to unwrap a nested object.
+    "truncated_array_one_object": None,
+    "truncated_array_two_objects": None,
+    # Step 1c(iv) accepted residual: recovers the later well-formed candidate.
+    "unfenced_earlier_malformed_then_valid": {"x": 2},
+    "hint_feedback_shape_single_line_fence": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
 }
 
 
 @pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
 def test_action_filter_extract_json_object(name: str, text: str) -> None:
     assert ActionFilterHarness._extract_json_object(text) == EXTRACT_JSON_OBJECT_EXPECTED[name]
+
+
+# ---------------------------------------------------------------------------
+# AC-910 Task 5 Step 2: guard against a new duplicate fence extractor
+# reappearing now that the seven originals are consolidated onto
+# harness.core.output_parser.extract_json.
+# ---------------------------------------------------------------------------
+
+_GUARDED_SRC_DIRS = ("agents", "execution")
+_ALLOWED_FENCE_REGEX_FILE = "output_parser.py"
+
+# AC-924: execution/judge.py has its own `_try_code_block_parse` fence regex,
+# one of FOUR ordered parsing strategies (marker-delimited, raw-JSON-with-
+# "score"-key, code-block, plain-text) whose ordering is observable and
+# entirely uncharacterized. Migrating it onto extract_json blind would be
+# exactly the mistake this plan keeps proving is wrong -- characterize
+# before you change. Tracked in AC-924, not fixed here.
+#
+# This is EXACT-SET equality, not an allow-list: it fails both when a NEW
+# offender appears (someone adds a fence regex) and when this known one
+# disappears (AC-924 lands and judge.py is migrated or the guard reverts to
+# a plain "no offenders" assertion) -- so a stale exemption can't survive
+# unnoticed the way a permissive allow-list would let it.
+_KNOWN_OFFENDERS = frozenset({"execution/judge.py"})
+
+
+def _guarded_python_files() -> list[Path]:
+    src_root = Path(__file__).resolve().parents[1] / "src" / "autocontext"
+    files: list[Path] = []
+    for dirname in _GUARDED_SRC_DIRS:
+        files.extend(sorted((src_root / dirname).rglob("*.py")))
+    return files
+
+
+def _fence_regex_offenders() -> set[str]:
+    """Return the set of guarded-directory-relative paths (e.g.
+    "agents/hint_feedback.py") containing a `re.compile(...)` call whose
+    pattern argument is a string literal containing three backticks.
+    """
+    src_root = Path(__file__).resolve().parents[1] / "src" / "autocontext"
+    offenders: set[str] = set()
+    for path in _guarded_python_files():
+        if path.name == _ALLOWED_FENCE_REGEX_FILE:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "compile"):
+                continue
+            if not (isinstance(func.value, ast.Name) and func.value.id == "re"):
+                continue
+            if not node.args:
+                continue
+            first_arg = node.args[0]
+            if not (isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str)):
+                continue
+            if "```" in first_arg.value:
+                offenders.add(str(path.relative_to(src_root)))
+    return offenders
+
+
+def test_no_new_markdown_fence_regex_outside_output_parser() -> None:
+    """No module under agents/ or execution/ may define its own markdown-fence
+    regex, beyond the single known, tracked exception -- that duplication is
+    exactly what this plan consolidated away. `output_parser.py` (the shared
+    parser's home) is the sole allowed owner; it doesn't live under either
+    guarded directory today, so excluding it by name is defense-in-depth
+    rather than load-bearing, in case it ever moves.
+
+    Exact-set equality against `_KNOWN_OFFENDERS`, not a plain "no offenders"
+    assertion and not a permissive allow-list: a NEW offender fails it (the
+    regression this guard exists to catch), and so does the known one
+    disappearing (so AC-924 landing forces this test's expected set to be
+    updated deliberately, rather than carrying a stale exemption forever).
+
+    Proven to fire in both directions this guard cares about (see
+    task-5-report.md for the pasted output):
+    1. A deliberately reintroduced `_JSON_FENCE_RE = re.compile(r"```...")`
+       added to an agents/ module -> fails, naming that file. Removed -> passes.
+    2. `_KNOWN_OFFENDERS` emptied while judge.py still offends -> fails.
+       Restored -> passes.
+    """
+    assert _fence_regex_offenders() == _KNOWN_OFFENDERS

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -238,7 +238,10 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     "fence_single_line": {"a": 1},
     "two_fenced_blocks": {"a": 1},
     "truncated_block": _Raises(json.JSONDecodeError),
-    "bare_json_with_prose": _Raises(json.JSONDecodeError),
+    # CHANGED by the Step 2 strengthening: no fence is present (the fence is
+    # unterminated), so extract_json now brace-scans the bare text -- same
+    # fallback action_filter already uses -- and recovers the object.
+    "bare_json_with_prose": {"a": 1},
     "json_array_not_object": _Raises(ValueError),
     "empty_string": _Raises(json.JSONDecodeError),
     "invalid_json_in_fence": _Raises(json.JSONDecodeError),
@@ -249,8 +252,15 @@ EXTRACT_JSON_EXPECTED: dict[str, Any] = {
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
     "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+    # NOT changed: the decoy JSON lives outside the fenced span. The brace
+    # scan is confined to the fence's own captured content, so it never
+    # reaches the decoy -- this is the AC-921 guard.
     "ac_921_corrupt_fence_with_decoy_json": _Raises(json.JSONDecodeError),
-    "uppercase_json_fence_tag": _Raises(json.JSONDecodeError),
+    # CHANGED by the Step 2 strengthening: a fence IS present, so the fallback
+    # stays confined to its captured content ('JSON\n{"a": 1}'), which itself
+    # contains a recoverable {...} span once the leaked tag is scanned past.
+    # This never reaches outside the fence, so it doesn't reintroduce AC-921.
+    "uppercase_json_fence_tag": {"a": 1},
 }
 
 
@@ -262,6 +272,56 @@ def test_extract_json(name: str, text: str) -> None:
             extract_json(text)
     else:
         assert extract_json(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# extract_json's strengthened fallback and on_failure policy (AC-910 task 2).
+# ---------------------------------------------------------------------------
+
+
+def test_extract_json_same_line_fence_parses() -> None:
+    assert extract_json('```json{"a": 1}```') == {"a": 1}
+
+
+def test_extract_json_prose_wrapped_bare_json_parses_via_brace_scan() -> None:
+    assert extract_json('Here is the result: {"a": 1} -- hope that helps!') == {"a": 1}
+
+
+def test_extract_json_broken_fence_tag_recovers_via_brace_scan_within_fence() -> None:
+    # The fenced content itself ('JSON\n{"a": 1}') doesn't parse directly
+    # because of the leaked uppercase tag, but brace-scanning WITHIN that
+    # captured span (not the wider text) recovers the object.
+    assert extract_json('```JSON\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_extract_json_json_array_raises_instead_of_being_coerced() -> None:
+    with pytest.raises(ValueError):
+        extract_json("```json\n[1, 2, 3]\n```")
+
+
+def test_extract_json_on_failure_none_returns_none_instead_of_raising() -> None:
+    assert extract_json("```json\n[1, 2, 3]\n```", on_failure="none") is None
+    assert extract_json('```json\n{a: 1, "b":}\n```', on_failure="none") is None
+    assert extract_json("", on_failure="none") is None
+
+
+def test_extract_json_default_on_failure_still_raises() -> None:
+    with pytest.raises(json.JSONDecodeError):
+        extract_json('```json\n{a: 1, "b":}\n```')
+
+
+def test_extract_json_ac_921_decoy_does_not_return_the_decoy_object() -> None:
+    """A broken fence must FAIL, never silently substitute unrelated prose JSON.
+
+    This is the specific input that made extract_strategy_deterministic return
+    the wrong-but-plausible {"x": 2} (AC-921, characterized in the CORPUS row
+    ac_921_corrupt_fence_with_decoy_json above). The strengthened extract_json
+    must not reproduce that: it should fail, not return the decoy.
+    """
+    decoy_text = '```json\n{a: 1, "b":}\n```  also see config: {"x": 2}'
+    assert extract_json(decoy_text, on_failure="none") is None
+    with pytest.raises(json.JSONDecodeError):
+        extract_json(decoy_text)
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -20,9 +20,13 @@ The seven call sites characterized here:
 3. ``agents.architect.parse_architect_tool_specs`` -- manual
    ``find("```json")`` / ``rfind("```")``, no regex, schema-specific
    (``{"tools": [...]}"``).
-4. ``agents.translator.StrategyTranslator._strip_fences`` -- delegates
-   verbatim to (1); pinned here to prove the delegation holds across the
-   whole corpus, not just eyeballed from the source.
+4. ``agents.translator.StrategyTranslator.translate`` -- the fail-hard site:
+   strips fences then ``json.loads``, raising a specific ``ValueError`` when
+   the result isn't an object. AC-910 Task 4 migrated this one onto
+   ``extract_json(text)`` (default ``on_failure="raise"``) rather than
+   ``on_failure="none"``, since this is the strategy actually scored by the
+   generation loop -- a parse failure here must raise, never silently
+   become an empty dict.
 5. ``agents.curator.KnowledgeCurator.rate_analyst_output`` -- calls (1) then
    does its own ``json.loads``, swallowing ``JSONDecodeError`` and silently
    discarding non-dict results, both without raising.
@@ -245,6 +249,19 @@ def _curator_rate(text: str) -> _CuratorRatingShape:
         correctness=rating.correctness,
         rationale=rating.rationale,
     )
+
+
+def _translate(text: str) -> dict[str, Any]:
+    """Run StrategyTranslator.translate's real parsing path on `text`.
+
+    `raw_output` is unrelated prose with no embedded JSON, so
+    extract_strategy_deterministic always returns None on it and the LLM
+    branch under test -- the one that parses `text` (the stubbed model
+    response) via extract_json -- always runs.
+    """
+    translator = StrategyTranslator(runtime=_StubRuntime(text), model="stub")
+    strategy, _execution = translator.translate(raw_output="no deterministic strategy here", strategy_interface="{}")
+    return strategy
 
 
 @dataclass(frozen=True, slots=True)
@@ -511,14 +528,52 @@ def test_parse_architect_tool_specs_ac_920_two_tools_blocks_uses_first_block() -
 
 
 # ---------------------------------------------------------------------------
-# Extractor 4: agents.translator.StrategyTranslator._strip_fences
-# Pinned identical to strip_json_fences on every case: it's a direct delegate.
+# Extractor 4: agents.translator.StrategyTranslator.translate (fail-hard site)
+#
+# AC-910 Task 4: translate() now calls extract_json(execution.content)
+# directly -- its own _strip_fences + json.loads is gone -- instead of
+# fence-stripping then parsing by hand. Every case matches
+# EXTRACT_JSON_EXPECTED exactly, since the stubbed "model response" IS
+# execution.content and nothing else touches it first (raw_output is a
+# fixed non-JSON string across every case, so the deterministic fast path
+# never intercepts; see _translate). The one behavioral seam: a successful
+# parse to a non-Mapping (json_array_not_object, bare_array_of_objects,
+# etc.) still raises ValueError, but translate() re-raises it with its own
+# more specific "translator did not return a JSON object" message instead
+# of extract_json's generic "Expected JSON object, got list" -- pinned
+# separately below, since _Raises only checks the exception type, not the
+# message. A genuine parse failure (bad syntax, e.g. truncated_block) is
+# NOT rewritten: it's re-raised as the same JSONDecodeError extract_json
+# raised, exactly as the pre-migration `json.loads` call would have let it
+# propagate uncaught.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
-def test_translator_strip_fences_matches_output_parser(name: str, text: str) -> None:
-    assert StrategyTranslator._strip_fences(text) == STRIP_JSON_FENCES_EXPECTED[name]
+def test_translator_translate(name: str, text: str) -> None:
+    expected = EXTRACT_JSON_EXPECTED[name]
+    if isinstance(expected, _Raises):
+        with pytest.raises(expected.exc_type):
+            _translate(text)
+    else:
+        assert _translate(text) == expected
+
+
+def test_translator_translate_wrong_type_uses_translator_specific_message() -> None:
+    """A parse that succeeds but isn't an object gets translate()'s own,
+    more specific message, not extract_json's generic one -- more useful to
+    whoever reads the log.
+    """
+    with pytest.raises(ValueError, match="translator did not return a JSON object"):
+        _translate("```json\n[1, 2, 3]\n```")
+
+
+def test_translator_translate_parse_failure_stays_a_plain_json_decode_error() -> None:
+    """A candidate that never parses at all (bad syntax) is not rewritten
+    with the translator-specific message -- only the wrong-type case is.
+    """
+    with pytest.raises(json.JSONDecodeError):
+        _translate('```json\n{a: 1, "b":}\n```')
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -1,8 +1,10 @@
 """Characterization tests for the seven ways autocontext pulls JSON out of LLM text.
 
-AC-910 plan 3 consolidates these onto a single parser. Before that happens, this
-file pins what EACH extractor does TODAY against a shared corpus of realistic LLM
-outputs, so the consolidation can be proven not to change observable behavior.
+AC-910 plan 3 consolidated these onto a single parser. This file pinned what
+EACH extractor did BEFORE that, against a shared corpus of realistic LLM
+outputs, so the consolidation could be proven not to change observable
+behavior; the tables now record the post-consolidation results, with the rows
+that moved annotated in place with why.
 
 This is a characterization test suite: every assertion records the *current*
 result, including ``None``, ``[]``, ``{}``, defaults, and raised exceptions. It
@@ -11,35 +13,43 @@ same input, that disagreement is the point -- see the report at
 ``.superpowers/sdd/2026-08-08-ac-910-plan3-model-json-consolidation/task-1-report.md``
 for the full disagreement table.
 
-The seven call sites characterized here:
+The call sites characterized here. There were eight when this file was written;
+``strip_json_fences`` was the ninth and is gone -- it was a generic fence
+stripper that ended the consolidation with zero production callers, so AC-910
+deleted it rather than leave behind the same uncalled-public-extractor shape
+the plan set out to remove:
 
-1. ``harness.core.output_parser.strip_json_fences`` -- generic fence stripper,
-   the widest-used regex in the codebase.
-2. ``harness.core.output_parser.extract_json`` -- fence-strip + ``json.loads``,
-   currently DEAD CODE (zero callers), and the consolidation target.
-3. ``agents.architect.parse_architect_tool_specs`` -- manual
+1. ``harness.core.output_parser.extract_json`` -- the consolidation target.
+   It had zero callers when this file was written; every site below that
+   still parses JSON now routes through it.
+2. ``agents.architect.parse_architect_tool_specs`` -- manual
    ``find("```json")`` / ``rfind("```")``, no regex, schema-specific
    (``{"tools": [...]}"``).
-4. ``agents.translator.StrategyTranslator.translate`` -- the fail-hard site:
+3. ``agents.translator.StrategyTranslator.translate`` -- the fail-hard site:
    strips fences then ``json.loads``, raising a specific ``ValueError`` when
    the result isn't an object. AC-910 Task 4 migrated this one onto
    ``extract_json(text)`` (default ``on_failure="raise"``) rather than
    ``on_failure="none"``, since this is the strategy actually scored by the
    generation loop -- a parse failure here must raise, never silently
    become an empty dict.
-5. ``agents.curator.KnowledgeCurator.rate_analyst_output`` -- calls (1) then
-   does its own ``json.loads``, swallowing ``JSONDecodeError`` and silently
-   discarding non-dict results, both without raising.
-6. ``agents.translator_simplification.extract_strategy_deterministic`` -- its
-   own fence regex (this one requires a literal newline after the fence,
-   unlike (1)'s optional-newline regex) with a bare-JSON-object regex
-   fallback and a whole-text last resort.
-7. ``agents.hint_feedback.parse_hint_feedback`` -- feeds a schema-specific
+4. ``agents.curator.KnowledgeCurator.rate_analyst_output`` -- the fail-soft
+   counterpart to (3). Originally stripped fences then ran its own
+   ``json.loads``, swallowing ``JSONDecodeError`` and silently discarding
+   non-dict results. AC-910 Task 5 migrated it onto
+   ``extract_json(..., on_failure="none")``, and the branch's final cleanup
+   added the schema guard that makes "degrades to defaults, never raises"
+   true of the WHOLE site rather than only of its parse step -- see
+   ``test_curator_rate_analyst_output_degrades_on_schema_mismatch``.
+5. ``agents.translator_simplification.extract_strategy_deterministic`` -- its
+   own fence regex (this one required a literal newline after the fence,
+   unlike the shared ``_JSON_FENCE_RE``'s optional-newline one) with a
+   bare-JSON-object regex fallback and a whole-text last resort.
+6. ``agents.hint_feedback.parse_hint_feedback`` -- feeds a schema-specific
    payload. Originally its own private fence regex requiring a literal
-   newline; AC-910 Task 5 migrated it onto (2), which recovers a single-line
+   newline; AC-910 Task 5 migrated it onto (1), which recovers a single-line
    fence this site used to silently miss (see
    ``hint_feedback_shape_single_line_fence`` below).
-8. ``execution.action_filter.ActionFilterHarness._extract_json_object`` --
+7. ``execution.action_filter.ActionFilterHarness._extract_json_object`` --
    tries a fenced-and-anchored regex, then falls back to naive
    first-``{``-to-last-``}`` scanning.
 
@@ -56,6 +66,7 @@ from __future__ import annotations
 
 import ast
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -68,7 +79,7 @@ from autocontext.agents.hint_feedback import parse_hint_feedback
 from autocontext.agents.translator import StrategyTranslator
 from autocontext.agents.translator_simplification import extract_strategy_deterministic
 from autocontext.execution.action_filter import ActionFilterHarness
-from autocontext.harness.core.output_parser import extract_json, strip_json_fences
+from autocontext.harness.core.output_parser import extract_json
 from autocontext.harness.core.types import RoleExecution, RoleUsage
 
 # ---------------------------------------------------------------------------
@@ -463,74 +474,7 @@ def _hint_feedback(text: str) -> _HintFeedbackShape:
 
 
 # ---------------------------------------------------------------------------
-# Extractor 1: output_parser.strip_json_fences
-# ---------------------------------------------------------------------------
-
-STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
-    "normal_fenced_block": '{"a": 1}',
-    "fence_no_language": '{"a": 1}',
-    "fence_single_line": '{"a": 1}',
-    "two_fenced_blocks": '{"a": 1}',
-    "truncated_block": '```json\n{"a": 1, "b": 2',
-    "bare_json_with_prose": 'Here is the result: {"a": 1} -- hope that helps!',
-    "json_array_not_object": "[1, 2, 3]",
-    "empty_string": "",
-    "invalid_json_in_fence": '{a: 1, "b":}',
-    "brace_in_string_value": '{"code": "if (x) { return 1; }", "ok": true}',
-    "trailing_stray_brace_no_fence": 'Result: {"text": "value } here"} and also check ref {2} today.',
-    "architect_valid_tools_block": '{"tools": [{"name": "n", "description": "d", "code": "c"}]}',
-    "whitespace_only": "",
-    "fenced_with_leading_prose_and_trailing_prose": '{"a": 1}',
-    "curator_rating_shape": '{"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"}',
-    "hint_feedback_shape": '{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}',
-    "ac_921_corrupt_fence_with_decoy_json": '{a: 1, "b":}',
-    "uppercase_json_fence_tag": 'JSON\n{"a": 1}',
-    "bare_array_of_objects": '[{"a": 1}]',
-    "fenced_array_of_objects": '[{"a": 1}]',
-    "fenced_mixed_array_with_object": '[1, {"a": 1}, 2]',
-    # No fence present -> passthrough unchanged, same as any other no-fence case.
-    "two_bare_json_objects_no_fence": (
-        'Option A: {"aggression": 0.9, "defense": 0.1}\nOption B: {"aggression": 0.5, "defense": 0.5}'
-    ),
-    "critical1_brace_in_string_with_decoy": (
-        'My rating: {"score": 5, "rationale": "matches rubric step 3}"} Ignore stale: {"score": 1, "rationale": "stale"}'
-    ),
-    "array_then_separate_object_no_fence": '[{"a": 1}], {"b": 2}',
-    "array_of_objects_in_prose_no_fence": 'Available tools: [{"name": "n1"}] let me know.',
-    "array_span_then_later_object_no_fence": 'Tools: [{"a": 1}] and {"b": 2}',
-    "brace_in_string_value_no_fence_no_decoy": '{"note": "step 3} done", "a": 1}',
-    "truncated_array_one_object": '[{"a": 1}',
-    "truncated_array_two_objects": '[{"a": 1}, {"b": 2}',
-    "unfenced_earlier_malformed_then_valid": 'first: {bad json,} then: {"x": 2}',
-    "hint_feedback_shape_single_line_fence": '{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}',
-    # strip_json_fences is UNCHANGED by the BOM fix -- it strips fences, and
-    # its `.strip()` cannot remove a U+FEFF any more than extract_json's
-    # could. The BOM is pinned as surviving all three of these on purpose:
-    # the fix lives in extract_json's scope normalization, not here, and if
-    # someone later moves it into strip_json_fences these rows say so.
-    "bom_truncated_array_no_fence": _BOM + '[{"a": 1}',
-    "bom_fenced_truncated_array": _BOM + '[{"a": 1}',
-    "bom_object_no_fence": _BOM + '{"a": 1}',
-    # C1: strip_json_fences is UNCHANGED and still takes the FIRST fence of any
-    # language, so it returns the reasoning/code preamble on all three. Only
-    # extract_json learned to prefer the ```json block. That divergence is
-    # deliberate -- this is a general fence stripper with callers that aren't
-    # extracting JSON, so it has no basis for preferring a json tag -- and
-    # these rows exist to say so out loud, since "why didn't the C1 fix touch
-    # strip_json_fences too" is the obvious next question.
-    "plain_fence_preamble_then_json_fence": "reasoning scratch",
-    "python_fence_preamble_then_json_fence": 'python\nplan = {"draft": 1}',
-    "braceless_fence_preamble_then_bare_json": "scratch",
-}
-
-
-@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
-def test_strip_json_fences(name: str, text: str) -> None:
-    assert strip_json_fences(text) == STRIP_JSON_FENCES_EXPECTED[name]
-
-
-# ---------------------------------------------------------------------------
-# Extractor 2: output_parser.extract_json (dead code today; consolidation target)
+# Extractor 1: output_parser.extract_json (dead code today; consolidation target)
 # ---------------------------------------------------------------------------
 
 EXTRACT_JSON_EXPECTED: dict[str, Any] = {
@@ -956,7 +900,7 @@ def test_extract_json_bom_does_not_walk_past_the_array_shape_check() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Extractor 3: agents.architect.parse_architect_tool_specs
+# Extractor 2: agents.architect.parse_architect_tool_specs
 # ---------------------------------------------------------------------------
 
 # AC-910 Task 3: parse_architect_tool_specs now delegates to the shared
@@ -1045,8 +989,37 @@ def test_parse_architect_tool_specs_ac_920_two_tools_blocks_uses_first_block() -
     assert parse_architect_tool_specs(two_tools_blocks) == [{"name": "n1", "description": "d1", "code": "c1"}]
 
 
+def test_parse_architect_tool_specs_only_warns_when_there_was_a_payload(caplog: pytest.LogCaptureFixture) -> None:
+    """The "possibly truncated" warning stays scoped to inputs that could hold an object.
+
+    Before this site was migrated onto extract_json it looked for a literal
+    "```json" and returned [] SILENTLY when there wasn't one, so an empty
+    string, bare prose, or an array-shaped answer logged nothing. Routing
+    every unparseable input through one warning turned all of those into log
+    volume, and the message they print -- "possibly truncated" -- is wrong
+    about them: nothing was truncated, there was no object to find.
+
+    The rule pinned here is the payload test, not the phrasing: warn when the
+    content holds a "{" (extract_json can only succeed by returning a Mapping,
+    so a "{" is what makes failure informative), stay silent otherwise.
+    """
+    caplog.set_level(logging.WARNING, logger="autocontext.agents.architect")
+
+    for silent in ("", "   ", "No tools this round, the harness already covers it.", "```json\n[1, 2, 3]\n```"):
+        caplog.clear()
+        assert parse_architect_tool_specs(silent) == []
+        assert caplog.records == [], f"expected no warning for {silent!r}"
+
+    # A real truncated proposal is the case the message is FOR, and it still warns.
+    caplog.clear()
+    assert parse_architect_tool_specs('```json\n{"tools": [{"name": "n", "descrip') == []
+    assert [r.message for r in caplog.records] == [
+        "architect output JSON block unparseable (possibly truncated); treating as no proposal"
+    ]
+
+
 # ---------------------------------------------------------------------------
-# Extractor 4: agents.translator.StrategyTranslator.translate (fail-hard site)
+# Extractor 3: agents.translator.StrategyTranslator.translate (fail-hard site)
 #
 # AC-910 Task 4: translate() now calls extract_json(execution.content)
 # directly -- its own _strip_fences + json.loads is gone -- instead of
@@ -1100,11 +1073,22 @@ def test_translator_translate_parse_failure_stays_a_plain_json_decode_error() ->
 
 
 # ---------------------------------------------------------------------------
-# Extractor 5: agents.curator.KnowledgeCurator.rate_analyst_output
-# Never raises: JSONDecodeError is swallowed, non-dict decoded values are
-# silently discarded. Both failure modes fall back to AnalystRating defaults
-# (actionability=specificity=correctness=3, rationale=""), which is why most
-# rows below look identical regardless of whether parsing "succeeded."
+# Extractor 4: agents.curator.KnowledgeCurator.rate_analyst_output
+# Fail-soft: a parse failure and a decoded value that isn't an object BOTH
+# fall back to AnalystRating defaults (actionability=specificity=correctness=3,
+# rationale=""), which is why most rows below look identical regardless of
+# whether parsing "succeeded."
+#
+# "Never raises" is what this comment used to claim, and it was FALSE both
+# before and after the consolidation: a payload that parses as JSON but not as
+# a rating (e.g. {"actionability": "not-a-number"}) reached
+# AnalystRating.from_dict and came back out as a pydantic ValidationError.
+# None of the corpus rows carry a schema-INVALID payload, so nothing in this
+# table ever observed it. The site now guards from_dict and degrades to
+# defaults, which is what makes the claim true for the first time; the input
+# that used to raise is pinned in
+# test_curator_rate_analyst_output_degrades_on_schema_mismatch below rather
+# than added to the corpus, since it only discriminates at this one site.
 # ---------------------------------------------------------------------------
 
 _CURATOR_DEFAULT = _CuratorRatingShape(actionability=3, specificity=3, correctness=3, rationale="")
@@ -1168,8 +1152,40 @@ def test_curator_rate_analyst_output(name: str, text: str) -> None:
     assert _curator_rate(text) == CURATOR_RATE_EXPECTED[name]
 
 
+def test_curator_rate_analyst_output_degrades_on_schema_mismatch() -> None:
+    """A payload that parses as JSON but not as a rating degrades, it does not raise.
+
+    This site is fail-soft by contract: the rating is feedback for the next
+    generation's analyst prompt, not the artifact the loop scores, and its
+    caller (_maybe_rate_analyst_output) runs mid-generation with no handler,
+    so an exception here costs a whole generation to save a cosmetic score.
+
+    Both rows below used to raise pydantic ValidationError out of
+    rate_analyst_output. The FENCED one raised before the consolidation too --
+    strip_json_fences + json.loads decoded it to a dict just fine, and the bad
+    value went straight into AnalystRating.from_dict. What the migration onto
+    extract_json changed is that the UNFENCED one now reaches from_dict as
+    well: json.loads(strip_json_fences(prose)) raised JSONDecodeError and was
+    swallowed into the default rating, whereas extract_json recovers the
+    object out of surrounding prose. So the raise is pre-existing and the set
+    of inputs reaching it got wider -- both are closed here.
+    """
+    unfenced = 'Rating: {"actionability": "not-a-number"} done'
+    fenced = '```json\n{"actionability": "not-a-number"}\n```'
+
+    assert _curator_rate(unfenced) == _CURATOR_DEFAULT
+    assert _curator_rate(fenced) == _CURATOR_DEFAULT
+
+    # Control: a schema-VALID payload in the same unfenced prose shape still
+    # flows through, so the guard above degrades only on real mismatches
+    # rather than swallowing every recovered payload.
+    assert _curator_rate('Rating: {"actionability": 5} done') == _CuratorRatingShape(
+        actionability=5, specificity=3, correctness=3, rationale=""
+    )
+
+
 # ---------------------------------------------------------------------------
-# Extractor 6: agents.translator_simplification.extract_strategy_deterministic
+# Extractor 5: agents.translator_simplification.extract_strategy_deterministic
 # ---------------------------------------------------------------------------
 
 # AC-910 Task 3: extract_strategy_deterministic now delegates to the shared
@@ -1261,7 +1277,7 @@ def test_extract_strategy_deterministic(name: str, text: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Extractor 7: agents.hint_feedback.parse_hint_feedback
+# Extractor 6: agents.hint_feedback.parse_hint_feedback
 # Never raises. Like curator, its schema-specific return type masks parse
 # success for corpus cases that don't use its "helpful"/"misleading"/"missing"
 # keys, which is why almost every row is the same all-empty shape.
@@ -1300,7 +1316,7 @@ def test_parse_hint_feedback(name: str, text: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Extractor 8: execution.action_filter.ActionFilterHarness._extract_json_object
+# Extractor 7: execution.action_filter.ActionFilterHarness._extract_json_object
 # ---------------------------------------------------------------------------
 
 # AC-910 Task 3: _extract_json_object now delegates to the shared

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -359,16 +359,29 @@ def test_extract_json_ac_921_decoy_does_not_return_the_decoy_object() -> None:
 # Extractor 3: agents.architect.parse_architect_tool_specs
 # ---------------------------------------------------------------------------
 
+# AC-910 Task 3: parse_architect_tool_specs now delegates to the shared
+# extract_json(..., on_failure="none") instead of its own find("```json") /
+# rfind("```") span. Every row below still returns the same value as before
+# the migration -- ARCH's [] here is (with one exception, noted per-row)
+# still a schema mismatch (extract_json returns a dict, just not one with a
+# "tools" list), not a parse failure. The one exception is `two_fenced_blocks`,
+# which changes from a JSONDecodeError-driven [] to a schema-mismatch-driven
+# [] -- same return value, different reason, not a value change (see the
+# dedicated AC-920 test below for the case where this DOES change the
+# return value).
 PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "normal_fenced_block": [],
-    "fence_no_language": [],  # requires the literal "```json" tag; plain fence never matches
+    "fence_no_language": [],
     "fence_single_line": [],
-    "two_fenced_blocks": [],  # rfind("```") grabs the SECOND block's closing fence -> corrupt span -> JSONDecodeError -> []
+    "two_fenced_blocks": [],  # extract_json grabs the FIRST block ({"a": 1}); still [] since it has no "tools" key
+    # extract_json can't find a complete JSON object -> None -> [] (now logs
+    # the warning; the old find/rfind short-circuited before ever trying to
+    # parse, so it silently returned [] without logging)
     "truncated_block": [],
     "bare_json_with_prose": [],
     "json_array_not_object": [],
     "empty_string": [],
-    "invalid_json_in_fence": [],
+    "invalid_json_in_fence": [],  # still unparseable within the fenced scope -> None -> [] with a warning, as before
     "brace_in_string_value": [],  # valid JSON, valid dict, but no "tools" key
     "trailing_stray_brace_no_fence": [],
     "architect_valid_tools_block": [{"name": "n", "description": "d", "code": "c"}],
@@ -376,17 +389,39 @@ PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
     "fenced_with_leading_prose_and_trailing_prose": [],
     "curator_rating_shape": [],
     "hint_feedback_shape": [],
-    "ac_921_corrupt_fence_with_decoy_json": [],  # body between the tag and last ``` is invalid JSON -> JSONDecodeError -> []
-    "uppercase_json_fence_tag": [],  # requires the literal "```json" tag; uppercase never matches find("```json")
-    "bare_array_of_objects": [],  # no "```json" tag at all
-    "fenced_array_of_objects": [],  # parses to a list, not a dict with a "tools" key
-    "fenced_mixed_array_with_object": [],  # same: parses to a list, not a dict with a "tools" key
+    # still fails within the fenced scope (decoy sits outside it) -> None ->
+    # [] with a warning, as before
+    "ac_921_corrupt_fence_with_decoy_json": [],
+    "uppercase_json_fence_tag": [],  # recovered via the within-scope brace scan despite the leaked tag; still no "tools" key
+    # scope parses to a list -> terminal ValueError -> None -> [] with a
+    # warning (previously [] via no "```json" tag found at all, no warning)
+    "bare_array_of_objects": [],
+    "fenced_array_of_objects": [],  # same terminal-list rule -> None -> [] with a warning
+    "fenced_mixed_array_with_object": [],  # same terminal-list rule -> None -> [] with a warning
 }
 
 
 @pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
 def test_parse_architect_tool_specs(name: str, text: str) -> None:
     assert parse_architect_tool_specs(text) == PARSE_ARCHITECT_TOOL_SPECS_EXPECTED[name]
+
+
+def test_parse_architect_tool_specs_ac_920_two_tools_blocks_uses_first_block() -> None:
+    """AC-920: an architect response offering an alternative (two fenced
+    ``{"tools": [...]}`` blocks) used to be treated as no proposal at all.
+
+    The old `find("```json")` / `rfind("```")` span took the LAST closing
+    fence, splicing the first block's opening through the second block's
+    opening into one corrupt, unparseable span -> JSONDecodeError -> [].
+    extract_json's regex is non-greedy and takes the FIRST complete fenced
+    block, so migrating onto it fixes this for free: the architect's first
+    proposal is now recovered instead of silently discarded.
+    """
+    two_tools_blocks = (
+        'Here is my primary proposal:\n```json\n{"tools": [{"name": "n1", "description": "d1", "code": "c1"}]}\n```\n'
+        'And an alternative:\n```json\n{"tools": [{"name": "n2", "description": "d2", "code": "c2"}]}\n```'
+    )
+    assert parse_architect_tool_specs(two_tools_blocks) == [{"name": "n1", "description": "d1", "code": "c1"}]
 
 
 # ---------------------------------------------------------------------------
@@ -444,33 +479,50 @@ def test_curator_rate_analyst_output(name: str, text: str) -> None:
 # Extractor 6: agents.translator_simplification.extract_strategy_deterministic
 # ---------------------------------------------------------------------------
 
+# AC-910 Task 3: extract_strategy_deterministic now delegates to the shared
+# extract_json(..., on_failure="none") instead of its own fence regex +
+# bare-object regex + whole-text fallback chain. Two rows changed value as a
+# result, both filed-bug fixes, not regressions:
+#
+# - `ac_921_corrupt_fence_with_decoy_json` ({"x": 2} -> None): this extractor
+#   WAS the AC-921 bug -- its bare-object regex fallback scanned the whole
+#   raw text and picked up the decoy object outside the corrupt fence.
+#   extract_json's brace scan stays confined to the fence's own captured
+#   content, so the decoy is never reached; the corrupt fence now fails
+#   closed (None) instead of returning the wrong-but-plausible object.
+# - `bare_array_of_objects` / `fenced_array_of_objects` /
+#   `fenced_mixed_array_with_object` ({"a": 1} -> None): same array-coercion
+#   defect Task 2 fixed inside extract_json itself (a successful parse to a
+#   list is terminal, not a cue to keep hunting for a nested object) --
+#   this extractor's own bare-object regex had the identical defect, and
+#   migrating removes it here too.
+#
+# Every other row is unchanged: extract_json's fence + no-fence brace-scan
+# fallbacks cover the same ground this extractor's three-layer chain did.
 EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
     "normal_fenced_block": {"a": 1},
     "fence_no_language": {"a": 1},
-    "fence_single_line": {"a": 1},  # fence regex requires a literal \n, but the bare-object regex fallback still finds it
+    "fence_single_line": {"a": 1},
     "two_fenced_blocks": {"a": 1},
     "truncated_block": None,
-    "bare_json_with_prose": {"a": 1},  # bare-object regex fallback
-    "json_array_not_object": None,  # not a dict; fenced+bare-object+whole-text all reject
+    "bare_json_with_prose": {"a": 1},
+    "json_array_not_object": None,  # scope parses to a list -> terminal ValueError -> None
     "empty_string": None,
     "invalid_json_in_fence": None,
     "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},
-    "trailing_stray_brace_no_fence": None,  # naive bare-object regex still fails to reconstruct valid JSON here
+    "trailing_stray_brace_no_fence": None,
     "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
     "whitespace_only": None,
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
     "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
-    "ac_921_corrupt_fence_with_decoy_json": {"x": 2},  # AC-921: decoy bare-object fallback picks up unrelated JSON
-    "uppercase_json_fence_tag": {"a": 1},  # bare-object regex fallback still finds it despite the leaky tag
-    # This extractor's own bare-object regex has the same array-coercion
-    # defect that AC-910 Task 2 fixed in extract_json: it finds the nested
-    # {"a": 1} inside the array and returns it instead of rejecting the
-    # array. Out of scope for this task (no call sites may change here) --
-    # pinned as-is per the characterization-suite mandate.
-    "bare_array_of_objects": {"a": 1},
-    "fenced_array_of_objects": {"a": 1},
-    "fenced_mixed_array_with_object": {"a": 1},
+    # AC-921 FIX (see comment above the table): was {"x": 2}, now None.
+    "ac_921_corrupt_fence_with_decoy_json": None,
+    "uppercase_json_fence_tag": {"a": 1},  # recovered via the within-scope brace scan on the leaked tag, not a bare-object regex
+    # Array-coercion FIX (see comment above the table): were all {"a": 1}, now None.
+    "bare_array_of_objects": None,
+    "fenced_array_of_objects": None,
+    "fenced_mixed_array_with_object": None,
 }
 
 
@@ -501,32 +553,45 @@ def test_parse_hint_feedback(name: str, text: str) -> None:
 # Extractor 8: execution.action_filter.ActionFilterHarness._extract_json_object
 # ---------------------------------------------------------------------------
 
+# AC-910 Task 3: _extract_json_object now delegates to the shared
+# extract_json(..., on_failure="none") instead of its own anchored fenced
+# regex + naive first-"{"-to-last-"}" fallback. Three rows changed value,
+# all the same array-coercion family Task 2 fixed inside extract_json
+# itself (a successful parse to a list is terminal, not a cue to keep
+# hunting for a nested object): `bare_array_of_objects`,
+# `fenced_array_of_objects`, `fenced_mixed_array_with_object`, all
+# {"a": 1} -> None. This extractor's naive find("{")/rfind("}") fallback had
+# the identical defect (no type check at all on what it recovers); migrating
+# removes it here too. `ac_921_corrupt_fence_with_decoy_json` does NOT
+# change (still None both ways) -- this extractor's corrupted-fence
+# candidate already failed to parse before reaching the naive whole-response
+# scan that could have picked up the decoy, so it was accidentally already
+# safe from AC-921, not by design.
 EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
     "normal_fenced_block": {"a": 1},
     "fence_no_language": {"a": 1},
     "fence_single_line": {"a": 1},
     "two_fenced_blocks": {"a": 1},
     "truncated_block": None,
-    "bare_json_with_prose": {"a": 1},  # naive find("{")/rfind("}") fallback happens to work here
-    "json_array_not_object": None,  # no "{" in the text at all; fenced regex requires one too
+    "bare_json_with_prose": {"a": 1},
+    "json_array_not_object": None,  # scope parses to a list -> terminal ValueError -> None
     "empty_string": None,
     "invalid_json_in_fence": None,
-    "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},  # fenced regex backtracks past the inner "}"
-    "trailing_stray_brace_no_fence": None,  # naive rfind("}") picks up the LATER stray "}" from "{2}", corrupting the span
+    "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},
+    "trailing_stray_brace_no_fence": None,
     "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
     "whitespace_only": None,
     "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
     "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
     "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
-    "ac_921_corrupt_fence_with_decoy_json": None,  # fenced candidate invalid; naive first-{-to-last-} scan also invalid
-    "uppercase_json_fence_tag": {"a": 1},  # fenced regex is case-insensitive, unlike strip_json_fences
-    # Same pre-existing array-coercion defect as extract_strategy_deterministic
-    # above: this extractor's naive first-"{"-to-last-"}" fallback has no type
-    # check at all, so it happily returns the nested object from an array.
-    # Out of scope here (no call sites may change); pinned as-is.
-    "bare_array_of_objects": {"a": 1},
-    "fenced_array_of_objects": {"a": 1},
-    "fenced_mixed_array_with_object": {"a": 1},
+    "ac_921_corrupt_fence_with_decoy_json": None,  # unchanged: fails within scope, decoy never reached, as before
+    "uppercase_json_fence_tag": {
+        "a": 1
+    },  # recovered via the within-scope brace scan on the leaked tag now, not case-insensitive tag matching
+    # Array-coercion FIX (see comment above the table): were all {"a": 1}, now None.
+    "bare_array_of_objects": None,
+    "fenced_array_of_objects": None,
+    "fenced_mixed_array_with_object": None,
 }
 
 

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -1,0 +1,395 @@
+"""Characterization tests for the seven ways autocontext pulls JSON out of LLM text.
+
+AC-910 plan 3 consolidates these onto a single parser. Before that happens, this
+file pins what EACH extractor does TODAY against a shared corpus of realistic LLM
+outputs, so the consolidation can be proven not to change observable behavior.
+
+This is a characterization test suite: every assertion records the *current*
+result, including ``None``, ``[]``, ``{}``, defaults, and raised exceptions. It
+does not judge whether a result is correct. Where two extractors disagree on the
+same input, that disagreement is the point -- see the report at
+``.superpowers/sdd/2026-08-08-ac-910-plan3-model-json-consolidation/task-1-report.md``
+for the full disagreement table.
+
+The seven call sites characterized here:
+
+1. ``harness.core.output_parser.strip_json_fences`` -- generic fence stripper,
+   the widest-used regex in the codebase.
+2. ``harness.core.output_parser.extract_json`` -- fence-strip + ``json.loads``,
+   currently DEAD CODE (zero callers), and the consolidation target.
+3. ``agents.architect.parse_architect_tool_specs`` -- manual
+   ``find("```json")`` / ``rfind("```")``, no regex, schema-specific
+   (``{"tools": [...]}"``).
+4. ``agents.translator.StrategyTranslator._strip_fences`` -- delegates
+   verbatim to (1); pinned here to prove the delegation holds across the
+   whole corpus, not just eyeballed from the source.
+5. ``agents.curator.KnowledgeCurator.rate_analyst_output`` -- calls (1) then
+   does its own ``json.loads``, swallowing ``JSONDecodeError`` and silently
+   discarding non-dict results, both without raising.
+6. ``agents.translator_simplification.extract_strategy_deterministic`` -- its
+   own fence regex (this one requires a literal newline after the fence,
+   unlike (1)'s optional-newline regex) with a bare-JSON-object regex
+   fallback and a whole-text last resort.
+7. ``agents.hint_feedback.parse_hint_feedback`` -- another private fence
+   regex requiring a literal newline, feeding a schema-specific payload.
+8. ``execution.action_filter.ActionFilterHarness._extract_json_object`` --
+   tries a fenced-and-anchored regex, then falls back to naive
+   first-``{``-to-last-``}`` scanning.
+
+Curator and hint_feedback's own callables have effect-shaped return types
+(``AnalystRating``, ``HintFeedback``) that route the extracted payload through
+a domain-specific schema, which masks parse success on schema-mismatched
+input (both quietly fall back to their all-defaults / all-empty shape). Two
+corpus cases (``curator_rating_shape``, ``hint_feedback_shape``) use payloads
+that satisfy that schema so the successful-parse path is actually observable,
+rather than indistinguishable from the various failure paths.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from autocontext.agents.architect import parse_architect_tool_specs
+from autocontext.agents.curator import KnowledgeCurator
+from autocontext.agents.hint_feedback import parse_hint_feedback
+from autocontext.agents.translator import StrategyTranslator
+from autocontext.agents.translator_simplification import extract_strategy_deterministic
+from autocontext.execution.action_filter import ActionFilterHarness
+from autocontext.harness.core.output_parser import extract_json, strip_json_fences
+from autocontext.harness.core.types import RoleExecution, RoleUsage
+
+# ---------------------------------------------------------------------------
+# Corpus: (case name, raw LLM text). Reused by every extractor's test below,
+# and by later AC-910 tasks that build the consolidated parser against it.
+# ---------------------------------------------------------------------------
+
+CORPUS: list[tuple[str, str]] = [
+    ("normal_fenced_block", '```json\n{"a": 1}\n```'),
+    ("fence_no_language", '```\n{"a": 1}\n```'),
+    ("fence_single_line", '```json{"a": 1}```'),
+    (
+        "two_fenced_blocks",
+        'first:\n```json\n{"a": 1}\n```\nsecond:\n```json\n{"b": 2}\n```',
+    ),
+    ("truncated_block", '```json\n{"a": 1, "b": 2'),
+    ("bare_json_with_prose", 'Here is the result: {"a": 1} -- hope that helps!'),
+    ("json_array_not_object", "```json\n[1, 2, 3]\n```"),
+    ("empty_string", ""),
+    ("invalid_json_in_fence", '```json\n{a: 1, "b":}\n```'),
+    (
+        "brace_in_string_value",
+        '```json\n{"code": "if (x) { return 1; }", "ok": true}\n```',
+    ),
+    (
+        "trailing_stray_brace_no_fence",
+        'Result: {"text": "value } here"} and also check ref {2} today.',
+    ),
+    (
+        "architect_valid_tools_block",
+        '```json\n{"tools": [{"name": "n", "description": "d", "code": "c"}]}\n```',
+    ),
+    ("whitespace_only", "   \n\t  "),
+    (
+        "fenced_with_leading_prose_and_trailing_prose",
+        'Sure, here you go:\n```json\n{"a": 1}\n```\nLet me know if you need more.',
+    ),
+    (
+        "curator_rating_shape",
+        '```json\n{"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"}\n```',
+    ),
+    (
+        "hint_feedback_shape",
+        '```json\n{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}\n```',
+    ),
+]
+
+CORPUS_IDS = [name for name, _ in CORPUS]
+
+
+class _Raises:
+    """Sentinel marking that an extractor is pinned to raise on this case."""
+
+    def __init__(self, exc_type: type[BaseException]) -> None:
+        self.exc_type = exc_type
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return f"Raises({self.exc_type.__name__})"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the two extractors whose JSON-extraction step is embedded
+# inside a larger method rather than exposed as a standalone function. Both
+# are exercised through their REAL production code path: a stub runtime
+# supplies canned model output, and the actual method under test parses it.
+# ---------------------------------------------------------------------------
+
+
+class _StubRuntime:
+    """Minimal SubagentRuntime stand-in: returns fixed content, no LLM call."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def run_task(self, task: Any) -> RoleExecution:
+        return RoleExecution(
+            role="curator",
+            content=self._content,
+            usage=RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model="stub"),
+            subagent_id="stub",
+            status="completed",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _CuratorRatingShape:
+    actionability: int
+    specificity: int
+    correctness: int
+    rationale: str
+
+
+def _curator_rate(text: str) -> _CuratorRatingShape:
+    """Run KnowledgeCurator.rate_analyst_output's real parsing path on `text`."""
+    curator = KnowledgeCurator(runtime=_StubRuntime(text), model="stub")
+    rating, _execution = curator.rate_analyst_output(analyst_markdown="irrelevant", generation=7)
+    return _CuratorRatingShape(
+        actionability=rating.actionability,
+        specificity=rating.specificity,
+        correctness=rating.correctness,
+        rationale=rating.rationale,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _HintFeedbackShape:
+    helpful: tuple[str, ...]
+    misleading: tuple[str, ...]
+    missing: tuple[str, ...]
+
+
+def _hint_feedback(text: str) -> _HintFeedbackShape:
+    """Run parse_hint_feedback's real parsing path on `text` (pure function, no LLM)."""
+    feedback = parse_hint_feedback(text, generation=7)
+    return _HintFeedbackShape(
+        helpful=tuple(feedback.helpful),
+        misleading=tuple(feedback.misleading),
+        missing=tuple(feedback.missing),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extractor 1: output_parser.strip_json_fences
+# ---------------------------------------------------------------------------
+
+STRIP_JSON_FENCES_EXPECTED: dict[str, str] = {
+    "normal_fenced_block": '{"a": 1}',
+    "fence_no_language": '{"a": 1}',
+    "fence_single_line": '{"a": 1}',
+    "two_fenced_blocks": '{"a": 1}',
+    "truncated_block": '```json\n{"a": 1, "b": 2',
+    "bare_json_with_prose": 'Here is the result: {"a": 1} -- hope that helps!',
+    "json_array_not_object": "[1, 2, 3]",
+    "empty_string": "",
+    "invalid_json_in_fence": '{a: 1, "b":}',
+    "brace_in_string_value": '{"code": "if (x) { return 1; }", "ok": true}',
+    "trailing_stray_brace_no_fence": 'Result: {"text": "value } here"} and also check ref {2} today.',
+    "architect_valid_tools_block": '{"tools": [{"name": "n", "description": "d", "code": "c"}]}',
+    "whitespace_only": "",
+    "fenced_with_leading_prose_and_trailing_prose": '{"a": 1}',
+    "curator_rating_shape": '{"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"}',
+    "hint_feedback_shape": '{"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]}',
+}
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_strip_json_fences(name: str, text: str) -> None:
+    assert strip_json_fences(text) == STRIP_JSON_FENCES_EXPECTED[name]
+
+
+# ---------------------------------------------------------------------------
+# Extractor 2: output_parser.extract_json (dead code today; consolidation target)
+# ---------------------------------------------------------------------------
+
+EXTRACT_JSON_EXPECTED: dict[str, Any] = {
+    "normal_fenced_block": {"a": 1},
+    "fence_no_language": {"a": 1},
+    "fence_single_line": {"a": 1},
+    "two_fenced_blocks": {"a": 1},
+    "truncated_block": _Raises(json.JSONDecodeError),
+    "bare_json_with_prose": _Raises(json.JSONDecodeError),
+    "json_array_not_object": _Raises(ValueError),
+    "empty_string": _Raises(json.JSONDecodeError),
+    "invalid_json_in_fence": _Raises(json.JSONDecodeError),
+    "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},
+    "trailing_stray_brace_no_fence": _Raises(json.JSONDecodeError),
+    "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "whitespace_only": _Raises(json.JSONDecodeError),
+    "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
+    "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
+    "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+}
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_extract_json(name: str, text: str) -> None:
+    expected = EXTRACT_JSON_EXPECTED[name]
+    if isinstance(expected, _Raises):
+        with pytest.raises(expected.exc_type):
+            extract_json(text)
+    else:
+        assert extract_json(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# Extractor 3: agents.architect.parse_architect_tool_specs
+# ---------------------------------------------------------------------------
+
+PARSE_ARCHITECT_TOOL_SPECS_EXPECTED: dict[str, list[dict[str, Any]]] = {
+    "normal_fenced_block": [],
+    "fence_no_language": [],  # requires the literal "```json" tag; plain fence never matches
+    "fence_single_line": [],
+    "two_fenced_blocks": [],  # rfind("```") grabs the SECOND block's closing fence -> corrupt span -> JSONDecodeError -> []
+    "truncated_block": [],
+    "bare_json_with_prose": [],
+    "json_array_not_object": [],
+    "empty_string": [],
+    "invalid_json_in_fence": [],
+    "brace_in_string_value": [],  # valid JSON, valid dict, but no "tools" key
+    "trailing_stray_brace_no_fence": [],
+    "architect_valid_tools_block": [{"name": "n", "description": "d", "code": "c"}],
+    "whitespace_only": [],
+    "fenced_with_leading_prose_and_trailing_prose": [],
+    "curator_rating_shape": [],
+    "hint_feedback_shape": [],
+}
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_parse_architect_tool_specs(name: str, text: str) -> None:
+    assert parse_architect_tool_specs(text) == PARSE_ARCHITECT_TOOL_SPECS_EXPECTED[name]
+
+
+# ---------------------------------------------------------------------------
+# Extractor 4: agents.translator.StrategyTranslator._strip_fences
+# Pinned identical to strip_json_fences on every case: it's a direct delegate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_translator_strip_fences_matches_output_parser(name: str, text: str) -> None:
+    assert StrategyTranslator._strip_fences(text) == STRIP_JSON_FENCES_EXPECTED[name]
+
+
+# ---------------------------------------------------------------------------
+# Extractor 5: agents.curator.KnowledgeCurator.rate_analyst_output
+# Never raises: JSONDecodeError is swallowed, non-dict decoded values are
+# silently discarded. Both failure modes fall back to AnalystRating defaults
+# (actionability=specificity=correctness=3, rationale=""), which is why most
+# rows below look identical regardless of whether parsing "succeeded."
+# ---------------------------------------------------------------------------
+
+_CURATOR_DEFAULT = _CuratorRatingShape(actionability=3, specificity=3, correctness=3, rationale="")
+
+CURATOR_RATE_EXPECTED: dict[str, _CuratorRatingShape] = {
+    "normal_fenced_block": _CURATOR_DEFAULT,  # parses fine, but no actionability/specificity/etc keys
+    "fence_no_language": _CURATOR_DEFAULT,
+    "fence_single_line": _CURATOR_DEFAULT,
+    "two_fenced_blocks": _CURATOR_DEFAULT,
+    "truncated_block": _CURATOR_DEFAULT,  # JSONDecodeError swallowed
+    "bare_json_with_prose": _CURATOR_DEFAULT,  # JSONDecodeError swallowed (no fence to strip first)
+    "json_array_not_object": _CURATOR_DEFAULT,  # parses to a list; isinstance(decoded, dict) is False -> discarded silently
+    "empty_string": _CURATOR_DEFAULT,
+    "invalid_json_in_fence": _CURATOR_DEFAULT,  # JSONDecodeError swallowed
+    "brace_in_string_value": _CURATOR_DEFAULT,  # parses fine, no matching keys
+    "trailing_stray_brace_no_fence": _CURATOR_DEFAULT,
+    "architect_valid_tools_block": _CURATOR_DEFAULT,  # parses fine, no matching keys
+    "whitespace_only": _CURATOR_DEFAULT,
+    "fenced_with_leading_prose_and_trailing_prose": _CURATOR_DEFAULT,
+    "curator_rating_shape": _CuratorRatingShape(actionability=4, specificity=5, correctness=2, rationale="solid"),
+    "hint_feedback_shape": _CURATOR_DEFAULT,
+}
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_curator_rate_analyst_output(name: str, text: str) -> None:
+    assert _curator_rate(text) == CURATOR_RATE_EXPECTED[name]
+
+
+# ---------------------------------------------------------------------------
+# Extractor 6: agents.translator_simplification.extract_strategy_deterministic
+# ---------------------------------------------------------------------------
+
+EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED: dict[str, dict[str, Any] | None] = {
+    "normal_fenced_block": {"a": 1},
+    "fence_no_language": {"a": 1},
+    "fence_single_line": {"a": 1},  # fence regex requires a literal \n, but the bare-object regex fallback still finds it
+    "two_fenced_blocks": {"a": 1},
+    "truncated_block": None,
+    "bare_json_with_prose": {"a": 1},  # bare-object regex fallback
+    "json_array_not_object": None,  # not a dict; fenced+bare-object+whole-text all reject
+    "empty_string": None,
+    "invalid_json_in_fence": None,
+    "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},
+    "trailing_stray_brace_no_fence": None,  # naive bare-object regex still fails to reconstruct valid JSON here
+    "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "whitespace_only": None,
+    "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
+    "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
+    "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+}
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_extract_strategy_deterministic(name: str, text: str) -> None:
+    assert extract_strategy_deterministic(text) == EXTRACT_STRATEGY_DETERMINISTIC_EXPECTED[name]
+
+
+# ---------------------------------------------------------------------------
+# Extractor 7: agents.hint_feedback.parse_hint_feedback
+# Never raises. Like curator, its schema-specific return type masks parse
+# success for corpus cases that don't use its "helpful"/"misleading"/"missing"
+# keys, which is why almost every row is the same all-empty shape.
+# ---------------------------------------------------------------------------
+
+_HINT_FEEDBACK_DEFAULT = _HintFeedbackShape(helpful=(), misleading=(), missing=())
+
+HINT_FEEDBACK_EXPECTED: dict[str, _HintFeedbackShape] = {name: _HINT_FEEDBACK_DEFAULT for name, _ in CORPUS}
+HINT_FEEDBACK_EXPECTED["hint_feedback_shape"] = _HintFeedbackShape(helpful=("h1",), misleading=("m1",), missing=("mi1",))
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_parse_hint_feedback(name: str, text: str) -> None:
+    assert _hint_feedback(text) == HINT_FEEDBACK_EXPECTED[name]
+
+
+# ---------------------------------------------------------------------------
+# Extractor 8: execution.action_filter.ActionFilterHarness._extract_json_object
+# ---------------------------------------------------------------------------
+
+EXTRACT_JSON_OBJECT_EXPECTED: dict[str, dict[str, Any] | None] = {
+    "normal_fenced_block": {"a": 1},
+    "fence_no_language": {"a": 1},
+    "fence_single_line": {"a": 1},
+    "two_fenced_blocks": {"a": 1},
+    "truncated_block": None,
+    "bare_json_with_prose": {"a": 1},  # naive find("{")/rfind("}") fallback happens to work here
+    "json_array_not_object": None,  # no "{" in the text at all; fenced regex requires one too
+    "empty_string": None,
+    "invalid_json_in_fence": None,
+    "brace_in_string_value": {"code": "if (x) { return 1; }", "ok": True},  # fenced regex backtracks past the inner "}"
+    "trailing_stray_brace_no_fence": None,  # naive rfind("}") picks up the LATER stray "}" from "{2}", corrupting the span
+    "architect_valid_tools_block": {"tools": [{"name": "n", "description": "d", "code": "c"}]},
+    "whitespace_only": None,
+    "fenced_with_leading_prose_and_trailing_prose": {"a": 1},
+    "curator_rating_shape": {"actionability": 4, "specificity": 5, "correctness": 2, "rationale": "solid"},
+    "hint_feedback_shape": {"helpful": ["h1"], "misleading": ["m1"], "missing": ["mi1"]},
+}
+
+
+@pytest.mark.parametrize("name,text", CORPUS, ids=CORPUS_IDS)
+def test_action_filter_extract_json_object(name: str, text: str) -> None:
+    assert ActionFilterHarness._extract_json_object(text) == EXTRACT_JSON_OBJECT_EXPECTED[name]

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -535,6 +535,12 @@ def test_extract_json_truncated_array_does_not_unwrap_inner_object() -> None:
     inside the unterminated array and returned it. A model hitting its
     token budget mid-array is a realistic truncation, not an exotic input
     (see AC-904/AC-905), so this silent unwrap mattered.
+
+    This is the UNFENCED half of the guard; see
+    test_extract_json_fenced_truncated_array_does_not_unwrap_inner_object
+    for the fenced half, where the exact same defect survived one fix wave
+    later because the array-shaped-scope check lived only in the no-fence
+    branch.
     """
     with pytest.raises(json.JSONDecodeError):
         extract_json('[{"a": 1}')
@@ -544,6 +550,41 @@ def test_extract_json_truncated_array_does_not_unwrap_inner_object() -> None:
     # pinned here as the control case this fix must not disturb.
     with pytest.raises(ValueError):
         extract_json('[{"a": 1}]')
+    # Plain object control: proves the array-only check doesn't over-tighten
+    # and start blocking the ordinary no-fence brace-scan rescue path.
+    assert extract_json('Here is the result: {"a": 1} -- hope that helps!') == {"a": 1}
+
+
+def test_extract_json_fenced_truncated_array_does_not_unwrap_inner_object() -> None:
+    """CRITICAL fix, AC-910 Task 5 fix wave: the array-shaped-scope check
+    that test_extract_json_truncated_array_does_not_unwrap_inner_object pins
+    for the UNFENCED case used to live only in that no-fence branch. The
+    fenced branch brace-scanned its captured content unconditionally,
+    regardless of whether that content opened with "[" -- so a truncated
+    array behind a fence still silently unwrapped its inner object even
+    after the unfenced case was hardened:
+
+        extract_json('```json\\n[{"a": 1}\\n```')  used to return {'a': 1},
+        silently wrong, while the unfenced extract_json('[{"a": 1}') already
+        raised. Both must now raise identically, fenced or not.
+
+    Fenced is the more likely real-world shape for a truncated array, not
+    less: models are prompted to emit fenced code blocks, so a mid-array
+    truncation is more often going to be behind a fence than bare in prose.
+    """
+    with pytest.raises(json.JSONDecodeError):
+        extract_json('```json\n[{"a": 1}\n```')
+    with pytest.raises(json.JSONDecodeError):
+        extract_json('```json\n[{"a": 1}, {"b": 2}\n```')
+    # Complete array, fenced: already terminal via the successful-list-parse
+    # rule (also pinned in CORPUS as fenced_array_of_objects) -- pinned here
+    # directly as the control case this fix must not disturb.
+    with pytest.raises(ValueError):
+        extract_json('```json\n[{"a": 1}]\n```')
+    # Plain object control, fenced: proves the array-only check doesn't
+    # over-tighten and start blocking the ordinary fenced brace-scan rescue
+    # path (see test_extract_json_broken_fence_tag_recovers_via_brace_scan_within_fence).
+    assert extract_json('```json\n{"a": 1}\n```') == {"a": 1}
 
 
 def test_extract_json_unfenced_earlier_malformed_candidate_is_skipped() -> None:
@@ -929,19 +970,51 @@ def test_action_filter_extract_json_object(name: str, text: str) -> None:
 _GUARDED_SRC_DIRS = ("agents", "execution")
 _ALLOWED_FENCE_REGEX_FILE = "output_parser.py"
 
-# AC-924: execution/judge.py has its own `_try_code_block_parse` fence regex,
-# one of FOUR ordered parsing strategies (marker-delimited, raw-JSON-with-
-# "score"-key, code-block, plain-text) whose ordering is observable and
-# entirely uncharacterized. Migrating it onto extract_json blind would be
-# exactly the mistake this plan keeps proving is wrong -- characterize
+# The four regex call sites this guard is aware of today, one per line,
+# collapsed to three files below because two of them (translator.py's
+# python-fence and generic-fence searches) live in the same module:
+#
+#   agents/translator.py:118            re.search  -- python code block
+#   agents/translator.py:121            re.search  -- generic fence
+#   execution/harness_synthesizer.py:233 re.search  -- python code block
+#   execution/judge.py:555              re.compile -- JSON (AC-924)
+#
+# judge.py is tracked, unmigrated JSON extraction: `_try_code_block_parse`
+# is one of FOUR ordered parsing strategies (marker-delimited, raw-JSON-
+# with-"score"-key, code-block, plain-text) whose ordering is observable
+# and entirely uncharacterized. Migrating it onto extract_json blind would
+# be exactly the mistake this plan keeps proving is wrong -- characterize
 # before you change. Tracked in AC-924, not fixed here.
 #
+# translator.py and harness_synthesizer.py are a DIFFERENT kind of
+# exemption, not a to-do: both regexes extract PYTHON source code from a
+# fence, not JSON. extract_json is a JSON parser (it feeds candidates to
+# json.loads); forcing a Python-code extraction onto it would be wrong, not
+# incomplete, so these are deliberately and permanently out of scope for
+# migration, unlike judge.py's AC-924 debt.
+#
 # This is EXACT-SET equality, not an allow-list: it fails both when a NEW
-# offender appears (someone adds a fence regex) and when this known one
-# disappears (AC-924 lands and judge.py is migrated or the guard reverts to
-# a plain "no offenders" assertion) -- so a stale exemption can't survive
-# unnoticed the way a permissive allow-list would let it.
-_KNOWN_OFFENDERS = frozenset({"execution/judge.py"})
+# offender appears (someone adds a fence regex) and when a known one
+# disappears (e.g. AC-924 lands and judge.py is migrated, or a file is
+# deleted) -- so a stale exemption can't survive unnoticed the way a
+# permissive allow-list would let it.
+_KNOWN_OFFENDERS = frozenset(
+    {
+        "execution/judge.py",
+        "agents/translator.py",
+        "execution/harness_synthesizer.py",
+    }
+)
+
+# re.* callables whose first positional argument, if a string literal
+# containing a markdown fence, marks the call as a fence-regex offender.
+# "compile" catches the pattern this guard was originally written for
+# (`_JSON_FENCE_RE = re.compile(...)`, reused across multiple calls); the
+# other three catch a pattern built inline at each call site instead
+# (`re.search(r"```...", text)`), which is exactly the shape translator.py
+# and harness_synthesizer.py use and the original "compile"-only check
+# missed entirely.
+_FENCE_REGEX_CONSTRUCTORS = frozenset({"compile", "search", "match", "finditer"})
 
 
 def _guarded_python_files() -> list[Path]:
@@ -954,8 +1027,33 @@ def _guarded_python_files() -> list[Path]:
 
 def _fence_regex_offenders() -> set[str]:
     """Return the set of guarded-directory-relative paths (e.g.
-    "agents/hint_feedback.py") containing a `re.compile(...)` call whose
-    pattern argument is a string literal containing three backticks.
+    "agents/hint_feedback.py") containing a `re.compile(...)`, `re.search(...)`,
+    `re.match(...)`, or `re.finditer(...)` call whose first positional
+    argument is a string literal containing three backticks.
+
+    What this DOES catch: a fence pattern passed directly as a string
+    literal to one of those four `re` module functions, e.g.
+    ``re.compile(r"```(?:json)?...")`` or ``re.search(r"```python\\s*\\n(.*?)```", text)``,
+    however many are in one file (a file with two such calls is still one
+    entry in the returned set).
+
+    What this does NOT catch, by construction of the AST check below --
+    each of these is a real, demonstrated way to defeat it, not a
+    theoretical gap:
+    - A pattern assigned to a module-level variable and passed by name
+      (``_P = re.compile(...)`` then ``_P.search(text)`` elsewhere) --
+      idiomatic Python, not evasion; a routine refactor would silently slip
+      past this guard exactly the way a deliberate bypass would.
+    - A pattern built by string concatenation or an f-string instead of a
+      single literal.
+    - ``from re import compile as _c`` (or any aliased import) followed by
+      ``_c(...)`` -- the check requires the call's object to be the bare
+      name ``re``.
+    - A fence string embedded in ordinary text that is never passed to a
+      `re.*` call at all (e.g. a prompt telling the model to emit fenced
+      output, as in agents/llm_client.py) -- deliberately not flagged,
+      since it isn't extracting anything and flagging it would just be
+      noise that gets the guard disabled.
     """
     src_root = Path(__file__).resolve().parents[1] / "src" / "autocontext"
     offenders: set[str] = set()
@@ -967,7 +1065,7 @@ def _fence_regex_offenders() -> set[str]:
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            if not (isinstance(func, ast.Attribute) and func.attr == "compile"):
+            if not (isinstance(func, ast.Attribute) and func.attr in _FENCE_REGEX_CONSTRUCTORS):
                 continue
             if not (isinstance(func.value, ast.Name) and func.value.id == "re"):
                 continue
@@ -983,23 +1081,52 @@ def _fence_regex_offenders() -> set[str]:
 
 def test_no_new_markdown_fence_regex_outside_output_parser() -> None:
     """No module under agents/ or execution/ may define its own markdown-fence
-    regex, beyond the single known, tracked exception -- that duplication is
-    exactly what this plan consolidated away. `output_parser.py` (the shared
-    parser's home) is the sole allowed owner; it doesn't live under either
-    guarded directory today, so excluding it by name is defense-in-depth
-    rather than load-bearing, in case it ever moves.
+    regex, beyond the known, tracked exceptions in `_KNOWN_OFFENDERS` --
+    that duplication is exactly what this plan consolidated away.
+    `output_parser.py` (the shared parser's home) is the sole allowed owner;
+    it doesn't live under either guarded directory today, so excluding it by
+    name is defense-in-depth rather than load-bearing, in case it ever moves.
+
+    This enforces exactly what `_fence_regex_offenders`' docstring says it
+    detects -- a fence pattern passed as a string literal directly to
+    `re.compile` / `re.search` / `re.match` / `re.finditer` -- and nothing
+    more. It does NOT catch a pattern assigned to a module-level variable
+    and reused, built by concatenation or an f-string, or reached through
+    an aliased `re` import; see that docstring for why each of those is
+    deliberately out of scope rather than an oversight. A guard that
+    implied broader coverage than that would be worse than one whose limits
+    are written down, because the false confidence is what lets a routine
+    refactor (moving a pattern to a module-level constant, which is
+    idiomatic, not evasive) slip a new duplicate fence extractor past it
+    unnoticed.
 
     Exact-set equality against `_KNOWN_OFFENDERS`, not a plain "no offenders"
     assertion and not a permissive allow-list: a NEW offender fails it (the
-    regression this guard exists to catch), and so does the known one
-    disappearing (so AC-924 landing forces this test's expected set to be
-    updated deliberately, rather than carrying a stale exemption forever).
+    regression this guard exists to catch), and so does a known one
+    disappearing (so migrating one of the tracked files forces this test's
+    expected set to be updated deliberately, rather than carrying a stale
+    exemption forever).
 
-    Proven to fire in both directions this guard cares about (see
-    task-5-report.md for the pasted output):
-    1. A deliberately reintroduced `_JSON_FENCE_RE = re.compile(r"```...")`
-       added to an agents/ module -> fails, naming that file. Removed -> passes.
-    2. `_KNOWN_OFFENDERS` emptied while judge.py still offends -> fails.
-       Restored -> passes.
+    Proven to fire in all three directions this guard cares about (see
+    task-5-fix-report.md for the pasted output):
+    1. The current tree passes with exactly `_KNOWN_OFFENDERS`.
+    2. A deliberately reintroduced fence regex added to an agents/ module
+       that already imports `re` (e.g. `_BYPASS = re.compile(r"```...")` in
+       agents/curator.py) -> fails, naming that file. Removed -> passes.
+       (A module that does NOT already import `re`, e.g. agents/coach.py,
+       fails at import instead of tripping the guard -- that failure looks
+       like a passing proof but tests the wrong thing, so the file used for
+       this check must already import `re`.)
+    3. `_KNOWN_OFFENDERS` missing one of the three tracked files while that
+       file still offends -> fails. Restored -> passes.
+
+    A module-level-variable bypass (`_BYPASS = re.compile(...)` assigned in
+    one place, called via `_BYPASS.search(...)` elsewhere) and an aliased-
+    import bypass (`from re import compile as _c`) were both demonstrated
+    live against this guard and neither is caught -- see this function's
+    docstring and `_fence_regex_offenders`' docstring for why: closing them
+    would require tracing assignments and import aliases, not just call
+    shapes, which is a bigger change than this guard's AST walk is designed
+    to do. Documented here rather than silently accepted.
     """
     assert _fence_regex_offenders() == _KNOWN_OFFENDERS

--- a/autocontext/tests/test_pipeline_adapter.py
+++ b/autocontext/tests/test_pipeline_adapter.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from autocontext.agents.llm_client import DeterministicDevClient
 from autocontext.agents.orchestrator import AgentOrchestrator
-from autocontext.agents.pipeline_adapter import build_mts_dag, build_role_handler
+from autocontext.agents.pipeline_adapter import RoleHandler, build_mts_dag, build_role_handler
 from autocontext.config.settings import AppSettings
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import RoleExecution, RoleUsage
@@ -193,17 +194,25 @@ class TestPipelineOrchestratorIntegration:
         assert isinstance(outputs.architect_tools, list)
         assert len(outputs.architect_tools) >= 1
 
-    def test_pipeline_malformed_translator_content_raises(self) -> None:
-        """AC-910 Task 5 Step 1c(iii): malformed translator content must
-        surface as a raise through the pipeline path (`_run_via_pipeline`).
+    def test_pipeline_malformed_translator_content_raises_inside_translate(self) -> None:
+        """Malformed model output reaching `StrategyTranslator.translate` in
+        the pipeline path propagates out of `run_generation` rather than being
+        swallowed by the engine.
 
-        Every other pipeline test here only exercises the happy path,
-        where extraction success is invisible in AgentOutputs -- there's
-        no field recording whether the translator's JSON actually parsed.
-        This is the recurring theme of the whole AC-910 plan: extraction
-        success must be verified at the raise, not inferred from a call
-        site's output, before `use_pipeline_engine` ever flips
-        default-on.
+        SCOPE, precisely -- an earlier version of this docstring overclaimed
+        and the claim is the thing being corrected: the raise happens inside
+        `translate` (translator.py:70), and the engine/adapter simply do not
+        catch it. `orchestrator.py:692`'s own `extract_json` call is NEVER
+        entered on this input, because `translate` raises before returning and
+        the pipeline never gets a translator RoleExecution to re-parse. What
+        this test pins is the propagation path, not that site. For coverage of
+        `orchestrator.py:692` itself see
+        `test_orchestrator_parses_translator_content_and_raises_on_malformed`
+        below, which stubs the handler so malformed content arrives there.
+
+        Both matter, and neither substitutes for the other: this one is the
+        production wiring (the raise a real malformed translator response
+        actually produces), the other one is the orchestrator's own parse.
         """
         client = DeterministicDevClient()
         settings = _make_settings(use_pipeline=True)
@@ -236,5 +245,128 @@ class TestPipelineOrchestratorIntegration:
         orch.translator.runtime.run_task = fake_translator_run_task  # type: ignore[method-assign]
 
         prompts = _make_prompt_bundle()
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(json.JSONDecodeError) as excinfo:
             orch.run_generation(prompts, generation_index=1)
+
+        # Pin WHERE, so this test can't quietly start covering something else:
+        # translate() is on the stack, the orchestrator's own parse is not.
+        frames = [str(entry.path) for entry in excinfo.traceback]
+        assert any(f.endswith("agents/translator.py") for f in frames)
+
+    def test_orchestrator_parses_translator_content_and_raises_on_malformed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`_run_via_pipeline`'s own `extract_json` (orchestrator.py:692) must
+        raise on malformed translator content -- reached here for real.
+
+        Getting to that line takes stubbing the role HANDLER, not the
+        translator runtime, and the reason is worth stating because it is a
+        wiring defect in its own right: `pipeline_adapter.py:95` calls
+        `orch.translator.translate(...)`, DISCARDS the `_strategy` it returns,
+        and hands back only `exec_result`. `_run_via_pipeline` then re-parses
+        `exec_result.content`, which is either `json.dumps(...)` (always valid)
+        or the exact string `translate` just parsed successfully. `extract_json`
+        is deterministic, so the second parse cannot disagree with the first.
+        Through the real adapter, orchestrator.py:692 therefore cannot fail:
+        any input bad enough to break it breaks `translate` first, one frame
+        earlier (the test above).
+
+        Replacing the handler removes `translate` from the path entirely and
+        delivers malformed content straight to the orchestrator, which is the
+        only way to exercise the parse the orchestrator actually performs. The
+        stub is narrow: every role except translator still runs the real
+        handler.
+
+        This is a defense-in-depth guard, not dead weight. The adapter's
+        discard-and-re-parse is not a contract -- an adapter that returned a
+        translator RoleExecution assembled from anywhere other than
+        `translate`'s own input (a cached execution, a retry, a future
+        streaming/partial-result path) would put un-vetted content in front of
+        that line, and `use_pipeline_engine` flipping default-on is when that
+        would start to matter. Pinning it now costs one test and means the
+        fail-hard behavior is verified rather than assumed.
+        """
+        client = DeterministicDevClient()
+        settings = _make_settings(use_pipeline=True)
+        orch = AgentOrchestrator(client=client, settings=settings)
+
+        def fail_if_called(raw_output: str, strategy_interface: str) -> tuple[dict[str, Any], RoleExecution]:
+            raise AssertionError("translate() must not run: the handler stub replaces it")
+
+        monkeypatch.setattr(orch.translator, "translate", fail_if_called)
+
+        real_build_role_handler = build_role_handler
+
+        def build_handler_with_malformed_translator(*args: Any, **kwargs: Any) -> RoleHandler:
+            inner = real_build_role_handler(*args, **kwargs)
+
+            def handler(name: str, prompt: str, completed: dict[str, RoleExecution]) -> RoleExecution:
+                if name != "translator":
+                    return inner(name, prompt, completed)
+                return RoleExecution(
+                    role="translator",
+                    content='{"aggression": 0.5, "defense":}',  # malformed: no value
+                    usage=RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model="stub"),
+                    subagent_id="test",
+                    status="completed",
+                )
+
+            return handler
+
+        prompts = _make_prompt_bundle()
+        with patch(
+            "autocontext.agents.pipeline_adapter.build_role_handler",
+            side_effect=build_handler_with_malformed_translator,
+        ):
+            with pytest.raises(json.JSONDecodeError) as excinfo:
+                orch.run_generation(prompts, generation_index=1)
+
+        # The mirror image of the assertion in the test above: the
+        # orchestrator's frame is on the stack and translate()'s is not, so
+        # this really is the parse at orchestrator.py:692 failing.
+        frames = [str(entry.path) for entry in excinfo.traceback]
+        assert any(f.endswith("agents/orchestrator.py") for f in frames)
+        assert not any(f.endswith("agents/translator.py") for f in frames)
+
+    def test_orchestrator_rejects_array_shaped_translator_content(self) -> None:
+        """Same site, the other behavior change its comment claims: a
+        translator response that parses fine but to a JSON ARRAY is rejected
+        at orchestrator.py:692 instead of being assigned to `strategy` as-is.
+
+        The old `json.loads(...)` there had no type check, so a list flowed
+        into a field every downstream consumer declares as `dict[str, Any]`.
+        Pinned separately from the malformed case because it exercises a
+        different rule (wrong-type-is-terminal, not a parse failure) and
+        raises a different exception -- a bare ValueError, checked exactly
+        here so a JSONDecodeError could not pass for it.
+        """
+        client = DeterministicDevClient()
+        settings = _make_settings(use_pipeline=True)
+        orch = AgentOrchestrator(client=client, settings=settings)
+
+        real_build_role_handler = build_role_handler
+
+        def build_handler_with_array_translator(*args: Any, **kwargs: Any) -> RoleHandler:
+            inner = real_build_role_handler(*args, **kwargs)
+
+            def handler(name: str, prompt: str, completed: dict[str, RoleExecution]) -> RoleExecution:
+                if name != "translator":
+                    return inner(name, prompt, completed)
+                return RoleExecution(
+                    role="translator",
+                    content='[{"aggression": 0.5}]',  # parses, but to a list
+                    usage=RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model="stub"),
+                    subagent_id="test",
+                    status="completed",
+                )
+
+            return handler
+
+        prompts = _make_prompt_bundle()
+        with patch(
+            "autocontext.agents.pipeline_adapter.build_role_handler",
+            side_effect=build_handler_with_array_translator,
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                orch.run_generation(prompts, generation_index=1)
+
+        assert type(excinfo.value) is ValueError  # not the JSONDecodeError subclass
+        assert "Expected JSON object, got list" in str(excinfo.value)

--- a/autocontext/tests/test_pipeline_adapter.py
+++ b/autocontext/tests/test_pipeline_adapter.py
@@ -1,8 +1,12 @@
 """Tests for PipelineEngine-backed orchestrator codepath."""
+
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from autocontext.agents.llm_client import DeterministicDevClient
 from autocontext.agents.orchestrator import AgentOrchestrator
@@ -30,7 +34,8 @@ def _make_prompt_bundle() -> PromptBundle:
         competitor=base + "Describe your strategy reasoning and recommend specific parameter values.",
         analyst=base + "Analyze strengths/failures and return markdown with sections: "
         "Findings, Root Causes, Actionable Recommendations.",
-        coach=base + (
+        coach=base
+        + (
             "You are the playbook coach. Produce TWO structured sections:\n\n"
             "1. A COMPLETE replacement playbook between markers.\n\n"
             "<!-- PLAYBOOK_START -->\n(Your consolidated playbook here)\n<!-- PLAYBOOK_END -->\n\n"
@@ -187,3 +192,49 @@ class TestPipelineOrchestratorIntegration:
         # DeterministicDevClient architect response has tools JSON
         assert isinstance(outputs.architect_tools, list)
         assert len(outputs.architect_tools) >= 1
+
+    def test_pipeline_malformed_translator_content_raises(self) -> None:
+        """AC-910 Task 5 Step 1c(iii): malformed translator content must
+        surface as a raise through the pipeline path (`_run_via_pipeline`).
+
+        Every other pipeline test here only exercises the happy path,
+        where extraction success is invisible in AgentOutputs -- there's
+        no field recording whether the translator's JSON actually parsed.
+        This is the recurring theme of the whole AC-910 plan: extraction
+        success must be verified at the raise, not inferred from a call
+        site's output, before `use_pipeline_engine` ever flips
+        default-on.
+        """
+        client = DeterministicDevClient()
+        settings = _make_settings(use_pipeline=True)
+        orch = AgentOrchestrator(client=client, settings=settings)
+
+        def fake_competitor_run(prompt: str, tool_context: str = "") -> tuple[str, RoleExecution]:
+            # Prose with no embedded JSON, so extract_strategy_deterministic
+            # returns None and translate() falls through to the runtime call
+            # below instead of short-circuiting on the deterministic path.
+            content = "I will play aggressively and hold the center."
+            return content, RoleExecution(
+                role="competitor",
+                content=content,
+                usage=RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model="stub"),
+                subagent_id="test",
+                status="completed",
+            )
+
+        orch.competitor.run = fake_competitor_run  # type: ignore[method-assign]
+
+        def fake_translator_run_task(task: object) -> RoleExecution:
+            return RoleExecution(
+                role="translator",
+                content='{"aggression": 0.5, "defense":}',  # malformed: no value
+                usage=RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model="stub"),
+                subagent_id="test",
+                status="completed",
+            )
+
+        orch.translator.runtime.run_task = fake_translator_run_task  # type: ignore[method-assign]
+
+        prompts = _make_prompt_bundle()
+        with pytest.raises(json.JSONDecodeError):
+            orch.run_generation(prompts, generation_index=1)


### PR DESCRIPTION
Consolidates seven duplicate model-JSON extractors under `agents/` and `execution/` onto one shared parser, `harness/core/output_parser.py::extract_json`, with an explicit `on_failure` policy. Third and final plan in the AC-910 sequence (after #1249 routing-parity fixtures and #1250 generated role-routing contract).

`extract_json` existed before this branch but had **zero callers** — every site had grown its own fence handling, and they disagreed with each other.

## Bugs found and fixed

Five of these were only findable by running the code against adversarial input. None were visible in a diff.

| Issue | Defect |
|---|---|
| AC-920 | `architect.py` used `find("```json")` + `rfind("```")`; two fenced blocks made the slice span both plus the prose between, silently yielding `[]` tools with a warning that blamed truncation |
| AC-921 | A malformed fence plus a prose decoy caused the decoy object to be adopted as the strategy |
| — | Array-shaped strategies were assigned as a `list` with no type check at all |
| — | `orchestrator.py`'s strategy path was fail-**open**: a parse failure became `{}`, which was then executed and scored into Elo/gate/best-score |
| — | A ````` ``` ````/```` ```python ```` preamble block before the JSON block destroyed recovery at three migrated sites (regression introduced mid-branch, caught in review) |
| — | Truncated arrays unwrapped to an inner object; BOM-prefixed input bypassed the array check |

## Deliberately deferred

- **AC-922** — O(n²) on degenerate repetition (1.07s at 46KB vs 0.0003s well-formed). Documented at the retry loop so nobody "optimizes" away a load-bearing retry.
- **AC-924** — `judge.py`'s 4-tier score parser keeps its own fence regex; tiers 2–3 require a `score` key the shared parser has no concept of, and tier ordering is observable but unpinned. Needs its own characterization pass.
- **AC-926** — `ambient/advise_gate.py`'s line filter, never migrated. Fail-soft and a genuinely different algorithm, so safe to leave, but it means "one shared parser" is not yet literally true.

## Guard against regrowth

`test_no_new_markdown_fence_regex_outside_output_parser` walks `agents/` and `execution/` and asserts **exact-set equality** against four tracked offenders, not an allow-list. Equality also fails when an offender is *removed*, so migrating one forces the expected set to be updated deliberately instead of carrying a stale exemption forever.

The guard shipped twice with blind spots that let real offenders through (`re.findall`, and patterns bound to a variable rather than written inline). Both are closed; the remaining gaps — aliased `re` imports, f-strings, runtime concatenation — are documented in the docstring rather than implied away.

## On the test count

~2300 lines added, most of it a characterization corpus written *before* any behavior changed. Note that raw counts overstate the evidence: three of the eight parametrized tables are ~95% non-discriminating (most rows assert the same default), so the informative row count is well below the nominal one.

Verified by mutation rather than by passing: the `break`-not-`continue` scan-termination rule and the orchestrator's fail-hard behavior were both **unpinned** when first written — the suite passed with them reverted. Both now fail against a reverted fix.

## Verification

- Full suite **8896 passed / 79 skipped / 0 failed** (net −38 from deleting `strip_json_fences`, which this branch left with zero production callers)
- `ruff check src tests` clean; `mypy src` clean, 739 files
- Deterministic `grid_ctf` smoke run reproduces `best_score=0.783`, `gate=advance`

One caveat worth recording: that smoke run **is** a valid regression check — the deterministic provider really does return raw text and `extract_json` really is called six times across five migrated sites — but every one of those calls succeeds on its first candidate. It never reaches the span scanner, the array check, or BOM normalization, so it is not evidence for any of the fixes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
