### PR TITLE
fix(AC-932): stop losing playbook updates silently when coach output drifts

### DIFF
--- a/autocontext/src/autocontext/agents/coach.py
+++ b/autocontext/src/autocontext/agents/coach.py
@@ -30,6 +30,19 @@ def parse_coach_sections(content: str) -> tuple[str, str, str]:
         else:
             # Legacy fallback: no markers at all means the model ignored the
             # format and the entire content is the playbook.
+            #
+            # AC-932: warn, because this is not a neutral fallback. Whatever the
+            # model wrote -- preamble, reasoning, an apology -- becomes the
+            # playbook and steers the next generation. Measured on llama3.1:8b,
+            # 2 of 10 coach responses carried no markers at all, so on an
+            # open-weight model this fires often enough to matter. TypeScript
+            # fails the opposite way and drops the update entirely; both were
+            # silent until now.
+            logger.warning(
+                "coach output has no playbook markers; treating the entire response as the playbook "
+                "(%d chars). Enable constrained output or check the model's format compliance.",
+                len(content.strip()),
+            )
             playbook = content.strip()
 
     return playbook, lessons or "", hints or ""

--- a/autocontext/tests/test_coach_marker_visibility.py
+++ b/autocontext/tests/test_coach_marker_visibility.py
@@ -1,0 +1,76 @@
+"""AC-932: a coach response that ignores the format must not fail silently.
+
+The playbook is the loop's memory. Losing an update costs a generation's worth
+of learning, and both engines used to lose it without saying so -- TypeScript by
+dropping the update when any of six markers is missing, Python by accepting
+whatever the model wrote as the playbook.
+
+Measured on llama3.1:8b, 10 trials of the real coach instruction: 8 produced all
+six markers, 2 produced none.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+def test_unmarked_coach_output_becomes_the_playbook_and_says_so(caplog: pytest.LogCaptureFixture) -> None:
+    """The fallback is not neutral: the model's prose becomes the playbook.
+
+    Pinning the behavior AND the warning together, because the behavior is the
+    reason the warning has to exist. Whatever the model wrote steers the next
+    generation; silently is the defect, not the substitution itself.
+    """
+    from autocontext.agents.coach import parse_coach_sections
+
+    prose = "Sure! Here's my advice:\n\nTry moving faster and avoid the guarded tiles."
+
+    with caplog.at_level(logging.WARNING):
+        playbook, lessons, hints = parse_coach_sections(prose)
+
+    assert playbook == prose.strip()
+    assert (lessons, hints) == ("", "")
+    assert any("no playbook markers" in r.message for r in caplog.records), (
+        "the whole response became the playbook with no warning"
+    )
+
+
+def test_well_formed_coach_output_warns_about_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    """The warning must not cry wolf on the normal path.
+
+    A warning that fires on every generation is one operators learn to ignore,
+    which would put us back where we started.
+    """
+    from autocontext.agents.coach import parse_coach_sections
+
+    marked = (
+        "<!-- PLAYBOOK_START -->\nP\n<!-- PLAYBOOK_END -->\n\n"
+        "<!-- LESSONS_START -->\nL\n<!-- LESSONS_END -->\n\n"
+        "<!-- COMPETITOR_HINTS_START -->\nH\n<!-- COMPETITOR_HINTS_END -->"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        playbook, lessons, hints = parse_coach_sections(marked)
+
+    assert (playbook, lessons, hints) == ("P", "L", "H")
+    assert not [r for r in caplog.records if "no playbook markers" in r.message]
+
+
+def test_truncated_coach_output_still_fails_closed(caplog: pytest.LogCaptureFixture) -> None:
+    """AC-904's guarantee must survive this change.
+
+    START without END is truncation, and persisting the fragment would make a
+    cut-off response the playbook. That path discards the update and warns; this
+    asserts AC-932's new warning did not displace it.
+    """
+    from autocontext.agents.coach import parse_coach_sections
+
+    truncated = "<!-- PLAYBOOK_START -->\nhalf a play"
+
+    with caplog.at_level(logging.WARNING):
+        playbook, _lessons, _hints = parse_coach_sections(truncated)
+
+    assert playbook == ""
+    assert any("truncated" in r.message for r in caplog.records)

--- a/ts/src/cli/commands/run.ts
+++ b/ts/src/cli/commands/run.ts
@@ -31,6 +31,7 @@ export async function cmdRun(dbPath: string): Promise<void> {
   const {
     executeAgentTaskRunCommandWorkflow,
     executeRunCommandWorkflow,
+    createRunCommandEventEmitter,
     planRunCommand,
     renderRunResult,
     RUN_HELP_TEXT,
@@ -131,10 +132,16 @@ export async function cmdRun(dbPath: string): Promise<void> {
     process.exit(1);
   }
 
+  const runsRoot = resolve(settings.runsRoot);
+  const events = createRunCommandEventEmitter({
+    runsRoot,
+    runId: plan.runId,
+    reportWarning: (message) => console.error(message),
+  });
   const result = await executeRunCommandWorkflow({
     dbPath,
     migrationsDir: getMigrationsDir(),
-    runsRoot: resolve(settings.runsRoot),
+    runsRoot,
     knowledgeRoot: resolve(settings.knowledgeRoot),
     settings,
     plan,
@@ -142,6 +149,7 @@ export async function cmdRun(dbPath: string): Promise<void> {
     ScenarioClass,
     assertFamilyContract,
     createStore: (runDbPath) => new SQLiteStore(asDbPath(runDbPath)),
+    events,
     createRunner: (runnerOpts) =>
       new GenerationRunner({
         ...(runnerOpts as import("../../loop/generation-runner.js").GenerationRunnerOpts),

--- a/ts/src/cli/run-command-workflow.ts
+++ b/ts/src/cli/run-command-workflow.ts
@@ -1,5 +1,12 @@
+import { join } from "node:path";
+
 import { asRunId } from "../domain/ids.js";
 import type { HookBus } from "../extensions/index.js";
+import { EventStreamEmitter } from "../loop/events.js";
+import {
+  formatPlaybookUpdateSkipped,
+  PLAYBOOK_UPDATE_SKIPPED_EVENT,
+} from "../loop/playbook-update-events.js";
 
 export const RUN_HELP_TEXT = `autoctx run — Run the generation loop for a scenario
 
@@ -86,6 +93,20 @@ export interface RunCommandResult {
   provider: string;
   skillPackage?: Record<string, unknown>;
   synthetic?: true;
+}
+
+export function createRunCommandEventEmitter(opts: {
+  runsRoot: string;
+  runId: string;
+  reportWarning: (message: string) => void;
+}): EventStreamEmitter {
+  const events = new EventStreamEmitter(join(opts.runsRoot, opts.runId, "events.ndjson"));
+  events.subscribe((event, payload) => {
+    if (event === PLAYBOOK_UPDATE_SKIPPED_EVENT) {
+      opts.reportWarning(`Warning: ${formatPlaybookUpdateSkipped(payload)}`);
+    }
+  });
+  return events;
 }
 
 type AgentTaskSolveExecutor = (opts: {
@@ -277,6 +298,7 @@ export async function executeRunCommandWorkflow<
   ScenarioClass: new () => TScenario;
   assertFamilyContract: (scenario: TScenario, family: "game", label: string) => void;
   createStore: (dbPath: string) => TStore;
+  events?: EventStreamEmitter;
   createRunner: (
     opts:
       | {
@@ -315,6 +337,7 @@ export async function executeRunCommandWorkflow<
           notifyWebhookUrl: unknown;
           notifyOn: unknown;
           runtimeSession?: TProviderBundle["runtimeSession"];
+          events?: EventStreamEmitter;
         }
       | Record<string, unknown>,
   ) => TRunner;
@@ -361,6 +384,7 @@ export async function executeRunCommandWorkflow<
       notifyWebhookUrl: opts.settings.notifyWebhookUrl,
       notifyOn: opts.settings.notifyOn,
       runtimeSession: opts.providerBundle.runtimeSession,
+      ...(opts.events ? { events: opts.events } : {}),
     });
     const result = await runner.run(asRunId(opts.plan.runId), opts.plan.gens);
     const provider = opts.providerBundle.defaultConfig.providerType;

--- a/ts/src/knowledge/playbook.ts
+++ b/ts/src/knowledge/playbook.ts
@@ -118,3 +118,27 @@ export class PlaybookGuard {
     return { approved: true, reason: "" };
   }
 }
+
+/**
+ * Which of the six playbook markers a coach response is missing (AC-932).
+ *
+ * Named and exported because the loop's decision to accept or drop a playbook
+ * update hangs on it, and "which ones" is what makes a dropped update
+ * actionable rather than mysterious. An empty array means the response is
+ * well-formed.
+ *
+ * Measured on llama3.1:8b: 8 of 10 coach responses carried all six markers,
+ * 2 carried none. On an open-weight model this is a routine outcome, not an
+ * edge case.
+ */
+export function missingPlaybookMarkers(text: string): string[] {
+  const required = [
+    ["playbook_start", PLAYBOOK_MARKERS.PLAYBOOK_START],
+    ["playbook_end", PLAYBOOK_MARKERS.PLAYBOOK_END],
+    ["lessons_start", PLAYBOOK_MARKERS.LESSONS_START],
+    ["lessons_end", PLAYBOOK_MARKERS.LESSONS_END],
+    ["hints_start", PLAYBOOK_MARKERS.HINTS_START],
+    ["hints_end", PLAYBOOK_MARKERS.HINTS_END],
+  ] as const;
+  return required.filter(([, marker]) => !text.includes(marker)).map(([name]) => name);
+}

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -19,7 +19,7 @@ import { BackpressureGate } from "./backpressure.js";
 import { applyAnnealingToGateDecision, deterministicAnnealingRandomValue } from "./annealing.js";
 import { renderLevyScoutGuidance } from "./levy-scout.js";
 import { ArtifactStore, EMPTY_PLAYBOOK_SENTINEL } from "../knowledge/artifact-store.js";
-import { PlaybookGuard, PLAYBOOK_MARKERS } from "../knowledge/playbook.js";
+import { PlaybookGuard, PLAYBOOK_MARKERS, missingPlaybookMarkers } from "../knowledge/playbook.js";
 import { effectiveHintStyle } from "../knowledge/soft-hints.js";
 import { ScoreTrajectoryBuilder } from "../knowledge/trajectory.js";
 import {
@@ -786,18 +786,30 @@ export class GenerationRunner {
 
     const currentPlaybook = this.#artifactStore.readPlaybook(this.#scenarioName);
     const normalizedPlaybook = currentPlaybook === EMPTY_PLAYBOOK_SENTINEL ? "" : currentPlaybook;
-    const hasStructuredPlaybook =
-      coachResult.text.includes(PLAYBOOK_MARKERS.PLAYBOOK_START) &&
-      coachResult.text.includes(PLAYBOOK_MARKERS.PLAYBOOK_END) &&
-      coachResult.text.includes(PLAYBOOK_MARKERS.LESSONS_START) &&
-      coachResult.text.includes(PLAYBOOK_MARKERS.LESSONS_END) &&
-      coachResult.text.includes(PLAYBOOK_MARKERS.HINTS_START) &&
-      coachResult.text.includes(PLAYBOOK_MARKERS.HINTS_END);
+    // AC-932: which markers are missing, not merely whether any are. A dropped
+    // playbook update is the loop failing to learn from a generation, and the
+    // operator can only fix it if they can see which half of the contract the
+    // model broke.
+    const missingMarkers = missingPlaybookMarkers(coachResult.text);
+    const hasStructuredPlaybook = missingMarkers.length === 0;
     const playbookCheck = this.#playbookGuard.check(normalizedPlaybook, coachResult.text);
 
     let nextPlaybook = "";
     if (hasStructuredPlaybook && playbookCheck.approved) {
       nextPlaybook = coachResult.text;
+    } else {
+      // Two different things used to look identical here. Format drift is a
+      // model or configuration problem the operator can act on; a guard
+      // rejection is the guard doing its job. Reporting them as one silent
+      // no-op made the first indistinguishable from the second, and neither
+      // visible at all.
+      this.emit("playbook_update_skipped", {
+        run_id: runId,
+        scenario: this.#scenario.name,
+        generation: gen,
+        reason: hasStructuredPlaybook ? "guard_rejected" : "missing_markers",
+        missing_markers: missingMarkers,
+      });
     }
 
     if (nextPlaybook && this.#curatorEnabled && normalizedPlaybook) {

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -77,6 +77,10 @@ import {
   type GenerationLoopOrchestration,
 } from "./generation-loop-orchestrator.js";
 import { GenerationRecovery } from "./generation-recovery.js";
+import {
+  PLAYBOOK_UPDATE_SKIPPED_EVENT,
+  type PlaybookUpdateSkippedPayload,
+} from "./playbook-update-events.js";
 import { hasRemainingGenerationCycles } from "./generation-cycle-state.js";
 import type { GenerationAttempt } from "./generation-phase-state.js";
 import type { GenerationAttemptOrchestration } from "./generation-attempt-orchestrator.js";
@@ -803,13 +807,17 @@ export class GenerationRunner {
       // rejection is the guard doing its job. Reporting them as one silent
       // no-op made the first indistinguishable from the second, and neither
       // visible at all.
-      this.emit("playbook_update_skipped", {
+      const payload: PlaybookUpdateSkippedPayload = {
         run_id: runId,
         scenario: this.#scenario.name,
         generation: gen,
         reason: hasStructuredPlaybook ? "guard_rejected" : "missing_markers",
         missing_markers: missingMarkers,
-      });
+        ...(hasStructuredPlaybook && playbookCheck.reason
+          ? { guard_reason: playbookCheck.reason }
+          : {}),
+      };
+      this.emit(PLAYBOOK_UPDATE_SKIPPED_EVENT, payload);
     }
 
     if (nextPlaybook && this.#curatorEnabled && normalizedPlaybook) {

--- a/ts/src/loop/playbook-update-events.ts
+++ b/ts/src/loop/playbook-update-events.ts
@@ -1,0 +1,40 @@
+export const PLAYBOOK_UPDATE_SKIPPED_EVENT = "playbook_update_skipped";
+
+export type PlaybookUpdateSkippedReason = "guard_rejected" | "missing_markers";
+
+export interface PlaybookUpdateSkippedPayload extends Record<string, unknown> {
+  run_id: string;
+  scenario: string;
+  generation: number;
+  reason: PlaybookUpdateSkippedReason;
+  missing_markers: string[];
+  guard_reason?: string;
+}
+
+/** Render the skipped-update event for human-facing CLI and TUI surfaces. */
+export function formatPlaybookUpdateSkipped(
+  payload: Record<string, unknown>,
+): string {
+  const generation = typeof payload.generation === "number"
+    ? ` in generation ${payload.generation}`
+    : "";
+
+  if (payload.reason === "missing_markers") {
+    const missingMarkers = Array.isArray(payload.missing_markers)
+      ? payload.missing_markers.filter((marker): marker is string => typeof marker === "string")
+      : [];
+    const markerDetail = missingMarkers.length > 0
+      ? `: missing coach markers ${missingMarkers.join(", ")}`
+      : ": coach output is missing required markers";
+    return `playbook update skipped${generation}${markerDetail}`;
+  }
+
+  if (payload.reason === "guard_rejected") {
+    const guardDetail = typeof payload.guard_reason === "string" && payload.guard_reason.trim()
+      ? ` (${payload.guard_reason.trim()})`
+      : "";
+    return `playbook update skipped${generation}: guard rejected the proposed playbook${guardDetail}`;
+  }
+
+  return `playbook update skipped${generation}`;
+}

--- a/ts/src/server/run-transcript-frame.ts
+++ b/ts/src/server/run-transcript-frame.ts
@@ -9,6 +9,7 @@ import {
   isAgentTaskPlanPayloadRetainable,
   sanitizeAgentTaskPlanPayload,
 } from "../loop/agent-task-plan.js";
+import { PLAYBOOK_UPDATE_SKIPPED_EVENT } from "../loop/playbook-update-events.js";
 import {
   REDACTED_PRESENTATION_VALUE,
   redactPresentationText,
@@ -86,6 +87,14 @@ const EVENT_PAYLOAD_FIELDS: Readonly<Record<string, readonly string[]>> = {
   generation_started: ["run_id", "generation"],
   generation_timing: ["run_id", "generation", "elapsed_seconds"],
   match_completed: ["run_id", "generation", "match_index", "score"],
+  [PLAYBOOK_UPDATE_SKIPPED_EVENT]: [
+    "run_id",
+    "scenario",
+    "generation",
+    "reason",
+    "missing_markers",
+    "guard_reason",
+  ],
   role_completed: ["run_id", "generation", "role", "latency_ms", "tokens"],
   run_completed: [
     "run_id",

--- a/ts/src/tui/activity-summary.ts
+++ b/ts/src/tui/activity-summary.ts
@@ -1,3 +1,8 @@
+import {
+  formatPlaybookUpdateSkipped,
+  PLAYBOOK_UPDATE_SKIPPED_EVENT,
+} from "../loop/playbook-update-events.js";
+
 export const TUI_ACTIVITY_FILTERS = [
   "all",
   "runtime",
@@ -107,6 +112,8 @@ function buildTuiActivitySummary(
       return runSummary(`run completed after ${String(payload.completed_generations)} generations`);
     case "run_failed":
       return runSummary(`run failed: ${String(payload.error ?? "unknown error")}`, true);
+    case PLAYBOOK_UPDATE_SKIPPED_EVENT:
+      return runSummary(formatPlaybookUpdateSkipped(payload), true);
     case "runtime_session_event":
       return summarizeRuntimeSessionEvent(payload, settings);
     default:

--- a/ts/tests/playbook-marker-visibility.test.ts
+++ b/ts/tests/playbook-marker-visibility.test.ts
@@ -8,8 +8,12 @@
  * Measured on llama3.1:8b, 10 trials of the real coach instruction: 8 produced
  * all six markers, 2 produced none. One generation in five, not an edge case.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { asDbPath, asRunId } from "../src/domain/ids.js";
 import { PLAYBOOK_MARKERS, missingPlaybookMarkers } from "../src/knowledge/playbook.js";
 
 const WELL_FORMED = [
@@ -51,5 +55,72 @@ describe("playbook marker visibility", () => {
     const missing = missingPlaybookMarkers(truncated);
     expect(missing).toContain("playbook_end");
     expect(missing).not.toContain("playbook_start");
+  });
+
+  it("emits the skipped-update diagnostic from a real generation run", async () => {
+    const { EventStreamEmitter } = await import("../src/loop/events.js");
+    const { GenerationRunner } = await import("../src/loop/generation-runner.js");
+    const { DeterministicProvider } = await import("../src/providers/deterministic.js");
+    const { GridCtfScenario } = await import("../src/scenarios/grid-ctf.js");
+    const { SQLiteStore } = await import("../src/storage/index.js");
+
+    class UnformattedCoachProvider extends DeterministicProvider {
+      override async complete(
+        opts: Parameters<InstanceType<typeof DeterministicProvider>["complete"]>[0],
+      ) {
+        if (opts.userPrompt.toLowerCase().includes("playbook coach")) {
+          return {
+            text: "Try moving faster and avoid guarded tiles.",
+            model: "unformatted-coach",
+            usage: {},
+          };
+        }
+        return super.complete(opts);
+      }
+    }
+
+    const dir = mkdtempSync(join(tmpdir(), "playbook-marker-visibility-"));
+    const store = new SQLiteStore(asDbPath(join(dir, "test.db")));
+    try {
+      store.migrate(join(import.meta.dirname, "..", "migrations"));
+      const events = new EventStreamEmitter(join(dir, "events.ndjson"));
+      const diagnostics: Array<Record<string, unknown>> = [];
+      events.subscribe((event, payload) => {
+        if (event === "playbook_update_skipped") diagnostics.push(payload);
+      });
+      const runner = new GenerationRunner({
+        provider: new UnformattedCoachProvider(),
+        scenario: new GridCtfScenario(),
+        store,
+        runsRoot: join(dir, "runs"),
+        knowledgeRoot: join(dir, "knowledge"),
+        matchesPerGeneration: 1,
+        maxRetries: 0,
+        minDelta: 0,
+        events,
+      });
+
+      await runner.run(asRunId("marker-drift"), 1);
+
+      expect(diagnostics).toEqual([
+        {
+          run_id: "marker-drift",
+          scenario: "grid_ctf",
+          generation: 1,
+          reason: "missing_markers",
+          missing_markers: [
+            "playbook_start",
+            "playbook_end",
+            "lessons_start",
+            "lessons_end",
+            "hints_start",
+            "hints_end",
+          ],
+        },
+      ]);
+    } finally {
+      store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/ts/tests/playbook-marker-visibility.test.ts
+++ b/ts/tests/playbook-marker-visibility.test.ts
@@ -1,0 +1,55 @@
+/**
+ * AC-932: a coach response that drops markers must not fail silently.
+ *
+ * The playbook is the loop's memory. `generation-runner.ts` refuses to update
+ * it unless all six markers are present, and until now refused without saying
+ * so -- the generation completed normally and the loop simply did not learn.
+ *
+ * Measured on llama3.1:8b, 10 trials of the real coach instruction: 8 produced
+ * all six markers, 2 produced none. One generation in five, not an edge case.
+ */
+import { describe, expect, it } from "vitest";
+
+import { PLAYBOOK_MARKERS, missingPlaybookMarkers } from "../src/knowledge/playbook.js";
+
+const WELL_FORMED = [
+  `${PLAYBOOK_MARKERS.PLAYBOOK_START}\nP\n${PLAYBOOK_MARKERS.PLAYBOOK_END}`,
+  `${PLAYBOOK_MARKERS.LESSONS_START}\nL\n${PLAYBOOK_MARKERS.LESSONS_END}`,
+  `${PLAYBOOK_MARKERS.HINTS_START}\nH\n${PLAYBOOK_MARKERS.HINTS_END}`,
+].join("\n\n");
+
+describe("playbook marker visibility", () => {
+  it("reports nothing missing for a well-formed response", () => {
+    expect(missingPlaybookMarkers(WELL_FORMED)).toEqual([]);
+  });
+
+  it("names all six when the model ignored the format entirely", () => {
+    // The observed 2-in-10 case: readable advice, no markers at all.
+    const prose = "Sure! Here's my advice:\n\nTry moving faster and avoid the guarded tiles.";
+    expect(missingPlaybookMarkers(prose)).toEqual([
+      "playbook_start",
+      "playbook_end",
+      "lessons_start",
+      "lessons_end",
+      "hints_start",
+      "hints_end",
+    ]);
+  });
+
+  it("names exactly the one that is missing", () => {
+    // The failure mode a boolean hides: five of six present is still a dropped
+    // update, and without the name nobody can tell which half broke.
+    const almost = WELL_FORMED.replace(PLAYBOOK_MARKERS.HINTS_END, "");
+    expect(missingPlaybookMarkers(almost)).toEqual(["hints_end"]);
+  });
+
+  it("distinguishes a truncated response from an unformatted one", () => {
+    // START without END is truncation (AC-904's signature); no markers at all
+    // is a model ignoring the contract. Different causes, different fixes, and
+    // the missing-marker list is what tells them apart.
+    const truncated = `${PLAYBOOK_MARKERS.PLAYBOOK_START}\nhalf a play`;
+    const missing = missingPlaybookMarkers(truncated);
+    expect(missing).toContain("playbook_end");
+    expect(missing).not.toContain("playbook_start");
+  });
+});

--- a/ts/tests/run-command-workflow.test.ts
+++ b/ts/tests/run-command-workflow.test.ts
@@ -1,6 +1,10 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  createRunCommandEventEmitter,
   executeAgentTaskRunCommandWorkflow,
   executeRunCommandWorkflow,
   planRunCommand,
@@ -16,6 +20,41 @@ describe("run command workflow", () => {
     expect(RUN_HELP_TEXT).toContain("--gens");
     expect(RUN_HELP_TEXT).toContain("--iterations");
     expect(RUN_HELP_TEXT).toContain("--matches");
+  });
+
+  it("reports and persists skipped playbook updates on the direct CLI event stream", () => {
+    const dir = mkdtempSync(join(tmpdir(), "autoctx-run-events-"));
+    const reportWarning = vi.fn();
+    try {
+      const events = createRunCommandEventEmitter({
+        runsRoot: dir,
+        runId: "run-marker-drift",
+        reportWarning,
+      });
+      events.emit("playbook_update_skipped", {
+        run_id: "run-marker-drift",
+        scenario: "grid_ctf",
+        generation: 2,
+        reason: "missing_markers",
+        missing_markers: ["playbook_end", "hints_end"],
+      });
+
+      expect(reportWarning).toHaveBeenCalledWith(
+        "Warning: playbook update skipped in generation 2: missing coach markers playbook_end, hints_end",
+      );
+      const persisted = JSON.parse(
+        readFileSync(join(dir, "run-marker-drift", "events.ndjson"), "utf-8").trim(),
+      ) as { event: string; payload: Record<string, unknown> };
+      expect(persisted).toMatchObject({
+        event: "playbook_update_skipped",
+        payload: {
+          reason: "missing_markers",
+          missing_markers: ["playbook_end", "hints_end"],
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("requires a resolved scenario", async () => {
@@ -150,6 +189,11 @@ describe("run command workflow", () => {
     });
     const createRunner = vi.fn(() => ({ run }));
     const assertFamilyContract = vi.fn();
+    const events = createRunCommandEventEmitter({
+      runsRoot: "/tmp/runs",
+      runId: "run-custom",
+      reportWarning: vi.fn(),
+    });
 
     const result = await executeRunCommandWorkflow({
       dbPath: "/tmp/autocontext.db",
@@ -195,6 +239,7 @@ describe("run command workflow", () => {
       ScenarioClass: FakeScenario,
       assertFamilyContract,
       createStore: vi.fn(() => store),
+      events,
       createRunner,
     });
 
@@ -240,6 +285,7 @@ describe("run command workflow", () => {
       levyScoutScale: 0.2,
       explorationCollapseGuard: false,
       explorationCollapseAutoMitigation: false,
+      events,
     });
     expect(run).toHaveBeenCalledWith("run-custom", 3);
     expect(close).toHaveBeenCalled();

--- a/ts/tests/run-transcript-store.test.ts
+++ b/ts/tests/run-transcript-store.test.ts
@@ -55,6 +55,30 @@ afterEach(() => {
 });
 
 describe("RunTranscriptStore", () => {
+  it("retains skipped playbook diagnostics across restart and replay", () => {
+    const { path, store } = makeStore();
+    const message: ServerMessage = {
+      type: "event",
+      event: "playbook_update_skipped",
+      payload: {
+        run_id: "engine-marker-drift",
+        scenario: "grid_ctf",
+        generation: 2,
+        reason: "missing_markers",
+        missing_markers: ["playbook_end", "hints_end"],
+      },
+    };
+    const frame = store.record({
+      clientRunId: "client-marker-drift",
+      runId: "engine-marker-drift",
+      message,
+    });
+
+    expect(frame?.message).toMatchObject(message);
+    const reloaded = new RunTranscriptStore(path);
+    expect(reloaded.framesAfter("client-marker-drift", 0).at(0)?.message).toEqual(frame?.message);
+  });
+
   it("retains complete long agent plans exactly across restart and replay", () => {
     const { path, store } = makeStore();
     const steps = Array.from({ length: 24 }, (_, index) => ({

--- a/ts/tests/tui-activity-summary.test.ts
+++ b/ts/tests/tui-activity-summary.test.ts
@@ -15,6 +15,39 @@ describe("TUI activity summary", () => {
     ).toBe("run run-123 started for support_triage");
   });
 
+  it("shows skipped playbook updates, including the actionable marker list", () => {
+    const payload = {
+      run_id: "run-123",
+      scenario: "grid_ctf",
+      generation: 3,
+      reason: "missing_markers",
+      missing_markers: ["playbook_end", "hints_start"],
+    };
+
+    expect(summarizeTuiEvent("playbook_update_skipped", payload)).toBe(
+      "playbook update skipped in generation 3: missing coach markers playbook_end, hints_start",
+    );
+    expect(
+      summarizeTuiEvent("playbook_update_skipped", payload, {
+        filter: "errors",
+        verbosity: "normal",
+      }),
+    ).not.toBeNull();
+  });
+
+  it("shows the concrete playbook guard rejection reason", () => {
+    expect(
+      summarizeTuiEvent("playbook_update_skipped", {
+        generation: 4,
+        reason: "guard_rejected",
+        missing_markers: [],
+        guard_reason: "Playbook shrink ratio 0.20 below threshold 0.3",
+      }),
+    ).toBe(
+      "playbook update skipped in generation 4: guard rejected the proposed playbook (Playbook shrink ratio 0.20 below threshold 0.3)",
+    );
+  });
+
   it("summarizes live runtime-session prompt events for the operator timeline", () => {
     expect(
       summarizeTuiEvent("runtime_session_event", {


### PR DESCRIPTION
Closes AC-932. Found while investigating whether the TypeScript loop consumes structured role output — this is the failure the local-first epic was actually chasing, and nobody had filed it.

## The defect

The playbook is the loop's memory. Both engines could discard or corrupt an update without saying so, **in opposite directions**:

**TypeScript** (`generation-runner.ts`) gates the update on all six coach markers. Miss one and `nextPlaybook` stays empty, the `if (nextPlaybook)` write is skipped, and the generation completes normally having learned nothing. There was no `else`.

**Python** (`parse_coach_sections`) fails the other way: with no markers at all it treats the **entire response** as the playbook — preamble, reasoning, an apology — and persists it to steer the next generation. That branch had no warning.

## Measured

`llama3.1:8b` via Ollama, 10 trials of the real six-marker coach instruction:

- **8/10** produced all six markers → update accepted
- **2/10** produced none → **update silently discarded**

One generation in five, not an edge case.

## Why this matters more than the analyst work next to it

AC-913 measured 100% → 0% analyst section loss, and that number is real — but the analyst's structured fields are **read by nothing** in either engine. I verified this by grepping every use of `.findings` / `.root_causes` / `.recommendations`; every hit belongs to unrelated subsystems, and both loops consume `analyst_typed.raw_markdown`. Losing analyst structure costs a well-formed artifact.

Losing a coach playbook update costs **the loop's memory for that generation**. This is the load-bearing one, and it was invisible.

## What changed

TypeScript now computes *which* markers are missing and emits `playbook_update_skipped` with the reason and the list. That separates two things the boolean conflated:

- **format drift** — a model or configuration problem an operator can act on
- **guard rejection** — the guard doing its job

Reported as one silent no-op, the first was indistinguishable from the second and neither was visible.

The check moved into `missingPlaybookMarkers()` in `knowledge/playbook.ts` — named and exported because the accept/drop decision hangs on it, and *which ones* is what makes a dropped update actionable rather than mysterious.

Python warns on the no-marker fallback, naming the substitution and its size. The fallback stays (removing it is a behavior change beyond this fix) but is no longer silent.

## Tests

Both sides pin the **behavior alongside the message**, because the behavior is why the message must exist. Python asserts the whole response really does become the playbook *and* that the warning fires. TypeScript asserts the exact missing list — including the five-of-six case a boolean hides — and that a truncated response (`START` without `END`, AC-904's signature) stays distinguishable from an unformatted one.

One test asserts the warning does **not** fire on well-formed output. A warning on every generation is one operators learn to ignore, which would put us back where we started.

Mutation-verified: removing the Python warning fails its tests; making `missingPlaybookMarkers` always return `[]` fails three TypeScript tests.

## Verification

Full Python suite green, ruff and mypy clean across 742 files. The 3 failing tests in `generation-runner-hooks` and `playbook-approval-gate` fail **identically with these changes stashed** — pre-existing local-environment baseline, not this change. `uv.lock` untouched.

## Follow-up worth considering separately

This makes the loss visible; it does not prevent it. The coach schema (`COACH_SCHEMA`) and `render_coach_markdown` already exist and emit all six markers from validated data — applying constrained decoding to the coach's production path would take the 2/10 to 0/10. That belongs in its own change rather than bundled here, since it touches the role-execution path rather than the reporting.