### PR TITLE
feat(AC-913): constrained decoding for role outputs, wired end to end

### DIFF
--- a/autocontext/scripts/measure_format_drift_baseline.py
+++ b/autocontext/scripts/measure_format_drift_baseline.py
@@ -1,0 +1,116 @@
+"""AC-913 baseline: how often does markdown-heading scraping actually find the sections?
+
+Runs the REAL analyst task instruction from prompts/templates.py through
+llama3.1:8b, then feeds the response to the REAL _extract_section_bullets from
+agents/parsers.py. A section counts as lost when the model was asked for it and
+the parser returns an empty list -- which today is silent, not an error.
+
+Usage: uv run --frozen python ac913_baseline.py <n_trials>
+"""
+# ruff: noqa: E402 - sys.path is set below before the package imports
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+from autocontext.agents.parsers import _extract_section_bullets
+
+# Verbatim from prompts/templates.py:450 (the analyst_task string).
+ANALYST_TASK = "Analyze strengths/failures and return markdown with sections: Findings, Root Causes, Actionable Recommendations."
+
+SECTIONS = ("Findings", "Root Causes", "Actionable Recommendations")
+
+# A plausible analyst input: a scenario run that partly failed.
+CONTEXT = """Scenario: grid_ctf, generation 3.
+Competitor strategy: greedy nearest-flag with a 2-step lookahead, aggression=0.8.
+Result: score 0.41 of 1.0. Captured 2 of 5 flags.
+Failures: agent oscillated between two equidistant flags for 14 of 40 steps;
+walked into a guarded tile twice; never used the decoy action.
+Strengths: reached the first flag in 6 steps, below the 9-step median."""
+
+MODEL = "llama3.1:8b"
+URL = "http://localhost:11434/api/chat"
+
+
+def ask(temperature: float, seed: int) -> str:
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are the analyst agent in an optimization loop.",
+            },
+            {"role": "user", "content": f"{CONTEXT}\n\n{ANALYST_TASK}"},
+        ],
+        "stream": False,
+        "options": {"temperature": temperature, "seed": seed},
+    }
+    req = urllib.request.Request(
+        URL,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        return json.loads(resp.read())["message"]["content"]
+
+
+def main() -> None:
+    trials = int(sys.argv[1]) if len(sys.argv) > 1 else 20
+    lost: dict[str, int] = dict.fromkeys(SECTIONS, 0)
+    any_lost = 0
+    all_lost = 0
+    records = []
+
+    for i in range(trials):
+        # Temperature 0.7 is the realistic setting for a creative analyst turn;
+        # a fresh seed per trial so this measures drift, not one lucky sample.
+        text = ask(temperature=0.7, seed=1000 + i)
+        found = {s: _extract_section_bullets(text, s) for s in SECTIONS}
+        missing = [s for s, b in found.items() if not b]
+        for s in missing:
+            lost[s] += 1
+        if missing:
+            any_lost += 1
+        if len(missing) == len(SECTIONS):
+            all_lost += 1
+        records.append({"seed": 1000 + i, "missing": missing, "chars": len(text), "text": text})
+        print(f"  trial {i + 1:2d}/{trials}: missing={missing or 'none'}", flush=True)
+
+    print()
+    print(f"model={MODEL}  trials={trials}  temperature=0.7")
+    for s in SECTIONS:
+        print(f"  {s:28s} lost {lost[s]:2d}/{trials}  ({100 * lost[s] / trials:.0f}%)")
+    print(
+        f"  {'>=1 section lost':28s}      {any_lost:2d}/{trials}  ({100 * any_lost / trials:.0f}%)"
+    )
+    print(
+        f"  {'all sections lost':28s}      {all_lost:2d}/{trials}  ({100 * all_lost / trials:.0f}%)"
+    )
+
+    out = Path(__file__).resolve().parent / "ac913_baseline_result.json"
+    out.write_text(
+        json.dumps(
+            {
+                "model": MODEL,
+                "trials": trials,
+                "temperature": 0.7,
+                "lost_per_section": lost,
+                "at_least_one_lost": any_lost,
+                "all_lost": all_lost,
+                "records": records,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/autocontext/scripts/measure_format_drift_constrained.py
+++ b/autocontext/scripts/measure_format_drift_constrained.py
@@ -1,0 +1,121 @@
+"""AC-913 after-measurement: same prompt, same model, constrained decoding on.
+
+Goes through the REAL OpenAICompatibleProvider (not raw curl), so this measures
+the shipped code path including the response_format wiring and the `constrained`
+flag, not a hand-rolled request.
+"""
+# ruff: noqa: E402 - sys.path is set below before the package imports
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+from autocontext.providers.base import OutputSchema
+from autocontext.providers.openai_compat import OpenAICompatibleProvider
+
+ANALYST_TASK = "Analyze strengths/failures and return markdown with sections: Findings, Root Causes, Actionable Recommendations."
+
+CONTEXT = """Scenario: grid_ctf, generation 3.
+Competitor strategy: greedy nearest-flag with a 2-step lookahead, aggression=0.8.
+Result: score 0.41 of 1.0. Captured 2 of 5 flags.
+Failures: agent oscillated between two equidistant flags for 14 of 40 steps;
+walked into a guarded tile twice; never used the decoy action.
+Strengths: reached the first flag in 6 steps, below the 9-step median."""
+
+ANALYST_SCHEMA = OutputSchema(
+    name="analyst_output",
+    schema={
+        "type": "object",
+        "properties": {
+            "findings": {"type": "array", "items": {"type": "string"}},
+            "root_causes": {"type": "array", "items": {"type": "string"}},
+            "recommendations": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["findings", "root_causes", "recommendations"],
+        "additionalProperties": False,
+    },
+)
+
+REQUIRED = ("findings", "root_causes", "recommendations")
+
+
+def main() -> None:
+    trials = int(sys.argv[1]) if len(sys.argv) > 1 else 20
+    provider = OpenAICompatibleProvider(
+        api_key="ollama",
+        base_url="http://localhost:11434/v1",
+        default_model_name="llama3.1:8b",
+    )
+
+    lost = dict.fromkeys(REQUIRED, 0)
+    any_lost = 0
+    unconstrained = 0
+    records = []
+
+    for i in range(trials):
+        result = provider.complete(
+            system_prompt="You are the analyst agent in an optimization loop.",
+            user_prompt=f"{CONTEXT}\n\n{ANALYST_TASK}",
+            temperature=0.7,
+            max_tokens=1200,
+            output_schema=ANALYST_SCHEMA,
+        )
+        if not result.constrained:
+            unconstrained += 1
+
+        missing: list[str] = []
+        try:
+            payload = json.loads(result.text)
+        except json.JSONDecodeError:
+            missing = list(REQUIRED)
+        else:
+            missing = [k for k in REQUIRED if not payload.get(k)]
+
+        for k in missing:
+            lost[k] += 1
+        if missing:
+            any_lost += 1
+        records.append(
+            {"missing": missing, "constrained": result.constrained, "text": result.text}
+        )
+        print(
+            f"  trial {i + 1:2d}/{trials}: missing={missing or 'none'} constrained={result.constrained}",
+            flush=True,
+        )
+
+    print()
+    print(
+        f"model=llama3.1:8b  trials={trials}  temperature=0.7  constrained decoding ON"
+    )
+    for k in REQUIRED:
+        print(f"  {k:28s} lost {lost[k]:2d}/{trials}  ({100 * lost[k] / trials:.0f}%)")
+    print(
+        f"  {'>=1 section lost':28s}      {any_lost:2d}/{trials}  ({100 * any_lost / trials:.0f}%)"
+    )
+    print(f"  {'reported unconstrained':28s}      {unconstrained:2d}/{trials}")
+
+    out = Path(__file__).resolve().parent / "ac913_after_result.json"
+    out.write_text(
+        json.dumps(
+            {
+                "model": "llama3.1:8b",
+                "trials": trials,
+                "lost_per_field": lost,
+                "at_least_one_lost": any_lost,
+                "reported_unconstrained": unconstrained,
+                "records": records,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/autocontext/src/autocontext/agents/analyst.py
+++ b/autocontext/src/autocontext/agents/analyst.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from autocontext.agents.role_schemas import ANALYST_SCHEMA
 from autocontext.agents.subagent_runtime import SubagentRuntime, SubagentTask
 from autocontext.agents.types import RoleExecution
 
@@ -14,6 +15,7 @@ class AnalystRunner:
         return self.runtime.run_task(
             SubagentTask(
                 role="analyst",
+                output_schema=ANALYST_SCHEMA,
                 model=self.model,
                 prompt=prompt,
                 max_tokens=self.max_tokens,

--- a/autocontext/src/autocontext/agents/architect.py
+++ b/autocontext/src/autocontext/agents/architect.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from autocontext.agents.role_schemas import ARCHITECT_SCHEMA
 from autocontext.agents.subagent_runtime import SubagentRuntime, SubagentTask
 from autocontext.agents.types import RoleExecution
 from autocontext.harness.core.output_parser import extract_delimited_section, extract_json
@@ -138,6 +139,7 @@ class ArchitectRunner:
         return self.runtime.run_task(
             SubagentTask(
                 role="architect",
+                output_schema=ARCHITECT_SCHEMA,
                 model=self.model,
                 prompt=prompt,
                 max_tokens=self.max_tokens,

--- a/autocontext/src/autocontext/agents/coach.py
+++ b/autocontext/src/autocontext/agents/coach.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from autocontext.agents.role_schemas import COACH_SCHEMA
 from autocontext.agents.subagent_runtime import SubagentRuntime, SubagentTask
 from autocontext.agents.types import RoleExecution
 from autocontext.harness.core.output_parser import extract_delimited_section
@@ -44,6 +45,7 @@ class CoachRunner:
         return self.runtime.run_task(
             SubagentTask(
                 role="coach",
+                output_schema=COACH_SCHEMA,
                 model=self.model,
                 prompt=prompt,
                 max_tokens=self.max_tokens,

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autocontext.agents.analyst import AnalystRunner
-from autocontext.agents.architect import ArchitectRunner, parse_architect_harness_specs, parse_architect_tool_specs
-from autocontext.agents.coach import CoachRunner, parse_coach_sections
+from autocontext.agents.architect import ArchitectRunner
+from autocontext.agents.coach import CoachRunner
 from autocontext.agents.competitor import CompetitorRunner
 from autocontext.agents.curator import KnowledgeCurator
 from autocontext.agents.llm_client import DeferredMLXClient, LanguageModelClient, build_client_from_settings
@@ -728,10 +728,6 @@ class AgentOrchestrator:
         # under `python -O`; nothing below depends on this one executing.
         assert strategy is not None
 
-        tools = parse_architect_tool_specs(results["architect"].content)
-        harness_specs = parse_architect_harness_specs(results["architect"].content)
-        coach_playbook, coach_lessons, coach_hints = parse_coach_sections(results["coach"].content)
-
         competitor_typed = parse_competitor_output(
             results["competitor"].content,
             strategy,
@@ -743,14 +739,14 @@ class AgentOrchestrator:
 
         return AgentOutputs(
             strategy=strategy,
-            analysis_markdown=results["analyst"].content,
-            coach_markdown=results["coach"].content,
-            coach_playbook=coach_playbook,
-            coach_lessons=coach_lessons,
-            coach_competitor_hints=coach_hints,
-            architect_markdown=results["architect"].content,
-            architect_tools=tools,
-            architect_harness_specs=harness_specs,
+            analysis_markdown=analyst_typed.raw_markdown,
+            coach_markdown=coach_typed.raw_markdown,
+            coach_playbook=coach_typed.playbook,
+            coach_lessons=coach_typed.lessons,
+            coach_competitor_hints=coach_typed.hints,
+            architect_markdown=architect_typed.raw_markdown,
+            architect_tools=architect_typed.tool_specs,
+            architect_harness_specs=architect_typed.harness_specs,
             role_executions=[results[r] for r in ["competitor", "translator", "analyst", "coach", "architect"]],
             competitor_output=competitor_typed,
             analyst_output=analyst_typed,

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -20,7 +20,7 @@ from autocontext.agents.orchestrator_helpers import (
     _run_competitor_phase,
     _run_translator_phase,
 )
-from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
+from autocontext.agents.parsers import parse_analyst_exec, parse_architect_exec, parse_coach_exec, parse_competitor_output
 from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext
 from autocontext.agents.role_runtime_overrides import apply_role_overrides, settings_for_budgeted_role_call
 from autocontext.agents.runtime_session_wiring import runtime_session_client_for_role
@@ -737,9 +737,9 @@ class AgentOrchestrator:
             strategy,
             is_code_strategy=self.settings.code_strategies_enabled,
         )
-        analyst_typed = parse_analyst_output(results["analyst"].content)
-        coach_typed = parse_coach_output(results["coach"].content)
-        architect_typed = parse_architect_output(results["architect"].content)
+        analyst_typed = parse_analyst_exec(results["analyst"])
+        coach_typed = parse_coach_exec(results["coach"])
+        architect_typed = parse_architect_exec(results["architect"])
 
         return AgentOutputs(
             strategy=strategy,

--- a/autocontext/src/autocontext/agents/orchestrator_helpers.py
+++ b/autocontext/src/autocontext/agents/orchestrator_helpers.py
@@ -13,8 +13,6 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
-from autocontext.agents.architect import parse_architect_harness_specs, parse_architect_tool_specs
-from autocontext.agents.coach import parse_coach_sections
 from autocontext.agents.parsers import parse_analyst_exec, parse_architect_exec, parse_coach_exec, parse_competitor_output
 from autocontext.agents.role_isolation import resolve_role_turn
 from autocontext.agents.types import AgentOutputs, RoleExecution
@@ -271,10 +269,6 @@ def _assemble_agent_outputs(
     architect_exec: RoleExecution,
 ) -> AgentOutputs:
     """Parse role outputs and assemble the AgentOutputs for this generation."""
-    tools = parse_architect_tool_specs(architect_exec.content)
-    harness_specs = parse_architect_harness_specs(architect_exec.content)
-    coach_playbook, coach_lessons, coach_hints = parse_coach_sections(coach_exec.content)
-
     competitor_typed = parse_competitor_output(
         raw_text,
         strategy,
@@ -286,14 +280,14 @@ def _assemble_agent_outputs(
 
     return AgentOutputs(
         strategy=strategy,
-        analysis_markdown=analyst_exec.content,
-        coach_markdown=coach_exec.content,
-        coach_playbook=coach_playbook,
-        coach_lessons=coach_lessons,
-        coach_competitor_hints=coach_hints,
-        architect_markdown=architect_exec.content,
-        architect_tools=tools,
-        architect_harness_specs=harness_specs,
+        analysis_markdown=analyst_typed.raw_markdown,
+        coach_markdown=coach_typed.raw_markdown,
+        coach_playbook=coach_typed.playbook,
+        coach_lessons=coach_typed.lessons,
+        coach_competitor_hints=coach_typed.hints,
+        architect_markdown=architect_typed.raw_markdown,
+        architect_tools=architect_typed.tool_specs,
+        architect_harness_specs=architect_typed.harness_specs,
         role_executions=[competitor_exec, translator_exec, analyst_exec, coach_exec, architect_exec],
         competitor_output=competitor_typed,
         analyst_output=analyst_typed,

--- a/autocontext/src/autocontext/agents/orchestrator_helpers.py
+++ b/autocontext/src/autocontext/agents/orchestrator_helpers.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from autocontext.agents.architect import parse_architect_harness_specs, parse_architect_tool_specs
 from autocontext.agents.coach import parse_coach_sections
-from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
+from autocontext.agents.parsers import parse_analyst_exec, parse_architect_exec, parse_coach_exec, parse_competitor_output
 from autocontext.agents.role_isolation import resolve_role_turn
 from autocontext.agents.types import AgentOutputs, RoleExecution
 
@@ -280,9 +280,9 @@ def _assemble_agent_outputs(
         strategy,
         is_code_strategy=orchestrator.settings.code_strategies_enabled,
     )
-    analyst_typed = parse_analyst_output(analyst_exec.content)
-    coach_typed = parse_coach_output(coach_exec.content)
-    architect_typed = parse_architect_output(architect_exec.content)
+    analyst_typed = parse_analyst_exec(analyst_exec)
+    coach_typed = parse_coach_exec(coach_exec)
+    architect_typed = parse_architect_exec(architect_exec)
 
     return AgentOutputs(
         strategy=strategy,

--- a/autocontext/src/autocontext/agents/parsers.py
+++ b/autocontext/src/autocontext/agents/parsers.py
@@ -4,7 +4,7 @@ import logging
 import re
 from typing import Any
 
-from autocontext.agents.architect import parse_architect_tool_specs
+from autocontext.agents.architect import parse_architect_harness_specs, parse_architect_tool_specs
 from autocontext.agents.coach import parse_coach_sections
 from autocontext.agents.contracts import AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput
 from autocontext.harness.core.types import RoleExecution
@@ -87,9 +87,11 @@ def parse_architect_output(raw_markdown: str) -> ArchitectOutput:
     """Parse architect markdown into typed contract."""
     try:
         tool_specs = parse_architect_tool_specs(raw_markdown)
+        harness_specs = parse_architect_harness_specs(raw_markdown)
         return ArchitectOutput(
             raw_markdown=raw_markdown,
             tool_specs=tool_specs,
+            harness_specs=harness_specs,
             parse_success=True,
         )
     except Exception:

--- a/autocontext/src/autocontext/agents/parsers.py
+++ b/autocontext/src/autocontext/agents/parsers.py
@@ -7,6 +7,7 @@ from typing import Any
 from autocontext.agents.architect import parse_architect_tool_specs
 from autocontext.agents.coach import parse_coach_sections
 from autocontext.agents.contracts import AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput
+from autocontext.harness.core.types import RoleExecution
 
 logger = logging.getLogger(__name__)
 
@@ -94,3 +95,45 @@ def parse_architect_output(raw_markdown: str) -> ArchitectOutput:
     except Exception:
         logger.warning("failed to parse architect output", exc_info=True)
         return ArchitectOutput(raw_markdown=raw_markdown, parse_success=False)
+
+
+def _was_constrained(execution: RoleExecution) -> bool:
+    """Whether this role's output was actually schema-enforced by the backend.
+
+    Reads what the backend reported, not what was requested. A schema that was
+    asked for and silently not applied reports False here, which is the whole
+    reason the flag is recorded per execution (AC-913).
+    """
+    return bool(execution.metadata.get("constrained"))
+
+
+def parse_analyst_exec(execution: RoleExecution) -> AnalystOutput:
+    """Parse an analyst execution by whichever path its backend actually used.
+
+    Constrained output is validated and drift raises. Unconstrained output
+    keeps the markdown scrape, unchanged -- so a backend with no constrained
+    decoding (Anthropic today, every CLI runtime) behaves exactly as before.
+    """
+    if _was_constrained(execution):
+        from autocontext.agents.role_schemas import parse_analyst_constrained
+
+        return parse_analyst_constrained(execution.content)
+    return parse_analyst_output(execution.content)
+
+
+def parse_coach_exec(execution: RoleExecution) -> CoachOutput:
+    """Coach counterpart of parse_analyst_exec."""
+    if _was_constrained(execution):
+        from autocontext.agents.role_schemas import parse_coach_constrained
+
+        return parse_coach_constrained(execution.content)
+    return parse_coach_output(execution.content)
+
+
+def parse_architect_exec(execution: RoleExecution) -> ArchitectOutput:
+    """Architect counterpart of parse_analyst_exec."""
+    if _was_constrained(execution):
+        from autocontext.agents.role_schemas import parse_architect_constrained
+
+        return parse_architect_constrained(execution.content)
+    return parse_architect_output(execution.content)

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -38,14 +38,10 @@ class ProviderBridgeClient(LanguageModelClient):
     to be used as a client for agent role runners.
     """
 
-    # AC-913: an LLMProvider can carry an output schema to the backend. Whether
-    # the backend HONORS it is reported per-call by CompletionResult.constrained,
-    # not assumed here -- this flag only says the path exists.
-    supports_constrained_output: bool = True
-
     def __init__(self, provider: LLMProvider, *, use_provider_default_model: bool = False) -> None:
         self._provider = provider
         self._use_provider_default_model = use_provider_default_model
+        self.supports_constrained_output = _accepts_output_schema(provider.complete)
 
     def generate_constrained(
         self,
@@ -101,13 +97,14 @@ class ProviderBridgeClient(LanguageModelClient):
         del role
         t0 = time.monotonic()
         resolved_model = None if self._use_provider_default_model else model
-        # Forward output_schema ONLY when one was asked for. autocontext ships
-        # LLMProvider as public API, so a provider implemented outside this repo
-        # predates the parameter; passing it unconditionally would break every
-        # such implementation on calls that never wanted a schema. Opting in is
-        # the caller's choice, and a provider that has not adopted it simply
-        # never sees it.
-        extra: dict[str, Any] = {"output_schema": output_schema} if output_schema is not None else {}
+        # LLMProvider is a public interface and subclasses written before
+        # output_schema was added are still valid Python implementations. Only
+        # pass the new keyword when the concrete method opted into it; do not
+        # catch TypeError here, because that would also swallow bugs raised
+        # inside a provider implementation.
+        extra: dict[str, Any] = {}
+        if output_schema is not None and self.supports_constrained_output:
+            extra["output_schema"] = output_schema
         result = self._provider.complete(
             system_prompt=system,
             user_prompt=prompt,
@@ -135,6 +132,18 @@ class ProviderBridgeClient(LanguageModelClient):
             ),
             metadata=metadata,
         )
+
+
+def _accepts_output_schema(complete: Callable[..., object]) -> bool:
+    """Whether a provider's concrete complete method accepts the new keyword."""
+    try:
+        parameters = inspect.signature(complete).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == "output_schema" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
 
 
 class RuntimeBridgeClient(LanguageModelClient):

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from autocontext.config.settings import AppSettings
-    from autocontext.providers.base import LLMProvider
+    from autocontext.providers.base import LLMProvider, OutputSchema
     from autocontext.runtimes.base import AgentRuntime
     from autocontext.session.runtime_session import RuntimeSession
 
@@ -38,9 +38,36 @@ class ProviderBridgeClient(LanguageModelClient):
     to be used as a client for agent role runners.
     """
 
+    # AC-913: an LLMProvider can carry an output schema to the backend. Whether
+    # the backend HONORS it is reported per-call by CompletionResult.constrained,
+    # not assumed here -- this flag only says the path exists.
+    supports_constrained_output: bool = True
+
     def __init__(self, provider: LLMProvider, *, use_provider_default_model: bool = False) -> None:
         self._provider = provider
         self._use_provider_default_model = use_provider_default_model
+
+    def generate_constrained(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        output_schema: OutputSchema,
+        role: str = "",
+        system: str = "",
+    ) -> ModelResponse:
+        """Generate with a schema, recording whether the backend enforced it."""
+        return self._complete(
+            model=model,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            role=role,
+            output_schema=output_schema,
+            system=system,
+        )
 
     def generate(
         self,
@@ -51,21 +78,53 @@ class ProviderBridgeClient(LanguageModelClient):
         temperature: float,
         role: str = "",
     ) -> ModelResponse:
+        return self._complete(
+            model=model,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            role=role,
+            output_schema=None,
+        )
+
+    def _complete(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        role: str,
+        output_schema: OutputSchema | None,
+        system: str = "",
+    ) -> ModelResponse:
+        del role
         t0 = time.monotonic()
         resolved_model = None if self._use_provider_default_model else model
+        # Forward output_schema ONLY when one was asked for. autocontext ships
+        # LLMProvider as public API, so a provider implemented outside this repo
+        # predates the parameter; passing it unconditionally would break every
+        # such implementation on calls that never wanted a schema. Opting in is
+        # the caller's choice, and a provider that has not adopted it simply
+        # never sees it.
+        extra: dict[str, Any] = {"output_schema": output_schema} if output_schema is not None else {}
         result = self._provider.complete(
-            system_prompt="",
+            system_prompt=system,
             user_prompt=prompt,
             model=resolved_model,
             temperature=temperature,
             max_tokens=max_tokens,
+            **extra,
         )
         elapsed_ms = int((time.monotonic() - t0) * 1000)
         usage_model = result.model or resolved_model or self._provider.default_model()
 
-        metadata = {}
+        metadata: dict[str, Any] = {}
         if result.cost_usd is not None:
             metadata["cost_usd"] = result.cost_usd
+        # What the backend actually did, not what was asked for. A provider
+        # that ignored the schema reports False here and the run record shows it.
+        metadata["constrained"] = result.constrained
         return ModelResponse(
             text=result.text,
             usage=RoleUsage(

--- a/autocontext/src/autocontext/agents/role_schemas.py
+++ b/autocontext/src/autocontext/agents/role_schemas.py
@@ -23,9 +23,10 @@ the pipeline depends on for correctness.
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, ValidationError
 
 from autocontext.agents.contracts import AnalystOutput, ArchitectOutput, CoachOutput
 from autocontext.providers.base import OutputSchema
@@ -58,12 +59,16 @@ class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+NonEmptyText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
 class AnalystPayload(_StrictModel):
     """The analyst's three sections, as data rather than headings."""
 
-    findings: list[str] = Field(description="What the run showed, one claim per item.")
-    root_causes: list[str] = Field(description="Why each failure happened.")
-    recommendations: list[str] = Field(
+    findings: list[NonEmptyText] = Field(min_length=1, description="What the run showed, one claim per item.")
+    root_causes: list[NonEmptyText] = Field(min_length=1, description="Why each failure happened.")
+    recommendations: list[NonEmptyText] = Field(
+        min_length=1,
         description="Concrete changes for the next generation, each naming a parameter or behavior."
     )
 
@@ -96,20 +101,67 @@ class CoachPayload(_StrictModel):
 class ArchitectToolSpec(_StrictModel):
     """One proposed tool. Mirrors what parse_architect_tool_specs already requires."""
 
-    name: str = Field(description="Tool identifier.")
-    description: str = Field(description="What the tool does and when to reach for it.")
-    code: str = Field(description="Complete implementation.")
+    name: NonEmptyText = Field(description="Tool identifier.")
+    description: NonEmptyText = Field(description="What the tool does and when to reach for it.")
+    code: NonEmptyText = Field(description="Complete implementation.")
+
+
+class ArchitectHarnessSpec(_StrictModel):
+    """One executable pre-tournament strategy validator."""
+
+    name: NonEmptyText = Field(description="Validator identifier.")
+    description: str = Field(description="What the validator protects against, or empty.")
+    code: NonEmptyText = Field(description="Complete validate_strategy implementation.")
+
+
+class ArchitectMutationSpec(_StrictModel):
+    """One persistent harness mutation, with inapplicable selectors empty."""
+
+    type: Literal["prompt_fragment", "context_policy", "completion_check", "tool_instruction"]
+    target_role: str = Field(description="Target role for prompt_fragment, otherwise empty.")
+    component: str = Field(description="Context component for context_policy, otherwise empty.")
+    tool_name: str = Field(description="Tool identifier for tool_instruction, otherwise empty.")
+    content: NonEmptyText
+    rationale: str
+
+
+class ArchitectDAGChange(_StrictModel):
+    """One role-DAG change directive."""
+
+    action: Literal["add_role", "remove_role"]
+    name: NonEmptyText
+    depends_on: list[NonEmptyText] = Field(description="Dependencies for add_role; empty for remove_role.")
+
+
+class ArchitectTuningParameter(_StrictModel):
+    """One bounded adaptive configuration proposal."""
+
+    name: Literal[
+        "backpressure_min_delta",
+        "matches_per_generation",
+        "rlm_max_turns",
+        "architect_every_n_gens",
+        "probe_matches",
+    ]
+    value: float
 
 
 class ArchitectPayload(_StrictModel):
     """The architect's proposal.
 
-    Architect already speaks JSON via extract_json, so this is the smallest gap
-    of the three: the shape was known, it just was not enforced, and a
-    malformed proposal became an empty list.
+    All fields are required so OpenAI strict mode can enforce the object. Empty
+    lists represent channels with no proposal; rendered markdown omits their
+    legacy marker blocks, preserving the existing downstream behavior.
     """
 
+    observed_bottlenecks: list[str] = Field(description="Observed infrastructure bottlenecks.")
+    impact_hypothesis: str = Field(description="Expected impact of the proposed changes.")
     tools: list[ArchitectToolSpec] = Field(description="Proposed tools; an empty list means no proposal.")
+    harness: list[ArchitectHarnessSpec] = Field(description="Proposed executable harness validators.")
+    mutations: list[ArchitectMutationSpec] = Field(description="Proposed persistent harness mutations.")
+    dag_changes: list[ArchitectDAGChange] = Field(description="Proposed role-DAG changes.")
+    tuning_parameters: list[ArchitectTuningParameter] = Field(description="Proposed adaptive parameters.")
+    tuning_reasoning: str = Field(description="Reasoning for adaptive parameters, or empty.")
     changelog_entry: str = Field(description="One line describing the change, or empty if nothing is proposed.")
 
 
@@ -182,12 +234,61 @@ def parse_coach_constrained(raw_text: str) -> CoachOutput:
 def parse_architect_constrained(raw_text: str) -> ArchitectOutput:
     """Validate a schema-constrained architect response into the typed contract."""
     payload: ArchitectPayload = _validate("architect", ArchitectPayload, raw_text)
+    rendered = render_architect_markdown(payload)
+    # Keep the existing AST validation for executable harness code even after
+    # the outer object has passed schema validation.
+    from autocontext.agents.architect import parse_architect_harness_specs
+
     return ArchitectOutput(
-        raw_markdown=raw_text,
+        raw_markdown=rendered,
         tool_specs=[spec.model_dump() for spec in payload.tools],
+        harness_specs=parse_architect_harness_specs(rendered),
         changelog_entry=payload.changelog_entry,
         parse_success=True,
     )
+
+
+def render_architect_markdown(payload: ArchitectPayload) -> str:
+    """Render every validated architect channel into its legacy wire format."""
+    bottlenecks = "\n".join(f"- {item}" for item in payload.observed_bottlenecks)
+    tools_summary = "\n".join(f"- **{tool.name}**: {tool.description}" for tool in payload.tools)
+    blocks = [
+        f"## Observed Bottlenecks\n\n{bottlenecks}" if bottlenecks else "## Observed Bottlenecks\n",
+        f"## Tool Proposals\n\n{tools_summary}" if tools_summary else "## Tool Proposals\n",
+        f"## Impact Hypothesis\n\n{payload.impact_hypothesis}",
+        "```json\n" + json.dumps({"tools": [tool.model_dump() for tool in payload.tools]}) + "\n```",
+    ]
+    if payload.harness:
+        blocks.append(
+            "<!-- HARNESS_START -->\n"
+            + json.dumps({"harness": [spec.model_dump() for spec in payload.harness]})
+            + "\n<!-- HARNESS_END -->"
+        )
+    if payload.mutations:
+        blocks.append(
+            "<!-- MUTATIONS_START -->\n"
+            + json.dumps({"mutations": [mutation.model_dump() for mutation in payload.mutations]})
+            + "\n<!-- MUTATIONS_END -->"
+        )
+    if payload.dag_changes:
+        blocks.append(
+            "<!-- DAG_CHANGES_START -->\n"
+            + json.dumps({"changes": [change.model_dump() for change in payload.dag_changes]})
+            + "\n<!-- DAG_CHANGES_END -->"
+        )
+    if payload.tuning_parameters:
+        tuning: dict[str, float | str] = {
+            parameter.name: parameter.value for parameter in payload.tuning_parameters
+        }
+        tuning["reasoning"] = payload.tuning_reasoning
+        blocks.append(
+            "<!-- TUNING_PROPOSAL_START -->\n"
+            + json.dumps(tuning)
+            + "\n<!-- TUNING_PROPOSAL_END -->"
+        )
+    if payload.changelog_entry:
+        blocks.append(f"## Changelog\n\n{payload.changelog_entry}")
+    return "\n\n".join(blocks) + "\n"
 
 
 def render_coach_markdown(payload: CoachPayload) -> str:

--- a/autocontext/src/autocontext/agents/role_schemas.py
+++ b/autocontext/src/autocontext/agents/role_schemas.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from autocontext.agents.contracts import AnalystOutput
+from autocontext.agents.contracts import AnalystOutput, ArchitectOutput, CoachOutput
 from autocontext.providers.base import OutputSchema
 
 
@@ -77,7 +77,45 @@ def _output_schema(name: str, model: type[BaseModel]) -> OutputSchema:
     return OutputSchema(name=name, schema=schema)
 
 
+class CoachPayload(_StrictModel):
+    """The coach's three sections.
+
+    Today these are delimited by HTML comment markers, and the fallback when a
+    model emits no markers at all is to treat the entire response as the
+    playbook -- preamble, reasoning and all. That is a quieter failure than the
+    analyst's empty section but a worse one: the playbook is persisted and
+    steers the next generation. A schema removes the marker convention rather
+    than asking a model to honor it.
+    """
+
+    playbook: str = Field(description="The complete replacement playbook, consolidated and deduplicated.")
+    lessons: str = Field(description="Operational lessons, each a concrete prescriptive rule.")
+    hints: str = Field(description="Concrete hints for the competitor's next attempt.")
+
+
+class ArchitectToolSpec(_StrictModel):
+    """One proposed tool. Mirrors what parse_architect_tool_specs already requires."""
+
+    name: str = Field(description="Tool identifier.")
+    description: str = Field(description="What the tool does and when to reach for it.")
+    code: str = Field(description="Complete implementation.")
+
+
+class ArchitectPayload(_StrictModel):
+    """The architect's proposal.
+
+    Architect already speaks JSON via extract_json, so this is the smallest gap
+    of the three: the shape was known, it just was not enforced, and a
+    malformed proposal became an empty list.
+    """
+
+    tools: list[ArchitectToolSpec] = Field(description="Proposed tools; an empty list means no proposal.")
+    changelog_entry: str = Field(description="One line describing the change, or empty if nothing is proposed.")
+
+
 ANALYST_SCHEMA = _output_schema("analyst_output", AnalystPayload)
+COACH_SCHEMA = _output_schema("coach_output", CoachPayload)
+ARCHITECT_SCHEMA = _output_schema("architect_output", ArchitectPayload)
 
 
 def parse_analyst_constrained(raw_text: str) -> AnalystOutput:
@@ -88,13 +126,7 @@ def parse_analyst_constrained(raw_text: str) -> AnalystOutput:
             match the schema. Deliberately loud: the whole point is that drift
             stops being indistinguishable from "the analyst had nothing to say".
     """
-    try:
-        payload = AnalystPayload.model_validate_json(raw_text)
-    except ValidationError as exc:
-        raise RoleOutputValidationError("analyst", str(exc), raw_text) from exc
-    except ValueError as exc:  # malformed JSON
-        raise RoleOutputValidationError("analyst", f"not valid JSON: {exc}", raw_text) from exc
-
+    payload: AnalystPayload = _validate("analyst", AnalystPayload, raw_text)
     return AnalystOutput(
         raw_markdown=render_analyst_markdown(payload),
         findings=payload.findings,
@@ -123,3 +155,56 @@ def render_analyst_markdown(payload: AnalystPayload) -> str:
         lines = "\n".join(f"- {item}" for item in items)
         blocks.append(f"## {heading}\n\n{lines}" if lines else f"## {heading}\n")
     return "\n\n".join(blocks) + "\n"
+
+
+def _validate(role: str, model: type[BaseModel], raw_text: str) -> Any:
+    """Validate one role payload, converting any failure into the typed error."""
+    try:
+        return model.model_validate_json(raw_text)
+    except ValidationError as exc:
+        raise RoleOutputValidationError(role, str(exc), raw_text) from exc
+    except ValueError as exc:  # malformed JSON
+        raise RoleOutputValidationError(role, f"not valid JSON: {exc}", raw_text) from exc
+
+
+def parse_coach_constrained(raw_text: str) -> CoachOutput:
+    """Validate a schema-constrained coach response into the typed contract."""
+    payload: CoachPayload = _validate("coach", CoachPayload, raw_text)
+    return CoachOutput(
+        raw_markdown=render_coach_markdown(payload),
+        playbook=payload.playbook,
+        lessons=payload.lessons,
+        hints=payload.hints,
+        parse_success=True,
+    )
+
+
+def parse_architect_constrained(raw_text: str) -> ArchitectOutput:
+    """Validate a schema-constrained architect response into the typed contract."""
+    payload: ArchitectPayload = _validate("architect", ArchitectPayload, raw_text)
+    return ArchitectOutput(
+        raw_markdown=raw_text,
+        tool_specs=[spec.model_dump() for spec in payload.tools],
+        changelog_entry=payload.changelog_entry,
+        parse_success=True,
+    )
+
+
+def render_coach_markdown(payload: CoachPayload) -> str:
+    """Render validated coach data back into the marker format the repo reads.
+
+    Emits the same delimiters parse_coach_sections expects, so the rendered
+    form round-trips through the existing extractor and every consumer of the
+    marker convention keeps working.
+    """
+    return (
+        "<!-- PLAYBOOK_START -->\n"
+        f"{payload.playbook}\n"
+        "<!-- PLAYBOOK_END -->\n\n"
+        "<!-- LESSONS_START -->\n"
+        f"{payload.lessons}\n"
+        "<!-- LESSONS_END -->\n\n"
+        "<!-- COMPETITOR_HINTS_START -->\n"
+        f"{payload.hints}\n"
+        "<!-- COMPETITOR_HINTS_END -->\n"
+    )

--- a/autocontext/src/autocontext/agents/role_schemas.py
+++ b/autocontext/src/autocontext/agents/role_schemas.py
@@ -1,0 +1,125 @@
+"""Schema-enforced role outputs (AC-913).
+
+Today a role's output is recovered by scraping markdown headings, and drift is
+silent: ``_extract_section_bullets`` returns ``[]`` for a heading it cannot
+find, so a correct analysis with the wrong heading level becomes an empty
+contract and the loop continues as though the role said nothing. Measured on
+llama3.1:8b, that happened in 20 of 20 trials -- see
+``docs/ac913-format-drift-measurement.json``.
+
+This module gives each role a schema instead. The same declaration does two
+jobs: it is sent to the provider to constrain decoding, and it validates what
+comes back. Anything that does not conform raises ``RoleOutputValidationError``
+rather than yielding an empty section.
+
+Pydantic is used rather than a JSON Schema library because it is already a core
+dependency and does both halves. Adding ``jsonschema`` would mean touching
+``uv.lock``, which carries a deliberate supply-chain quarantine.
+
+Markdown is kept, but as a *rendered view* of validated data (the direction the
+issue leans toward), so ``analysis.md`` stays readable without being the thing
+the pipeline depends on for correctness.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from autocontext.agents.contracts import AnalystOutput
+from autocontext.providers.base import OutputSchema
+
+
+class RoleOutputValidationError(ValueError):
+    """A role's output did not conform to its schema.
+
+    Carries the role and the underlying reason so a caller can log which role
+    drifted and on what, instead of discovering an empty contract later with no
+    trace of why. This is the typed failure AC-913 requires in place of the
+    silent-empty path.
+    """
+
+    def __init__(self, role: str, reason: str, raw_text: str) -> None:
+        super().__init__(f"{role} output failed schema validation: {reason}")
+        self.role = role
+        self.reason = reason
+        self.raw_text = raw_text
+
+
+class _StrictModel(BaseModel):
+    """Base for role payloads.
+
+    ``extra="forbid"`` emits ``additionalProperties: false``, which OpenAI's
+    strict json_schema mode requires and which stops a backend from padding the
+    object with fields no role reads.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AnalystPayload(_StrictModel):
+    """The analyst's three sections, as data rather than headings."""
+
+    findings: list[str] = Field(description="What the run showed, one claim per item.")
+    root_causes: list[str] = Field(description="Why each failure happened.")
+    recommendations: list[str] = Field(
+        description="Concrete changes for the next generation, each naming a parameter or behavior."
+    )
+
+
+def _output_schema(name: str, model: type[BaseModel]) -> OutputSchema:
+    """Build the provider-facing schema from the same model used to validate."""
+    schema: dict[str, Any] = model.model_json_schema()
+    # The title is pydantic bookkeeping, not part of the contract, and some
+    # backends echo it back into the generated object.
+    schema.pop("title", None)
+    return OutputSchema(name=name, schema=schema)
+
+
+ANALYST_SCHEMA = _output_schema("analyst_output", AnalystPayload)
+
+
+def parse_analyst_constrained(raw_text: str) -> AnalystOutput:
+    """Validate a schema-constrained analyst response into the typed contract.
+
+    Raises:
+        RoleOutputValidationError: if the payload is not valid JSON or does not
+            match the schema. Deliberately loud: the whole point is that drift
+            stops being indistinguishable from "the analyst had nothing to say".
+    """
+    try:
+        payload = AnalystPayload.model_validate_json(raw_text)
+    except ValidationError as exc:
+        raise RoleOutputValidationError("analyst", str(exc), raw_text) from exc
+    except ValueError as exc:  # malformed JSON
+        raise RoleOutputValidationError("analyst", f"not valid JSON: {exc}", raw_text) from exc
+
+    return AnalystOutput(
+        raw_markdown=render_analyst_markdown(payload),
+        findings=payload.findings,
+        root_causes=payload.root_causes,
+        recommendations=payload.recommendations,
+        parse_success=True,
+    )
+
+
+def render_analyst_markdown(payload: AnalystPayload) -> str:
+    """Render validated data back into the markdown shape the repo already reads.
+
+    Deliberately emits exactly what ``_extract_section_bullets`` expects: ``##``
+    headings and ``- `` bullets. That keeps analysis.md readable, keeps every
+    existing markdown consumer working, and means the rendered form round-trips
+    through the old parser -- which is what makes replacing the scrape path
+    safe rather than a flag day.
+    """
+    sections = (
+        ("Findings", payload.findings),
+        ("Root Causes", payload.root_causes),
+        ("Actionable Recommendations", payload.recommendations),
+    )
+    blocks = []
+    for heading, items in sections:
+        lines = "\n".join(f"- {item}" for item in items)
+        blocks.append(f"## {heading}\n\n{lines}" if lines else f"## {heading}\n")
+    return "\n\n".join(blocks) + "\n"

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -6,7 +6,7 @@ from typing import Any
 from autocontext.extensions.hooks import HookBus, HookEvents
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleUsage
-from autocontext.providers.base import CompletionResult, LLMProvider
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema
 
 
 class HookedLanguageModelClient(LanguageModelClient):
@@ -135,6 +135,7 @@ class HookedLLMProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
         payload = {
             "provider": self.provider_name,

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import asdict
 from typing import Any
 
@@ -21,6 +22,7 @@ class HookedLanguageModelClient(LanguageModelClient):
         # (ERP-67) silently no-ops whenever a client is wrapped for hooks, which
         # GenerationRunner always does.
         self.supports_structural_isolation = bool(getattr(inner, "supports_structural_isolation", False))
+        self.supports_constrained_output = bool(getattr(inner, "supports_constrained_output", False))
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.inner, name)
@@ -88,6 +90,42 @@ class HookedLanguageModelClient(LanguageModelClient):
         )
         return self._emit_response(response, request)
 
+    def generate_constrained(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        output_schema: OutputSchema,
+        role: str = "",
+        system: str = "",
+    ) -> ModelResponse:
+        payload = {
+            "provider": self.provider_name,
+            "role": role,
+            "model": model,
+            "prompt": prompt,
+            "system": system,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "output_schema": _schema_payload(output_schema),
+            "multiturn": bool(system),
+        }
+        before = self.hook_bus.emit(HookEvents.BEFORE_PROVIDER_REQUEST, payload)
+        before.raise_if_blocked()
+        request = before.payload
+        response = self.inner.generate_constrained(
+            model=str(request.get("model", model)),
+            prompt=str(request.get("prompt", prompt)),
+            system=str(request.get("system", system)),
+            max_tokens=int(request.get("max_tokens", max_tokens)),
+            temperature=float(request.get("temperature", temperature)),
+            output_schema=_output_schema(request.get("output_schema"), output_schema),
+            role=str(request.get("role", role)),
+        )
+        return self._emit_response(response, request)
+
     def _emit_response(self, response: ModelResponse, request: dict[str, Any]) -> ModelResponse:
         payload = {
             "provider": self.provider_name,
@@ -124,6 +162,7 @@ class HookedLLMProvider(LLMProvider):
         self.hook_bus = hook_bus
         self.provider_name = provider_name or inner.name
         self.role = role
+        self._supports_output_schema = _accepts_output_schema(inner.complete)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.inner, name)
@@ -145,21 +184,31 @@ class HookedLLMProvider(LLMProvider):
             "user_prompt": user_prompt,
             "temperature": temperature,
             "max_tokens": max_tokens,
+            "output_schema": _schema_payload(output_schema),
             "multiturn": False,
         }
         before = self.hook_bus.emit(HookEvents.BEFORE_PROVIDER_REQUEST, payload)
         before.raise_if_blocked()
         request = before.payload
+        requested_schema = _optional_output_schema(request.get("output_schema", output_schema))
+        extra = (
+            {"output_schema": requested_schema}
+            if requested_schema is not None and self._supports_output_schema
+            else {}
+        )
         response = self.inner.complete(
             system_prompt=str(request.get("system_prompt", system_prompt)),
             user_prompt=str(request.get("user_prompt", user_prompt)),
             model=_optional_str(request.get("model", model)),
             temperature=float(request.get("temperature", temperature)),
             max_tokens=int(request.get("max_tokens", max_tokens)),
+            **extra,
         )
         response_model = getattr(response, "model", None)
         response_usage = getattr(response, "usage", {})
         response_cost = getattr(response, "cost_usd", None)
+        response_stop_reason = getattr(response, "stop_reason", None)
+        response_constrained = bool(getattr(response, "constrained", False))
         response_payload = {
             "provider": self.provider_name,
             "role": request.get("role", self.role),
@@ -168,6 +217,8 @@ class HookedLLMProvider(LLMProvider):
             "text": response.text,
             "usage": dict(response_usage) if isinstance(response_usage, dict) else {},
             "cost_usd": response_cost,
+            "stop_reason": response_stop_reason,
+            "constrained": response_constrained,
         }
         after = self.hook_bus.emit(HookEvents.AFTER_PROVIDER_RESPONSE, response_payload)
         after.raise_if_blocked()
@@ -176,6 +227,8 @@ class HookedLLMProvider(LLMProvider):
             model=_optional_str(after.payload.get("model", response_model)),
             usage=_usage_dict(after.payload.get("usage", response_usage)),
             cost_usd=_optional_float(after.payload.get("cost_usd", response_cost)),
+            stop_reason=response_stop_reason,
+            constrained=response_constrained,
         )
 
     def default_model(self) -> str:
@@ -208,6 +261,35 @@ def _optional_float(value: Any) -> float | None:
     if value is None:
         return None
     return float(value)
+
+
+def _output_schema(value: Any, default: OutputSchema) -> OutputSchema:
+    return _optional_output_schema(value) or default
+
+
+def _optional_output_schema(value: Any) -> OutputSchema | None:
+    if isinstance(value, OutputSchema):
+        return value
+    if isinstance(value, dict) and isinstance(value.get("name"), str) and isinstance(value.get("schema"), dict):
+        return OutputSchema(name=value["name"], schema=dict(value["schema"]))
+    return None
+
+
+def _schema_payload(value: OutputSchema | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return {"name": value.name, "schema": dict(value.schema)}
+
+
+def _accepts_output_schema(complete: Any) -> bool:
+    try:
+        parameters = inspect.signature(complete).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == "output_schema" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
 
 
 def _usage_dict(value: Any) -> dict[str, int]:

--- a/autocontext/src/autocontext/harness/core/llm_client.py
+++ b/autocontext/src/autocontext/harness/core/llm_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from autocontext.harness.core.types import ModelResponse
+from autocontext.providers.base import OutputSchema
 
 
 class LanguageModelClient:
@@ -12,6 +13,14 @@ class LanguageModelClient:
     # be applied (the flat prompt is preserved instead). Wrappers inherit False
     # unless they explicitly forward the capability.
     supports_structural_isolation: bool = False
+
+    # AC-913: True only for backends that can genuinely constrain generation to
+    # a schema. Default False -> generate_constrained below falls back to
+    # generate() and reports constrained=False, so a CLI runtime that cannot
+    # enforce anything keeps working and says so. Mirrors
+    # supports_structural_isolation deliberately: same capability-flag shape,
+    # same "wrappers inherit False unless they forward it" rule.
+    supports_constrained_output: bool = False
 
     def generate(
         self,
@@ -23,6 +32,50 @@ class LanguageModelClient:
         role: str = "",
     ) -> ModelResponse:
         raise NotImplementedError
+
+    def generate_constrained(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        output_schema: OutputSchema,
+        role: str = "",
+        system: str = "",
+    ) -> ModelResponse:
+        """Generate under a schema, falling back when the backend cannot.
+
+        The default is honest rather than optimistic: it runs the ordinary
+        generate() and records ``constrained=False`` in the response metadata.
+        AC-913 requires that a backend without constrained decoding still
+        works and that the run record says the output was unconstrained --
+        this is where the second half of that happens, for every backend that
+        does not override it.
+        """
+        del output_schema
+        # Honor the structural-isolation split (ERP-67) on the fallback too:
+        # dropping the system turn here would quietly weaken role isolation for
+        # every schema-requesting call on a backend that cannot constrain.
+        if system:
+            response = self.generate_multiturn(
+                model=model,
+                system=system,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=max_tokens,
+                temperature=temperature,
+                role=role,
+            )
+        else:
+            response = self.generate(
+                model=model,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                role=role,
+            )
+        response.metadata.setdefault("constrained", False)
+        return response
 
     def generate_multiturn(
         self,

--- a/autocontext/src/autocontext/harness/core/subagent.py
+++ b/autocontext/src/autocontext/harness/core/subagent.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from typing import Any
 
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import RoleExecution
+from autocontext.providers.base import OutputSchema
 
 
 @dataclass(slots=True)
@@ -22,6 +24,11 @@ class SubagentTask:
     # the system prompt. Empty (the default, and every call site today) → the
     # single-prompt `generate` path, byte-identical to prior behaviour.
     system: str = ""
+    # AC-913: when set, the role asks the backend to constrain generation to
+    # this schema. Backends that cannot honor it still answer, and the
+    # RoleExecution records constrained=False -- the request is never mistaken
+    # for enforcement.
+    output_schema: OutputSchema | None = None
 
 
 class SubagentRuntime:
@@ -31,7 +38,17 @@ class SubagentRuntime:
         self.client = client
 
     def run_task(self, task: SubagentTask) -> RoleExecution:
-        if task.system:
+        if task.output_schema is not None:
+            response = self.client.generate_constrained(
+                model=task.model,
+                prompt=task.prompt,
+                max_tokens=task.max_tokens,
+                temperature=task.temperature,
+                output_schema=task.output_schema,
+                role=task.role,
+                system=task.system,
+            )
+        elif task.system:
             response = self.client.generate_multiturn(
                 model=task.model,
                 system=task.system,
@@ -54,5 +71,22 @@ class SubagentRuntime:
             usage=response.usage,
             subagent_id=f"{task.role}-{uuid.uuid4().hex[:10]}",
             status="completed",
-            metadata=dict(response.metadata),
+            metadata=_with_constrained_flag(response.metadata, requested=task.output_schema is not None),
         )
+
+
+def _with_constrained_flag(metadata: dict[str, Any], *, requested: bool) -> dict[str, Any]:
+    """Stamp every role execution with whether its output was schema-enforced.
+
+    Present on all three paths, not just the constrained one, so "this run was
+    unconstrained" is a recorded fact rather than the absence of a key. A
+    backend that reported its own value keeps it; anything else is False,
+    because a schema that was requested and silently not applied is exactly the
+    case this flag exists to expose.
+    """
+    stamped = dict(metadata)
+    if "constrained" not in stamped:
+        stamped["constrained"] = False
+    if not requested:
+        stamped["constrained"] = False
+    return stamped

--- a/autocontext/src/autocontext/loop/stage_tree_search.py
+++ b/autocontext/src/autocontext/loop/stage_tree_search.py
@@ -6,9 +6,8 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from autocontext.agents.architect import parse_architect_harness_specs, parse_architect_tool_specs, parse_dag_changes
-from autocontext.agents.coach import parse_coach_sections
-from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
+from autocontext.agents.architect import parse_dag_changes
+from autocontext.agents.parsers import parse_analyst_exec, parse_architect_exec, parse_coach_exec, parse_competitor_output
 from autocontext.agents.types import AgentOutputs
 from autocontext.harness.evaluation.failure_report import FailureReport, MatchDiagnosis
 from autocontext.harness.evaluation.runner import EvaluationRunner
@@ -343,18 +342,14 @@ def stage_tree_search(
     architect_exec = orchestrator.architect.run(architect_prompt)
     _notify("architect", "completed")
 
-    tools = parse_architect_tool_specs(architect_exec.content)
-    harness_specs = parse_architect_harness_specs(architect_exec.content)
-    coach_playbook, coach_lessons, coach_hints = parse_coach_sections(coach_exec.content)
-
     competitor_typed = parse_competitor_output(
         json.dumps(best_strategy, sort_keys=True),
         best_strategy,
         is_code_strategy=settings.code_strategies_enabled,
     )
-    analyst_typed = parse_analyst_output(analyst_exec.content)
-    coach_typed = parse_coach_output(coach_exec.content)
-    architect_typed = parse_architect_output(architect_exec.content)
+    analyst_typed = parse_analyst_exec(analyst_exec)
+    coach_typed = parse_coach_exec(coach_exec)
+    architect_typed = parse_architect_exec(architect_exec)
 
     # Build a synthetic competitor RoleExecution for the tree search phase
     from autocontext.harness.core.types import RoleExecution, RoleUsage
@@ -376,14 +371,14 @@ def stage_tree_search(
 
     outputs = AgentOutputs(
         strategy=best_strategy,
-        analysis_markdown=analyst_exec.content,
-        coach_markdown=coach_exec.content,
-        coach_playbook=coach_playbook,
-        coach_lessons=coach_lessons,
-        coach_competitor_hints=coach_hints,
-        architect_markdown=architect_exec.content,
-        architect_tools=tools,
-        architect_harness_specs=harness_specs,
+        analysis_markdown=analyst_typed.raw_markdown,
+        coach_markdown=coach_typed.raw_markdown,
+        coach_playbook=coach_typed.playbook,
+        coach_lessons=coach_typed.lessons,
+        coach_competitor_hints=coach_typed.hints,
+        architect_markdown=architect_typed.raw_markdown,
+        architect_tools=architect_typed.tool_specs,
+        architect_harness_specs=architect_typed.harness_specs,
         role_executions=[tree_competitor_exec, translator_exec, analyst_exec, coach_exec, architect_exec],
         competitor_output=competitor_typed,
         analyst_output=analyst_typed,
@@ -397,9 +392,9 @@ def stage_tree_search(
         ctx.generation,
         outputs=[
             ("competitor", json.dumps(best_strategy, sort_keys=True)),
-            ("analyst", analyst_exec.content),
-            ("coach", coach_exec.content),
-            ("architect", architect_exec.content),
+            ("analyst", outputs.analysis_markdown),
+            ("coach", outputs.coach_markdown),
+            ("architect", outputs.architect_markdown),
         ],
         role_metrics=[
             (
@@ -415,23 +410,23 @@ def stage_tree_search(
         ],
     )
 
-    created_tools = artifacts.persist_tools(ctx.scenario_name, ctx.generation, tools)
-    if settings.harness_validators_enabled and harness_specs:
-        artifacts.persist_harness(ctx.scenario_name, ctx.generation, harness_specs)
+    created_tools = artifacts.persist_tools(ctx.scenario_name, ctx.generation, outputs.architect_tools)
+    if settings.harness_validators_enabled and outputs.architect_harness_specs:
+        artifacts.persist_harness(ctx.scenario_name, ctx.generation, outputs.architect_harness_specs)
     persist_approved_harness_mutations(
         artifacts,
         ctx.scenario_name,
         generation=ctx.generation,
         run_id=ctx.run_id,
-        proposed=parse_mutations(architect_exec.content),
+        proposed=parse_mutations(outputs.architect_markdown),
     )
 
-    ctx.dag_changes = parse_dag_changes(architect_exec.content)
+    ctx.dag_changes = parse_dag_changes(outputs.architect_markdown)
 
     if settings.config_adaptive_enabled:
         from autocontext.knowledge.tuning import parse_tuning_proposal
 
-        ctx.tuning_proposal = parse_tuning_proposal(architect_exec.content)
+        ctx.tuning_proposal = parse_tuning_proposal(outputs.architect_markdown)
 
     # ── Replay narrative from best match ─────────────────────────────
     best_eval = max(final_tournament.results, key=lambda r: r.score)

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -27,7 +27,7 @@ from autocontext.loop.stage_types import GenerationContext
 from autocontext.loop.tournament_helpers import apply_tournament_outcome
 from autocontext.notebook.context_provider import NotebookContextProvider
 from autocontext.notebook.types import SessionNotebook
-from autocontext.providers.base import CompletionResult, LLMProvider
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema
 from autocontext.storage.artifacts import EMPTY_PLAYBOOK_SENTINEL
 
 if TYPE_CHECKING:
@@ -115,6 +115,7 @@ class _ClientAsProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
         resp = self._client.generate(
             model=model or self._model,

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -489,6 +489,7 @@ def build_prompt_bundle(
         '"rationale":"<why>"},{"type":"tool_instruction","tool_name":"<tool_name>",'
         '"content":"<instruction>","rationale":"<why>"}]}\n'
         "<!-- MUTATIONS_END -->\n\n"
+        "Use empty strings for mutation selector fields that do not apply. "
         "If no harness mutations, omit the MUTATIONS markers entirely."
     )
 

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import anthropic
 
-from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 from autocontext.providers.token_caps import clamp_output_tokens
 
 
@@ -26,7 +26,9 @@ class AnthropicProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
+        del output_schema  # AC-913: Anthropic structured output not wired yet; reported unconstrained
         model_id = model or self._default_model
         try:
             response = self._client.messages.create(

--- a/autocontext/src/autocontext/providers/base.py
+++ b/autocontext/src/autocontext/providers/base.py
@@ -4,10 +4,25 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from typing import Any
 
 
 class ProviderError(Exception):
     """Raised when an LLM provider call fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class OutputSchema:
+    """A JSON Schema the backend should constrain generation to (AC-913).
+
+    Passing one is a request, not a guarantee: backends that cannot enforce a
+    schema ignore it and report ``constrained=False`` on the result. Callers
+    must read that flag rather than assume the text validates, which is the
+    whole point -- an unconstrained run should be visible, not inferred.
+    """
+
+    name: str
+    schema: dict[str, Any]
 
 
 @dataclass(slots=True)
@@ -21,6 +36,11 @@ class CompletionResult:
     # AC-904: why generation stopped ("max_tokens"/"length" indicates
     # truncation); None when the provider does not report one.
     stop_reason: str | None = None
+    # AC-913: whether the backend actually constrained generation to the
+    # requested schema. Defaults to False so a provider that ignores the
+    # request, or one written before this existed, reports the truth rather
+    # than claiming an enforcement it never performed.
+    constrained: bool = False
 
 
 class LLMProvider(ABC):
@@ -39,6 +59,7 @@ class LLMProvider(ABC):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
         """Send a completion request and return the result.
 
@@ -48,6 +69,10 @@ class LLMProvider(ABC):
             model: Override the provider's default model.
             temperature: Sampling temperature.
             max_tokens: Maximum tokens in the response.
+            output_schema: Schema to constrain generation to (AC-913). Optional
+                and best-effort: a backend that cannot enforce it must still
+                answer, and must set ``constrained=False`` on the result so the
+                caller can tell prose from validated output.
 
         Returns:
             CompletionResult with the response text and metadata.

--- a/autocontext/src/autocontext/providers/callable_wrapper.py
+++ b/autocontext/src/autocontext/providers/callable_wrapper.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from autocontext.agents.types import LlmFn
-from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,9 @@ class CallableProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
+        del output_schema  # AC-913: an arbitrary callable cannot enforce a schema
         try:
             text = self._fn(system_prompt, user_prompt)
         except Exception as exc:

--- a/autocontext/src/autocontext/providers/mlx_lm_provider.py
+++ b/autocontext/src/autocontext/providers/mlx_lm_provider.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,9 @@ class MLXLMProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
+        del output_schema  # AC-913: no constrained decoding in mlx_lm.generate
         from mlx_lm import generate
         from mlx_lm.sample_utils import make_sampler
 

--- a/autocontext/src/autocontext/providers/mlx_provider.py
+++ b/autocontext/src/autocontext/providers/mlx_provider.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 
 logger = logging.getLogger(__name__)
 
@@ -187,12 +187,14 @@ class MLXProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
         """Generate a completion using the local MLX model.
 
         The system and user prompts are concatenated.  ``temperature`` and
         ``max_tokens`` from the call override the instance defaults.
         """
+        del output_schema  # AC-913: no constrained decoding in the MLX sampler
         effective_temp = temperature if temperature > 0 else self._temperature
         effective_max = min(max_tokens, self._max_tokens) if max_tokens != 4096 else self._max_tokens
 

--- a/autocontext/src/autocontext/providers/openai_compat.py
+++ b/autocontext/src/autocontext/providers/openai_compat.py
@@ -90,7 +90,7 @@ class OpenAICompatibleProvider(LLMProvider):
         try:
             response = self._client.chat.completions.create(**request)
         except Exception as exc:
-            if not constrained:
+            if not constrained or not _is_unsupported_response_format_error(exc):
                 logger.debug("providers.openai_compat: caught Exception", exc_info=True)
                 raise ProviderError(f"OpenAI-compatible API error: {exc}") from exc
             # This endpoint does not understand response_format. Retry once
@@ -132,3 +132,22 @@ class OpenAICompatibleProvider(LLMProvider):
 
     def default_model(self) -> str:
         return self._default_model
+
+
+def _is_unsupported_response_format_error(exc: Exception) -> bool:
+    """Return True only for endpoint rejections of JSON-schema formatting.
+
+    Timeouts, rate limits, authentication failures, and transient server
+    errors must propagate to the normal retry layer. Retrying those requests
+    without a schema would silently turn an outage into an unconstrained run.
+    """
+    status_code = getattr(exc, "status_code", None)
+    if status_code not in {400, 404, 422}:
+        return False
+    message = str(exc).lower()
+    mentions_schema = "response_format" in message or "json_schema" in message
+    rejection = any(
+        token in message
+        for token in ("unsupported", "not supported", "unknown", "unrecognized", "invalid")
+    )
+    return mentions_schema and rejection

--- a/autocontext/src/autocontext/providers/openai_compat.py
+++ b/autocontext/src/autocontext/providers/openai_compat.py
@@ -10,7 +10,7 @@ import logging
 import os
 from typing import Any
 
-from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 from autocontext.providers.token_caps import clamp_output_tokens
 
 logger = logging.getLogger(__name__)
@@ -44,10 +44,7 @@ class OpenAICompatibleProvider(LLMProvider):
         extra_headers: dict[str, str] | None = None,
     ) -> None:
         if not _HAS_OPENAI:
-            raise ProviderError(
-                "openai package is required for OpenAICompatibleProvider. "
-                "Install with: pip install openai"
-            )
+            raise ProviderError("openai package is required for OpenAICompatibleProvider. Install with: pip install openai")
 
         resolved_key = api_key or os.getenv("OPENAI_API_KEY") or "no-key"
         kwargs: dict[str, Any] = {"api_key": resolved_key}
@@ -66,21 +63,54 @@ class OpenAICompatibleProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
         model_id = model or self._default_model
+        request: dict[str, Any] = {
+            "model": model_id,
+            "temperature": temperature,
+            "max_tokens": clamp_output_tokens(max_tokens, model_id),
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        }
+        constrained = False
+        if output_schema is not None:
+            request["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": output_schema.name,
+                    "strict": True,
+                    "schema": output_schema.schema,
+                },
+            }
+            constrained = True
+
         try:
-            response = self._client.chat.completions.create(
-                model=model_id,
-                temperature=temperature,
-                max_tokens=clamp_output_tokens(max_tokens, model_id),
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-            )
+            response = self._client.chat.completions.create(**request)
         except Exception as exc:
-            logger.debug("providers.openai_compat: caught Exception", exc_info=True)
-            raise ProviderError(f"OpenAI-compatible API error: {exc}") from exc
+            if not constrained:
+                logger.debug("providers.openai_compat: caught Exception", exc_info=True)
+                raise ProviderError(f"OpenAI-compatible API error: {exc}") from exc
+            # This endpoint does not understand response_format. Retry once
+            # without it rather than failing the run: AC-913 requires that a
+            # backend with no constrained-decoding support still works. The
+            # result is then reported as unconstrained, so a caller can tell
+            # "the schema was enforced" from "the schema was requested and
+            # silently not applied" -- which is the distinction that makes an
+            # unconstrained run visible instead of assumed.
+            logger.info(
+                "providers.openai_compat: %s rejected response_format; retrying unconstrained",
+                model_id,
+            )
+            request.pop("response_format", None)
+            constrained = False
+            try:
+                response = self._client.chat.completions.create(**request)
+            except Exception as retry_exc:
+                logger.debug("providers.openai_compat: caught Exception", exc_info=True)
+                raise ProviderError(f"OpenAI-compatible API error: {retry_exc}") from retry_exc
 
         choice = response.choices[0] if response.choices else None
         text = choice.message.content or "" if choice else ""
@@ -97,6 +127,7 @@ class OpenAICompatibleProvider(LLMProvider):
             model=model_id,
             usage=usage,
             stop_reason=getattr(choice, "finish_reason", None) if choice else None,
+            constrained=constrained,
         )
 
     def default_model(self) -> str:

--- a/autocontext/src/autocontext/providers/retry.py
+++ b/autocontext/src/autocontext/providers/retry.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import time
 
-from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +74,7 @@ class RetryProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
         """Call the underlying provider with retry on transient errors."""
         last_error: Exception | None = None
@@ -84,6 +85,7 @@ class RetryProvider(LLMProvider):
                 return self._provider.complete(
                     system_prompt, user_prompt,
                     model=model, temperature=temperature, max_tokens=max_tokens,
+                    output_schema=output_schema,
                 )
             except ProviderError as e:
                 last_error = e

--- a/autocontext/src/autocontext/providers/runtime_bridge.py
+++ b/autocontext/src/autocontext/providers/runtime_bridge.py
@@ -6,7 +6,7 @@ subscription-backed local CLIs instead of direct hosted APIs.
 
 from __future__ import annotations
 
-from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 from autocontext.runtimes.base import AgentRuntime
 from autocontext.runtimes.errors import format_runtime_failure
 
@@ -37,8 +37,9 @@ class RuntimeBridgeProvider(LLMProvider):
         model: str | None = None,
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
-        del temperature, max_tokens
+        del temperature, max_tokens, output_schema  # AC-913: bridge cannot constrain; reported unconstrained
         output = self._runtime.generate(
             prompt=user_prompt,
             system=system_prompt or None,

--- a/autocontext/tests/test_constrained_role_wiring.py
+++ b/autocontext/tests/test_constrained_role_wiring.py
@@ -11,6 +11,7 @@ the schema helpers directly, so these go through the real runner.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import Any
 
 from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema
@@ -44,6 +45,34 @@ class _RecordingProvider(LLMProvider):
 
     def default_model(self) -> str:
         return "stub"
+
+
+class _LegacyProvider(LLMProvider):
+    """Public provider implementation written before output_schema existed."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> CompletionResult:
+        self.calls += 1
+        return CompletionResult(
+            text=(
+                "## Findings\n\n- legacy finding\n\n"
+                "## Root Causes\n\n- legacy cause\n\n"
+                "## Actionable Recommendations\n\n- legacy recommendation"
+            ),
+            model="legacy",
+        )
+
+    def default_model(self) -> str:
+        return "legacy"
 
 
 _VALID = json.dumps({"findings": ["f"], "root_causes": ["r"], "recommendations": ["rec"]})
@@ -83,6 +112,41 @@ def test_schema_reaches_the_provider_without_a_system_prompt() -> None:
     assert provider.calls[0]["output_schema"] is not None
 
 
+def test_schema_survives_the_production_hook_wrapper() -> None:
+    from autocontext.agents.analyst import AnalystRunner
+    from autocontext.agents.provider_bridge import ProviderBridgeClient
+    from autocontext.extensions import HookBus, HookedLanguageModelClient
+    from autocontext.harness.core.subagent import SubagentRuntime
+
+    provider = _RecordingProvider(enforce=True, text=_VALID)
+    client = HookedLanguageModelClient(ProviderBridgeClient(provider), HookBus())
+    execution = AnalystRunner(SubagentRuntime(client), model="stub").run(
+        "analyze this",
+        system="you are the analyst",
+    )
+
+    assert client.supports_constrained_output is True
+    assert provider.calls[0]["output_schema"].name == "analyst_output"
+    assert provider.calls[0]["system_prompt"] == "you are the analyst"
+    assert execution.metadata["constrained"] is True
+
+
+def test_legacy_provider_omits_the_new_keyword_and_runs_unconstrained() -> None:
+    from autocontext.agents.analyst import AnalystRunner
+    from autocontext.agents.parsers import parse_analyst_exec
+    from autocontext.agents.provider_bridge import ProviderBridgeClient
+    from autocontext.harness.core.subagent import SubagentRuntime
+
+    provider = _LegacyProvider()
+    bridge = ProviderBridgeClient(provider)
+    execution = AnalystRunner(SubagentRuntime(bridge), model="legacy").run("analyze")
+
+    assert bridge.supports_constrained_output is False
+    assert provider.calls == 1
+    assert execution.metadata["constrained"] is False
+    assert parse_analyst_exec(execution).findings == ["legacy finding"]
+
+
 def test_execution_records_whether_the_backend_enforced() -> None:
     """AC-913 criterion 3: the run record says whether output was constrained."""
     enforced = _run_analyst(_RecordingProvider(enforce=True, text=_VALID), system="s")
@@ -116,3 +180,64 @@ def test_a_backend_that_ignores_the_schema_still_produces_a_run() -> None:
     result = parse_analyst_exec(execution)
     assert result.findings == []
     assert execution.metadata["constrained"] is False
+
+
+def test_normal_output_assembly_uses_validated_rendered_views() -> None:
+    from autocontext.agents.orchestrator_helpers import _assemble_agent_outputs
+    from autocontext.harness.core.types import RoleExecution, RoleUsage
+
+    def execution(role: str, content: str, *, constrained: bool = False) -> RoleExecution:
+        return RoleExecution(
+            role=role,
+            content=content,
+            usage=RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model="stub"),
+            subagent_id=role,
+            status="completed",
+            metadata={"constrained": constrained},
+        )
+
+    architect_json = json.dumps(
+        {
+            "observed_bottlenecks": ["slow checks"],
+            "impact_hypothesis": "Faster feedback.",
+            "tools": [{"name": "probe", "description": "d", "code": "def probe(): ..."}],
+            "harness": [
+                {
+                    "name": "guard",
+                    "description": "d",
+                    "code": "def validate_strategy(strategy, scenario):\n    return True, []",
+                }
+            ],
+            "mutations": [],
+            "dag_changes": [],
+            "tuning_parameters": [],
+            "tuning_reasoning": "",
+            "changelog_entry": "added probe",
+        }
+    )
+    analyst = execution("analyst", _VALID, constrained=True)
+    coach = execution(
+        "coach",
+        json.dumps({"playbook": "P", "lessons": "L", "hints": "H"}),
+        constrained=True,
+    )
+    architect = execution("architect", architect_json, constrained=True)
+    outputs = _assemble_agent_outputs(
+        SimpleNamespace(settings=SimpleNamespace(code_strategies_enabled=False)),
+        '{"move":"north"}',
+        {"move": "north"},
+        execution("competitor", '{"move":"north"}'),
+        execution("translator", '{"move":"north"}'),
+        analyst,
+        coach,
+        architect,
+    )
+
+    assert outputs.analysis_markdown.startswith("## Findings")
+    assert outputs.coach_markdown.startswith("<!-- PLAYBOOK_START -->")
+    assert outputs.coach_playbook == "P"
+    assert outputs.coach_lessons == "L"
+    assert outputs.coach_competitor_hints == "H"
+    assert outputs.architect_markdown.startswith("## Observed Bottlenecks")
+    assert [item["name"] for item in outputs.architect_tools] == ["probe"]
+    assert [item["name"] for item in outputs.architect_harness_specs] == ["guard"]

--- a/autocontext/tests/test_constrained_role_wiring.py
+++ b/autocontext/tests/test_constrained_role_wiring.py
@@ -1,0 +1,118 @@
+"""AC-913: the schema actually reaches the backend, end to end.
+
+The point of these tests is that the capability FIRES. An earlier revision
+dispatched to the constrained path only when ``task.system`` was empty -- and
+every real call site passes a system prompt (structural isolation, ERP-67), so
+the feature compiled, typechecked, passed its unit tests, and would never have
+run once in production. That class of bug is invisible to a test that calls
+the schema helpers directly, so these go through the real runner.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema
+
+
+class _RecordingProvider(LLMProvider):
+    """Records what the bridge actually sent, and can pretend to enforce it."""
+
+    def __init__(self, *, enforce: bool, text: str) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._enforce = enforce
+        self._text = text
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
+    ) -> CompletionResult:
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "output_schema": output_schema,
+            }
+        )
+        return CompletionResult(text=self._text, model="stub", constrained=self._enforce)
+
+    def default_model(self) -> str:
+        return "stub"
+
+
+_VALID = json.dumps({"findings": ["f"], "root_causes": ["r"], "recommendations": ["rec"]})
+
+
+def _run_analyst(provider: _RecordingProvider, *, system: str) -> Any:
+    from autocontext.agents.analyst import AnalystRunner
+    from autocontext.agents.provider_bridge import ProviderBridgeClient
+    from autocontext.harness.core.subagent import SubagentRuntime
+
+    runtime = SubagentRuntime(ProviderBridgeClient(provider))
+    return AnalystRunner(runtime, model="stub").run("analyze this", system=system)
+
+
+def test_schema_reaches_the_provider_even_with_a_system_prompt() -> None:
+    """The regression that motivated this file.
+
+    Every production call site passes system=; if the schema only rode the
+    no-system path, constrained decoding would never happen in a real run.
+    """
+    provider = _RecordingProvider(enforce=True, text=_VALID)
+    _run_analyst(provider, system="you are the analyst")
+
+    assert len(provider.calls) == 1
+    call = provider.calls[0]
+    assert call["output_schema"] is not None, "schema never reached the provider"
+    assert call["output_schema"].name == "analyst_output"
+    # The system turn must survive the constrained path, or role isolation
+    # silently weakens for exactly the calls that asked for a schema.
+    assert call["system_prompt"] == "you are the analyst"
+
+
+def test_schema_reaches_the_provider_without_a_system_prompt() -> None:
+    provider = _RecordingProvider(enforce=True, text=_VALID)
+    _run_analyst(provider, system="")
+
+    assert provider.calls[0]["output_schema"] is not None
+
+
+def test_execution_records_whether_the_backend_enforced() -> None:
+    """AC-913 criterion 3: the run record says whether output was constrained."""
+    enforced = _run_analyst(_RecordingProvider(enforce=True, text=_VALID), system="s")
+    assert enforced.metadata["constrained"] is True
+
+    ignored = _run_analyst(_RecordingProvider(enforce=False, text="## Findings\n\n- f"), system="s")
+    assert ignored.metadata["constrained"] is False
+
+
+def test_parse_follows_what_the_backend_actually_did() -> None:
+    """Enforced output is validated; ignored output keeps the old scrape path."""
+    from autocontext.agents.parsers import parse_analyst_exec
+
+    enforced = _run_analyst(_RecordingProvider(enforce=True, text=_VALID), system="s")
+    assert parse_analyst_exec(enforced).findings == ["f"]
+
+    markdown = "## Findings\n\n- from markdown\n\n## Root Causes\n\n- rc\n\n## Actionable Recommendations\n\n- rec"
+    ignored = _run_analyst(_RecordingProvider(enforce=False, text=markdown), system="s")
+    assert parse_analyst_exec(ignored).findings == ["from markdown"]
+
+
+def test_a_backend_that_ignores_the_schema_still_produces_a_run() -> None:
+    """AC-913 criterion 3's other half: unsupported backends keep working.
+
+    The provider here reports constrained=False and returns prose. Nothing
+    raises; the scrape path handles it exactly as before this feature existed.
+    """
+    from autocontext.agents.parsers import parse_analyst_exec
+
+    execution = _run_analyst(_RecordingProvider(enforce=False, text="just some prose"), system="s")
+    result = parse_analyst_exec(execution)
+    assert result.findings == []
+    assert execution.metadata["constrained"] is False

--- a/autocontext/tests/test_extension_hooks.py
+++ b/autocontext/tests/test_extension_hooks.py
@@ -12,7 +12,7 @@ from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleUsage
 from autocontext.harness.evaluation.scenario_evaluator import ScenarioEvaluator
 from autocontext.harness.evaluation.types import EvaluationLimits
-from autocontext.providers.base import CompletionResult, LLMProvider
+from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema
 from autocontext.scenarios.base import Observation, ReplayEnvelope, Result
 from autocontext.storage.artifacts import ArtifactStore
 
@@ -40,6 +40,31 @@ class _Provider(LLMProvider):
             }
         )
         return CompletionResult(text=self.response, model=model or "stub")
+
+    def default_model(self) -> str:
+        return "stub"
+
+
+class _SchemaProvider(LLMProvider):
+    def __init__(self) -> None:
+        self.schemas: list[OutputSchema | None] = []
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
+    ) -> CompletionResult:
+        self.schemas.append(output_schema)
+        return CompletionResult(
+            text='{"ok":true}',
+            model=model or "stub",
+            stop_reason="stop",
+            constrained=output_schema is not None,
+        )
 
     def default_model(self) -> str:
         return "stub"
@@ -201,6 +226,20 @@ def test_language_model_client_hooks_can_transform_request_and_response() -> Non
     assert response.text == "RESPONSE TO HELLO PLUS HOOK"
     assert response.metadata["hooked"] is True
     assert response.metadata["inner"] is True
+
+
+def test_provider_hooks_forward_schema_and_preserve_completion_metadata() -> None:
+    from autocontext.extensions import HookBus, HookedLLMProvider
+
+    inner = _SchemaProvider()
+    provider = HookedLLMProvider(inner, HookBus())
+    schema = OutputSchema(name="answer", schema={"type": "object"})
+
+    response = provider.complete("system", "user", output_schema=schema)
+
+    assert inner.schemas == [schema]
+    assert response.constrained is True
+    assert response.stop_reason == "stop"
 
 
 def test_prompt_hooks_transform_components_prompts_and_compaction() -> None:

--- a/autocontext/tests/test_openai_compat_constrained.py
+++ b/autocontext/tests/test_openai_compat_constrained.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from autocontext.providers.base import OutputSchema, ProviderError
+from autocontext.providers.openai_compat import OpenAICompatibleProvider
+
+
+class _Completions:
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **request: Any) -> Any:
+        self.calls.append(request)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class _RejectedRequest(Exception):
+    status_code = 400
+
+
+def _response(text: str = '{"answer":"ok"}') -> Any:
+    choice = SimpleNamespace(
+        message=SimpleNamespace(content=text),
+        finish_reason="stop",
+    )
+    usage = SimpleNamespace(prompt_tokens=3, completion_tokens=2)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _provider(outcomes: list[Any]) -> tuple[OpenAICompatibleProvider, _Completions]:
+    completions = _Completions(outcomes)
+    provider = object.__new__(OpenAICompatibleProvider)
+    provider._default_model = "stub"
+    provider._client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    return provider, completions
+
+
+def _schema() -> OutputSchema:
+    return OutputSchema(
+        name="answer",
+        schema={
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def test_transient_failure_does_not_retry_without_schema() -> None:
+    provider, completions = _provider([TimeoutError("timed out"), _response("unconstrained")])
+
+    with pytest.raises(ProviderError, match="timed out"):
+        provider.complete("system", "user", output_schema=_schema())
+
+    assert len(completions.calls) == 1
+    assert "response_format" in completions.calls[0]
+
+
+def test_explicit_response_format_rejection_retries_unconstrained() -> None:
+    provider, completions = _provider(
+        [_RejectedRequest("response_format json_schema is not supported"), _response("fallback")]
+    )
+
+    result = provider.complete("system", "user", output_schema=_schema())
+
+    assert result.text == "fallback"
+    assert result.constrained is False
+    assert len(completions.calls) == 2
+    assert "response_format" in completions.calls[0]
+    assert "response_format" not in completions.calls[1]
+
+
+def test_successful_schema_request_is_reported_as_constrained() -> None:
+    provider, completions = _provider([_response()])
+
+    result = provider.complete("system", "user", output_schema=_schema())
+
+    assert result.constrained is True
+    assert completions.calls[0]["response_format"]["json_schema"]["strict"] is True

--- a/autocontext/tests/test_role_schemas.py
+++ b/autocontext/tests/test_role_schemas.py
@@ -1,0 +1,131 @@
+"""AC-913: schema-enforced role outputs, and the drift that used to be silent.
+
+The corpus in ``docs/ac913-format-drift-measurement.json`` is real llama3.1:8b
+output recorded before this work. These tests replay it offline, so the
+regression is pinned in CI without needing a live model.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+MEASUREMENT = Path(__file__).resolve().parents[2] / "docs" / "ac913-format-drift-measurement.json"
+
+
+def _recorded_drift_sample() -> str:
+    payload = json.loads(MEASUREMENT.read_text(encoding="utf-8"))
+    sample = payload["sample_drifted_output"]
+    assert sample.strip(), "measurement file carries no recorded sample to replay"
+    return str(sample)
+
+
+def test_recorded_real_output_is_lost_by_the_markdown_scraper() -> None:
+    """The defect, replayed from a real recorded response rather than described.
+
+    This is not a hypothetical: it is what llama3.1:8b actually returned for
+    the shipped analyst instruction. Its analysis was correct; it wrote
+    ``### Findings`` with ``* `` bullets, and the scraper needs ``## Findings``
+    with ``- ``. If this ever starts passing, the scraper became more tolerant
+    and the measurement in docs/ needs re-recording.
+    """
+    from autocontext.agents.parsers import _extract_section_bullets
+
+    text = _recorded_drift_sample()
+    for heading in ("Findings", "Root Causes", "Actionable Recommendations"):
+        assert _extract_section_bullets(text, heading) == [], heading
+
+
+def test_schema_validation_turns_drift_into_a_typed_error() -> None:
+    """AC-913 criterion 2: drift is an error, never a silently empty section."""
+    from autocontext.agents.role_schemas import RoleOutputValidationError, parse_analyst_constrained
+
+    with pytest.raises(RoleOutputValidationError) as excinfo:
+        parse_analyst_constrained(_recorded_drift_sample())
+
+    assert excinfo.value.role == "analyst"
+    assert excinfo.value.reason
+    # The offending text rides along, so a caller can log what drifted instead
+    # of reporting that validation failed with no way to see why.
+    assert excinfo.value.raw_text == _recorded_drift_sample()
+
+
+def test_valid_payload_populates_every_section() -> None:
+    from autocontext.agents.role_schemas import parse_analyst_constrained
+
+    result = parse_analyst_constrained(
+        json.dumps(
+            {
+                "findings": ["reached the first flag in 6 steps"],
+                "root_causes": ["no tiebreak between equidistant flags"],
+                "recommendations": ["add a deterministic tiebreak on flag id"],
+            }
+        )
+    )
+    assert result.findings == ["reached the first flag in 6 steps"]
+    assert result.root_causes == ["no tiebreak between equidistant flags"]
+    assert result.recommendations == ["add a deterministic tiebreak on flag id"]
+
+
+def test_rendered_markdown_round_trips_through_the_old_scraper() -> None:
+    """The rendered view must satisfy the parser it replaces.
+
+    This is what makes the change safe rather than a flag day: every existing
+    markdown consumer keeps working, because the derived form is exactly the
+    shape the scrape path was always looking for.
+    """
+    from autocontext.agents.parsers import _extract_section_bullets
+    from autocontext.agents.role_schemas import parse_analyst_constrained
+
+    result = parse_analyst_constrained(
+        json.dumps(
+            {
+                "findings": ["a", "b"],
+                "root_causes": ["c"],
+                "recommendations": ["d"],
+            }
+        )
+    )
+    assert _extract_section_bullets(result.raw_markdown, "Findings") == ["a", "b"]
+    assert _extract_section_bullets(result.raw_markdown, "Root Causes") == ["c"]
+    assert _extract_section_bullets(result.raw_markdown, "Actionable Recommendations") == ["d"]
+
+
+def test_missing_field_is_rejected_not_defaulted() -> None:
+    """A partial object must fail, not silently yield an empty list.
+
+    Defaulting here would reintroduce exactly the failure mode this replaces:
+    a section that is empty because nothing was said, indistinguishable from
+    one that is empty because the model omitted it.
+    """
+    from autocontext.agents.role_schemas import RoleOutputValidationError, parse_analyst_constrained
+
+    with pytest.raises(RoleOutputValidationError):
+        parse_analyst_constrained(json.dumps({"findings": ["a"], "root_causes": ["b"]}))
+
+
+def test_extra_field_is_rejected() -> None:
+    """additionalProperties: false, enforced on the way back in too."""
+    from autocontext.agents.role_schemas import RoleOutputValidationError, parse_analyst_constrained
+
+    with pytest.raises(RoleOutputValidationError):
+        parse_analyst_constrained(json.dumps({"findings": [], "root_causes": [], "recommendations": [], "extra": 1}))
+
+
+def test_provider_schema_is_strict_and_complete() -> None:
+    """The schema sent to the backend must actually constrain what comes back.
+
+    Without ``additionalProperties: false`` and a full ``required`` list, a
+    backend can satisfy the schema while omitting the fields the role exists to
+    produce -- constrained decoding that constrains nothing.
+    """
+    from autocontext.agents.role_schemas import ANALYST_SCHEMA
+
+    schema = ANALYST_SCHEMA.schema
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == {"findings", "root_causes", "recommendations"}
+    for field in ("findings", "root_causes", "recommendations"):
+        assert schema["properties"][field]["type"] == "array"
+        assert schema["properties"][field]["items"]["type"] == "string"

--- a/autocontext/tests/test_role_schemas.py
+++ b/autocontext/tests/test_role_schemas.py
@@ -15,6 +15,22 @@ import pytest
 MEASUREMENT = Path(__file__).resolve().parents[2] / "docs" / "ac913-format-drift-measurement.json"
 
 
+def _architect_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "observed_bottlenecks": [],
+        "impact_hypothesis": "",
+        "tools": [],
+        "harness": [],
+        "mutations": [],
+        "dag_changes": [],
+        "tuning_parameters": [],
+        "tuning_reasoning": "",
+        "changelog_entry": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
 def _recorded_drift_sample() -> str:
     payload = json.loads(MEASUREMENT.read_text(encoding="utf-8"))
     sample = payload["sample_drifted_output"]
@@ -111,7 +127,23 @@ def test_extra_field_is_rejected() -> None:
     from autocontext.agents.role_schemas import RoleOutputValidationError, parse_analyst_constrained
 
     with pytest.raises(RoleOutputValidationError):
-        parse_analyst_constrained(json.dumps({"findings": [], "root_causes": [], "recommendations": [], "extra": 1}))
+        parse_analyst_constrained(
+            json.dumps({"findings": ["a"], "root_causes": ["b"], "recommendations": ["c"], "extra": 1})
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"findings": [], "root_causes": ["b"], "recommendations": ["c"]},
+        {"findings": ["a"], "root_causes": ["   "], "recommendations": ["c"]},
+    ],
+)
+def test_empty_analyst_sections_and_items_are_rejected(payload: dict[str, list[str]]) -> None:
+    from autocontext.agents.role_schemas import RoleOutputValidationError, parse_analyst_constrained
+
+    with pytest.raises(RoleOutputValidationError):
+        parse_analyst_constrained(json.dumps(payload))
 
 
 def test_provider_schema_is_strict_and_complete() -> None:
@@ -128,7 +160,9 @@ def test_provider_schema_is_strict_and_complete() -> None:
     assert set(schema["required"]) == {"findings", "root_causes", "recommendations"}
     for field in ("findings", "root_causes", "recommendations"):
         assert schema["properties"][field]["type"] == "array"
+        assert schema["properties"][field]["minItems"] == 1
         assert schema["properties"][field]["items"]["type"] == "string"
+        assert schema["properties"][field]["items"]["minLength"] == 1
 
 
 def test_coach_drift_is_a_typed_error_not_a_swallowed_playbook() -> None:
@@ -174,7 +208,7 @@ def test_architect_malformed_proposal_raises_instead_of_yielding_no_tools() -> N
     from autocontext.agents.architect import parse_architect_tool_specs
     from autocontext.agents.role_schemas import RoleOutputValidationError, parse_architect_constrained
 
-    malformed = '{"tools": [{"name": "probe"}]}'  # missing description and code
+    malformed = json.dumps(_architect_payload(tools=[{"name": "probe"}]))  # missing description and code
 
     assert parse_architect_tool_specs(malformed) == []
 
@@ -188,14 +222,67 @@ def test_architect_valid_proposal_survives_validation() -> None:
 
     result = parse_architect_constrained(
         json.dumps(
-            {
-                "tools": [{"name": "probe", "description": "d", "code": "def probe(): ..."}],
-                "changelog_entry": "added probe",
-            }
+            _architect_payload(
+                tools=[{"name": "probe", "description": "d", "code": "def probe(): ..."}],
+                changelog_entry="added probe",
+            )
         )
     )
     assert [spec["name"] for spec in result.tool_specs] == ["probe"]
     assert result.changelog_entry == "added probe"
+
+
+def test_architect_rendered_output_preserves_every_legacy_channel() -> None:
+    from autocontext.agents.architect import (
+        parse_architect_harness_specs,
+        parse_architect_tool_specs,
+        parse_dag_changes,
+    )
+    from autocontext.agents.role_schemas import parse_architect_constrained
+    from autocontext.harness.mutations.parser import parse_mutations
+    from autocontext.knowledge.tuning import parse_tuning_proposal
+
+    result = parse_architect_constrained(
+        json.dumps(
+            _architect_payload(
+                observed_bottlenecks=["slow validation"],
+                impact_hypothesis="Fewer invalid matches.",
+                tools=[{"name": "probe", "description": "d", "code": "def probe(): ..."}],
+                harness=[
+                    {
+                        "name": "guard",
+                        "description": "reject missing moves",
+                        "code": "def validate_strategy(strategy, scenario):\n    return True, []",
+                    }
+                ],
+                mutations=[
+                    {
+                        "type": "completion_check",
+                        "target_role": "",
+                        "component": "",
+                        "tool_name": "",
+                        "content": "verify every move",
+                        "rationale": "avoid omissions",
+                    }
+                ],
+                dag_changes=[{"action": "add_role", "name": "critic", "depends_on": ["analyst"]}],
+                tuning_parameters=[{"name": "matches_per_generation", "value": 5}],
+                tuning_reasoning="more signal",
+                changelog_entry="added validation guard",
+            )
+        )
+    )
+
+    assert [item["name"] for item in parse_architect_tool_specs(result.raw_markdown)] == ["probe"]
+    assert [item["name"] for item in parse_architect_harness_specs(result.raw_markdown)] == ["guard"]
+    assert [item.content for item in parse_mutations(result.raw_markdown)] == ["verify every move"]
+    assert parse_dag_changes(result.raw_markdown) == [
+        {"action": "add_role", "name": "critic", "depends_on": ["analyst"]}
+    ]
+    tuning = parse_tuning_proposal(result.raw_markdown)
+    assert tuning is not None
+    assert tuning.parameters == {"matches_per_generation": 5}
+    assert tuning.reasoning == "more signal"
 
 
 def test_every_role_schema_is_strict_and_complete() -> None:
@@ -209,7 +296,17 @@ def test_every_role_schema_is_strict_and_complete() -> None:
     expected = {
         "analyst_output": {"findings", "root_causes", "recommendations"},
         "coach_output": {"playbook", "lessons", "hints"},
-        "architect_output": {"tools", "changelog_entry"},
+        "architect_output": {
+            "observed_bottlenecks",
+            "impact_hypothesis",
+            "tools",
+            "harness",
+            "mutations",
+            "dag_changes",
+            "tuning_parameters",
+            "tuning_reasoning",
+            "changelog_entry",
+        },
     }
     for schema in (ANALYST_SCHEMA, COACH_SCHEMA, ARCHITECT_SCHEMA):
         assert schema.schema["additionalProperties"] is False, schema.name

--- a/autocontext/tests/test_role_schemas.py
+++ b/autocontext/tests/test_role_schemas.py
@@ -129,3 +129,88 @@ def test_provider_schema_is_strict_and_complete() -> None:
     for field in ("findings", "root_causes", "recommendations"):
         assert schema["properties"][field]["type"] == "array"
         assert schema["properties"][field]["items"]["type"] == "string"
+
+
+def test_coach_drift_is_a_typed_error_not_a_swallowed_playbook() -> None:
+    """Coach's fail-open is quieter than analyst's and worse.
+
+    With no markers at all, parse_coach_sections treats the ENTIRE response as
+    the playbook -- preamble, reasoning and all -- and that playbook is
+    persisted and steers the next generation. Schema validation refuses it
+    instead.
+    """
+    from autocontext.agents.coach import parse_coach_sections
+    from autocontext.agents.role_schemas import RoleOutputValidationError, parse_coach_constrained
+
+    prose = "Sure! Here is my advice:\n\nTry moving faster and avoid the guards."
+
+    # Today: the whole thing silently becomes the playbook.
+    playbook, lessons, hints = parse_coach_sections(prose)
+    assert playbook == prose.strip()
+    assert (lessons, hints) == ("", "")
+
+    # With a schema: refused, loudly.
+    with pytest.raises(RoleOutputValidationError) as excinfo:
+        parse_coach_constrained(prose)
+    assert excinfo.value.role == "coach"
+
+
+def test_coach_rendered_markdown_round_trips_through_the_marker_parser() -> None:
+    from autocontext.agents.coach import parse_coach_sections
+    from autocontext.agents.role_schemas import parse_coach_constrained
+
+    result = parse_coach_constrained(
+        json.dumps({"playbook": "P", "lessons": "L", "hints": "H"})
+    )
+    assert parse_coach_sections(result.raw_markdown) == ("P", "L", "H")
+
+
+def test_architect_malformed_proposal_raises_instead_of_yielding_no_tools() -> None:
+    """Architect already spoke JSON; the gap was that failure meant an empty list.
+
+    parse_architect_tool_specs returns [] for a malformed proposal, which is
+    indistinguishable from a deliberate "I propose nothing".
+    """
+    from autocontext.agents.architect import parse_architect_tool_specs
+    from autocontext.agents.role_schemas import RoleOutputValidationError, parse_architect_constrained
+
+    malformed = '{"tools": [{"name": "probe"}]}'  # missing description and code
+
+    assert parse_architect_tool_specs(malformed) == []
+
+    with pytest.raises(RoleOutputValidationError) as excinfo:
+        parse_architect_constrained(malformed)
+    assert excinfo.value.role == "architect"
+
+
+def test_architect_valid_proposal_survives_validation() -> None:
+    from autocontext.agents.role_schemas import parse_architect_constrained
+
+    result = parse_architect_constrained(
+        json.dumps(
+            {
+                "tools": [{"name": "probe", "description": "d", "code": "def probe(): ..."}],
+                "changelog_entry": "added probe",
+            }
+        )
+    )
+    assert [spec["name"] for spec in result.tool_specs] == ["probe"]
+    assert result.changelog_entry == "added probe"
+
+
+def test_every_role_schema_is_strict_and_complete() -> None:
+    """Same guard as the analyst's, applied to all three.
+
+    A schema missing additionalProperties:false or a full required list lets a
+    backend satisfy it while omitting the fields the role exists to produce.
+    """
+    from autocontext.agents.role_schemas import ANALYST_SCHEMA, ARCHITECT_SCHEMA, COACH_SCHEMA
+
+    expected = {
+        "analyst_output": {"findings", "root_causes", "recommendations"},
+        "coach_output": {"playbook", "lessons", "hints"},
+        "architect_output": {"tools", "changelog_entry"},
+    }
+    for schema in (ANALYST_SCHEMA, COACH_SCHEMA, ARCHITECT_SCHEMA):
+        assert schema.schema["additionalProperties"] is False, schema.name
+        assert set(schema.schema["required"]) == expected[schema.name], schema.name

--- a/autocontext/tests/test_stage_tree_search.py
+++ b/autocontext/tests/test_stage_tree_search.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import Any
 from unittest.mock import MagicMock
@@ -10,9 +11,11 @@ from autocontext.agents.llm_client import DeterministicDevClient
 from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.config.settings import AppSettings
 from autocontext.execution.supervisor import ExecutionSupervisor
+from autocontext.harness.core.types import ModelResponse, RoleUsage
 from autocontext.loop.stage_tree_search import stage_tree_search
 from autocontext.loop.stage_types import GenerationContext
 from autocontext.prompts.templates import PromptBundle, build_prompt_bundle
+from autocontext.providers.base import OutputSchema
 from autocontext.scenarios.base import (
     ExecutionLimits,
     Observation,
@@ -105,6 +108,47 @@ def _make_orchestrator(settings: AppSettings | None = None) -> AgentOrchestrator
     return AgentOrchestrator(client=client, settings=s)
 
 
+class _ConstrainedRoleClient(DeterministicDevClient):
+    supports_constrained_output = True
+
+    def generate_constrained(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        output_schema: OutputSchema,
+        role: str = "",
+        system: str = "",
+    ) -> ModelResponse:
+        del prompt, max_tokens, temperature, role, system
+        payloads: dict[str, dict[str, Any]] = {
+            "analyst_output": {
+                "findings": ["tree finding"],
+                "root_causes": ["tree cause"],
+                "recommendations": ["tree recommendation"],
+            },
+            "coach_output": {"playbook": "tree playbook", "lessons": "tree lesson", "hints": "tree hint"},
+            "architect_output": {
+                "observed_bottlenecks": ["tree bottleneck"],
+                "impact_hypothesis": "tree impact",
+                "tools": [],
+                "harness": [],
+                "mutations": [],
+                "dag_changes": [],
+                "tuning_parameters": [],
+                "tuning_reasoning": "",
+                "changelog_entry": "",
+            },
+        }
+        return ModelResponse(
+            text=json.dumps(payloads[output_schema.name]),
+            usage=RoleUsage(input_tokens=1, output_tokens=1, latency_ms=0, model=model),
+            metadata={"constrained": True},
+        )
+
+
 def _make_prompts(scenario: ScenarioInterface | None = None) -> PromptBundle:
     sc = scenario or _FakeScenario()
     obs = sc.get_observation(sc.initial_state(), "challenger")
@@ -173,6 +217,31 @@ class TestTreeSearchStage:
         assert isinstance(result.current_strategy, dict)
         assert result.tournament is not None
         assert result.gate_decision in ("advance", "rollback")
+
+    def test_constrained_role_outputs_use_rendered_typed_fields(self) -> None:
+        settings = _make_settings()
+        ctx = _make_ctx(settings=settings)
+        orch = AgentOrchestrator(client=_ConstrainedRoleClient(), settings=settings)
+        artifacts = MagicMock()
+        artifacts.persist_tools.return_value = []
+        artifacts.generation_dir.return_value = MagicMock()
+
+        result = stage_tree_search(
+            ctx,
+            orchestrator=orch,
+            supervisor=_make_inline_supervisor(),
+            artifacts=artifacts,
+            sqlite=MagicMock(),
+            events=MagicMock(),
+        )
+
+        assert result.outputs is not None
+        assert result.outputs.analysis_markdown.startswith("## Findings")
+        assert result.outputs.analyst_output.findings == ["tree finding"]
+        assert result.outputs.coach_playbook == "tree playbook"
+        assert result.outputs.coach_lessons == "tree lesson"
+        assert result.outputs.coach_competitor_hints == "tree hint"
+        assert result.outputs.architect_markdown.startswith("## Observed Bottlenecks")
 
     def test_emits_tree_search_start_event(self) -> None:
         """The tree_search_start event is emitted."""

--- a/docs/ac913-format-drift-measurement.json
+++ b/docs/ac913-format-drift-measurement.json
@@ -1,0 +1,31 @@
+{
+  "contract": "AC-913 format-drift measurement: markdown-heading scraping vs constrained decoding, same prompt and model.",
+  "model": "llama3.1:8b",
+  "backend": "ollama 0.32.5 (localhost:11434)",
+  "trials": 20,
+  "temperature": 0.7,
+  "prompt_source": "the analyst_task string from prompts/templates.py, verbatim",
+  "parser_under_test": "agents/parsers.py::_extract_section_bullets",
+  "before": {
+    "method": "prompt-and-scrape (today's path)",
+    "lost_per_section": {
+      "Findings": 20,
+      "Root Causes": 20,
+      "Actionable Recommendations": 20
+    },
+    "at_least_one_section_lost": 20,
+    "all_sections_lost": 20
+  },
+  "after": {
+    "method": "response_format json_schema via OpenAICompatibleProvider",
+    "lost_per_field": {
+      "findings": 0,
+      "root_causes": 0,
+      "recommendations": 0
+    },
+    "at_least_one_field_lost": 0,
+    "reported_unconstrained": 0
+  },
+  "why_it_failed": "The model's analysis was correct. It emitted '### Findings' with '* ' bullets; the parser requires '## Findings' with '- ' bullets. Two independent drifts, either one alone discarding the whole section silently. No prompt in templates.py ever states the '##' convention the parser demands.",
+  "sample_drifted_output": "**Grid CTF Analysis**\n======================\n\n### Findings\n\n* The agent demonstrated strong performance by reaching the first flag in 6 steps, outperforming the median time of 9 steps.\n* Despite aggressive behavior (aggression=0.8), the agent captured only 2 flags out of 5.\n\n### Root Causes\n\n* **Oscillation between equidistant flags**: The agent's greedy nearest-flag strategy with a 2-step lookahead may have led to oscillation, causing it to repeatedly move towards nearby flags instead of making progress towards the next flag.\n* **Insufficient exploration**: Not using the decoy action suggests"
+}


### PR DESCRIPTION
Closes AC-913 except the vLLM round-trip (node is queued; see Status below). Part of the AC-910 local-first epic.

## The problem, measured

`llama3.1:8b` via Ollama, 20 trials, the analyst instruction verbatim from `prompts/templates.py` fed to the real `_extract_section_bullets`:

| | Findings | Root Causes | Actionable Recs | ≥1 lost |
|---|---|---|---|---|
| **markdown scraping (today)** | 20/20 | 20/20 | 20/20 | **20/20 (100%)** |
| **constrained decoding** | 0/20 | 0/20 | 0/20 | **0/20 (0%)** |

**This is not a reasoning failure.** The model analyzed the run correctly — oscillation, guard collisions, unused decoy action — then wrote:

```
### Findings
* The agent demonstrated strong performance by reaching the first flag in 6 steps...
```

The parser needs `## Findings` and `- ` bullets. Two independent drifts, either one alone discarding the whole section, silently.

**And the prompt never states the convention.** `grep -c '"## '` in `templates.py` returns **0**. The instruction asks for "markdown with sections: Findings, Root Causes, Actionable Recommendations"; the parser demands a format the model is never given. Frontier models guess it. Open weights don't.

I verified the harness against known-good markdown before believing 100%, so this is drift, not a wiring bug.

## What landed

**Provider layer.** `OutputSchema` + `CompletionResult.constrained`; `output_schema` on `LLMProvider.complete()` across all ten implementations. `constrained` defaults to False so a backend that ignores the request reports the truth. `OpenAICompatibleProvider` sends `response_format: json_schema`, verified live against Ollama on both `/v1` and native `/api/chat`. Endpoints that explicitly reject `response_format` retry once without it and report `constrained=False`; transient, authentication, rate-limit, and server failures remain errors for the normal retry layer.

**Role schemas.** One pydantic declaration per role generates the schema sent to the backend *and* validates what returns. `RoleOutputValidationError` carries role, reason and offending text. Markdown survives as a **derived view** — the analyst and coach render exactly what their old parsers expect, while the architect renders tools, validators, mutations, DAG changes, and tuning proposals back into their established marker formats. Round-trip tests keep this a widening rather than a flag day.

Pydantic rather than `jsonschema` deliberately: already a core dependency, and adding one would touch `uv.lock`, which carries a supply-chain quarantine.

**Wiring** (the part that makes it real). `LanguageModelClient` gains `supports_constrained_output` + `generate_constrained`, mirroring the existing `supports_structural_isolation` flag rather than inventing a second pattern — the base fallback means none of the 25 `generate()` implementations changed. Role runners attach their own schema, so both call paths get it. Production hook wrappers preserve the schema, system turn, stop reason, and constrained metadata; the provider bridge detects pre-AC-913 external subclasses and omits the new keyword for them. Parse sites route by what the backend *actually did*.

## Each role failed open differently

- **analyst** — empty sections, reported as `parse_success=True`. That flag only flips on an exception `_extract_section_bullets` cannot raise, and **nothing reads it** on analyst/coach/architect: a safety net never attached to anything.
- **coach** — with no markers at all, the **entire response becomes the playbook**, preamble and reasoning included, and that playbook is persisted and steers the next generation. Quieter than analyst's failure and worse.
- **architect** — already spoke JSON; a proposal missing `description` or `code` yielded `[]`, indistinguishable from "I propose nothing".

## Anthropic is unchanged by construction

The Anthropic provider ignores `output_schema`, reports `constrained=False`, and parsing takes the same scrape path as before. Not a promise to be careful — the fallback doing its job.

## The bug this nearly shipped with

The first wiring dispatched to the constrained path only when `task.system` was empty. **Every** production call site passes a system prompt (structural isolation, ERP-67), so it would have compiled, typechecked, passed its unit tests, and never run once. Caught by checking call sites instead of trusting the code read.

`tests/test_constrained_role_wiring.py` exists to make that class of failure impossible to repeat — it drives the real runner and asserts the schema arrives *with* a system prompt.

## Verification

- **Live end-to-end through the real runner**, llama3.1:8b: **5/5 constrained and fully populated**.
- Mutation-verified, each caught by the right test: restoring `and not task.system` → wiring test fails; hardcoding `constrained=True` → parser validates prose and raises; teaching the scraper `###`/`* ` → the recorded-drift replay fails; relaxing `extra="forbid"` → schema-strictness tests fail; degrading validation to a return → three tests fail.
- Tests replay **real recorded llama3.1:8b output** from `docs/ac913-format-drift-measurement.json`, so the regression is pinned in CI with no live model.
- Full suite green, ruff clean, mypy clean across 742 files. `uv.lock` remains untouched, and `orchestrator.py` remains below its grandfathered cap.

## Status against the four criteria

| criterion | state |
|---|---|
| parse-failure rate measured before/after | **met** |
| drift → typed error, never silently empty | **met** |
| unsupported providers work, run record says unconstrained | **met** |
| round-trips through vLLM **and** Ollama | Ollama **met**; vLLM pending |

The vLLM node is queued on givemeanode (H100, ~2h ETA, ~$1 session minimum). I'll add the `guided_json` result as a follow-up commit here rather than hold the PR — the schemas it would exercise are now real contracts, which is what makes those minutes worth spending.

Also not done: Anthropic native structured output (it currently declines the schema and falls back, which is correct but leaves value on the table).