### PR TITLE
fix: remediate recent merge audit findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,16 @@ AUTOCONTEXT_CLAUDE_SKILLS_PATH=.claude/skills
 AUTOCONTEXT_EVENT_STREAM_PATH=runs/events.ndjson
 
 # Model selection
-AUTOCONTEXT_MODEL_COMPETITOR=claude-sonnet-4-5-20250929
-AUTOCONTEXT_MODEL_ANALYST=claude-sonnet-4-5-20250929
-AUTOCONTEXT_MODEL_COACH=claude-opus-4-6
-AUTOCONTEXT_MODEL_ARCHITECT=claude-opus-4-6
-AUTOCONTEXT_MODEL_TRANSLATOR=claude-sonnet-4-5-20250929
-AUTOCONTEXT_MODEL_CURATOR=claude-opus-4-6
+# Leave these unset to inherit the selected provider's defaults. For a local
+# endpoint, AUTOCONTEXT_LOCAL_MODEL fills every otherwise-unset role/tier slot.
+# Explicit per-role or per-tier values take precedence over LOCAL_MODEL.
+# AUTOCONTEXT_LOCAL_MODEL=qwen3:32b
+# AUTOCONTEXT_MODEL_COMPETITOR=claude-sonnet-4-5-20250929
+# AUTOCONTEXT_MODEL_ANALYST=claude-sonnet-4-5-20250929
+# AUTOCONTEXT_MODEL_COACH=claude-opus-4-6
+# AUTOCONTEXT_MODEL_ARCHITECT=claude-opus-4-6
+# AUTOCONTEXT_MODEL_TRANSLATOR=claude-sonnet-4-5-20250929
+# AUTOCONTEXT_MODEL_CURATOR=claude-opus-4-6
 
 # API credentials (set when using live providers)
 # Prefer provider-native env vars like ANTHROPIC_API_KEY; AUTOCONTEXT_ANTHROPIC_API_KEY remains a compatibility alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - TypeScript interactive runs now advertise `agent_progress_notes_v1` to transcript clients and emit concise, strict `agent_progress_note` updates for intent, discovery, decisions, verification, and blockers. Notes are safety-redacted and bounded before emission, may cite only earlier same-run durable action/artifact IDs, and replay with exact ordering and identity across reconnects and server restarts within the transcript's finite retention horizon. Python parity is deferred until it can provide the same durable transcript guarantees (AC-897).
 
+### Fixed
+
+- Provider-aware role and tier model defaults now reach the production orchestrator in both `role_routing=off` and `auto` modes. Explicit role models retain precedence over automatic tiers, OpenAI-compatible defaults match the provider factory, and `AUTOCONTEXT_LOCAL_MODEL` is documented as the single local-endpoint override.
+- Persistent interpreter workspace summaries and migration no longer invoke candidate-defined `__len__`, `__repr__`, or `__deepcopy__` hooks outside the execution timeout; plain built-in working data remains safely copyable while custom objects degrade to bounded metadata or omission.
+- Model JSON recovery skips Markdown/prose brackets before a later object and bounds failed structural decode attempts, preserving truncated-array fail-closed behavior without the AC-922 quadratic path.
+
 ## [0.14.0] - 2026-07-21
 
 ### Added

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -50,6 +50,20 @@ AUTOCONTEXT_AGENT_PROVIDER=claude-cli AUTOCONTEXT_CLAUDE_MODEL=sonnet uv run aut
 AUTOCONTEXT_AGENT_PROVIDER=codex AUTOCONTEXT_CODEX_MODEL=o4-mini uv run autoctx solve "..." --iterations 3
 ```
 
+Ollama uses `llama3.1` by default. Set one local model override to fill every
+otherwise-unset role and tier slot, regardless of whether role routing is off
+or automatic:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=ollama \
+AUTOCONTEXT_LOCAL_MODEL=qwen3:32b \
+uv run autoctx solve "..." --iterations 3
+```
+
+An explicit `AUTOCONTEXT_MODEL_<ROLE>` or `AUTOCONTEXT_TIER_<TIER>_MODEL`
+still takes precedence. `AUTOCONTEXT_LOCAL_MODEL` does not alter Anthropic's
+shipped per-role defaults.
+
 ## Common commands
 
 | Command                                                                                | Purpose                                                                                                |

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -607,6 +607,7 @@ autoctx run my_task --json
 
 # Ollama (local, no API key needed)
 AUTOCONTEXT_AGENT_PROVIDER=ollama \
+AUTOCONTEXT_LOCAL_MODEL=qwen3:32b \
 AUTOCONTEXT_JUDGE_PROVIDER=ollama \
 autoctx run my_task --json
 
@@ -666,6 +667,7 @@ Key environment variables:
 | `AUTOCONTEXT_AGENT_PROVIDER`                                         | Agent provider: `anthropic`, `openai-compatible`, `ollama`, `vllm`, `pi`, `pi-rpc`, `deterministic`                                                                                                                                                                                                 |
 | `AUTOCONTEXT_AGENT_API_KEY`                                          | Global agent API key override (or use provider-native env vars such as `ANTHROPIC_API_KEY`)                                                                                                                                                                                                         |
 | `AUTOCONTEXT_AGENT_BASE_URL`                                         | Global base URL for OpenAI-compatible agent endpoints                                                                                                                                                                                                                                               |
+| `AUTOCONTEXT_LOCAL_MODEL`                                            | One model id for every otherwise-unset role/tier slot on non-Anthropic providers. Explicit `AUTOCONTEXT_MODEL_<ROLE>` and `AUTOCONTEXT_TIER_<TIER>_MODEL` values win; otherwise known provider defaults apply (`ollama=llama3.1`, `openai`/`openai-compatible=gpt-4o`, `vllm=default`). Works with role routing both `off` and `auto`. |
 | `AUTOCONTEXT_COMPETITOR_API_KEY` / `AUTOCONTEXT_COMPETITOR_BASE_URL` | Optional competitor-specific credential and endpoint override                                                                                                                                                                                                                                       |
 | `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL`       | Optional analyst-specific credential and endpoint override                                                                                                                                                                                                                                          |
 | `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL`           | Optional coach-specific credential and endpoint override                                                                                                                                                                                                                                            |

--- a/autocontext/src/autocontext/agents/model_router.py
+++ b/autocontext/src/autocontext/agents/model_router.py
@@ -5,6 +5,7 @@ problem complexity to appropriate reasoning capacity.  Supports harness-aware
 dynamic demotion (AC-164): when harness coverage is strong, the competitor
 can be demoted to a cheaper tier since the harness catches invalid strategies.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -56,7 +57,26 @@ class ModelRouter:
         is_plateau: bool,
         harness_coverage: HarnessCoverage | None = None,
     ) -> str | None:
-        """Return model name for the given role and context, or None if routing disabled.
+        """Return model name for the given role and context, or None if routing disabled."""
+        tier = self.select_tier(
+            role,
+            generation=generation,
+            retry_count=retry_count,
+            is_plateau=is_plateau,
+            harness_coverage=harness_coverage,
+        )
+        return self._tier_map[tier] if tier is not None else None
+
+    def select_tier(
+        self,
+        role: str,
+        *,
+        generation: int,
+        retry_count: int,
+        is_plateau: bool,
+        harness_coverage: HarnessCoverage | None = None,
+    ) -> str | None:
+        """Return the selected tier name so callers can resolve its provider-specific model.
 
         Args:
             role: Agent role (competitor, analyst, coach, etc.).
@@ -105,7 +125,7 @@ class ModelRouter:
             if is_plateau:
                 tier = self._max_tier(tier, "opus")
 
-        return self._tier_map[tier]
+        return tier
 
     def _max_tier(self, a: str, b: str) -> str:
         """Return the higher of two tiers."""

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -29,6 +29,7 @@ from autocontext.agents.subagent_runtime import SubagentRuntime
 from autocontext.agents.translator import StrategyTranslator
 from autocontext.agents.trial_summary import build_trial_summary as _build_trial_summary
 from autocontext.agents.types import AgentOutputs, RoleExecution
+from autocontext.config.provider_model_defaults import resolve_model_default
 from autocontext.config.settings import AppSettings
 from autocontext.execution.harness_coverage import HarnessCoverage
 from autocontext.extensions import HookBus, wrap_language_model_client
@@ -420,13 +421,6 @@ class AgentOrchestrator:
             or self._scenario_bound_default_client(role, scenario_name=scenario_name)
             or self._client_for_role(role)
         )
-        model = self.resolve_model(
-            role,
-            generation=generation,
-            retry_count=retry_count,
-            is_plateau=is_plateau,
-            scenario_name=scenario_name,
-        )
         provider_config = self._resolve_role_provider_config(
             role,
             generation=generation,
@@ -434,11 +428,28 @@ class AgentOrchestrator:
             is_plateau=is_plateau,
             scenario_name=scenario_name,
         )
+        effective_config = provider_config or self._role_router.route(role)
+        model = self.resolve_model(
+            role,
+            generation=generation,
+            retry_count=retry_count,
+            is_plateau=is_plateau,
+            scenario_name=scenario_name,
+            provider=effective_config.provider_type,
+        )
         if provider_config is None:
-            return client, model
+            # role_routing="off" disables provider selection, not effective
+            # model resolution. The runners were constructed from raw
+            # AppSettings defaults (Claude ids), so leaving ``model`` as None
+            # here leaks those ids to Ollama/vLLM/OpenAI-compatible clients.
+            if self._role_router.role_model_is_explicit(role):
+                return client, self._role_router.resolved_role_model(role, effective_config.provider_type)
+            return client, model or effective_config.model
         client = self._client_for_provider_config(role, provider_config, scenario_name=scenario_name)
         if provider_config.provider_class == ProviderClass.LOCAL:
             return client, provider_config.model
+        if self._role_router.role_model_is_explicit(role):
+            return client, self._role_router.resolved_role_model(role, provider_config.provider_type)
         return client, model or provider_config.model
 
     def resolve_role_execution(
@@ -757,16 +768,30 @@ class AgentOrchestrator:
         is_plateau: bool = False,
         scenario_name: str = "",
         harness_coverage: HarnessCoverage | None = None,
+        provider: str | None = None,
     ) -> str | None:
         """Return the model to use for a role, or None to use the default."""
         if harness_coverage is None and role == "competitor":
             harness_coverage = self._get_harness_coverage(scenario_name)
-        return self._model_router.select(
+        tier = self._model_router.select_tier(
             role,
             generation=generation,
             retry_count=retry_count,
             is_plateau=is_plateau,
             harness_coverage=harness_coverage,
+        )
+        if tier is None:
+            return None
+        field_name = f"tier_{tier}_model"
+        configured: str = getattr(self.settings, field_name)
+        return (
+            resolve_model_default(
+                self.settings,
+                provider=provider or self.settings.agent_provider,
+                field_name=field_name,
+                configured=configured,
+            )
+            or configured
         )
 
     def _get_harness_coverage(self, scenario_name: str) -> HarnessCoverage | None:

--- a/autocontext/src/autocontext/agents/role_router.py
+++ b/autocontext/src/autocontext/agents/role_router.py
@@ -228,6 +228,15 @@ class RoleRouter:
             configured=configured,
         )
 
+    def role_model_is_explicit(self, role: str) -> bool:
+        """Whether the caller explicitly configured this role's model slot."""
+        field = self._role_model_fields.get(role)
+        return field is not None and field in self._settings.model_fields_set
+
+    def resolved_role_model(self, role: str, provider: str) -> str | None:
+        """Resolve a role slot for the effective provider."""
+        return self._resolve_role_model(role, provider)
+
     def _resolve_class_model(self, role: str, provider_class: ProviderClass, provider: str) -> str | None:
         """Tier model for ``provider``, falling back to the role model."""
         from autocontext.config.provider_model_defaults import resolve_model_default

--- a/autocontext/src/autocontext/config/provider_model_defaults.py
+++ b/autocontext/src/autocontext/config/provider_model_defaults.py
@@ -61,7 +61,7 @@ class _SupportsFieldsSet(Protocol):
 PROVIDER_DEFAULT_MODEL: dict[str, str] = {
     "ollama": "llama3.1",
     "openai": "gpt-4o",
-    "openai-compatible": "default",
+    "openai-compatible": "gpt-4o",
     "vllm": "default",
     "openrouter": "anthropic/claude-sonnet-4",
 }

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -52,7 +52,7 @@ class AppSettings(WorkspaceInterpreterFields, OutputBudgetFields, BaseModel):
     agent_provider: str = Field(default="anthropic")
     anthropic_api_key: str | None = Field(default=None)
     # AC-912: fills unset role/tier slots. See config/provider_model_defaults.py.
-    local_model: str = Field(default="")
+    local_model: str = Field(default="", description="Model id for every unset non-Anthropic role/tier slot")
     model_competitor: str = Field(default="claude-sonnet-4-5-20250929")
     model_analyst: str = Field(default="claude-sonnet-4-5-20250929")
     model_coach: str = Field(default="claude-opus-4-6")

--- a/autocontext/src/autocontext/execution/interpreter_workspace.py
+++ b/autocontext/src/autocontext/execution/interpreter_workspace.py
@@ -22,6 +22,136 @@ from autocontext.harness.repl.types import ReplCommand, ReplResult
 from autocontext.harness.repl.worker import CodeTimeout, ReplWorker
 
 _SUMMARY_MAX_CHARS = 120
+_SUMMARY_MAX_ITEMS = 20
+_SUMMARY_MAX_DEPTH = 6
+_SUMMARY_MAX_NODES = 200
+_SAFE_ATOMIC_TYPES = frozenset({type(None), bool, int, float, complex, str, bytes, range})
+_SAFE_SIZED_TYPES = frozenset({str, bytes, bytearray, range, list, tuple, dict, set, frozenset})
+
+
+class _UnsupportedWorkspaceValue(TypeError):
+    """Raised when migration would have to execute candidate-defined code."""
+
+
+def _type_name(value: Any) -> str:
+    """Read a type name without dispatching through a candidate metaclass."""
+    value_type = type(value)
+    try:
+        name = type.__getattribute__(value_type, "__name__")
+        return name if isinstance(name, str) else "object"
+    except KeyboardInterrupt:
+        raise
+    except BaseException:  # pragma: no cover - defensive against exotic extension types
+        return "object"
+
+
+def _safe_summary(
+    value: Any,
+    *,
+    seen: set[int] | None = None,
+    budget: list[int] | None = None,
+    depth: int = 0,
+) -> str:
+    """Render bounded metadata without calling candidate-defined magic methods."""
+    budget = budget if budget is not None else [_SUMMARY_MAX_NODES]
+    if budget[0] <= 0:
+        return "..."
+    budget[0] -= 1
+    value_type = type(value)
+    if value_type is str:
+        clipped = value[:_SUMMARY_MAX_CHARS]
+        return repr(clipped) + ("..." if len(value) > len(clipped) else "")
+    if value_type in {bytes, bytearray}:
+        clipped = value[:_SUMMARY_MAX_CHARS]
+        return repr(clipped) + ("..." if len(value) > len(clipped) else "")
+    if value_type is int and value.bit_length() > 4096:
+        return "<int>"
+    if value_type in _SAFE_ATOMIC_TYPES:
+        return repr(value)
+
+    if value_type not in {list, tuple, dict, set, frozenset}:
+        return f"<{_type_name(value)}>"
+    if depth >= _SUMMARY_MAX_DEPTH or len(value) > _SUMMARY_MAX_ITEMS:
+        return f"<{_type_name(value)}>"
+
+    seen = seen if seen is not None else set()
+    value_id = id(value)
+    if value_id in seen:
+        return "..."
+    seen.add(value_id)
+    try:
+        if value_type is list:
+            return (
+                "["
+                + ", ".join(_safe_summary(item, seen=seen, budget=budget, depth=depth + 1) for item in value)
+                + "]"
+            )
+        if value_type is tuple:
+            rendered = ", ".join(
+                _safe_summary(item, seen=seen, budget=budget, depth=depth + 1) for item in value
+            )
+            return f"({rendered}{',' if len(value) == 1 else ''})"
+        if value_type is dict:
+            rendered = ", ".join(
+                f"{_safe_summary(key, seen=seen, budget=budget, depth=depth + 1)}: "
+                f"{_safe_summary(item, seen=seen, budget=budget, depth=depth + 1)}"
+                for key, item in value.items()
+            )
+            return "{" + rendered + "}"
+        rendered = ", ".join(
+            _safe_summary(item, seen=seen, budget=budget, depth=depth + 1) for item in value
+        )
+        if value_type is set:
+            return "set()" if not value else "{" + rendered + "}"
+        return f"frozenset({{{rendered}}})"
+    finally:
+        seen.remove(value_id)
+
+
+def _safe_clone(value: Any, *, memo: dict[int, Any] | None = None, active: set[int] | None = None) -> Any:
+    """Clone plain built-in data recursively without invoking ``__deepcopy__``."""
+    value_type = type(value)
+    if value_type in _SAFE_ATOMIC_TYPES:
+        return value
+    if value_type is bytearray:
+        return bytearray(value)
+    if value_type not in {list, tuple, dict, set, frozenset}:
+        raise _UnsupportedWorkspaceValue(_type_name(value))
+
+    memo = memo if memo is not None else {}
+    active = active if active is not None else set()
+    value_id = id(value)
+    if value_id in memo:
+        return memo[value_id]
+    if value_id in active:
+        raise _UnsupportedWorkspaceValue("cyclic immutable container")
+    active.add(value_id)
+    try:
+        if value_type is list:
+            cloned_list: list[Any] = []
+            memo[value_id] = cloned_list
+            cloned_list.extend(_safe_clone(item, memo=memo, active=active) for item in value)
+            return cloned_list
+        if value_type is dict:
+            cloned_dict: dict[Any, Any] = {}
+            memo[value_id] = cloned_dict
+            for key, item in value.items():
+                cloned_dict[_safe_clone(key, memo=memo, active=active)] = _safe_clone(item, memo=memo, active=active)
+            return cloned_dict
+        if value_type is set:
+            cloned_set: set[Any] = set()
+            memo[value_id] = cloned_set
+            cloned_set.update(_safe_clone(item, memo=memo, active=active) for item in value)
+            return cloned_set
+        if value_type is tuple:
+            cloned_tuple = tuple(_safe_clone(item, memo=memo, active=active) for item in value)
+            memo[value_id] = cloned_tuple
+            return cloned_tuple
+        cloned_frozen = frozenset(_safe_clone(item, memo=memo, active=active) for item in value)
+        memo[value_id] = cloned_frozen
+        return cloned_frozen
+    finally:
+        active.remove(value_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,11 +166,11 @@ class WorkspaceVariable:
 
 @dataclass(slots=True)
 class WorkspaceSnapshot:
-    """Deep-copied user variables captured for migration or inspection.
+    """Safely copied user variables captured for migration or inspection.
 
-    ``skipped`` records variables whose values could not be deep-copied
-    (generators, open handles, ...); they degrade to omission, never to a
-    crash, so migration always proceeds with what is copyable.
+    ``skipped`` records values outside the plain built-in data contract
+    (generators, custom instances, open handles, ...). Candidate-defined copy
+    hooks are never executed; unsupported values degrade to omission.
     """
 
     variables: dict[str, Any]
@@ -85,7 +215,9 @@ class InterpreterWorkspace:
             for name, value in seed.items():
                 try:
                     self._worker.namespace[name] = copy.deepcopy(value)
-                except Exception:
+                except KeyboardInterrupt:
+                    raise
+                except BaseException:  # noqa: BLE001
                     self._worker.namespace[name] = value
         self._closed = False
 
@@ -128,17 +260,18 @@ class InterpreterWorkspace:
         self._ensure_open()
         described: list[WorkspaceVariable] = []
         for name, value in self._user_items():
+            value_type = type(value)
             try:
-                size: int | None = len(value)
-            except TypeError:
+                size = len(value) if value_type in _SAFE_SIZED_TYPES else None
+                summary = _safe_summary(value)
+            except KeyboardInterrupt:
+                raise
+            except BaseException:  # noqa: BLE001
                 size = None
-            try:
-                summary = repr(value)
-            except Exception:
-                summary = f"<{type(value).__name__}>"
+                summary = f"<{_type_name(value)}>"
             if len(summary) > _SUMMARY_MAX_CHARS:
                 summary = summary[: _SUMMARY_MAX_CHARS - 3] + "..."
-            described.append(WorkspaceVariable(name=name, type_name=type(value).__name__, size=size, summary=summary))
+            described.append(WorkspaceVariable(name=name, type_name=_type_name(value), size=size, summary=summary))
         return described
 
     def render_markdown(self, max_vars: int = 20) -> str:
@@ -153,19 +286,21 @@ class InterpreterWorkspace:
         return "\n".join(lines)
 
     def snapshot(self) -> WorkspaceSnapshot:
-        """Deep-copy user variables; non-copyable values are skipped, not fatal."""
+        """Copy plain built-in user variables without executing candidate hooks."""
         self._ensure_open()
         variables: dict[str, Any] = {}
         skipped: list[str] = []
         for name, value in self._user_items():
             try:
-                variables[name] = copy.deepcopy(value)
-            except Exception:
+                variables[name] = _safe_clone(value)
+            except KeyboardInterrupt:
+                raise
+            except BaseException:  # noqa: BLE001
                 skipped.append(name)
         return WorkspaceSnapshot(variables=variables, skipped=tuple(skipped))
 
     def restore(self, snap: WorkspaceSnapshot) -> None:
-        """Replace user variables with a deep copy of the snapshot's.
+        """Replace user variables with a safe copy of the snapshot's.
 
         The second copy keeps lineages independent: restoring the same
         snapshot into several islands must never share mutable objects.
@@ -177,8 +312,10 @@ class InterpreterWorkspace:
         staged: dict[str, Any] = {}
         for name, value in snap.variables.items():
             try:
-                staged[name] = copy.deepcopy(value)
-            except Exception:
+                staged[name] = _safe_clone(value)
+            except KeyboardInterrupt:
+                raise
+            except BaseException:  # noqa: BLE001
                 continue
         for name, _ in self._user_items():
             del self._worker.namespace[name]

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -28,6 +28,13 @@ _JSON_FENCE_RE = re.compile(
 # an editor.
 _BOM = chr(0xFEFF)
 
+# Each failed raw_decode may scan the remaining suffix. Bounding failures keeps
+# adversarial repetition linear in input size while retaining generous recovery
+# for ordinary prose with a handful of stray braces (AC-922).
+_MAX_FAILED_DECODE_ATTEMPTS = 64
+_JSON_NUMBER_AT_ARRAY_START_RE = re.compile(r"-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?(?=\s*(?:[,\]]|$))")
+_NUMERIC_CITATION_RE = re.compile(r"\[\s*\d+(?:\s*,\s*\d+)*\s*\]")
+
 
 def _scope_text(raw: str) -> str:
     """Normalize a candidate scope: strip surrounding whitespace and any leading BOM.
@@ -59,6 +66,24 @@ def strip_json_fences(text: str) -> str:
     return match.group("body").strip() if match else text.strip()
 
 
+def _plausible_json_array_start(text: str, start: int) -> bool:
+    """Distinguish a truncated JSON array from Markdown/prose brackets."""
+    cursor = start + 1
+    while cursor < len(text) and text[cursor].isspace():
+        cursor += 1
+    if cursor == len(text):
+        return True
+    if text[cursor] in {'"', "{", "[", "]"}:
+        return True
+    suffix = text[cursor:]
+    if _JSON_NUMBER_AT_ARRAY_START_RE.match(suffix):
+        return True
+    return any(
+        suffix.startswith(literal) and (len(suffix) == len(literal) or suffix[len(literal)] in " \t\r\n,]")
+        for literal in ("true", "false", "null")
+    )
+
+
 def _top_level_object_spans(text: str) -> list[str]:
     """Find each top-level JSON value span (``{...}`` or ``[...]``) in ``text``, in order.
 
@@ -83,14 +108,16 @@ def _top_level_object_spans(text: str) -> list[str]:
 
     A malformed object start is skipped and scanning resumes one character
     later, so side-by-side top-level objects are still returned separately.
-    A malformed array start is different: scanning into it could expose a
-    complete nested object and silently unwrap that object as the answer. Its
-    remaining text is therefore returned as one terminal failing candidate,
-    and scanning stops.
+    Recovery attempts are capped because each failed ``raw_decode`` may scan
+    the remaining suffix; the cap makes degenerate repetition bounded rather
+    than quadratic. A malformed *plausible JSON array* is terminal so its
+    nested objects cannot be promoted, while Markdown/prose brackets such as
+    ``[draft]`` are skipped like ordinary text.
     """
     spans: list[str] = []
     decoder = json.JSONDecoder()
     i = 0
+    failed_attempts = 0
     while True:
         starts = [p for p in (text.find("{", i), text.find("[", i)) if p != -1]
         if not starts:
@@ -99,16 +126,15 @@ def _top_level_object_spans(text: str) -> list[str]:
         try:
             _value, end = decoder.raw_decode(text, start)
         except ValueError:
-            if text[start] == "[":
+            failed_attempts += 1
+            if text[start] == "[" and _plausible_json_array_start(text, start):
                 # A truncated array can still contain complete object values.
                 # Treat the whole remainder as one failing candidate instead
                 # of walking into it and promoting one of those nested values.
                 spans.append(text[start:])
                 return spans
-            # AC-922: retrying one character later is O(n^2) on degenerate
-            # repetitive input (e.g. '{"a": ' * n); load-bearing for
-            # correctness (it's what lets side-by-side spans still separate
-            # after a stray unclosed brace), so don't "optimize" it away here.
+            if failed_attempts >= _MAX_FAILED_DECODE_ATTEMPTS:
+                return spans
             i = start + 1
             continue
         spans.append(text[start:end])
@@ -209,11 +235,12 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     valid one is the closest match to what a human reader would take as the
     answer.
 
-    A scope whose first JSON container is ``[`` -- fenced or not, and even
-    when prose precedes it -- is exempt from object rescue. If it parses, it
-    is a decisive answer about the model's output shape (see the wrong-type
-    note below); if it is truncated, that parse failure is terminal too,
-    rather than a cue to scan into the array and unwrap a nested object.
+    A scope whose first plausible JSON container is ``[`` -- fenced or not,
+    and even when prose precedes it -- is exempt from object rescue. If it
+    parses, it is a decisive answer about the model's output shape (see the
+    wrong-type note below); if it is truncated, that parse failure is terminal
+    too, rather than a cue to scan into the array and unwrap a nested object.
+    Markdown/prose brackets are skipped unless they look like JSON values.
 
     ``on_failure`` controls what happens when no JSON object is found:
     ``"raise"`` (default) re-raises the underlying parse error; ``"none"``
@@ -246,9 +273,25 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
             # whose Extra-data JSONDecodeError is part of the public outcome.
             if array_start == 0:
                 continue
-            array_candidate = _top_level_object_spans(scope)[0]
-            if array_candidate != scope:
-                candidates.append(array_candidate)
+            structural_candidates = _top_level_object_spans(scope)
+            if structural_candidates:
+                first_object_index = next(
+                    (index for index, candidate in enumerate(structural_candidates) if candidate.startswith("{")),
+                    None,
+                )
+                citation_prefix = (
+                    array_start > 0
+                    and first_object_index is not None
+                    and first_object_index > 0
+                    and all(_NUMERIC_CITATION_RE.fullmatch(candidate) for candidate in structural_candidates[:first_object_index])
+                )
+                if citation_prefix:
+                    assert first_object_index is not None
+                    candidates.append(structural_candidates[first_object_index])
+                    continue
+                first_candidate = structural_candidates[0]
+                if first_candidate != scope:
+                    candidates.append(first_candidate)
             continue
         if has_fence:
             # NOTE: this crude first-`{`-to-last-`}` rescue is weaker than the

--- a/autocontext/tests/test_interpreter_workspace.py
+++ b/autocontext/tests/test_interpreter_workspace.py
@@ -153,6 +153,47 @@ def test_base_exception_from_candidate_is_contained() -> None:
     assert after.error is None and "2" in after.stdout
 
 
+def test_variables_never_invoke_candidate_repr_or_len() -> None:
+    ws = InterpreterWorkspace()
+    result = ws.run(
+        "def explode(self):\n"
+        "    raise SystemExit(7)\n"
+        'Trap = type("Trap", (), {"__repr__": explode, "__len__": explode})\n'
+        "value = Trap()"
+    )
+    assert result.error is None
+
+    by_name = {variable.name: variable for variable in ws.variables()}
+    assert by_name["value"].type_name == "Trap"
+    assert by_name["value"].size is None
+    assert by_name["value"].summary == "<Trap>"
+
+
+def test_snapshot_never_invokes_candidate_deepcopy() -> None:
+    ws = InterpreterWorkspace()
+    result = ws.run(
+        "def explode(self, memo):\n"
+        "    raise SystemExit(9)\n"
+        'Trap = type("Trap", (), {"__deepcopy__": explode})\n'
+        "value = Trap()\n"
+        "plain = [[1], [2]]"
+    )
+    assert result.error is None
+
+    snapshot = ws.snapshot()
+    assert "value" in snapshot.skipped
+    assert snapshot.variables["plain"] == [[1], [2]]
+
+
+def test_variable_summary_has_global_budget_for_shared_container_graphs() -> None:
+    ws = InterpreterWorkspace()
+    result = ws.run("value = [0]\nfor _ in range(6):\n    value = [value] * 20")
+    assert result.error is None
+
+    by_name = {variable.name: variable for variable in ws.variables()}
+    assert len(by_name["value"].summary) <= 120
+
+
 def test_seed_values_do_not_alias_caller_state() -> None:
     caller_pool = [1, 2, 3]
     ws = InterpreterWorkspace(seed={"pool": caller_pool})

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -615,6 +615,35 @@ def test_extract_json_prose_wrapped_bare_json_parses_via_brace_scan() -> None:
     assert extract_json('Here is the result: {"a": 1} -- hope that helps!') == {"a": 1}
 
 
+@pytest.mark.parametrize(
+    "text",
+    (
+        'Use [draft] while reasoning, then return {"a": 1}',
+        'See [working notes](https://example.test/notes), then return {"a": 1}',
+        'Sources [1, 2] support the result {"a": 1}',
+    ),
+)
+def test_extract_json_skips_bracket_prose_before_object(text: str) -> None:
+    assert extract_json(text) == {"a": 1}
+
+
+def test_extract_json_bounds_failed_structural_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    from autocontext.harness.core import output_parser
+
+    class AlwaysFailDecoder:
+        calls = 0
+
+        def raw_decode(self, text: str, start: int):  # type: ignore[no-untyped-def]
+            self.calls += 1
+            raise ValueError
+
+    decoder = AlwaysFailDecoder()
+    monkeypatch.setattr(output_parser.json, "JSONDecoder", lambda: decoder)
+
+    assert output_parser._top_level_object_spans('{"a": ' * 1000) == []
+    assert decoder.calls == output_parser._MAX_FAILED_DECODE_ATTEMPTS
+
+
 def test_extract_json_uppercase_json_fence_tag_is_recognized() -> None:
     assert extract_json('```JSON\n{"a": 1}\n```') == {"a": 1}
 

--- a/autocontext/tests/test_per_provider_model_defaults.py
+++ b/autocontext/tests/test_per_provider_model_defaults.py
@@ -21,6 +21,8 @@ Two rows must never change, and are asserted against ``_BEFORE`` on purpose:
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 ROLES = ("competitor", "analyst", "coach", "architect", "curator", "translator")
@@ -39,7 +41,9 @@ _CLAUDE_BY_ROLE: dict[str, str] = {
 }
 
 # provider -> role -> resolved model, as of 29199664 (pre-fix).
-_BEFORE: dict[str, dict[str, str]] = {provider: dict(_CLAUDE_BY_ROLE) for provider in ("anthropic", "ollama", "vllm", "openai")}
+_BEFORE: dict[str, dict[str, str]] = {
+    provider: dict(_CLAUDE_BY_ROLE) for provider in ("anthropic", "ollama", "vllm", "openai", "openai-compatible")
+}
 _BEFORE["mlx"] = dict.fromkeys(ROLES, _MLX_PATH)
 
 # The same measurement after AC-912. Unchanged rows are spelled out rather
@@ -50,6 +54,7 @@ _AFTER: dict[str, dict[str, str]] = {
     "ollama": dict.fromkeys(ROLES, "llama3.1"),
     "vllm": dict.fromkeys(ROLES, "default"),
     "openai": dict.fromkeys(ROLES, "gpt-4o"),
+    "openai-compatible": dict.fromkeys(ROLES, "gpt-4o"),
 }
 
 _UNCHANGED_PROVIDERS = ("anthropic", "mlx")
@@ -97,7 +102,7 @@ def test_preserved_providers_are_byte_identical_to_before(monkeypatch: pytest.Mo
     assert _route(_settings(monkeypatch, provider), role) == _BEFORE[provider][role]
 
 
-@pytest.mark.parametrize("provider", ("ollama", "vllm", "openai"))
+@pytest.mark.parametrize("provider", ("ollama", "vllm", "openai", "openai-compatible"))
 def test_no_claude_id_reaches_a_non_anthropic_provider(monkeypatch: pytest.MonkeyPatch, provider: str) -> None:
     """The inverse of the original defect test, which is the point of the fix.
 
@@ -174,3 +179,82 @@ def test_explicit_override_is_distinguishable_from_the_default(
     chosen = _settings(monkeypatch, "ollama", AUTOCONTEXT_MODEL_COMPETITOR=_CLAUDE_SONNET)
     assert "model_competitor" in chosen.model_fields_set
     assert chosen.model_competitor == _CLAUDE_SONNET
+
+
+def _orchestrator_model(settings, *, role: str = "competitor", generation: int = 1) -> str | None:
+    """Resolve through the production orchestrator, without constructing a live provider."""
+    from autocontext.agents.llm_client import DeterministicDevClient
+    from autocontext.agents.orchestrator import AgentOrchestrator
+
+    client = DeterministicDevClient()
+    orchestrator = AgentOrchestrator(client, settings)
+    with patch("autocontext.agents.provider_bridge.create_role_client", return_value=client):
+        _resolved_client, model = orchestrator.resolve_role_execution(role, generation=generation)
+    return model
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    (
+        ("ollama", "llama3.1"),
+        ("vllm", "default"),
+        ("openai", "gpt-4o"),
+        ("openai-compatible", "gpt-4o"),
+    ),
+)
+def test_routing_off_resolves_provider_default_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    expected: str,
+) -> None:
+    """The shipped routing-off mode must not bypass provider-aware defaults."""
+    assert _orchestrator_model(_settings(monkeypatch, provider)) == expected
+
+
+def test_tier_routing_resolves_tier_against_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(
+        monkeypatch,
+        "ollama",
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_TIER_ROUTING_ENABLED="true",
+    )
+    assert _orchestrator_model(settings) == "llama3.1"
+
+
+@pytest.mark.parametrize("role_routing", ("off", "auto"))
+def test_tier_routing_resolves_against_per_role_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    role_routing: str,
+) -> None:
+    settings = _settings(
+        monkeypatch,
+        "anthropic",
+        AUTOCONTEXT_ROLE_ROUTING=role_routing,
+        AUTOCONTEXT_TIER_ROUTING_ENABLED="true",
+        AUTOCONTEXT_COMPETITOR_PROVIDER="ollama",
+    )
+    assert _orchestrator_model(settings) == "llama3.1"
+
+
+@pytest.mark.parametrize("tier_routing", ("false", "true"))
+def test_explicit_role_model_wins_in_auto_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_routing: str,
+) -> None:
+    settings = _settings(
+        monkeypatch,
+        "ollama",
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_TIER_ROUTING_ENABLED=tier_routing,
+        AUTOCONTEXT_MODEL_COMPETITOR="qwen3:custom",
+    )
+    assert _orchestrator_model(settings) == "qwen3:custom"
+
+
+def test_openai_compatible_default_matches_provider_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    from autocontext.config.provider_model_defaults import PROVIDER_DEFAULT_MODEL
+    from autocontext.providers.registry import create_provider
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = create_provider("openai-compatible", api_key="test-key")
+    assert PROVIDER_DEFAULT_MODEL["openai-compatible"] == provider.default_model() == "gpt-4o"


### PR DESCRIPTION
## Summary

- make production role and tier model resolution provider-aware in both `role_routing=off` and `auto`, including per-role provider overrides
- preserve explicit role-model precedence and align the OpenAI-compatible default with the provider factory (`gpt-4o`)
- harden persistent interpreter metadata and migration so candidate-defined `__len__`, `__repr__`, and `__deepcopy__` hooks cannot escape execution controls
- bound workspace summary traversal and JSON structural recovery, while recovering valid objects after Markdown/prose brackets and numeric citations
- document `AUTOCONTEXT_LOCAL_MODEL`, its precedence, and provider-aware defaults

## Root causes addressed

The recent-merge audit found three related gaps:

1. provider-aware defaults existed in the routing layer but the production orchestrator could bypass them in the default/off path and tier routing could resolve against the global provider instead of a per-role provider
2. workspace inspection and migration used generic Python protocols outside the candidate execution timeout, allowing custom magic methods to terminate or stall the host process
3. JSON recovery treated any leading bracket as an array claim and retried malformed structural starts without a bound, causing false negatives for ordinary prose and a quadratic adversarial path

## Behavior and compatibility

- explicit per-role and per-tier model settings still win
- Anthropic defaults remain unchanged
- local provider slots inherit `AUTOCONTEXT_LOCAL_MODEL` only when otherwise unset
- workspace snapshots intentionally migrate plain built-in data; unsupported custom objects are skipped rather than executing candidate hooks
- malformed plausible JSON arrays remain fail-closed so nested objects are not silently promoted

## Validation

- Python full suite: 8,979 passed, 79 skipped; the three host-restricted tests from the sandbox run were rerun with host memory/loopback access and passed
- TypeScript full suite: 6,055 passed across 834 files
- `ruff check src tests`
- `mypy src` (740 source files)
- `npm run lint`
- `npm run check:schemas`
- Python/TypeScript routing parity tests
- focused provider-routing, workspace, parser, and module-size regression tests
- `git diff --check`
