### PR TITLE
test(AC-919): pin the unset-settings layer before AC-912 rewrites it

### DIFF
--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -74,13 +74,20 @@ _EXPECTED_DIVERGENCE_CASE_IDS = {
     "explicit_override.mixed_case_provider_name",
     "explicit_override.whitespace_only_provider_name",
     "routing_off.unknown_role_model",
+    # AC-919 item 2. Every other fixture case supplies all 16 settings fields
+    # non-empty, so nothing reached the unset/empty layer -- the exact layer
+    # AC-912 rewrites. These five pin its before-state so that rewrite can be
+    # diffed rather than trusted.
+    "unset_settings.agent_provider_empty",
+    "unset_settings.blank_local_artifact",
+    "unset_settings.mlx_model_path_empty",
+    "unset_settings.role_model_empty_routing_off",
+    "unset_settings.tier_model_empty",
 }
 
 # Fixture groups whose cases are single route() calls compared field by field.
 # Groups with a different shape (cost estimation) get their own replay test.
-ROUTE_GROUPS: tuple[str, ...] = tuple(
-    group for group in _EXPECTED_CASE_IDS if group != "cost_estimation"
-)
+ROUTE_GROUPS: tuple[str, ...] = tuple(group for group in _EXPECTED_CASE_IDS if group != "cost_estimation")
 _EXPECTED_GROUPS = set(_EXPECTED_CASE_IDS)
 _EXPECTED_ASSIGNMENT_KEYS = {
     "provider_type",

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -355,6 +355,106 @@
       },
       "reason": "Python has no fallback for an unregistered role under routing_off and returns None for the model, while TypeScript's roleSpecificModel falls back to the sonnet tier model. provider_type ('anthropic') and provider_class ('frontier') agree in both; only model differs.",
       "resolution": "AC-911: the RoleAssignment work must decide one behavior for an unregistered role under routing_off, rather than inheriting Python's None and TypeScript's tier-default fallback as two separate defaults."
+    },
+    {
+      "case": "unset_settings.agent_provider_empty",
+      "role": "competitor",
+      "settings": { "agent_provider": "" },
+      "context": {},
+      "python": {
+        "provider_type": "",
+        "model": "opus-tier-model",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "typescript": {
+        "provider_type": "anthropic",
+        "model": "opus-tier-model",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "reason": "An empty default provider is returned verbatim by Python but coerced to 'anthropic' by TypeScript's normalizeProvider fallback. The model and class agree; only the transport name differs.",
+      "resolution": "AC-912 rewrites this layer: role and tier defaults get resolved against the effective provider instead of one vendor's hardcoded ids. This entry exists so that rewrite has a before-state to diff against; when AC-912 makes both languages agree the replay tests fail, and this entry must be deleted rather than updated."
+    },
+    {
+      "case": "unset_settings.blank_local_artifact",
+      "role": "competitor",
+      "settings": {},
+      "context": { "availableLocalModels": ["  "] },
+      "python": {
+        "provider_type": "mlx",
+        "model": "  ",
+        "provider_class": "local",
+        "cost_per_1k_tokens": 0.0
+      },
+      "typescript": {
+        "provider_type": "mlx",
+        "model": "/models/default-local",
+        "provider_class": "local",
+        "cost_per_1k_tokens": 0.0
+      },
+      "reason": "A whitespace-only local artifact is treated as a usable model id by Python and returned verbatim, while TypeScript trims it away and falls back to the configured mlx model path.",
+      "resolution": "AC-912 rewrites this layer: role and tier defaults get resolved against the effective provider instead of one vendor's hardcoded ids. This entry exists so that rewrite has a before-state to diff against; when AC-912 makes both languages agree the replay tests fail, and this entry must be deleted rather than updated."
+    },
+    {
+      "case": "unset_settings.mlx_model_path_empty",
+      "role": "competitor",
+      "settings": { "competitor_provider": "mlx", "mlx_model_path": "" },
+      "context": {},
+      "python": {
+        "provider_type": "mlx",
+        "model": "",
+        "provider_class": "local",
+        "cost_per_1k_tokens": 0.0
+      },
+      "typescript": {
+        "provider_type": "mlx",
+        "model": "local",
+        "provider_class": "local",
+        "cost_per_1k_tokens": 0.0
+      },
+      "reason": "For a local provider with an empty model path Python returns the empty string, while TypeScript's tierModel('local', ...) falls back to the literal 'local'.",
+      "resolution": "AC-912 rewrites this layer: role and tier defaults get resolved against the effective provider instead of one vendor's hardcoded ids. This entry exists so that rewrite has a before-state to diff against; when AC-912 makes both languages agree the replay tests fail, and this entry must be deleted rather than updated."
+    },
+    {
+      "case": "unset_settings.role_model_empty_routing_off",
+      "role": "competitor",
+      "settings": { "model_competitor": "", "role_routing": "off" },
+      "context": {},
+      "python": {
+        "provider_type": "anthropic",
+        "model": "",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "typescript": {
+        "provider_type": "anthropic",
+        "model": "claude-sonnet-4-5-20250929",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "reason": "With routing off and an empty role model Python returns the empty string, while TypeScript falls back to its hardcoded DEFAULT_ROLE_MODELS entry for the role.",
+      "resolution": "AC-912 rewrites this layer: role and tier defaults get resolved against the effective provider instead of one vendor's hardcoded ids. This entry exists so that rewrite has a before-state to diff against; when AC-912 makes both languages agree the replay tests fail, and this entry must be deleted rather than updated."
+    },
+    {
+      "case": "unset_settings.tier_model_empty",
+      "role": "competitor",
+      "settings": { "tier_opus_model": "" },
+      "context": {},
+      "python": {
+        "provider_type": "anthropic",
+        "model": "",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "typescript": {
+        "provider_type": "anthropic",
+        "model": "claude-opus-4-6",
+        "provider_class": "frontier",
+        "cost_per_1k_tokens": 0.015
+      },
+      "reason": "With an empty tier model Python returns the empty string as the model, while TypeScript falls back to its hardcoded tierModel default. Python has no equivalent fallback table.",
+      "resolution": "AC-912 rewrites this layer: role and tier defaults get resolved against the effective provider instead of one vendor's hardcoded ids. This entry exists so that rewrite has a before-state to diff against; when AC-912 makes both languages agree the replay tests fail, and this entry must be deleted rather than updated."
     }
   ]
 }

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -94,18 +94,23 @@ const EXPECTED_CASE_IDS = {
   cost_estimation: ["default_auto_mode_totals", "with_local_artifacts_totals"],
 } as const satisfies Record<string, readonly string[]>;
 
+// Compared with .sort(), so this list must stay in sorted order.
 const EXPECTED_DIVERGENCE_CASE_IDS = [
   "explicit_override.mixed_case_provider_name",
   "explicit_override.whitespace_only_provider_name",
   "routing_off.unknown_role_model",
+  // AC-919 item 2. Every other fixture case supplies all 16 settings fields
+  // non-empty, so nothing reached the unset/empty layer -- the exact layer
+  // AC-912 rewrites. These five pin its before-state so that rewrite can be
+  // diffed rather than trusted.
+  "unset_settings.agent_provider_empty",
+  "unset_settings.blank_local_artifact",
+  "unset_settings.mlx_model_path_empty",
+  "unset_settings.role_model_empty_routing_off",
+  "unset_settings.tier_model_empty",
 ];
 
-const EXPECTED_ASSIGNMENT_KEYS = [
-  "cost_per_1k_tokens",
-  "model",
-  "provider_class",
-  "provider_type",
-];
+const EXPECTED_ASSIGNMENT_KEYS = ["cost_per_1k_tokens", "model", "provider_class", "provider_type"];
 
 const EXPECTED_GROUPS = Object.keys(EXPECTED_CASE_IDS).sort();
 


### PR DESCRIPTION
Unblocks AC-912.

## Why this is a prerequisite, not hygiene

AC-912 replaces the hardcoded Claude role/tier model defaults with per-provider resolution. **No parity fixture case could reach that layer**: every existing case supplies all 16 settings fields non-empty, so the unset/empty branch was never executed in either language.

Landing AC-912 against that would have meant its acceptance criterion — *"Anthropic-provider defaults are byte-identical to today"* — was unverifiable by anything except reading the diff.

This is the failure mode AC-910 Plan 3 (#1252) hit five times: coverage existed but could not reach the code it named, so a fully green suite proved nothing and a live regression reached review.

## What this pins

Five live divergences in that layer, each replayed by **both** languages:

| settings | Python | TypeScript |
|---|---|---|
| `tier_opus_model: ""` | `""` | `claude-opus-4-6` |
| `model_competitor: ""` + routing off | `""` | `claude-sonnet-4-5-20250929` |
| `agent_provider: ""` | provider `""` | provider `anthropic` |
| `competitor_provider: mlx`, `mlx_model_path: ""` | `""` | `local` |
| `availableLocalModels: ["  "]` | `"  "` | `/models/default-local` |

Root cause is structural: TypeScript carries fallback tables (`DEFAULT_ROLE_MODELS`, `tierModel` defaults, `normalizeProvider`'s `?? "anthropic"`) that Python has no equivalent for, so Python returns the empty/whitespace value verbatim.

All ten values (5 cases x 2 languages) were captured by **executing both routers**, not copied from the issue text. AC-919 recorded them on 2026-08-07; they were re-verified here against `origin/main`.

## Self-deleting by construction

The existing mechanism asserts `python != typescript` and replays the real input in each language. When AC-912 makes the two agree, these tests **fail**, and the entries must be deleted rather than updated — so the pins cannot rot into stale documentation.

Proved by perturbing a recorded value: the owning language's test fails while the other stays green.

## Triage correction

AC-919 items **1, 3, and 4 are already done on main**. The divergence-replay mechanism the issue describes as "never built" exists and is stronger than described — it executes the divergent input in both languages rather than only checking that five keys are present. Item 2 was the only live part of items 1-3. Item 5 (`SETTINGS_KEY_MAP` drift) stays with AC-911, which deletes that code. The issue has been updated.

## Verification

- `test_role_routing_parity.py` 39 passed; `role-routing-parity.test.ts` 44 passed
- Full Python suite exit 0
- `ruff check src tests` clean; `mypy src` clean, 739 files; `tsc --noEmit` clean
- Fixture diff is **+100 / -0** — pure addition, no reformatting churn (an earlier `json.dump` pass rewrote 22 unrelated lines and was reverted; prettier is not this file's formatter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
