### PR TITLE
feat(AC-929): constrained decoding in TypeScript, restoring cross-language parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: TypeScript package boundary checks
         working-directory: ts
         run: npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts
+      - name: Role output schema drift check
+        working-directory: autocontext
+        run: uv run --frozen python scripts/generate_role_output_schemas.py --check
       - name: Python/TS schema sync drift check
         working-directory: ts
         run: uv run --frozen --project ../autocontext -- npm run check:schemas

--- a/autocontext/scripts/generate_role_output_schemas.py
+++ b/autocontext/scripts/generate_role_output_schemas.py
@@ -1,0 +1,58 @@
+"""Emit docs/role-output-schemas.json from the pydantic role models.
+
+The models are the single source of truth. TypeScript reads the generated
+artifact rather than retyping the schemas, because retyping is exactly how the
+two drift: a hand-copied version of the analyst schema has already been written
+twice during AC-913/AC-929, once losing the field descriptions (which ride to
+the model and shape generation) and once losing `minItems`, which is the
+difference between "the key exists" and "the section has content".
+
+Usage:
+    python scripts/generate_role_output_schemas.py           # write
+    python scripts/generate_role_output_schemas.py --check   # CI gate
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OUT = REPO_ROOT / "docs" / "role-output-schemas.json"
+
+
+def build() -> str:
+    sys.path.insert(0, str(REPO_ROOT / "autocontext" / "src"))
+    from autocontext.agents.role_schemas import ANALYST_SCHEMA, ARCHITECT_SCHEMA, COACH_SCHEMA
+
+    payload = {
+        "contract": (
+            "Role output schemas, generated from the pydantic models in "
+            "autocontext/agents/role_schemas.py. Both packages read this file; "
+            "neither retypes it. Regenerate with "
+            "autocontext/scripts/generate_role_output_schemas.py."
+        ),
+        "schemas": {
+            schema.name: schema.schema for schema in (ANALYST_SCHEMA, COACH_SCHEMA, ARCHITECT_SCHEMA)
+        },
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    generated = build()
+    if "--check" in sys.argv:
+        current = OUT.read_text(encoding="utf-8") if OUT.exists() else ""
+        if current != generated:
+            print(f"DRIFT: {OUT} differs from the pydantic models. Regenerate with:")
+            print("  python autocontext/scripts/generate_role_output_schemas.py")
+            return 1
+        return 0
+    OUT.write_text(generated, encoding="utf-8")
+    print(f"wrote {OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/role-output-schemas.json
+++ b/docs/role-output-schemas.json
@@ -1,0 +1,330 @@
+{
+  "contract": "Role output schemas, generated from the pydantic models in autocontext/agents/role_schemas.py. Both packages read this file; neither retypes it. Regenerate with autocontext/scripts/generate_role_output_schemas.py.",
+  "schemas": {
+    "analyst_output": {
+      "additionalProperties": false,
+      "description": "The analyst's three sections, as data rather than headings.",
+      "properties": {
+        "findings": {
+          "description": "What the run showed, one claim per item.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Findings",
+          "type": "array"
+        },
+        "recommendations": {
+          "description": "Concrete changes for the next generation, each naming a parameter or behavior.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Recommendations",
+          "type": "array"
+        },
+        "root_causes": {
+          "description": "Why each failure happened.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Root Causes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "findings",
+        "root_causes",
+        "recommendations"
+      ],
+      "type": "object"
+    },
+    "architect_output": {
+      "$defs": {
+        "ArchitectDAGChange": {
+          "additionalProperties": false,
+          "description": "One role-DAG change directive.",
+          "properties": {
+            "action": {
+              "enum": [
+                "add_role",
+                "remove_role"
+              ],
+              "title": "Action",
+              "type": "string"
+            },
+            "depends_on": {
+              "description": "Dependencies for add_role; empty for remove_role.",
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "title": "Depends On",
+              "type": "array"
+            },
+            "name": {
+              "minLength": 1,
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "name",
+            "depends_on"
+          ],
+          "title": "ArchitectDAGChange",
+          "type": "object"
+        },
+        "ArchitectHarnessSpec": {
+          "additionalProperties": false,
+          "description": "One executable pre-tournament strategy validator.",
+          "properties": {
+            "code": {
+              "description": "Complete validate_strategy implementation.",
+              "minLength": 1,
+              "title": "Code",
+              "type": "string"
+            },
+            "description": {
+              "description": "What the validator protects against, or empty.",
+              "title": "Description",
+              "type": "string"
+            },
+            "name": {
+              "description": "Validator identifier.",
+              "minLength": 1,
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "description",
+            "code"
+          ],
+          "title": "ArchitectHarnessSpec",
+          "type": "object"
+        },
+        "ArchitectMutationSpec": {
+          "additionalProperties": false,
+          "description": "One persistent harness mutation, with inapplicable selectors empty.",
+          "properties": {
+            "component": {
+              "description": "Context component for context_policy, otherwise empty.",
+              "title": "Component",
+              "type": "string"
+            },
+            "content": {
+              "minLength": 1,
+              "title": "Content",
+              "type": "string"
+            },
+            "rationale": {
+              "title": "Rationale",
+              "type": "string"
+            },
+            "target_role": {
+              "description": "Target role for prompt_fragment, otherwise empty.",
+              "title": "Target Role",
+              "type": "string"
+            },
+            "tool_name": {
+              "description": "Tool identifier for tool_instruction, otherwise empty.",
+              "title": "Tool Name",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "prompt_fragment",
+                "context_policy",
+                "completion_check",
+                "tool_instruction"
+              ],
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "target_role",
+            "component",
+            "tool_name",
+            "content",
+            "rationale"
+          ],
+          "title": "ArchitectMutationSpec",
+          "type": "object"
+        },
+        "ArchitectToolSpec": {
+          "additionalProperties": false,
+          "description": "One proposed tool. Mirrors what parse_architect_tool_specs already requires.",
+          "properties": {
+            "code": {
+              "description": "Complete implementation.",
+              "minLength": 1,
+              "title": "Code",
+              "type": "string"
+            },
+            "description": {
+              "description": "What the tool does and when to reach for it.",
+              "minLength": 1,
+              "title": "Description",
+              "type": "string"
+            },
+            "name": {
+              "description": "Tool identifier.",
+              "minLength": 1,
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "description",
+            "code"
+          ],
+          "title": "ArchitectToolSpec",
+          "type": "object"
+        },
+        "ArchitectTuningParameter": {
+          "additionalProperties": false,
+          "description": "One bounded adaptive configuration proposal.",
+          "properties": {
+            "name": {
+              "enum": [
+                "backpressure_min_delta",
+                "matches_per_generation",
+                "rlm_max_turns",
+                "architect_every_n_gens",
+                "probe_matches"
+              ],
+              "title": "Name",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "value"
+          ],
+          "title": "ArchitectTuningParameter",
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "description": "The architect's proposal.\n\nAll fields are required so OpenAI strict mode can enforce the object. Empty\nlists represent channels with no proposal; rendered markdown omits their\nlegacy marker blocks, preserving the existing downstream behavior.",
+      "properties": {
+        "changelog_entry": {
+          "description": "One line describing the change, or empty if nothing is proposed.",
+          "title": "Changelog Entry",
+          "type": "string"
+        },
+        "dag_changes": {
+          "description": "Proposed role-DAG changes.",
+          "items": {
+            "$ref": "#/$defs/ArchitectDAGChange"
+          },
+          "title": "Dag Changes",
+          "type": "array"
+        },
+        "harness": {
+          "description": "Proposed executable harness validators.",
+          "items": {
+            "$ref": "#/$defs/ArchitectHarnessSpec"
+          },
+          "title": "Harness",
+          "type": "array"
+        },
+        "impact_hypothesis": {
+          "description": "Expected impact of the proposed changes.",
+          "title": "Impact Hypothesis",
+          "type": "string"
+        },
+        "mutations": {
+          "description": "Proposed persistent harness mutations.",
+          "items": {
+            "$ref": "#/$defs/ArchitectMutationSpec"
+          },
+          "title": "Mutations",
+          "type": "array"
+        },
+        "observed_bottlenecks": {
+          "description": "Observed infrastructure bottlenecks.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Observed Bottlenecks",
+          "type": "array"
+        },
+        "tools": {
+          "description": "Proposed tools; an empty list means no proposal.",
+          "items": {
+            "$ref": "#/$defs/ArchitectToolSpec"
+          },
+          "title": "Tools",
+          "type": "array"
+        },
+        "tuning_parameters": {
+          "description": "Proposed adaptive parameters.",
+          "items": {
+            "$ref": "#/$defs/ArchitectTuningParameter"
+          },
+          "title": "Tuning Parameters",
+          "type": "array"
+        },
+        "tuning_reasoning": {
+          "description": "Reasoning for adaptive parameters, or empty.",
+          "title": "Tuning Reasoning",
+          "type": "string"
+        }
+      },
+      "required": [
+        "observed_bottlenecks",
+        "impact_hypothesis",
+        "tools",
+        "harness",
+        "mutations",
+        "dag_changes",
+        "tuning_parameters",
+        "tuning_reasoning",
+        "changelog_entry"
+      ],
+      "type": "object"
+    },
+    "coach_output": {
+      "additionalProperties": false,
+      "description": "The coach's three sections.\n\nToday these are delimited by HTML comment markers, and the fallback when a\nmodel emits no markers at all is to treat the entire response as the\nplaybook -- preamble, reasoning and all. That is a quieter failure than the\nanalyst's empty section but a worse one: the playbook is persisted and\nsteers the next generation. A schema removes the marker convention rather\nthan asking a model to honor it.",
+      "properties": {
+        "hints": {
+          "description": "Concrete hints for the competitor's next attempt.",
+          "title": "Hints",
+          "type": "string"
+        },
+        "lessons": {
+          "description": "Operational lessons, each a concrete prescriptive rule.",
+          "title": "Lessons",
+          "type": "string"
+        },
+        "playbook": {
+          "description": "The complete replacement playbook, consolidated and deduplicated.",
+          "title": "Playbook",
+          "type": "string"
+        }
+      },
+      "required": [
+        "playbook",
+        "lessons",
+        "hints"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -144,9 +144,10 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc && npm run build:cli-contract && npm run build:production-traces-sdk-cjs",
+    "build": "tsc && npm run build:cli-contract && npm run build:role-output-schemas && npm run build:production-traces-sdk-cjs",
     "build:browser-contract-types": "node scripts/generate-browser-contract-types.mjs",
     "build:cli-contract": "node scripts/copy-cli-contract.mjs",
+    "build:role-output-schemas": "node scripts/copy-role-output-schemas.mjs",
     "generate:root-index": "node scripts/generate-root-index.mjs",
     "check:root-index": "node scripts/generate-root-index.mjs --check",
     "build:production-traces-sdk-cjs": "node scripts/build-production-traces-sdk-cjs.mjs",

--- a/ts/scripts/copy-role-output-schemas.mjs
+++ b/ts/scripts/copy-role-output-schemas.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Copy the generated cross-runtime role schemas into the npm package.
+ *
+ * Source development reads the canonical artifact from the repository's
+ * docs/ directory. Published consumers do not have the repository around
+ * them, so npm run build places the same artifact inside dist/, which is part
+ * of the package's files allowlist.
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const source = resolve(repoRoot, "docs", "role-output-schemas.json");
+const distDir = resolve(here, "..", "dist");
+const destination = resolve(distDir, "role-output-schemas.json");
+
+if (!existsSync(source)) {
+  console.error(`copy-role-output-schemas: source not found: ${source}`);
+  process.exit(1);
+}
+
+mkdirSync(distDir, { recursive: true });
+copyFileSync(source, destination);
+console.log(`copy-role-output-schemas: ${source} -> ${destination}`);

--- a/ts/src/agents/orchestrator.ts
+++ b/ts/src/agents/orchestrator.ts
@@ -13,6 +13,13 @@ import {
   parseCoachOutput,
   parseCompetitorOutput,
 } from "./roles.js";
+import {
+  ANALYST_SCHEMA,
+  COACH_SCHEMA,
+  parseAnalystConstrained,
+  parseCoachConstrained,
+} from "./role-schemas.js";
+import type { OutputSchema } from "../types/index.js";
 import type { AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput } from "./roles.js";
 
 export interface GenerationPrompts {
@@ -49,11 +56,26 @@ export class AgentOrchestrator {
     return this.#roleProviders[role] ?? this.#provider;
   }
 
+  // AC-929: the schema a role asks its backend to constrain generation to.
+  // Roles without one (competitor emits a strategy object, not a role contract)
+  // are simply absent from the map and keep today's behavior.
+  //
+  // architect is deliberately absent. Its Python payload carries nine channels
+  // and renders them back into a legacy wire format, re-running AST validation
+  // over proposed harness code; porting that faithfully is its own piece of
+  // work, and a half-port would silently drop seven channels. It keeps the
+  // scrape path until then.
+  static readonly #ROLE_SCHEMAS: Partial<Record<GenerationRole, OutputSchema>> = {
+    analyst: ANALYST_SCHEMA,
+    coach: COACH_SCHEMA,
+  };
+
   #completeRole(role: GenerationRole, userPrompt: string) {
     return this.#providerForRole(role).complete({
       systemPrompt: "",
       userPrompt,
       model: this.#roleModels[role],
+      outputSchema: AgentOrchestrator.#ROLE_SCHEMAS[role],
     });
   }
 
@@ -77,10 +99,19 @@ export class AgentOrchestrator {
         : Promise.resolve({ text: "", usage: {} }),
     ]);
 
+    // Parse by what the backend ACTUALLY did, not what was requested. A
+    // backend that ignored the schema reports constrained !== true and keeps
+    // the markdown scrape, unchanged.
     return {
       competitorOutput,
-      analystOutput: parseAnalystOutput(analystResult.text),
-      coachOutput: parseCoachOutput(coachResult.text),
+      analystOutput:
+        analystResult.constrained === true
+          ? parseAnalystConstrained(analystResult.text)
+          : parseAnalystOutput(analystResult.text),
+      coachOutput:
+        coachResult.constrained === true
+          ? parseCoachConstrained(coachResult.text)
+          : parseCoachOutput(coachResult.text),
       architectOutput: parseArchitectOutput(architectResult.text),
     };
   }

--- a/ts/src/agents/orchestrator.ts
+++ b/ts/src/agents/orchestrator.ts
@@ -18,6 +18,7 @@ import {
   COACH_SCHEMA,
   parseAnalystConstrained,
   parseCoachConstrained,
+  wasConstrained,
 } from "./role-schemas.js";
 import type { OutputSchema } from "../types/index.js";
 import type { AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput } from "./roles.js";
@@ -104,14 +105,12 @@ export class AgentOrchestrator {
     // the markdown scrape, unchanged.
     return {
       competitorOutput,
-      analystOutput:
-        analystResult.constrained === true
-          ? parseAnalystConstrained(analystResult.text)
-          : parseAnalystOutput(analystResult.text),
-      coachOutput:
-        coachResult.constrained === true
-          ? parseCoachConstrained(coachResult.text)
-          : parseCoachOutput(coachResult.text),
+      analystOutput: wasConstrained(analystResult)
+        ? parseAnalystConstrained(analystResult.text)
+        : parseAnalystOutput(analystResult.text),
+      coachOutput: wasConstrained(coachResult)
+        ? parseCoachConstrained(coachResult.text)
+        : parseCoachOutput(coachResult.text),
       architectOutput: parseArchitectOutput(architectResult.text),
     };
   }

--- a/ts/src/agents/role-schemas.ts
+++ b/ts/src/agents/role-schemas.ts
@@ -23,6 +23,19 @@ import { Ajv, type ValidateFunction } from "ajv";
 import type { OutputSchema } from "../types/index.js";
 import type { AnalystOutput, ArchitectOutput, CoachOutput } from "./roles.js";
 
+/**
+ * Whether a backend actually enforced the requested schema.
+ *
+ * `CompletionResult.constrained` is `boolean | undefined` on purpose --
+ * see the note on the type -- and "absent" and "false" both mean unconstrained.
+ * Reading it through one helper keeps that comparison in a single place, so a
+ * later `if (result.constrained)` cannot quietly treat undefined as a third
+ * state, and callers never have to remember the `=== true`.
+ */
+export function wasConstrained(result: { constrained?: boolean }): boolean {
+  return result.constrained === true;
+}
+
 /** A role's output did not conform to its schema. */
 export class RoleOutputValidationError extends Error {
   readonly role: string;
@@ -179,7 +192,7 @@ export function parseCoachConstrained(rawText: string): CoachOutput {
  * NOT wired into the orchestrator yet. The Python payload carries nine channels
  * and a legacy-format renderer; this maps only tools and the changelog entry,
  * so wiring it would silently drop the rest. Kept as the starting point for
- * that port, and exercised by tests so it cannot rot in the meantime.
+ * that port (tracked as AC-930), and exercised by tests so it cannot rot.
  */
 export function parseArchitectConstrained(rawText: string): ArchitectOutput {
   const payload = parsePayload<{

--- a/ts/src/agents/role-schemas.ts
+++ b/ts/src/agents/role-schemas.ts
@@ -57,12 +57,12 @@ type SchemaArtifact = {
 };
 
 function loadArtifact(): SchemaArtifact {
-  // Resolved from this module rather than cwd so it works from the package,
-  // the test runner, and a consumer's node_modules alike.
+  // Resolve from this module rather than cwd. Builds copy the artifact into
+  // dist/, while source execution falls back to the repository's docs/ tree.
   const here = dirname(fileURLToPath(import.meta.url));
   const candidates = [
+    join(here, "..", "role-output-schemas.json"),
     join(here, "..", "..", "..", "docs", "role-output-schemas.json"),
-    join(here, "..", "..", "docs", "role-output-schemas.json"),
   ];
   for (const path of candidates) {
     try {

--- a/ts/src/agents/role-schemas.ts
+++ b/ts/src/agents/role-schemas.ts
@@ -1,0 +1,196 @@
+/**
+ * Schema-enforced role outputs for the TypeScript engine (AC-929).
+ *
+ * Mirrors Python's autocontext/agents/role_schemas.py. The schemas themselves
+ * are NOT retyped here: they are read from docs/role-output-schemas.json,
+ * generated from the pydantic models. Retyping is precisely how the two engines
+ * drift — during AC-913/AC-929 a hand-copied analyst schema was written twice,
+ * once dropping the field descriptions (which ride to the model and shape what
+ * it generates) and once dropping `minItems`, which is the whole difference
+ * between "the key exists" and "the section has content".
+ *
+ * AJV validates responses against the same schema that was sent, so a payload
+ * the backend accepted but that fails the contract raises rather than becoming
+ * a silently empty section.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Ajv, type ValidateFunction } from "ajv";
+
+import type { OutputSchema } from "../types/index.js";
+import type { AnalystOutput, ArchitectOutput, CoachOutput } from "./roles.js";
+
+/** A role's output did not conform to its schema. */
+export class RoleOutputValidationError extends Error {
+  readonly role: string;
+  readonly reason: string;
+  readonly rawText: string;
+
+  constructor(role: string, reason: string, rawText: string) {
+    super(`${role} output failed schema validation: ${reason}`);
+    this.name = "RoleOutputValidationError";
+    this.role = role;
+    this.reason = reason;
+    this.rawText = rawText;
+  }
+}
+
+type SchemaArtifact = {
+  contract: string;
+  schemas: Record<string, Record<string, unknown>>;
+};
+
+function loadArtifact(): SchemaArtifact {
+  // Resolved from this module rather than cwd so it works from the package,
+  // the test runner, and a consumer's node_modules alike.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, "..", "..", "..", "docs", "role-output-schemas.json"),
+    join(here, "..", "..", "docs", "role-output-schemas.json"),
+  ];
+  for (const path of candidates) {
+    try {
+      return JSON.parse(readFileSync(path, "utf-8")) as SchemaArtifact;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(
+    "role-output-schemas.json not found. Regenerate with " +
+      "autocontext/scripts/generate_role_output_schemas.py",
+  );
+}
+
+const ARTIFACT = loadArtifact();
+
+function outputSchema(name: string): OutputSchema {
+  const schema = ARTIFACT.schemas[name];
+  if (!schema) {
+    throw new Error(`role-output-schemas.json has no schema named ${name}`);
+  }
+  return { name, schema };
+}
+
+export const ANALYST_SCHEMA = outputSchema("analyst_output");
+export const COACH_SCHEMA = outputSchema("coach_output");
+export const ARCHITECT_SCHEMA = outputSchema("architect_output");
+
+// strict:false — the generated schemas carry pydantic's `title`/`description`
+// annotations, which AJV's strict mode rejects as unknown keywords. They are
+// meaningful to the model, so they stay in the artifact rather than being
+// stripped to satisfy the validator.
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validators = new Map<string, ValidateFunction>();
+
+function validatorFor(schema: OutputSchema): ValidateFunction {
+  let validate = validators.get(schema.name);
+  if (!validate) {
+    validate = ajv.compile(schema.schema);
+    validators.set(schema.name, validate);
+  }
+  return validate;
+}
+
+function parsePayload<T>(role: string, schema: OutputSchema, rawText: string): T {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (err) {
+    throw new RoleOutputValidationError(role, `not valid JSON: ${String(err)}`, rawText);
+  }
+  const validate = validatorFor(schema);
+  if (!validate(parsed)) {
+    const reason = (validate.errors ?? [])
+      .map((e) => `${e.instancePath || "/"} ${e.message ?? ""}`.trim())
+      .join("; ");
+    throw new RoleOutputValidationError(role, reason || "did not match schema", rawText);
+  }
+  return parsed as T;
+}
+
+/** Render validated data into the markdown shape the existing scraper reads. */
+export function renderAnalystMarkdown(payload: {
+  findings: string[];
+  root_causes: string[];
+  recommendations: string[];
+}): string {
+  const sections: Array<[string, string[]]> = [
+    ["Findings", payload.findings],
+    ["Root Causes", payload.root_causes],
+    ["Actionable Recommendations", payload.recommendations],
+  ];
+  return (
+    sections
+      .map(([heading, items]) =>
+        items.length
+          ? `## ${heading}\n\n${items.map((i) => `- ${i}`).join("\n")}`
+          : `## ${heading}\n`,
+      )
+      .join("\n\n") + "\n"
+  );
+}
+
+export function parseAnalystConstrained(rawText: string): AnalystOutput {
+  const payload = parsePayload<{
+    findings: string[];
+    root_causes: string[];
+    recommendations: string[];
+  }>("analyst", ANALYST_SCHEMA, rawText);
+  return {
+    rawMarkdown: renderAnalystMarkdown(payload),
+    findings: payload.findings,
+    rootCauses: payload.root_causes,
+    recommendations: payload.recommendations,
+    parseSuccess: true,
+  };
+}
+
+export function renderCoachMarkdown(payload: {
+  playbook: string;
+  lessons: string;
+  hints: string;
+}): string {
+  return (
+    `<!-- PLAYBOOK_START -->\n${payload.playbook}\n<!-- PLAYBOOK_END -->\n\n` +
+    `<!-- LESSONS_START -->\n${payload.lessons}\n<!-- LESSONS_END -->\n\n` +
+    `<!-- COMPETITOR_HINTS_START -->\n${payload.hints}\n<!-- COMPETITOR_HINTS_END -->\n`
+  );
+}
+
+export function parseCoachConstrained(rawText: string): CoachOutput {
+  const payload = parsePayload<{ playbook: string; lessons: string; hints: string }>(
+    "coach",
+    COACH_SCHEMA,
+    rawText,
+  );
+  return {
+    rawMarkdown: renderCoachMarkdown(payload),
+    playbook: payload.playbook,
+    lessons: payload.lessons,
+    hints: payload.hints,
+    parseSuccess: true,
+  };
+}
+
+/**
+ * NOT wired into the orchestrator yet. The Python payload carries nine channels
+ * and a legacy-format renderer; this maps only tools and the changelog entry,
+ * so wiring it would silently drop the rest. Kept as the starting point for
+ * that port, and exercised by tests so it cannot rot in the meantime.
+ */
+export function parseArchitectConstrained(rawText: string): ArchitectOutput {
+  const payload = parsePayload<{
+    tools: Array<{ name: string; description: string; code: string }>;
+    changelog_entry: string;
+  }>("architect", ARCHITECT_SCHEMA, rawText);
+  return {
+    rawMarkdown: rawText,
+    toolSpecs: payload.tools.map((tool) => ({ ...tool })),
+    harnessSpecs: [],
+    changelogEntry: payload.changelog_entry,
+    parseSuccess: true,
+  };
+}

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -87,13 +87,8 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
     name: "openai-compatible",
     defaultModel: () => defaultModel,
     complete: async (callOpts) => {
-      const res = await fetch(`${baseUrl}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
+      const buildBody = (withSchema: boolean) =>
+        JSON.stringify({
           model: callOpts.model || defaultModel,
           max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, callOpts.model || defaultModel),
           temperature: callOpts.temperature ?? 0,
@@ -101,8 +96,42 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
             { role: "system", content: callOpts.systemPrompt },
             { role: "user", content: callOpts.userPrompt },
           ],
-        }),
-      });
+          ...(withSchema && callOpts.outputSchema
+            ? {
+                response_format: {
+                  type: "json_schema",
+                  json_schema: {
+                    name: callOpts.outputSchema.name,
+                    strict: true,
+                    schema: callOpts.outputSchema.schema,
+                  },
+                },
+              }
+            : {}),
+        });
+
+      const post = (withSchema: boolean) =>
+        fetch(`${baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: buildBody(withSchema),
+        });
+
+      let constrained = Boolean(callOpts.outputSchema);
+      let res = await post(constrained);
+
+      if (!res.ok && constrained) {
+        // This endpoint does not understand response_format. Retry once
+        // without it rather than failing the run: a backend with no
+        // constrained-decoding support must still work, and the result then
+        // reports constrained=false so the caller can tell "the schema was
+        // enforced" from "the schema was requested and silently not applied".
+        constrained = false;
+        res = await post(false);
+      }
 
       if (!res.ok) {
         const body = await res.text();
@@ -121,6 +150,7 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
         model: data.model,
         usage: { input: data.usage.prompt_tokens, output: data.usage.completion_tokens },
         stopReason: data.choices[0]?.finish_reason,
+        constrained,
       } satisfies CompletionResult;
     },
   };

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -78,6 +78,21 @@ export interface OpenAICompatibleProviderOpts {
   model?: string;
 }
 
+function isUnsupportedResponseFormatError(status: number, body: string): boolean {
+  if (![400, 404, 422].includes(status)) return false;
+
+  const message = body.toLowerCase();
+  const mentionsSchema = message.includes("response_format") || message.includes("json_schema");
+  const rejectsSchema = [
+    "unsupported",
+    "not supported",
+    "unknown",
+    "unrecognized",
+    "invalid",
+  ].some((token) => message.includes(token));
+  return mentionsSchema && rejectsSchema;
+}
+
 export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpts): LLMProvider {
   const defaultModel = opts.model || "gpt-4o";
   const baseUrl = (opts.baseUrl ?? "https://api.openai.com/v1").replace(/\/+$/, "");
@@ -124,11 +139,14 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
       let res = await post(constrained);
 
       if (!res.ok && constrained) {
-        // This endpoint does not understand response_format. Retry once
-        // without it rather than failing the run: a backend with no
-        // constrained-decoding support must still work, and the result then
-        // reports constrained=false so the caller can tell "the schema was
-        // enforced" from "the schema was requested and silently not applied".
+        const body = await res.text();
+        if (!isUnsupportedResponseFormatError(res.status, body)) {
+          throw new ProviderError(`OpenAI API error ${res.status}: ${body.slice(0, 200)}`);
+        }
+
+        // This endpoint explicitly rejected response_format. Retry once
+        // without it so a backend with no constrained-decoding support still
+        // works, and report that the returned text was unconstrained.
         constrained = false;
         res = await post(false);
       }

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -17,6 +17,15 @@ export const CompletionResultSchema = z.object({
   // truncation); absent when the provider does not report one.
   stopReason: z.string().nullish(),
   metadata: z.record(z.unknown()).optional(),
+  // AC-929: whether the backend actually constrained generation to the
+  // requested schema. Mirrors Python's CompletionResult.constrained (AC-913).
+  //
+  // Optional rather than .default(false): a default makes the field REQUIRED on
+  // the inferred output type, so every construction site -- including
+  // LLMProvider implementations written outside this repo, since this is public
+  // API -- would stop compiling. Absent and false both mean unconstrained, so
+  // read it as `constrained === true` and nothing breaks.
+  constrained: z.boolean().optional(),
 });
 
 export type CompletionResult = z.infer<typeof CompletionResultSchema>;
@@ -28,6 +37,19 @@ export class ProviderError extends Error {
   }
 }
 
+/**
+ * A JSON Schema the backend should constrain generation to (AC-929).
+ *
+ * Passing one is a request, not a guarantee: backends that cannot enforce a
+ * schema ignore it and report `constrained: false`. Callers must read that
+ * flag rather than assume the text validates -- an unconstrained run should be
+ * visible, not inferred.
+ */
+export interface OutputSchema {
+  name: string;
+  schema: Record<string, unknown>;
+}
+
 export interface LLMProvider {
   complete(opts: {
     systemPrompt: string;
@@ -35,6 +57,13 @@ export interface LLMProvider {
     model?: string;
     temperature?: number;
     maxTokens?: number;
+    /**
+     * Optional and best-effort. An implementation that cannot honor it must
+     * still answer and must leave `constrained` false. Optional on purpose:
+     * LLMProvider is public API, so a provider written outside this repo keeps
+     * compiling and keeps working.
+     */
+    outputSchema?: OutputSchema;
   }): Promise<CompletionResult>;
 
   defaultModel(): string;

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -24,7 +24,8 @@ export const CompletionResultSchema = z.object({
   // the inferred output type, so every construction site -- including
   // LLMProvider implementations written outside this repo, since this is public
   // API -- would stop compiling. Absent and false both mean unconstrained, so
-  // read it as `constrained === true` and nothing breaks.
+  // read it through wasConstrained() in agents/role-schemas.ts, which keeps
+  // the `=== true` comparison in exactly one place.
   constrained: z.boolean().optional(),
 });
 

--- a/ts/tests/package-parity.test.ts
+++ b/ts/tests/package-parity.test.ts
@@ -14,6 +14,7 @@ const PACKAGE_JSON = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"),
   bin: { autoctx: string };
 };
 let didBuild = false;
+let packedFiles: string[] | undefined;
 
 function ensureBuiltPackage(): void {
   if (didBuild) return;
@@ -24,6 +25,21 @@ function ensureBuiltPackage(): void {
     env: { ...process.env, NODE_NO_WARNINGS: "1" },
   });
   didBuild = true;
+}
+
+function packedFilePaths(): string[] {
+  if (packedFiles) return packedFiles;
+  ensureBuiltPackage();
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: PACKAGE_ROOT,
+    encoding: "utf8",
+    timeout: 120000,
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+  });
+  const metadata = JSON.parse(output);
+  const paths = metadata[0].files.map((file: { path: string }) => file.path);
+  packedFiles = paths;
+  return paths;
 }
 
 function createConsumerWorkspace(): string {
@@ -180,6 +196,10 @@ describe("CLI help matches README", () => {
 // ---------------------------------------------------------------------------
 
 describe("Package exports", () => {
+  it("ships the generated role-output schemas used by the root entry point", () => {
+    expect(packedFilePaths()).toContain("dist/role-output-schemas.json");
+  });
+
   it("exports GenerationRunner", async () => {
     expect(importPackageExport("GenerationRunner")).toBe(true);
   });

--- a/ts/tests/providers.test.ts
+++ b/ts/tests/providers.test.ts
@@ -190,6 +190,98 @@ describe("OpenAICompatibleProvider", () => {
     vi.unstubAllGlobals();
   });
 
+  it("sends a JSON schema and reports a constrained response", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '{"answer":"ok"}' } }],
+        model: "gpt-4o",
+        usage: { prompt_tokens: 2, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await provider.complete({
+      systemPrompt: "sys",
+      userPrompt: "test",
+      outputSchema: {
+        name: "test_output",
+        schema: { type: "object", properties: { answer: { type: "string" } } },
+      },
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.response_format.json_schema.name).toBe("test_output");
+    expect(body.response_format.json_schema.strict).toBe(true);
+    expect(result.constrained).toBe(true);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("retries without a schema only when the endpoint explicitly rejects it", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => "response_format json_schema is not supported",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "fallback markdown" } }],
+          model: "local-model",
+          usage: { prompt_tokens: 2, completion_tokens: 3 },
+        }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await provider.complete({
+      systemPrompt: "sys",
+      userPrompt: "test",
+      outputSchema: { name: "test_output", schema: { type: "object" } },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toHaveProperty("response_format");
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).not.toHaveProperty("response_format");
+    expect(result.text).toBe("fallback markdown");
+    expect(result.constrained).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    [400, "invalid model name"],
+    [401, "response_format json_schema is not supported"],
+    [429, "response_format json_schema is not supported"],
+    [500, "response_format json_schema is not supported"],
+  ])("does not retry a non-capability HTTP %i response", async (status, message) => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      text: async () => message,
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(
+      provider.complete({
+        systemPrompt: "sys",
+        userPrompt: "test",
+        outputSchema: { name: "test_output", schema: { type: "object" } },
+      }),
+    ).rejects.toThrow(`OpenAI API error ${status}`);
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    vi.unstubAllGlobals();
+  });
+
   it("should parse OpenAI response correctly", async () => {
     const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
     const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });

--- a/ts/tests/role-schemas.test.ts
+++ b/ts/tests/role-schemas.test.ts
@@ -15,6 +15,7 @@ import {
   RoleOutputValidationError,
   parseAnalystConstrained,
   parseCoachConstrained,
+  wasConstrained,
 } from "../src/agents/role-schemas.js";
 import { parseAnalystOutput } from "../src/agents/roles.js";
 import type { CompletionResult, LLMProvider, OutputSchema } from "../src/types/index.js";
@@ -122,6 +123,18 @@ describe("role output schemas", () => {
         Object.keys(body.properties ?? {}).sort(),
       );
     }
+  });
+});
+
+describe("wasConstrained", () => {
+  it("treats absent as unconstrained, not as a third state", () => {
+    // The reason the helper exists: `constrained` is optional so external
+    // LLMProvider implementations keep compiling, which makes `undefined` a
+    // real value at every read site.
+    expect(wasConstrained({})).toBe(false);
+    expect(wasConstrained({ constrained: undefined })).toBe(false);
+    expect(wasConstrained({ constrained: false })).toBe(false);
+    expect(wasConstrained({ constrained: true })).toBe(true);
   });
 });
 

--- a/ts/tests/role-schemas.test.ts
+++ b/ts/tests/role-schemas.test.ts
@@ -1,0 +1,157 @@
+/**
+ * AC-929: TypeScript constrained decoding, and the parity it restores.
+ *
+ * The schemas are read from docs/role-output-schemas.json, generated from the
+ * pydantic models, so these tests also guard the property that makes that
+ * indirection worth having: the two engines validate the SAME contract.
+ */
+import { describe, expect, it } from "vitest";
+
+import { AgentOrchestrator } from "../src/agents/orchestrator.js";
+import {
+  ANALYST_SCHEMA,
+  ARCHITECT_SCHEMA,
+  COACH_SCHEMA,
+  RoleOutputValidationError,
+  parseAnalystConstrained,
+  parseCoachConstrained,
+} from "../src/agents/role-schemas.js";
+import { parseAnalystOutput } from "../src/agents/roles.js";
+import type { CompletionResult, LLMProvider, OutputSchema } from "../src/types/index.js";
+
+/** Records what the orchestrator sent, and can pretend to enforce it. */
+class RecordingProvider implements LLMProvider {
+  readonly name = "recording";
+  readonly calls: Array<{ outputSchema?: OutputSchema }> = [];
+  #enforce: boolean;
+  #text: string;
+
+  constructor(enforce: boolean, text: string) {
+    this.#enforce = enforce;
+    this.#text = text;
+  }
+
+  async complete(opts: {
+    systemPrompt: string;
+    userPrompt: string;
+    outputSchema?: OutputSchema;
+  }): Promise<CompletionResult> {
+    this.calls.push({ outputSchema: opts.outputSchema });
+    return { text: this.#text, usage: {}, constrained: this.#enforce };
+  }
+
+  defaultModel() {
+    return "stub";
+  }
+}
+
+const VALID_ANALYST = JSON.stringify({
+  findings: ["reached the first flag in 6 steps"],
+  root_causes: ["no tiebreak between equidistant flags"],
+  recommendations: ["add a deterministic tiebreak on flag id"],
+});
+
+const DRIFTED = "### Findings\n\n* the agent oscillated between two flags";
+
+describe("role output schemas", () => {
+  it("rejects the drift the markdown scraper loses silently", () => {
+    // Same defect as Python's: correct analysis, wrong heading level and
+    // bullet marker, so every section comes back empty with nothing raised.
+    const scraped = parseAnalystOutput(DRIFTED);
+    expect(scraped.findings).toEqual([]);
+    expect(scraped.parseSuccess).toBe(true); // reports success while empty
+
+    expect(() => parseAnalystConstrained(DRIFTED)).toThrow(RoleOutputValidationError);
+  });
+
+  it("rejects an empty section rather than accepting it", () => {
+    // minItems in the shared artifact is what makes this fail. Without it a
+    // schema-valid payload could still carry an empty findings array, which is
+    // the exact failure this work removes.
+    expect(() =>
+      parseAnalystConstrained(
+        JSON.stringify({ findings: [], root_causes: ["r"], recommendations: ["x"] }),
+      ),
+    ).toThrow(RoleOutputValidationError);
+  });
+
+  it("rejects a missing field rather than defaulting it", () => {
+    expect(() =>
+      parseAnalystConstrained(JSON.stringify({ findings: ["f"], root_causes: ["r"] })),
+    ).toThrow(RoleOutputValidationError);
+  });
+
+  it("carries the role, reason and offending text on the error", () => {
+    try {
+      parseAnalystConstrained(DRIFTED);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const e = err as RoleOutputValidationError;
+      expect(e.role).toBe("analyst");
+      expect(e.reason).toBeTruthy();
+      expect(e.rawText).toBe(DRIFTED);
+    }
+  });
+
+  it("renders markdown that round-trips through the scraper it replaces", () => {
+    const out = parseAnalystConstrained(VALID_ANALYST);
+    expect(parseAnalystOutput(out.rawMarkdown).findings).toEqual(out.findings);
+    expect(parseAnalystOutput(out.rawMarkdown).rootCauses).toEqual(out.rootCauses);
+  });
+
+  it("round-trips coach output through the marker parser", () => {
+    const out = parseCoachConstrained(JSON.stringify({ playbook: "P", lessons: "L", hints: "H" }));
+    expect(out.rawMarkdown).toContain("<!-- PLAYBOOK_START -->");
+    expect(out.playbook).toBe("P");
+  });
+
+  it("every schema is strict and complete", () => {
+    // Derived, not hardcoded: every declared property must be required, which
+    // is the invariant that stops a backend satisfying the schema while
+    // omitting the fields the role exists to produce. A hardcoded list would
+    // also drift the moment the pydantic models gain a channel -- which has
+    // already happened once to architect.
+    for (const schema of [ANALYST_SCHEMA, COACH_SCHEMA, ARCHITECT_SCHEMA]) {
+      const body = schema.schema as {
+        additionalProperties?: boolean;
+        required?: string[];
+        properties?: Record<string, unknown>;
+      };
+      expect(body.additionalProperties, schema.name).toBe(false);
+      expect([...(body.required ?? [])].sort(), schema.name).toEqual(
+        Object.keys(body.properties ?? {}).sort(),
+      );
+    }
+  });
+});
+
+describe("orchestrator wiring", () => {
+  const prompts = {
+    competitorPrompt: "c",
+    analystPrompt: "a",
+    coachPrompt: "co",
+    architectPrompt: "ar",
+  };
+
+  it("sends each role's schema to its provider", async () => {
+    // The AC-913 lesson: a capability nothing passes is a capability that never
+    // runs. This asserts the schema actually leaves the orchestrator.
+    const provider = new RecordingProvider(true, VALID_ANALYST);
+    await new AgentOrchestrator(provider).runGeneration(prompts).catch(() => undefined);
+
+    const names = provider.calls.map((c) => c.outputSchema?.name);
+    expect(names).toContain("analyst_output");
+    expect(names).toContain("coach_output");
+    // architect deliberately absent until its nine-channel payload is ported;
+    // asserted so the exclusion is a recorded decision rather than an omission.
+    expect(names).not.toContain("architect_output");
+  });
+
+  it("falls back to scraping when the backend did not enforce", async () => {
+    const markdown =
+      "## Findings\n\n- from markdown\n\n## Root Causes\n\n- rc\n\n## Actionable Recommendations\n\n- rec";
+    const provider = new RecordingProvider(false, markdown);
+    const result = await new AgentOrchestrator(provider).runGeneration(prompts);
+    expect(result.analystOutput.findings).toEqual(["from markdown"]);
+  });
+});

--- a/ts/tests/type-assertions.test.ts
+++ b/ts/tests/type-assertions.test.ts
@@ -155,7 +155,10 @@ describe("TypeScript type assertion budget", () => {
     // whose AJV validators use the same ajv CJS-default-interop cast pattern
     // already sanctioned above, plus manifest/fixture field-access casts in
     // the cross-package parity tests. Same "bump, don't reverse-engineer" policy.
-    expect(total).toBeLessThanOrEqual(1063);
+    // Bumped to 1065 for AC-929's generated role-schema artifact boundary and
+    // validated payload handoff. Both casts sit directly beside runtime
+    // validation; neither weakens an unchecked internal boundary.
+    expect(total).toBeLessThanOrEqual(1065);
   });
 
   it("mission/store.ts should use row types instead of inline casts", () => {


### PR DESCRIPTION
Closes AC-929. **0.15.0 release gate** — AC-913 shipped structured role output in Python only.

## The gap

Same model, same prompt, opposite behavior depending on which engine you ran:

| engine | analyst sections lost (llama3.1:8b, 20 trials) |
|---|---|
| Python (after AC-913) | **0/20** |
| TypeScript (before this PR) | **20/20**, silently |

`ts/src/agents/roles.ts` still carried the identical `extractSectionBullets` scraper and `ts/src/providers/` had no schema parameter at all. Nothing failed, because no parity fixture reaches the role-output layer.

**After this PR, measured through the real TypeScript orchestrator: 0/20 lost, 0 validation errors.**

## Schemas are generated, not retyped

`docs/role-output-schemas.json` is emitted from the pydantic models by `autocontext/scripts/generate_role_output_schemas.py` (with a `--check` gate); TypeScript reads it, and AJV validates responses against the same schema that was sent.

That indirection earned itself during this work. I hand-copied the analyst schema twice and got it wrong both times:

- once dropping the field `description`s — which ride to the model as part of the schema and shape what it generates
- once dropping `minItems`, which is the entire difference between *"the key exists"* and *"the section has content"*

The second produced a live failure: `constrained=true` with an empty `findings` array — the exact silent-empty outcome this work exists to remove. Retyping can't be made safe by being careful, so it's now structurally impossible.

Worth noting the shipped **Python** schema already had `minItems` and correctly raises on an empty section. I briefly believed it had the same hole and was wrong; the hole was only ever in my probe.

## Compatibility, deliberately

`constrained` is `z.boolean().optional()`, **not** `.default(false)`. A zod default makes the field *required* on the inferred type, so every construction site — including `LLMProvider` implementations written outside this repo, since `complete()` is public API — would stop compiling. Absent and false both mean unconstrained. **Zero existing construction sites changed.** `outputSchema` is likewise optional on the options object.

An endpoint that rejects `response_format` is retried once without it and reports `constrained: false`, matching Python.

## Scope: architect is deliberately excluded

analyst and coach are wired. Architect is **not**, and that's a decision rather than an oversight: its Python payload carries nine channels (`observed_bottlenecks`, `mutations`, `dag_changes`, `tuning_parameters`, …) and renders them back into a legacy wire format, re-running AST validation over proposed harness code. A half-port would silently drop seven channels — the same class of bug this PR fixes.

`parseArchitectConstrained` is exported and tested as the starting point, and **a test asserts architect is NOT sent a schema**, so the exclusion is recorded rather than something to rediscover later.

The strictness test also derives its expectation from each schema's own properties instead of a hardcoded field list — architect's payload has already grown once during this epic, and a hardcoded list would have quietly stopped checking the new channels.

## Verification

- 9 new tests; 76 pass across the role-schema and routing-parity suites.
- `tsc --noEmit` and `tsc -p tsconfig.test.json` clean.
- Python suite for role schemas green; generator `--check` confirms the artifact matches the models.
- Live against Ollama 0.32.5 through the real orchestrator, not a harness.
- `uv.lock` untouched.

## Review notes

Two things I'd most like eyes on:

1. **The `.optional()` vs `.default(false)` call** — I chose not to break external providers, at the cost of `boolean | undefined` at read sites. Every read is `=== true`.
2. **Scoping architect out.** The alternative was porting the nine-channel renderer in this PR; I judged that too large to land safely alongside the parity fix, but it does mean architect stays on the scrape path in TypeScript for now.