### PR TITLE
docs(AC-916): running the whole loop on your own hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ autoctx solve "improve customer-support replies for billing disputes" --iteratio
 ```
 
 Use `AUTOCONTEXT_AGENT_PROVIDER=anthropic`, `openai-compatible`, `claude-cli`, `codex`, `pi-rpc`, or another provider when you need that runtime. See [agent integration](autocontext/docs/agent-integration.md) for the full matrix.
+
+Running it on your own GPU instead? [Self-hosted models](autocontext/docs/self-hosted-models.md) covers the whole loop on vLLM, Ollama, or any OpenAI-compatible endpoint — including what each role actually resolves to, and why constrained output matters more on open weights.
 Self-hosted endpoints can additionally declare `AUTOCONTEXT_PROVIDER_HOSTING=local` and a `fast`, `mid_tier`, or `frontier` `AUTOCONTEXT_PROVIDER_CAPABILITY`; role-specific endpoints use matching `<ROLE>_PROVIDER_*` declarations.
 
 ## Agent Entry Points

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -108,6 +108,7 @@ Python runtime-backed `run` and `solve` calls append provider prompts/responses 
 Detailed setup moved out of this README:
 
 - External agents and provider routing: [docs/agent-integration.md](docs/agent-integration.md)
+- Self-hosted models, end to end: [docs/self-hosted-models.md](docs/self-hosted-models.md)
 - Persistent worker trust boundaries: [docs/persistent-host.md](docs/persistent-host.md)
 - Sandbox/executor notes: [docs/sandbox.md](docs/sandbox.md)
 - Extension hooks: [docs/extensions.md](docs/extensions.md)

--- a/autocontext/docs/self-hosted-models.md
+++ b/autocontext/docs/self-hosted-models.md
@@ -1,0 +1,233 @@
+# Running autocontext on your own hardware
+
+Every role in the loop can run against an endpoint you host. Nothing about the
+shipped defaults changes: without the settings below, autocontext behaves
+exactly as it always has.
+
+Every routing table and error message on this page was produced by executing
+the code, not read off it. Where something is untested, it says so.
+
+For the full provider matrix and every environment variable,
+see [agent-integration.md](agent-integration.md). This page is the narrative
+version: what to set, what you get, and why.
+
+## The shortest version
+
+```bash
+ollama serve                      # already listening on :11434
+ollama pull llama3.1:8b
+
+AUTOCONTEXT_AGENT_PROVIDER=ollama \
+AUTOCONTEXT_LOCAL_MODEL=llama3.1:8b \
+  autoctx run my_task
+```
+
+That is the whole configuration. No API key, no per-role model variables, no
+base URL — `ollama` defaults to `http://localhost:11434/v1`.
+
+## What each role actually gets
+
+Naming the provider and nothing else:
+
+```
+AUTOCONTEXT_AGENT_PROVIDER=ollama
+
+role         provider   model      $/1k
+competitor   ollama     llama3.1   0.0
+analyst      ollama     llama3.1   0.0
+coach        ollama     llama3.1   0.0
+architect    ollama     llama3.1   0.0
+curator      ollama     llama3.1   0.0
+translator   ollama     llama3.1   0.0
+```
+
+`llama3.1` is the per-provider default. Before this work every one of those
+rows said `claude-opus-4-6` or `claude-sonnet-4-5`, which a local server cannot
+serve — the request failed at the endpoint rather than at configuration time.
+
+`AUTOCONTEXT_LOCAL_MODEL` replaces every slot you have not configured
+explicitly, which is usually what you want when one endpoint serves one model:
+
+```
+AUTOCONTEXT_AGENT_PROVIDER=ollama
+AUTOCONTEXT_LOCAL_MODEL=llama3.1:8b     → every role: llama3.1:8b, $0.00
+```
+
+An explicit `AUTOCONTEXT_MODEL_<ROLE>` always wins over it.
+
+### Cost is zero because hosting is local, not because the model is small
+
+Self-hosted inference has no per-token API cost however capable the model is.
+That is a property of where it runs, not of what it can do, and the two are now
+separate:
+
+```
+AUTOCONTEXT_AGENT_PROVIDER=openai-compatible                     → $0.015 / $0.003 / $0.001 per role tier
+AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
+AUTOCONTEXT_PROVIDER_HOSTING=local                               → $0.00 for every role
+```
+
+`ollama`, `vllm` and `mlx` are known-local and need no declaration.
+`openai-compatible` is the generic escape hatch, so it is assumed remote —
+declare `local` when you are pointing it at your own box (llama.cpp, LM Studio,
+a private vLLM behind a gateway). Over-reporting cost on a self-hosted endpoint
+is a nuisance; under-reporting it on a paid API is a surprise on the invoice,
+which is why the ambiguous case defaults the safe way.
+
+## Declaring what your endpoint can do
+
+Capability used to be inferred from the transport name: `ollama` and `vllm`
+were hardcoded mid-tier, so a self-hosted frontier-class model was permanently
+misclassified and could never serve `architect`. Now the endpoint declares it.
+
+```bash
+AUTOCONTEXT_PROVIDER_CAPABILITY=frontier   # or mid_tier, or fast
+```
+
+Declarations apply only to locally hosted transports. A cloud endpoint has a
+knowable capability, and confining the override is what keeps Anthropic
+behavior identical whether or not you set this.
+
+A role asks for a capability; an endpoint has one. Asking a `fast` endpoint for
+frontier work does not make it frontier — the request is **clamped down** to
+what the endpoint offers, never raised:
+
+```
+AUTOCONTEXT_AGENT_PROVIDER=vllm
+AUTOCONTEXT_ROLE_ROUTING=auto
+AUTOCONTEXT_PROVIDER_CAPABILITY=fast
+
+architect    class=fast     (asked for frontier, got what the endpoint declared)
+```
+
+### Per-role declarations
+
+Each role that takes a provider override takes a capability and hosting
+override too, for the case where roles sit on different boxes:
+
+```bash
+AUTOCONTEXT_ARCHITECT_PROVIDER=vllm
+AUTOCONTEXT_ARCHITECT_PROVIDER_CAPABILITY=frontier
+```
+
+```
+role         provider   class
+competitor   vllm       frontier
+analyst      vllm       mid_tier
+architect    vllm       frontier     ← declared
+curator      vllm       fast
+```
+
+The same pattern exists for `COMPETITOR`, `ANALYST` and `COACH`, and for
+`_PROVIDER_HOSTING`.
+
+### Typos fail before the run starts
+
+```
+AUTOCONTEXT_PROVIDER_CAPABILITY=excellent
+
+ValidationError: provider_capability
+  Input should be '', 'fast', 'mid_tier' or 'frontier'
+```
+
+Not partway through a generation when one role happens to take the path that
+reads it.
+
+## Structured output
+
+This is the setting that matters most on open weights, and the one whose
+absence is easiest to miss, because the failure is silent.
+
+Role outputs used to be recovered by scraping markdown headings. Measured on
+`llama3.1:8b` over 20 trials, using the analyst instruction autocontext
+actually ships:
+
+|                      | Findings   | Root Causes | Actionable Recs |
+| -------------------- | ---------- | ----------- | --------------- |
+| markdown scraping    | lost 20/20 | lost 20/20  | lost 20/20      |
+| constrained decoding | lost 0/20  | lost 0/20   | lost 0/20       |
+
+**That is not a reasoning failure.** The model's analysis was correct. It wrote
+`### Findings` with `* ` bullets; the parser wanted `## Findings` with `- `
+bullets. Two independent drifts, either one alone discarding the whole section
+with nothing raised. The analyst contract came back empty and the loop
+continued as though the analyst had said nothing.
+
+Nothing needs configuring: role calls carry their schema automatically.
+
+| backend                              | how                                     | status                            |
+| ------------------------------------ | --------------------------------------- | --------------------------------- |
+| Ollama                               | `response_format: json_schema` on `/v1` | verified against Ollama 0.32.5    |
+| vLLM, OpenAI-compatible              | same                                    | same request path; see note below |
+| OpenAI                               | same                                    | same request path                 |
+| Anthropic                            | not implemented                         | falls back, reports unconstrained |
+| CLI runtimes (claude-cli, codex, pi) | cannot constrain                        | falls back, reports unconstrained |
+
+A backend that rejects the parameter is retried once without it. It keeps
+working, and the run records `constrained=false` — an unconstrained run is
+visible rather than assumed. When output _is_ constrained, drift raises
+`RoleOutputValidationError` instead of yielding an empty section.
+
+The measurement and its harness are committed:
+`docs/ac913-format-drift-measurement.json`, and
+`autocontext/scripts/measure_format_drift_baseline.py`.
+
+## Local agentic execution
+
+A local model can drive workspace-touching execution, not just generate text.
+There are two ways in, and they are different things.
+
+**Through a gateway** — treat Hermes as an OpenAI-compatible endpoint. This is
+the form used in [agent-integration.md](agent-integration.md):
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
+AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1
+AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b
+AUTOCONTEXT_PROVIDER_HOSTING=local
+```
+
+**As a CLI runtime** — `AUTOCONTEXT_AGENT_PROVIDER=hermes` drives the Hermes
+binary as a subprocess, which is what gives it workspace access rather than
+plain text generation:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=hermes
+AUTOCONTEXT_HERMES_BASE_URL=http://localhost:8000/v1
+AUTOCONTEXT_HERMES_API_KEY=no-key            # required by the client, unused locally
+```
+
+`runtimes/hermes_cli.py` exports those two as `OPENAI_BASE_URL` /
+`OPENAI_API_KEY` to the subprocess, and a base URL takes precedence over any
+provider setting. Pi has the same shape (`AUTOCONTEXT_PI_*`).
+
+**Untested here.** Both paths exist in the code and are described because
+nothing else describes the runtime one, but every other claim on this page was
+executed and these were not. Treat them as a starting point.
+
+Note that a CLI runtime cannot constrain output — it reports
+`constrained=false` and role parsing falls back to markdown scraping, with the
+drift rate described above.
+
+## Choosing a model
+
+The measurement above used `llama3.1:8b` and shows what constrained decoding
+fixes: **format compliance**. It says nothing about whether an 8B model
+produces _good_ analysis — that was not measured, and a small model that emits
+perfectly-shaped empty-calorie findings will steer the loop just as
+confidently as a large one.
+
+If you have the memory, run the largest model you can. Declare its capability
+honestly: an over-declared endpoint gets handed architect work it cannot do,
+and the loop has no way to notice.
+
+## Not covered yet
+
+**Endpoint preflight.** There is no check that your endpoint is reachable, has
+enough context window, or supports structured output before a run starts. It
+is tracked as AC-914; until it lands, a misconfigured endpoint surfaces as a
+failure mid-run.
+
+**llama.cpp.** Reachable through `openai-compatible` with
+`AUTOCONTEXT_PROVIDER_HOSTING=local`, but not exercised while writing this
+page, so it is listed rather than documented.

--- a/autocontext/docs/self-hosted-models.md
+++ b/autocontext/docs/self-hosted-models.md
@@ -106,6 +106,9 @@ Each role that takes a provider override takes a capability and hosting
 override too, for the case where roles sit on different boxes:
 
 ```bash
+AUTOCONTEXT_AGENT_PROVIDER=vllm
+AUTOCONTEXT_ROLE_ROUTING=auto
+AUTOCONTEXT_PROVIDER_CAPABILITY=frontier
 AUTOCONTEXT_ARCHITECT_PROVIDER=vllm
 AUTOCONTEXT_ARCHITECT_PROVIDER_CAPABILITY=frontier
 ```
@@ -149,9 +152,14 @@ actually ships:
 
 **That is not a reasoning failure.** The model's analysis was correct. It wrote
 `### Findings` with `* ` bullets; the parser wanted `## Findings` with `- `
-bullets. Two independent drifts, either one alone discarding the whole section
-with nothing raised. The analyst contract came back empty and the loop
-continued as though the analyst had said nothing.
+bullets. Two independent drifts, either one alone leaving the corresponding
+typed array empty with nothing raised.
+
+The raw response was not discarded. Python still passed it to the coach and
+persisted it for readers such as the curator, while neither engine currently
+uses those parsed analyst arrays to drive the loop. Constrained decoding makes
+the typed contract reliable and normalizes the rendered markdown; it does not
+decide whether the analyst's prose reaches the rest of the Python loop.
 
 Nothing needs configuring: role calls carry their schema automatically.
 
@@ -182,25 +190,29 @@ Role calls then carry no schema, backends report `constrained=false`, and
 parsing falls back to markdown — the same path a backend without support
 already takes, not a separate mode.
 
-You are unlikely to want this on an open-weight model, where it is the
-difference between the loop reading your analyst's output and discarding it.
-It exists because constrained decoding also changed OpenAI-compatible **cloud**
-models, and while the quality comparison came out favourable it was measured on
-one 8B local model: fewer and shorter items, but a higher share citing the
-run's actual numbers and naming a parameter to change. If your analysis gets
-worse on a cloud model, this is the switch, and the measurement you would be
-contradicting is in `docs/ac928-constrained-quality-measurement.json`.
+You are unlikely to want this on an open-weight model when you depend on the
+typed contract or stable rendered markdown. It exists because constrained
+decoding also changes OpenAI-compatible **cloud** models. The committed
+measurement on this page covers format compliance on one 8B local model; it
+does not establish a quality advantage. If a model's analysis gets worse under
+constraint, this is the switch to use while you measure the tradeoff.
 
 ### The coach is the role that matters most
 
 The analyst's sections are what the format-drift measurement above counts, but
-the **coach** is where drift actually costs you something. The loop refuses to
-update the playbook unless the coach emits all six of its marker pairs, and the
-playbook is what carries learning between generations.
+the **coach** is where drift can change the loop's persistent state. The two
+engines handle malformed coach output differently:
 
-Measured on `llama3.1:8b`, 10 trials: 8 produced all six markers, 2 produced
-none. Roughly one generation in five silently lost its update before this was
-made visible; a dropped update now reports which markers were missing.
+- TypeScript updates the playbook only when all six markers (three pairs) are
+  present. Otherwise it keeps the previous playbook and reports exactly which
+  markers were missing.
+- Python discards a response with `PLAYBOOK_START` but no matching end marker.
+  When there are no playbook markers at all, it instead stores the entire
+  response as the playbook and emits a warning.
+
+Measured on `llama3.1:8b`, 10 trials: 8 produced all six markers and 2 produced
+none. Those two responses were dropped updates in TypeScript and free-form
+playbook replacements in Python. Both outcomes are now visible to the operator.
 
 Constrained decoding is the fix rather than the diagnosis, which is another
 reason to leave it on.
@@ -216,9 +228,13 @@ the form used in [agent-integration.md](agent-integration.md):
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
 AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1
-AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b
+AUTOCONTEXT_LOCAL_MODEL=hermes-3-llama-3.1-8b
 AUTOCONTEXT_PROVIDER_HOSTING=local
 ```
+
+`AUTOCONTEXT_LOCAL_MODEL` fills every unset role and tier slot. By contrast,
+`AUTOCONTEXT_AGENT_DEFAULT_MODEL` configures only the underlying client; the
+role resolver would still request the provider default (`gpt-4o`).
 
 **As a CLI runtime** — `AUTOCONTEXT_AGENT_PROVIDER=hermes` drives the Hermes
 binary as a subprocess, which is what gives it workspace access rather than
@@ -232,7 +248,13 @@ AUTOCONTEXT_HERMES_API_KEY=no-key            # required by the client, unused lo
 
 `runtimes/hermes_cli.py` exports those two as `OPENAI_BASE_URL` /
 `OPENAI_API_KEY` to the subprocess, and a base URL takes precedence over any
-provider setting. Pi has the same shape (`AUTOCONTEXT_PI_*`).
+provider setting.
+
+Pi is a separate CLI/RPC runtime rather than an endpoint-configured equivalent.
+Its active settings include `AUTOCONTEXT_PI_COMMAND`, `AUTOCONTEXT_PI_MODEL`,
+`AUTOCONTEXT_PI_WORKSPACE` and `AUTOCONTEXT_PI_NO_CONTEXT_FILES`. The legacy
+`AUTOCONTEXT_PI_RPC_ENDPOINT` and `AUTOCONTEXT_PI_RPC_API_KEY` fields are kept
+for compatibility but are not used by the current runtime.
 
 **Untested here.** Both paths exist in the code and are described because
 nothing else describes the runtime one, but every other claim on this page was

--- a/autocontext/docs/self-hosted-models.md
+++ b/autocontext/docs/self-hosted-models.md
@@ -172,6 +172,39 @@ The measurement and its harness are committed:
 `docs/ac913-format-drift-measurement.json`, and
 `autocontext/scripts/measure_format_drift_baseline.py`.
 
+### Turning it off
+
+```bash
+AUTOCONTEXT_CONSTRAINED_OUTPUT=false
+```
+
+Role calls then carry no schema, backends report `constrained=false`, and
+parsing falls back to markdown — the same path a backend without support
+already takes, not a separate mode.
+
+You are unlikely to want this on an open-weight model, where it is the
+difference between the loop reading your analyst's output and discarding it.
+It exists because constrained decoding also changed OpenAI-compatible **cloud**
+models, and while the quality comparison came out favourable it was measured on
+one 8B local model: fewer and shorter items, but a higher share citing the
+run's actual numbers and naming a parameter to change. If your analysis gets
+worse on a cloud model, this is the switch, and the measurement you would be
+contradicting is in `docs/ac928-constrained-quality-measurement.json`.
+
+### The coach is the role that matters most
+
+The analyst's sections are what the format-drift measurement above counts, but
+the **coach** is where drift actually costs you something. The loop refuses to
+update the playbook unless the coach emits all six of its marker pairs, and the
+playbook is what carries learning between generations.
+
+Measured on `llama3.1:8b`, 10 trials: 8 produced all six markers, 2 produced
+none. Roughly one generation in five silently lost its update before this was
+made visible; a dropped update now reports which markers were missing.
+
+Constrained decoding is the fix rather than the diagnosis, which is another
+reason to leave it on.
+
 ## Local agentic execution
 
 A local model can drive workspace-touching execution, not just generate text.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 ## Integrating External Agents
 
 - [External agent integration guide](../autocontext/docs/agent-integration.md)
+- [Running the loop on your own hardware](../autocontext/docs/self-hosted-models.md)
 - [Hermes Curator + autocontext positioning](hermes-positioning.md)
 - [Python and TypeScript extension hooks](../autocontext/docs/extensions.md)
 - [Sandbox and executor notes](../autocontext/docs/sandbox.md)


### PR DESCRIPTION
Closes AC-916. 0.15.0 item — the headline of this release is "run it on your own hardware", and shipping that undocumented undercuts it.

## The constraint that shaped this

AC-916's acceptance criterion is that **every claim be executed, not written from the code**. That is not ceremony — holding to it caught four errors in my own draft:

- `autocontext run --scenario grid_ctf` **doesn't exist**. The CLI is `autoctx run my_task`. My page was the only place in the repo using that form, because I invented it.
- `AUTOCONTEXT_EXECUTOR_MODE=hermes` isn't a thing. Hermes is selected by `AUTOCONTEXT_AGENT_PROVIDER=hermes` (CLI runtime, gets workspace access) *or* through an OpenAI-compatible gateway — genuinely different capabilities that I'd collapsed into one wrong variable.
- `agent-integration.md` already covered much of this, so the page now cross-references rather than duplicating and drifting.
- **`main` had moved past what I believed shipped.** AC-911 as merged carries per-role capability *and* hosting declarations in a new `config/role_routing.py`. Writing from memory would have documented a system that doesn't exist.

Same discipline this round: `AUTOCONTEXT_CONSTRAINED_OUTPUT` was verified by executing it (`false` and `0` both → `False`, default `True`), not derived from the naming convention.

## Contents

Measured routing tables for every role, the minimum config (one variable beyond naming the provider), why cost is zero for local hosting regardless of capability, capability declaration including the clamp-down rule, per-role overrides, and structured output per backend.

Two sections state plainly that they were **not** executed — the Hermes/Pi agentic path and llama.cpp. Endpoint preflight is called out as not existing yet, pointing at AC-914, rather than described as though it does.

## The section I'd most like reviewed

**"The coach is the role that matters most."** The format-drift measurement everyone quotes counts *analyst* sections — but the analyst's structured fields are read by nothing in either engine; the loop consumes the rendered markdown. The **coach** is where drift costs something real: the playbook only updates when all six markers are present, and the playbook is what carries learning between generations. Measured 8/10 on llama3.1:8b, so roughly one generation in five silently lost its update before AC-932.

A reader deciding whether to enable constrained output should be told *that*, not the analyst number. If you disagree with leading with it, that's the paragraph to push back on.

## Verification

- Routing tables re-verified against current `main` after AC-929, AC-931, AC-932 landed — unchanged.
- All three new links resolve (root README, `docs/README.md`, `autocontext/README.md`).
- Full Python suite green.
- `README.md` is prettier-dirty, but **it already was before this change** — left alone rather than dragging an unrelated reformat into a docs PR.

Depends on #1261 (AC-931) for the escape-hatch section to be accurate on `main`.