### PR TITLE
feat(AC-912): resolve model defaults against the effective provider

### DIFF
--- a/autocontext/src/autocontext/agents/role_router.py
+++ b/autocontext/src/autocontext/agents/role_router.py
@@ -108,6 +108,23 @@ class RoleRouter:
             "translator": settings.model_translator,
             "curator": settings.model_curator,
         }
+        # AC-912: the settings field backing each slot, so model resolution can
+        # ask whether the user actually configured it. Kept beside the tables
+        # above rather than derived, because a wrong mapping here would
+        # silently resolve the wrong field.
+        self._class_model_fields: dict[ProviderClass, str] = {
+            ProviderClass.FRONTIER: "tier_opus_model",
+            ProviderClass.MID_TIER: "tier_sonnet_model",
+            ProviderClass.FAST: "tier_haiku_model",
+        }
+        self._role_model_fields: dict[str, str] = {
+            "competitor": "model_competitor",
+            "analyst": "model_analyst",
+            "coach": "model_coach",
+            "architect": "model_architect",
+            "translator": "model_translator",
+            "curator": "model_curator",
+        }
         self._role_providers: dict[str, str] = {
             "competitor": settings.competitor_provider,
             "analyst": settings.analyst_provider,
@@ -194,6 +211,38 @@ class RoleRouter:
         # Fallback
         return self._config_for_class(role, preferences[0] if preferences else ProviderClass.MID_TIER)
 
+    def _resolve_role_model(self, role: str, provider: str) -> str | None:
+        """Role model for ``provider``, honoring an explicit override first."""
+        from autocontext.config.provider_model_defaults import resolve_model_default
+
+        field = self._role_model_fields.get(role)
+        configured = self._role_models.get(role)
+        if field is None:
+            # An unregistered role has no backing field to check, so there is
+            # nothing to resolve against -- preserve today's behavior exactly.
+            return configured
+        return resolve_model_default(
+            self._settings,
+            provider=provider,
+            field_name=field,
+            configured=configured,
+        )
+
+    def _resolve_class_model(self, role: str, provider_class: ProviderClass, provider: str) -> str | None:
+        """Tier model for ``provider``, falling back to the role model."""
+        from autocontext.config.provider_model_defaults import resolve_model_default
+
+        field = self._class_model_fields.get(provider_class)
+        configured = self._class_to_model.get(provider_class)
+        if field is None or configured is None:
+            return self._resolve_role_model(role, provider)
+        return resolve_model_default(
+            self._settings,
+            provider=provider,
+            field_name=field,
+            configured=configured,
+        )
+
     def _config_for_class(
         self,
         role: str,
@@ -211,7 +260,7 @@ class RoleRouter:
             )
         return ProviderConfig(
             provider_type=self._settings.agent_provider,
-            model=self._class_to_model.get(provider_class, self._role_models.get(role)),
+            model=self._resolve_class_model(role, provider_class, self._settings.agent_provider),
             provider_class=provider_class,
             estimated_cost_per_1k_tokens=_COST_TABLE.get(provider_class, 0.003),
         )
@@ -224,7 +273,11 @@ class RoleRouter:
         )
         return ProviderConfig(
             provider_type=provider_type,
-            model=self._settings.mlx_model_path if provider_class == ProviderClass.LOCAL else self._role_models.get(role),
+            model=(
+                self._settings.mlx_model_path
+                if provider_class == ProviderClass.LOCAL
+                else self._resolve_role_model(role, provider_type)
+            ),
             provider_class=provider_class,
             estimated_cost_per_1k_tokens=_COST_TABLE.get(provider_class, 0.003),
         )
@@ -237,7 +290,11 @@ class RoleRouter:
         )
         return ProviderConfig(
             provider_type=self._settings.agent_provider,
-            model=self._settings.mlx_model_path if provider_class == ProviderClass.LOCAL else self._role_models.get(role),
+            model=(
+                self._settings.mlx_model_path
+                if provider_class == ProviderClass.LOCAL
+                else self._resolve_role_model(role, self._settings.agent_provider)
+            ),
             provider_class=provider_class,
             estimated_cost_per_1k_tokens=_COST_TABLE.get(provider_class, 0.003),
         )

--- a/autocontext/src/autocontext/config/provider_model_defaults.py
+++ b/autocontext/src/autocontext/config/provider_model_defaults.py
@@ -1,0 +1,100 @@
+"""AC-912: resolve role and tier model defaults against the effective provider.
+
+Every ``model_*`` and ``tier_*`` default in ``AppSettings`` is a Claude model
+id. Those defaults are read unconditionally, so setting only
+``AUTOCONTEXT_AGENT_PROVIDER=ollama`` sends ``claude-opus-4-6`` to a local
+server, which fails at the endpoint instead of at configuration time. The user
+has to discover and set eight-plus separate vars before anything works.
+
+The resolution order here is deliberately conservative:
+
+1. **An explicitly configured value always wins.** ``load_settings`` only
+   passes kwargs for fields that came from the environment or a preset, so
+   ``model_fields_set`` distinguishes "the user chose this" from "nobody
+   touched it" -- even when the chosen value is byte-equal to the default.
+   Without that distinction a fix cannot tell an unset field from a deliberate
+   Claude choice, and would silently override the latter.
+2. **``AUTOCONTEXT_LOCAL_MODEL`` fills every unset slot** for non-Anthropic
+   providers, so the common case is one env var instead of eight.
+3. **A known per-provider default**, below.
+4. **Otherwise the field default stands**, unchanged.
+
+``anthropic`` is deliberately absent from the table so it falls through to
+step 4 and keeps today's per-role Claude ids byte for byte. Unknown providers
+fall through for the same reason: this module narrows a leak, it does not
+invent behavior for transports nobody has characterized.
+
+The values mirror the per-provider fallbacks ``create_provider()`` already
+applies in ``providers/registry.py`` when it is handed ``model=None``. Those
+fallbacks exist but were unreachable from the role path, which always passes a
+concrete value. A single default per provider (rather than per role) matches
+how these servers actually work: a local endpoint typically serves one model,
+so asking it for three tiers is meaningless.
+
+``mlx`` is absent because it already resolves correctly -- its model comes from
+``mlx_model_path``, its own setting, rather than the shared role/tier defaults.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Set as AbstractSet
+
+
+class _SupportsFieldsSet(Protocol):
+    """The slice of AppSettings this module needs.
+
+    Narrower than AppSettings on purpose: it keeps the resolver testable with a
+    stub and documents that nothing here depends on the rest of settings.
+    """
+
+    local_model: str
+
+    @property
+    def model_fields_set(self) -> AbstractSet[str]: ...
+
+
+# Provider -> the model id to use when a role/tier slot was never configured.
+# Keep in sync with providers/registry.py's create_provider() fallbacks.
+PROVIDER_DEFAULT_MODEL: dict[str, str] = {
+    "ollama": "llama3.1",
+    "openai": "gpt-4o",
+    "openai-compatible": "default",
+    "vllm": "default",
+    "openrouter": "anthropic/claude-sonnet-4",
+}
+
+# Providers whose defaults must not change. Anthropic is the shipped default
+# and its per-role tiering is the behavior AC-912 promises to preserve exactly.
+_PRESERVED_PROVIDERS = frozenset({"anthropic"})
+
+
+def resolve_model_default(
+    settings: _SupportsFieldsSet,
+    *,
+    provider: str,
+    field_name: str,
+    configured: str | None,
+) -> str | None:
+    """Return the model a role/tier slot should use for ``provider``.
+
+    ``field_name`` is the ``AppSettings`` field backing the slot (for example
+    ``"model_coach"`` or ``"tier_opus_model"``); ``configured`` is that field's
+    current value. Returns ``configured`` unchanged whenever this module has no
+    better-informed answer, so every caller can substitute it for a direct
+    settings read without changing Anthropic behavior.
+    """
+    if field_name in settings.model_fields_set:
+        return configured
+
+    normalized = provider.strip().lower()
+    if normalized in _PRESERVED_PROVIDERS:
+        return configured
+
+    local_model = (settings.local_model or "").strip()
+    if local_model:
+        return local_model
+
+    return PROVIDER_DEFAULT_MODEL.get(normalized, configured)

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -51,6 +51,8 @@ class AppSettings(WorkspaceInterpreterFields, OutputBudgetFields, BaseModel):
     executor_mode: str = Field(default="local")
     agent_provider: str = Field(default="anthropic")
     anthropic_api_key: str | None = Field(default=None)
+    # AC-912: fills unset role/tier slots. See config/provider_model_defaults.py.
+    local_model: str = Field(default="")
     model_competitor: str = Field(default="claude-sonnet-4-5-20250929")
     model_analyst: str = Field(default="claude-sonnet-4-5-20250929")
     model_coach: str = Field(default="claude-opus-4-6")

--- a/autocontext/tests/test_per_provider_model_defaults.py
+++ b/autocontext/tests/test_per_provider_model_defaults.py
@@ -1,0 +1,103 @@
+"""AC-912: per-provider default model resolution.
+
+Characterization first. Every value in ``_BASELINE`` below was captured by
+running the real ``RoleRouter`` against real ``load_settings()`` output on
+2026-08-09 at 29199664, before any behavior changed. The point of pinning a
+defect is that the fix produces a *reviewable diff* of this table rather than
+an unverifiable claim that nothing else moved.
+
+The defect: with no ``AUTOCONTEXT_MODEL_*`` overrides set, every provider
+except ``mlx`` resolves every role to a Claude model id, so pointing the loop
+at a local server sends it ``claude-opus-4-6`` and the request fails at the
+endpoint rather than at configuration time.
+
+``mlx`` is the only provider that already resolves correctly today, because
+it is the only one whose model comes from its own setting
+(``mlx_model_path``) rather than from the shared role/tier defaults.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+ROLES = ("competitor", "analyst", "coach", "architect", "curator", "translator")
+
+_CLAUDE_SONNET = "claude-sonnet-4-5-20250929"
+_CLAUDE_OPUS = "claude-opus-4-6"
+
+# provider -> role -> resolved model, as of 29199664.
+_BASELINE: dict[str, dict[str, str]] = {
+    provider: {
+        "competitor": _CLAUDE_SONNET,
+        "analyst": _CLAUDE_SONNET,
+        "coach": _CLAUDE_OPUS,
+        "architect": _CLAUDE_OPUS,
+        "curator": _CLAUDE_OPUS,
+        "translator": _CLAUDE_SONNET,
+    }
+    for provider in ("anthropic", "ollama", "vllm", "openai")
+}
+_BASELINE["mlx"] = dict.fromkeys(ROLES, "/models/pinned-local")
+
+
+def _settings(monkeypatch: pytest.MonkeyPatch, provider: str, **env: str):
+    """Load real settings with a scrubbed AUTOCONTEXT_* environment."""
+    import os
+
+    from autocontext.config.settings import load_settings
+
+    for key in list(os.environ):
+        if key.startswith("AUTOCONTEXT_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("AUTOCONTEXT_AGENT_PROVIDER", provider)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return load_settings()
+
+
+def _route(settings, role: str) -> str | None:
+    from autocontext.agents.role_router import RoleRouter, RoutingContext
+
+    return RoleRouter(settings).route(role, context=RoutingContext()).model
+
+
+@pytest.mark.parametrize("provider", sorted(_BASELINE))
+@pytest.mark.parametrize("role", ROLES)
+def test_default_model_per_provider_and_role(monkeypatch: pytest.MonkeyPatch, provider: str, role: str) -> None:
+    """Pin what each provider sends for each role when nothing is overridden."""
+    env = {"AUTOCONTEXT_MLX_MODEL_PATH": "/models/pinned-local"} if provider == "mlx" else {}
+    settings = _settings(monkeypatch, provider, **env)
+    assert _route(settings, role) == _BASELINE[provider][role]
+
+
+def test_non_anthropic_providers_currently_receive_claude_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defect itself, stated as one assertion.
+
+    This test is expected to FAIL once AC-912 lands -- that failure is the
+    signal the fix worked, and this test must then be replaced by its inverse
+    rather than deleted, so the guarantee survives.
+    """
+    for provider in ("ollama", "vllm", "openai"):
+        settings = _settings(monkeypatch, provider)
+        assert _route(settings, "coach") == _CLAUDE_OPUS, provider
+
+
+def test_explicit_override_is_distinguishable_from_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mechanism AC-912's fix depends on.
+
+    ``load_settings`` only passes kwargs for fields that came from the
+    environment or a preset, so ``model_fields_set`` separates "the user chose
+    this" from "nobody touched it" -- even when the chosen value is byte-equal
+    to the default. Without that, a fix cannot tell an unset field from a
+    deliberate Claude choice, and would silently override the latter.
+    """
+    untouched = _settings(monkeypatch, "ollama")
+    assert "model_competitor" not in untouched.model_fields_set
+
+    chosen = _settings(monkeypatch, "ollama", AUTOCONTEXT_MODEL_COMPETITOR=_CLAUDE_SONNET)
+    assert "model_competitor" in chosen.model_fields_set
+    assert chosen.model_competitor == _CLAUDE_SONNET

--- a/autocontext/tests/test_per_provider_model_defaults.py
+++ b/autocontext/tests/test_per_provider_model_defaults.py
@@ -1,19 +1,22 @@
 """AC-912: per-provider default model resolution.
 
-Characterization first. Every value in ``_BASELINE`` below was captured by
-running the real ``RoleRouter`` against real ``load_settings()`` output on
-2026-08-09 at 29199664, before any behavior changed. The point of pinning a
-defect is that the fix produces a *reviewable diff* of this table rather than
-an unverifiable claim that nothing else moved.
+Characterization first. The ``_BEFORE`` table was captured by running the real
+``RoleRouter`` against real ``load_settings()`` output at 29199664, before any
+behavior changed; ``_AFTER`` is the same measurement once the fix landed.
+Keeping both makes the change a reviewable diff rather than an unverifiable
+claim that nothing else moved.
 
 The defect: with no ``AUTOCONTEXT_MODEL_*`` overrides set, every provider
-except ``mlx`` resolves every role to a Claude model id, so pointing the loop
-at a local server sends it ``claude-opus-4-6`` and the request fails at the
+except ``mlx`` resolved every role to a Claude model id, so pointing the loop
+at a local server sent it ``claude-opus-4-6`` and the request failed at the
 endpoint rather than at configuration time.
 
-``mlx`` is the only provider that already resolves correctly today, because
-it is the only one whose model comes from its own setting
-(``mlx_model_path``) rather than from the shared role/tier defaults.
+Two rows must never change, and are asserted against ``_BEFORE`` on purpose:
+
+* ``anthropic`` is the shipped default, and AC-912 promises its behavior is
+  byte-identical.
+* ``mlx`` already resolved correctly, because its model comes from
+  ``mlx_model_path`` rather than the shared role/tier defaults.
 """
 
 from __future__ import annotations
@@ -24,20 +27,32 @@ ROLES = ("competitor", "analyst", "coach", "architect", "curator", "translator")
 
 _CLAUDE_SONNET = "claude-sonnet-4-5-20250929"
 _CLAUDE_OPUS = "claude-opus-4-6"
+_MLX_PATH = "/models/pinned-local"
 
-# provider -> role -> resolved model, as of 29199664.
-_BASELINE: dict[str, dict[str, str]] = {
-    provider: {
-        "competitor": _CLAUDE_SONNET,
-        "analyst": _CLAUDE_SONNET,
-        "coach": _CLAUDE_OPUS,
-        "architect": _CLAUDE_OPUS,
-        "curator": _CLAUDE_OPUS,
-        "translator": _CLAUDE_SONNET,
-    }
-    for provider in ("anthropic", "ollama", "vllm", "openai")
+_CLAUDE_BY_ROLE: dict[str, str] = {
+    "competitor": _CLAUDE_SONNET,
+    "analyst": _CLAUDE_SONNET,
+    "coach": _CLAUDE_OPUS,
+    "architect": _CLAUDE_OPUS,
+    "curator": _CLAUDE_OPUS,
+    "translator": _CLAUDE_SONNET,
 }
-_BASELINE["mlx"] = dict.fromkeys(ROLES, "/models/pinned-local")
+
+# provider -> role -> resolved model, as of 29199664 (pre-fix).
+_BEFORE: dict[str, dict[str, str]] = {provider: dict(_CLAUDE_BY_ROLE) for provider in ("anthropic", "ollama", "vllm", "openai")}
+_BEFORE["mlx"] = dict.fromkeys(ROLES, _MLX_PATH)
+
+# The same measurement after AC-912. Unchanged rows are spelled out rather
+# than referenced so a future edit to one table cannot silently move the other.
+_AFTER: dict[str, dict[str, str]] = {
+    "anthropic": dict(_CLAUDE_BY_ROLE),
+    "mlx": dict.fromkeys(ROLES, _MLX_PATH),
+    "ollama": dict.fromkeys(ROLES, "llama3.1"),
+    "vllm": dict.fromkeys(ROLES, "default"),
+    "openai": dict.fromkeys(ROLES, "gpt-4o"),
+}
+
+_UNCHANGED_PROVIDERS = ("anthropic", "mlx")
 
 
 def _settings(monkeypatch: pytest.MonkeyPatch, provider: str, **env: str):
@@ -50,6 +65,8 @@ def _settings(monkeypatch: pytest.MonkeyPatch, provider: str, **env: str):
         if key.startswith("AUTOCONTEXT_"):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("AUTOCONTEXT_AGENT_PROVIDER", provider)
+    if provider == "mlx":
+        monkeypatch.setenv("AUTOCONTEXT_MLX_MODEL_PATH", _MLX_PATH)
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     return load_settings()
@@ -61,39 +78,95 @@ def _route(settings, role: str) -> str | None:
     return RoleRouter(settings).route(role, context=RoutingContext()).model
 
 
-@pytest.mark.parametrize("provider", sorted(_BASELINE))
+@pytest.mark.parametrize("provider", sorted(_AFTER))
 @pytest.mark.parametrize("role", ROLES)
 def test_default_model_per_provider_and_role(monkeypatch: pytest.MonkeyPatch, provider: str, role: str) -> None:
     """Pin what each provider sends for each role when nothing is overridden."""
-    env = {"AUTOCONTEXT_MLX_MODEL_PATH": "/models/pinned-local"} if provider == "mlx" else {}
-    settings = _settings(monkeypatch, provider, **env)
-    assert _route(settings, role) == _BASELINE[provider][role]
+    assert _route(_settings(monkeypatch, provider), role) == _AFTER[provider][role]
 
 
-def test_non_anthropic_providers_currently_receive_claude_ids(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The defect itself, stated as one assertion.
+@pytest.mark.parametrize("provider", _UNCHANGED_PROVIDERS)
+@pytest.mark.parametrize("role", ROLES)
+def test_preserved_providers_are_byte_identical_to_before(monkeypatch: pytest.MonkeyPatch, provider: str, role: str) -> None:
+    """AC-912's hard constraint, asserted against the pre-fix measurement.
 
-    This test is expected to FAIL once AC-912 lands -- that failure is the
-    signal the fix worked, and this test must then be replaced by its inverse
-    rather than deleted, so the guarantee survives.
+    Deliberately redundant with the table above: this one compares against
+    ``_BEFORE``, so editing ``_AFTER`` to match a regression cannot make both
+    pass.
     """
-    for provider in ("ollama", "vllm", "openai"):
-        settings = _settings(monkeypatch, provider)
-        assert _route(settings, "coach") == _CLAUDE_OPUS, provider
+    assert _route(_settings(monkeypatch, provider), role) == _BEFORE[provider][role]
+
+
+@pytest.mark.parametrize("provider", ("ollama", "vllm", "openai"))
+def test_no_claude_id_reaches_a_non_anthropic_provider(monkeypatch: pytest.MonkeyPatch, provider: str) -> None:
+    """The inverse of the original defect test, which is the point of the fix.
+
+    Its predecessor asserted that these providers DID receive Claude ids; that
+    test failing is what proved the fix landed. It was replaced rather than
+    deleted so the guarantee survives as an assertion.
+    """
+    settings = _settings(monkeypatch, provider)
+    for role in ROLES:
+        model = _route(settings, role)
+        assert model is not None
+        assert "claude" not in model.lower(), f"{provider}/{role} still receives {model}"
+
+
+def test_local_model_fills_every_unset_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One env var instead of eight-plus, which was the usability half of AC-912."""
+    settings = _settings(monkeypatch, "ollama", AUTOCONTEXT_LOCAL_MODEL="qwen3:32b")
+    assert {_route(settings, role) for role in ROLES} == {"qwen3:32b"}
+
+
+def test_local_model_does_not_touch_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anthropic keeps its per-role tiering even when a local model is named.
+
+    Setting both is contradictory; resolving it in favor of the explicit
+    provider keeps the byte-identical guarantee unconditional rather than
+    "unless you also set this other var".
+    """
+    settings = _settings(monkeypatch, "anthropic", AUTOCONTEXT_LOCAL_MODEL="qwen3:32b")
+    for role in ROLES:
+        assert _route(settings, role) == _BEFORE["anthropic"][role]
+
+
+def test_explicit_override_beats_the_provider_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicitly configured model wins, even against a local provider.
+
+    The value chosen here is byte-equal to the Claude field default, which is
+    the case a naive "is it still the default?" check gets wrong: the user did
+    choose it, so it must survive.
+    """
+    settings = _settings(
+        monkeypatch,
+        "ollama",
+        AUTOCONTEXT_MODEL_COMPETITOR=_CLAUDE_SONNET,
+        AUTOCONTEXT_LOCAL_MODEL="qwen3:32b",
+    )
+    assert _route(settings, "competitor") == _CLAUDE_SONNET
+    assert _route(settings, "analyst") == "qwen3:32b"
+
+
+def test_unknown_provider_keeps_todays_behavior(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An uncharacterized transport falls through unchanged.
+
+    This module narrows a known leak; it does not invent defaults for
+    providers nobody has measured.
+    """
+    settings = _settings(monkeypatch, "some-unknown-provider")
+    assert _route(settings, "coach") == _CLAUDE_OPUS
 
 
 def test_explicit_override_is_distinguishable_from_the_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The mechanism AC-912's fix depends on.
+    """The mechanism the fix depends on.
 
     ``load_settings`` only passes kwargs for fields that came from the
     environment or a preset, so ``model_fields_set`` separates "the user chose
     this" from "nobody touched it" -- even when the chosen value is byte-equal
-    to the default. Without that, a fix cannot tell an unset field from a
-    deliberate Claude choice, and would silently override the latter.
+    to the default. Without that, the resolver cannot tell an unset field from
+    a deliberate Claude choice, and would silently override the latter.
     """
     untouched = _settings(monkeypatch, "ollama")
     assert "model_competitor" not in untouched.model_fields_set

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -117,6 +117,10 @@ _SETTINGS_DEFAULTS: dict[str, str] = {
     "tier_sonnet_model": "sonnet-tier-model",
     "tier_haiku_model": "haiku-tier-model",
     "mlx_model_path": "/models/default-local",
+    # AC-912. Empty is the shipped default; a non-empty value would fill every
+    # unset role/tier slot for non-anthropic providers, which is a different
+    # contract than this fixture pins.
+    "local_model": "",
 }
 
 # The fixture uses the TypeScript spelling for context fields so one file drives
@@ -149,11 +153,25 @@ def _divergence_cases() -> list[tuple[str, dict[str, Any]]]:
 
 
 def _settings_from_fixture(overrides: dict[str, Any]) -> MagicMock:
-    """Build a settings double from fixture overrides layered on shared defaults."""
+    """Build a settings double from fixture overrides layered on shared defaults.
+
+    Specced against ``_SETTINGS_DEFAULTS`` (AC-919 item 8). A bare MagicMock
+    returns a truthy auto-Mock for any attribute a refactor newly reads, so
+    Python silently opted into new behavior while TypeScript's literal
+    baseSettings() opted out -- AC-912 hit exactly that, resolving a role model
+    to ``mock.local_model.strip()``. With a spec, an unlisted field raises
+    AttributeError and names itself instead.
+
+    ``model_fields_set`` reports every field the double defines, because the
+    fixture specifies a concrete value for all of them: within this contract
+    every setting is configured, so provider-default resolution (AC-912) must
+    not treat any of them as untouched.
+    """
     unknown = set(overrides) - set(_SETTINGS_DEFAULTS)
     if unknown:
         raise AssertionError(f"fixture sets unknown settings keys: {sorted(unknown)}")
-    settings = MagicMock()
+    settings = MagicMock(spec=[*_SETTINGS_DEFAULTS, "model_fields_set"])
+    settings.model_fields_set = frozenset(_SETTINGS_DEFAULTS)
     for key, default in _SETTINGS_DEFAULTS.items():
         setattr(settings, key, overrides.get(key, default))
     return settings


### PR DESCRIPTION
Closes the model-id leak in AC-912. Builds on #1253's parity pins.

## The defect

Every role and tier model default is a Claude id, read unconditionally. Setting `AUTOCONTEXT_AGENT_PROVIDER=ollama` alone sent `claude-opus-4-6` to a local server — failing at the endpoint rather than at configuration time — and the user had to discover and set eight-plus vars before anything worked.

## Measured, before and after

Captured by executing the real `RoleRouter` against real `load_settings()` output, both times.

| provider | before | after |
|---|---|---|
| `anthropic` | per-role Claude ids | **unchanged** |
| `mlx` | `mlx_model_path` | **unchanged** |
| `ollama` | `claude-opus-4-6` etc. | `llama3.1` |
| `vllm` | `claude-opus-4-6` etc. | `default` |
| `openai` | `claude-opus-4-6` etc. | `gpt-4o` |

**Broader than the issue framed it:** `openai` was affected identically, so this was never only about local endpoints. One vendor's ids were hardcoded as universal defaults.

## Resolution order

1. An **explicitly configured** value always wins
2. `AUTOCONTEXT_LOCAL_MODEL` — one var instead of eight
3. A known **per-provider default** (mirrors the fallbacks `create_provider()` already applies when handed `model=None`, which the role path could never reach)
4. Otherwise the **field default, unchanged**

`anthropic` is deliberately *absent* from the provider table so it falls through to step 4 — the byte-identical guarantee is structural, not a value that happens to match. Unknown providers fall through the same way: this narrows a known leak, it does not invent behavior for transports nobody has characterized.

The distinction rests on `model_fields_set`. `load_settings()` only passes kwargs for fields present in env or a preset, so a user who explicitly sets a role model **to** the Claude default still gets it. A naive "is it still the default value?" check would silently override that deliberate choice.

## Two guardrails fired, both correctly

- **The #1253 parity pins caught 10 failures**, cause exactly as AC-919 item 8 predicted in writing: the bare `MagicMock` settings double returned a truthy auto-Mock for the new field, resolving a role model to `mock.local_model.strip()`. Now specced, so an unlisted field raises and names itself. All divergence expectations came back **unchanged** — this alters no behavior the parity contract covers.
- **The module-size ratchet** caught `settings.py` at 853/850. Comment trimmed to fit rather than raising the limit.

## Known drift introduced

Python's `_SETTINGS_DEFAULTS` now carries a `local_model` key that TypeScript's `baseSettings()` lacks, because the TS router does not implement per-provider defaults. Recorded rather than adding dead config to TS. AC-911 deletes that mirroring mechanism.

## Not closed by this PR

AC-912's third criterion — *"mismatches fail loudly at preflight, not mid-generation"* — needs the endpoint probe from **AC-914**. This stops the leak; it does not yet validate a model id against a live endpoint.

## Verification

- Full suite **8959 passed / 79 skipped / 0 failed**
- `ruff check src tests` clean; `mypy src` clean, 740 files
- The pre-fix defect test failed on exactly 18 rows (ollama/vllm/openai x 6 roles) and **zero** anthropic or mlx rows, then was replaced by its inverse rather than deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
