### PR TITLE
feat(providers): add OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -407,6 +407,13 @@ def _provider_api_key(provider_type: str, settings: AppSettings, *, role: str = 
             or os.getenv("OPENROUTER_API_KEY")
             or os.getenv("AUTOCONTEXT_OPENROUTER_API_KEY")
         )
+    if provider_type == "orcarouter":
+        return (
+            settings.agent_api_key
+            or settings.judge_api_key
+            or os.getenv("ORCAROUTER_API_KEY")
+            or os.getenv("AUTOCONTEXT_ORCAROUTER_API_KEY")
+        )
     if provider_type == "vllm":
         return settings.agent_api_key or settings.judge_api_key or "no-key"
     return settings.agent_api_key or settings.judge_api_key
@@ -623,7 +630,7 @@ def create_role_client(
         return RuntimeBridgeClient(HermesCLIRuntime(hermes_config))
 
     # LLMProvider-based providers — use the bridge
-    if provider_type in ("mlx", "openai", "openai-compatible", "openrouter", "ollama", "vllm"):
+    if provider_type in ("mlx", "openai", "openai-compatible", "openrouter", "orcarouter", "ollama", "vllm"):
         return _create_provider_bridge(provider_type, settings, model_override=model_override, role=role)
 
     raise ValueError(f"unsupported role provider: {provider_type!r}")

--- a/autocontext/src/autocontext/agents/role_routing_contract_generated.py
+++ b/autocontext/src/autocontext/agents/role_routing_contract_generated.py
@@ -53,6 +53,7 @@ PROVIDER_DEFAULT_MODEL: Final[dict[str, str]] = {
     "openai": "gpt-4o",
     "openai-compatible": "gpt-4o",
     "openrouter": "anthropic/claude-sonnet-4",
+    "orcarouter": "openai/gpt-5.5",
     "vllm": "default",
 }
 

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -21,6 +21,7 @@ SUPPORTED_PROVIDER_TYPES: frozenset[str] = frozenset(
         "openai",
         "openai-compatible",
         "openrouter",
+        "orcarouter",
         "ollama",
         "vllm",
         "mlx",
@@ -95,6 +96,18 @@ def create_provider(
             )
         )
 
+    if provider_type == "orcarouter":
+        from autocontext.providers.openai_compat import OpenAICompatibleProvider
+        from autocontext.providers.retry import RetryProvider
+
+        return RetryProvider(
+            OpenAICompatibleProvider(
+                api_key=(api_key or os.getenv("ORCAROUTER_API_KEY") or os.getenv("AUTOCONTEXT_ORCAROUTER_API_KEY")),
+                base_url=base_url or "https://api.orcarouter.ai/v1",
+                default_model_name=model or "openai/gpt-5.5",
+            )
+        )
+
     if provider_type == "ollama":
         from autocontext.providers.openai_compat import OpenAICompatibleProvider
         from autocontext.providers.retry import RetryProvider
@@ -126,7 +139,7 @@ def create_provider(
             raise ProviderError("MLX provider requires a model path (model_path). Set AUTOCONTEXT_MLX_MODEL_PATH.")
         return MLXProvider(model_path=model)
 
-    supported = "anthropic, openai, openai-compatible, openrouter, ollama, vllm, mlx"
+    supported = "anthropic, openai, openai-compatible, openrouter, orcarouter, ollama, vllm, mlx"
     raise ProviderError(f"Unknown provider type: {provider_type!r}. Supported: {supported}")
 
 
@@ -266,6 +279,10 @@ def get_provider(settings: AppSettings) -> LLMProvider:
     if not api_key:
         if provider_type in ("openai", "openai-compatible"):
             api_key = os.getenv("OPENAI_API_KEY")
+        elif provider_type == "openrouter":
+            api_key = os.getenv("OPENROUTER_API_KEY") or os.getenv("AUTOCONTEXT_OPENROUTER_API_KEY")
+        elif provider_type == "orcarouter":
+            api_key = os.getenv("ORCAROUTER_API_KEY") or os.getenv("AUTOCONTEXT_ORCAROUTER_API_KEY")
         else:
             api_key = settings.anthropic_api_key or os.getenv("ANTHROPIC_API_KEY") or os.getenv("AUTOCONTEXT_ANTHROPIC_API_KEY")
 

--- a/autocontext/tests/test_per_provider_model_defaults.py
+++ b/autocontext/tests/test_per_provider_model_defaults.py
@@ -55,6 +55,7 @@ _AFTER: dict[str, dict[str, str]] = {
     "vllm": dict.fromkeys(ROLES, "default"),
     "openai": dict.fromkeys(ROLES, "gpt-4o"),
     "openai-compatible": dict.fromkeys(ROLES, "gpt-4o"),
+    "orcarouter": dict.fromkeys(ROLES, "openai/gpt-5.5"),
 }
 
 _UNCHANGED_PROVIDERS = ("anthropic", "mlx")
@@ -200,6 +201,7 @@ def _orchestrator_model(settings, *, role: str = "competitor", generation: int =
         ("vllm", "default"),
         ("openai", "gpt-4o"),
         ("openai-compatible", "gpt-4o"),
+        ("orcarouter", "openai/gpt-5.5"),
     ),
 )
 def test_routing_off_resolves_provider_default_in_production(
@@ -293,3 +295,12 @@ def test_openai_compatible_default_matches_provider_factory(monkeypatch: pytest.
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     provider = create_provider("openai-compatible", api_key="test-key")
     assert PROVIDER_DEFAULT_MODEL["openai-compatible"] == provider.default_model() == "gpt-4o"
+
+
+def test_orcarouter_default_matches_provider_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    from autocontext.config.provider_model_defaults import PROVIDER_DEFAULT_MODEL
+    from autocontext.providers.registry import create_provider
+
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    provider = create_provider("orcarouter", api_key="sk-orca-test")
+    assert PROVIDER_DEFAULT_MODEL["orcarouter"] == provider.default_model() == "openai/gpt-5.5"

--- a/autocontext/tests/test_providers.py
+++ b/autocontext/tests/test_providers.py
@@ -141,6 +141,17 @@ class TestRegistry:
         )
         assert p.default_model() == "custom-model"
 
+    @_skip_no_openai
+    def test_create_orcarouter_provider(self):
+        p = create_provider("orcarouter", api_key="sk-orca-test", model="openai/gpt-5.5")
+        assert p.default_model() == "openai/gpt-5.5"
+        assert "OpenAICompatibleProvider" in p.name  # may be wrapped in RetryProvider
+
+    @_skip_no_openai
+    def test_create_orcarouter_default_model(self):
+        p = create_provider("orcarouter", api_key="sk-orca-test")
+        assert p.default_model() == "openai/gpt-5.5"
+
 
 # ---------------------------------------------------------------------------
 # LLMJudge with provider

--- a/docs/role-routing-contract.json
+++ b/docs/role-routing-contract.json
@@ -24,7 +24,8 @@
     "openai": "gpt-4o",
     "openai-compatible": "gpt-4o",
     "vllm": "default",
-    "openrouter": "anthropic/claude-sonnet-4"
+    "openrouter": "anthropic/claude-sonnet-4",
+    "orcarouter": "openai/gpt-5.5"
   },
   "model_default_preserved_providers": ["anthropic"],
   "provider_hosting": {
@@ -104,6 +105,10 @@
     "openai": { "packages": ["python", "typescript"] },
     "openai-compatible": { "packages": ["python", "typescript"] },
     "openrouter": { "packages": ["python", "typescript"] },
+    "orcarouter": {
+      "packages": ["python"],
+      "reason": "no OrcaRouter wiring in the TypeScript provider factory yet"
+    },
     "ollama": { "packages": ["python", "typescript"] },
     "vllm": { "packages": ["python", "typescript"] },
     "claude-cli": { "packages": ["python", "typescript"] },

--- a/ts/src/providers/role-routing-contract.generated.ts
+++ b/ts/src/providers/role-routing-contract.generated.ts
@@ -65,6 +65,7 @@ export const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
   openai: "gpt-4o",
   "openai-compatible": "gpt-4o",
   openrouter: "anthropic/claude-sonnet-4",
+  orcarouter: "openai/gpt-5.5",
   vllm: "default",
 };
 


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a named provider in the Python package, mirroring the existing OpenRouter wiring exactly. OrcaRouter is an OpenAI-compatible gateway (base URL `https://api.orcarouter.ai`, API rooted at `/v1`) that fronts a broad model catalog under namespaced IDs (e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4.6`).

## What this changes

- `autocontext/src/autocontext/providers/registry.py` — `orcarouter` added to `SUPPORTED_PROVIDER_TYPES` and to `create_provider()` (an `OpenAICompatibleProvider` pointed at `https://api.orcarouter.ai/v1`, default model `openai/gpt-5.5`, key from `ORCAROUTER_API_KEY` / `AUTOCONTEXT_ORCAROUTER_API_KEY`). `get_provider()`'s key fallback now reads the provider-specific env vars for `orcarouter` (and `openrouter`, which previously fell through to the Anthropic key).
- `autocontext/src/autocontext/agents/provider_bridge.py` — `orcarouter` accepted as a role-provider type, with the same api-key fallback chain as OpenRouter.
- `docs/role-routing-contract.json` — `orcarouter` declared in `supported_provider_types` (Python-only, with reason) and `provider_default_model` (`openai/gpt-5.5`). The codegen outputs for both packages are regenerated in this PR.
- Tests — provider construction, default-model fallback, and per-provider role-model resolution coverage for `orcarouter`.

## Why a named provider

The provider factory already treats OpenAI-compatible aggregators as first-class named providers (OpenRouter, Ollama, vLLM). OrcaRouter is the same shape, so routing it through the generic `openai-compatible` path would silently lose the dedicated key env var, base URL, and default model. Keeping it named gives operators the same one-var setup every other gateway gets:

```bash
export ORCAROUTER_API_KEY=sk-orca-...
AUTOCONTEXT_AGENT_PROVIDER=orcarouter uv run autoctx run --scenario grid_ctf --gens 1
```

## Verification

- `pytest tests/test_role_routing_contract.py tests/test_provider_retry.py` — passed (the per-provider-model-default and bridge tests import the execution layer, which imports the Unix-only `resource` module and cannot collect on this Windows host; they fail identically on `main` without these changes).
- `ruff check` — clean on all changed files.
- Codegen drift gate — `node ts/scripts/generate-role-routing-contract.mjs --check` passes.
- L3 live: `create_provider("orcarouter", api_key=<real key>)` → `complete()` against `https://api.orcarouter.ai/v1/chat/completions` with `openai/gpt-5.5` → HTTP 200, response `"ORCA-OK"`.

## Disclosure

I'm an engineer on the OrcaRouter team. OrcaRouter is an API gateway that never inspects or stores prompt/response content in plaintext; credentials are forwarded only to the upstream model provider chosen for the request.
