### PR TITLE
feat(AC-931): let users turn constrained decoding off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ AUTOCONTEXT_EVENT_STREAM_PATH=runs/events.ndjson
 # AUTOCONTEXT_MODEL_ARCHITECT=claude-opus-4-6
 # AUTOCONTEXT_MODEL_TRANSLATOR=claude-sonnet-4-5-20250929
 # AUTOCONTEXT_MODEL_CURATOR=claude-opus-4-6
+# OpenAI-compatible role generation uses output schemas by default. Set false
+# to send ordinary unconstrained requests and parse the returned Markdown.
+AUTOCONTEXT_CONSTRAINED_OUTPUT=true
 
 # API credentials (set when using live providers)
 # Prefer provider-native env vars like ANTHROPIC_API_KEY; AUTOCONTEXT_ANTHROPIC_API_KEY remains a compatibility alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Schema-constrained role output now has an explicit, default-on escape hatch: Python users can set `AUTOCONTEXT_CONSTRAINED_OUTPUT=false`, including with dedicated role providers, and TypeScript `AgentOrchestrator` users can pass `constrainedOutput: false` to retain Markdown generation and parsing (AC-931).
 - TypeScript interactive runs now advertise `agent_progress_notes_v1` to transcript clients and emit concise, strict `agent_progress_note` updates for intent, discovery, decisions, verification, and blockers. Notes are safety-redacted and bounded before emission, may cite only earlier same-run durable action/artifact IDs, and replay with exact ordering and identity across reconnects and server restarts within the transcript's finite retention horizon. Python parity is deferred until it can provide the same durable transcript guarantees (AC-897).
 - Role routing now separates endpoint hosting from capability in both runtimes. Default and role-specific endpoints can declare `local`/`remote` hosting and a local maximum capability (`fast`, `mid_tier`, or `frontier`); routing cost and automatic model tiers honor those declarations, while unset values retain conservative transport inference (AC-911).
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -74,6 +74,12 @@ role-specific endpoint uses the corresponding
 `AUTOCONTEXT_<ROLE>_PROVIDER_CAPABILITY` declarations instead of the default
 endpoint's declarations.
 
+OpenAI-compatible role generation requests schema-constrained output by
+default. If that changes output quality for a backend, set
+`AUTOCONTEXT_CONSTRAINED_OUTPUT=false` to omit schemas from every role request
+and use the existing Markdown parsers instead. The setting also applies to
+roles with dedicated provider overrides.
+
 ## Common commands
 
 | Command                                                                                | Purpose                                                                                                |

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -155,7 +155,7 @@ class AgentOrchestrator:
         # so the key is a variable-length tuple of optional strings.
         self._routed_clients: dict[tuple[str | None, ...], LanguageModelClient] = {}
         self._disposable_client_ids: set[int] = set()
-        runtime = SubagentRuntime(client=self.client)
+        runtime = SubagentRuntime(client=self.client, constrained_output=settings.constrained_output)
         self.competitor = CompetitorRunner(runtime, settings.model_competitor, settings.competitor_max_tokens)
         self.translator = StrategyTranslator(runtime, settings.model_translator, settings.translator_max_tokens)
         self.analyst = AnalystRunner(runtime, settings.model_analyst, settings.analyst_max_tokens)

--- a/autocontext/src/autocontext/agents/role_runtime_overrides.py
+++ b/autocontext/src/autocontext/agents/role_runtime_overrides.py
@@ -63,7 +63,10 @@ def apply_role_overrides(orch: Any, settings: AppSettings) -> None:
             continue
         client = orch._wrap_client(client, provider_name=f"{provider_type}:{role}")
         orch._role_clients[role] = client
-        runtime = SubagentRuntime(client=client)
+        runtime = SubagentRuntime(
+            client=client,
+            constrained_output=settings.constrained_output,
+        )
         runner = getattr(orch, runner_name)
         runner.runtime = runtime
         logger.info("role '%s' using dedicated provider config: %s", role, provider_type)

--- a/autocontext/src/autocontext/config/role_routing.py
+++ b/autocontext/src/autocontext/config/role_routing.py
@@ -14,6 +14,16 @@ class RoleRoutingFields(BaseModel):
     """Capability, hosting, and connection settings used by role routing."""
 
     role_routing: Literal["off", "auto"] = Field(default="off", description="Role routing mode")
+    # AC-931: the escape hatch. Constrained decoding is on by default because it
+    # removes a silent failure mode (AC-913 measured 100% -> 0% section loss on
+    # an open-weight model). It is switchable because the OpenAI-compatible
+    # backends it changes include cloud models whose analysis quality we could
+    # not measure, and "pin to 0.14" is not an acceptable answer for someone who
+    # sees a regression.
+    constrained_output: bool = Field(
+        default=True,
+        description="Ask backends to constrain role output to its schema; off falls back to markdown parsing",
+    )
     provider_capability: CapabilityDeclaration = Field(
         default="",
         description="Default endpoint capability: frontier, mid_tier, or fast",

--- a/autocontext/src/autocontext/harness/core/subagent.py
+++ b/autocontext/src/autocontext/harness/core/subagent.py
@@ -34,17 +34,23 @@ class SubagentTask:
 class SubagentRuntime:
     """Lightweight subagent runtime abstraction over configured LLM provider."""
 
-    def __init__(self, client: LanguageModelClient) -> None:
+    def __init__(self, client: LanguageModelClient, *, constrained_output: bool = True) -> None:
         self.client = client
+        # AC-931: gated here rather than at each role runner so a role added
+        # later cannot forget the switch. Off means the schema never leaves this
+        # method, which is what the test asserts -- the request itself, not the
+        # intent to make one.
+        self.constrained_output = constrained_output
 
     def run_task(self, task: SubagentTask) -> RoleExecution:
-        if task.output_schema is not None:
+        output_schema = task.output_schema if self.constrained_output else None
+        if output_schema is not None:
             response = self.client.generate_constrained(
                 model=task.model,
                 prompt=task.prompt,
                 max_tokens=task.max_tokens,
                 temperature=task.temperature,
-                output_schema=task.output_schema,
+                output_schema=output_schema,
                 role=task.role,
                 system=task.system,
             )
@@ -71,7 +77,7 @@ class SubagentRuntime:
             usage=response.usage,
             subagent_id=f"{task.role}-{uuid.uuid4().hex[:10]}",
             status="completed",
-            metadata=_with_constrained_flag(response.metadata, requested=task.output_schema is not None),
+            metadata=_with_constrained_flag(response.metadata, requested=output_schema is not None),
         )
 
 

--- a/autocontext/tests/test_constrained_role_wiring.py
+++ b/autocontext/tests/test_constrained_role_wiring.py
@@ -241,3 +241,49 @@ def test_normal_output_assembly_uses_validated_rendered_views() -> None:
     assert outputs.architect_markdown.startswith("## Observed Bottlenecks")
     assert [item["name"] for item in outputs.architect_tools] == ["probe"]
     assert [item["name"] for item in outputs.architect_harness_specs] == ["guard"]
+
+
+def test_escape_hatch_stops_the_schema_reaching_the_provider() -> None:
+    """AC-931: off means no schema on the wire, not merely "we meant not to".
+
+    Asserts what the provider RECEIVED. The AC-913 near-miss was a dispatch
+    condition that looked right and never fired; the only defence is checking
+    the request itself.
+    """
+    from autocontext.agents.analyst import AnalystRunner
+    from autocontext.agents.provider_bridge import ProviderBridgeClient
+    from autocontext.harness.core.subagent import SubagentRuntime
+
+    provider = _RecordingProvider(enforce=True, text=_VALID)
+    runtime = SubagentRuntime(ProviderBridgeClient(provider), constrained_output=False)
+    execution = AnalystRunner(runtime, model="stub").run("analyze this", system="s")
+
+    assert provider.calls[0]["output_schema"] is None
+    # And the run records the truth: nothing was enforced.
+    assert execution.metadata["constrained"] is False
+
+
+def test_escape_hatch_output_still_parses_via_markdown() -> None:
+    """Turning it off must not create a new failure mode, just the old one."""
+    from autocontext.agents.analyst import AnalystRunner
+    from autocontext.agents.parsers import parse_analyst_exec
+    from autocontext.agents.provider_bridge import ProviderBridgeClient
+    from autocontext.harness.core.subagent import SubagentRuntime
+
+    markdown = "## Findings\n\n- a\n\n## Root Causes\n\n- b\n\n## Actionable Recommendations\n\n- c"
+    runtime = SubagentRuntime(
+        ProviderBridgeClient(_RecordingProvider(enforce=False, text=markdown)),
+        constrained_output=False,
+    )
+    result = parse_analyst_exec(AnalystRunner(runtime, model="stub").run("p", system="s"))
+    assert result.findings == ["a"]
+
+
+def test_default_is_on_so_the_improvement_is_the_default() -> None:
+    from autocontext.agents.analyst import AnalystRunner
+    from autocontext.agents.provider_bridge import ProviderBridgeClient
+    from autocontext.harness.core.subagent import SubagentRuntime
+
+    provider = _RecordingProvider(enforce=True, text=_VALID)
+    AnalystRunner(SubagentRuntime(ProviderBridgeClient(provider)), model="stub").run("p", system="s")
+    assert provider.calls[0]["output_schema"] is not None

--- a/autocontext/tests/test_per_role_provider.py
+++ b/autocontext/tests/test_per_role_provider.py
@@ -390,6 +390,32 @@ class TestOrchestratorPerRoleWiring:
         assert orch.analyst.runtime.client is orch.coach.runtime.client
 
     @patch("autocontext.agents.provider_bridge.create_role_client")
+    def test_constrained_output_escape_hatch_survives_role_override(self, mock_create: MagicMock) -> None:
+        """A dedicated role runtime must inherit the run-wide schema setting."""
+        from autocontext.agents.orchestrator import AgentOrchestrator
+        from autocontext.config.settings import AppSettings
+
+        mock_client = MagicMock(spec=LanguageModelClient)
+        mock_client.generate.return_value = ModelResponse(
+            text="## Findings\n\n- finding",
+            usage=RoleUsage(input_tokens=1, output_tokens=1, latency_ms=1, model="override"),
+        )
+        mock_create.return_value = mock_client
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            analyst_provider="openai",
+            constrained_output=False,
+        )
+        orch = AgentOrchestrator.from_settings(settings)
+
+        execution = orch.analyst.run("analyze")
+
+        mock_client.generate.assert_called_once()
+        mock_client.generate_constrained.assert_not_called()
+        assert execution.metadata["constrained"] is False
+
+    @patch("autocontext.agents.provider_bridge.create_role_client")
     def test_multiple_role_overrides(self, mock_create: MagicMock) -> None:
         """Multiple per-role overrides work simultaneously."""
         from autocontext.agents.orchestrator import AgentOrchestrator

--- a/ts/README.md
+++ b/ts/README.md
@@ -59,6 +59,18 @@ hosting inference and `AUTOCONTEXT_PROVIDER_CAPABILITY=fast|mid_tier|frontier`
 to cap automatic tiers for a local endpoint. Role-specific endpoints use the
 matching `AUTOCONTEXT_<ROLE>_PROVIDER_*` declarations.
 
+Library consumers using `AgentOrchestrator` get schema-constrained analyst and
+coach output by default. Pass `constrainedOutput: false` to omit those schemas
+and use the existing Markdown parsers instead:
+
+```ts
+import { AgentOrchestrator } from "autoctx";
+
+const orchestrator = new AgentOrchestrator(provider, {
+  constrainedOutput: false,
+});
+```
+
 ## CLI surfaces
 
 | Command                                                | Purpose                                                      |

--- a/ts/src/agents/orchestrator.ts
+++ b/ts/src/agents/orchestrator.ts
@@ -40,6 +40,8 @@ export interface GenerationResult {
 export interface AgentOrchestratorOpts {
   roleProviders?: Partial<Record<GenerationRole, LLMProvider>>;
   roleModels?: Partial<Record<GenerationRole, string>>;
+  /** AC-931: ask backends to constrain role output to its schema. Defaults true. */
+  constrainedOutput?: boolean;
 }
 
 export class AgentOrchestrator {
@@ -47,10 +49,14 @@ export class AgentOrchestrator {
   #roleProviders: Partial<Record<GenerationRole, LLMProvider>>;
   #roleModels: Partial<Record<GenerationRole, string>>;
 
+  #constrainedOutput: boolean;
+
   constructor(provider: LLMProvider, opts: AgentOrchestratorOpts = {}) {
     this.#provider = provider;
     this.#roleProviders = opts.roleProviders ?? {};
     this.#roleModels = opts.roleModels ?? {};
+    // Defaults on, matching Python's constrained_output setting.
+    this.#constrainedOutput = opts.constrainedOutput ?? true;
   }
 
   #providerForRole(role: GenerationRole): LLMProvider {
@@ -76,7 +82,10 @@ export class AgentOrchestrator {
       systemPrompt: "",
       userPrompt,
       model: this.#roleModels[role],
-      outputSchema: AgentOrchestrator.#ROLE_SCHEMAS[role],
+      // AC-931: off means the schema never reaches the provider, so the run
+      // takes the ordinary unconstrained path and parsing falls back to
+      // markdown -- the existing fallback, not a second way to be unconstrained.
+      outputSchema: this.#constrainedOutput ? AgentOrchestrator.#ROLE_SCHEMAS[role] : undefined,
     });
   }
 

--- a/ts/tests/role-schemas.test.ts
+++ b/ts/tests/role-schemas.test.ts
@@ -160,6 +160,25 @@ describe("orchestrator wiring", () => {
     expect(names).not.toContain("architect_output");
   });
 
+  it("AC-931: the escape hatch stops the schema reaching the provider", async () => {
+    // Asserts what the provider RECEIVED, not what the orchestrator intended.
+    const provider = new RecordingProvider(true, VALID_ANALYST);
+    await new AgentOrchestrator(provider, { constrainedOutput: false })
+      .runGeneration(prompts)
+      .catch(() => undefined);
+
+    expect(provider.calls.every((c) => c.outputSchema === undefined)).toBe(true);
+  });
+
+  it("AC-931: output still parses via markdown when the hatch is open", async () => {
+    const markdown =
+      "## Findings\n\n- a\n\n## Root Causes\n\n- b\n\n## Actionable Recommendations\n\n- c";
+    const result = await new AgentOrchestrator(new RecordingProvider(false, markdown), {
+      constrainedOutput: false,
+    }).runGeneration(prompts);
+    expect(result.analystOutput.findings).toEqual(["a"]);
+  });
+
   it("falls back to scraping when the backend did not enforce", async () => {
     const markdown =
       "## Findings\n\n- from markdown\n\n## Root Causes\n\n- rc\n\n## Actionable Recommendations\n\n- rec";


### PR DESCRIPTION
Closes AC-931. 0.15.0 item — the direct mitigation for the one unmeasured behavior change in the local-first epic.

## Why

AC-913 and AC-929 switched **every OpenAI-compatible backend** to constrained decoding with no way out. The quality evidence is favourable but narrow: one 8B local model, where constrained output came back *fewer and shorter items but denser* — more grounded in the run's numbers, more likely to name a parameter (AC-928).

The backends actually changed include **OpenAI cloud**, which this project doesn't use and therefore can't measure. autocontext ships to PyPI and npm, so somebody runs it on OpenAI. Shipping them an unmeasured behavior change whose only remedy is pinning to 0.14 is the part worth fixing — and a switch is cheaper than a measurement nobody can currently take.

It also makes the release note honest. *"Constrained decoding is on for OpenAI-compatible backends; set X to disable"* is a complete statement. *"We think it's fine"* isn't.

## Shape

Gated on the **runtime**, not on each role runner, so a role added later can't forget it. Off means the schema never leaves `run_task`: backends report `constrained=false` and parsing takes the markdown path — the existing fallback, already exercised, rather than a second way to be unconstrained. There should be exactly one "this run wasn't schema-enforced" state, and there is.

Defaults **on**, so the improvement is the default and the hatch is the exception.

Both engines, since AC-929 restored parity and this shouldn't cost it. Python reads `constrained_output` from settings (in `config/role_routing.py`, beside the other routing settings); TypeScript takes `constrainedOutput` on `AgentOrchestratorOpts`.

## Tests

They assert what the provider **received**, not what the caller intended. The AC-913 near-miss was a dispatch condition that read correctly and never fired; only inspecting the request catches that.

Mutation-verified in both languages: ignoring the flag fails `test_escape_hatch_stops_the_schema_reaching_the_provider` and its TypeScript counterpart, and nothing else.

Full Python suite green, mypy clean across 742 files, 12/12 TypeScript. `uv.lock` untouched.