### PR TITLE
fix(AC-926): migrate the advise gate to the shared model-JSON parser

### DIFF
--- a/autocontext/src/autocontext/ambient/advise_gate.py
+++ b/autocontext/src/autocontext/ambient/advise_gate.py
@@ -11,12 +11,12 @@ Prompt shape adapted from prime-agent's auto-refine review gate.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import NamedTuple
 
 from pydantic import BaseModel, ValidationError
 
+from autocontext.harness.core.output_parser import extract_json
 from autocontext.providers.base import LLMProvider
 
 logger = logging.getLogger(__name__)
@@ -44,15 +44,6 @@ class GateOutcome(NamedTuple):
     failure: str  # "" | "provider_error" | "parse_error"
 
 
-def _strip_fences(text: str) -> str:
-    stripped = text.strip()
-    if stripped.startswith("```"):
-        lines = stripped.splitlines()
-        body = [line for line in lines if not line.strip().startswith("```")]
-        return "\n".join(body).strip()
-    return stripped
-
-
 def run_advise_gate(
     provider: LLMProvider,
     model: str,
@@ -78,9 +69,19 @@ def run_advise_gate(
     except Exception:
         logger.warning("advise gate provider call failed; degrading to LLM-free path", exc_info=True)
         return GateOutcome(None, "provider_error")
-    try:
-        decision = AdviseGateDecision.model_validate(json.loads(_strip_fences(result.text)))
-    except (ValueError, ValidationError):
+    # AC-926: the shared model-JSON parser, not a local fence stripper. The
+    # hand-rolled version required the payload to be the ENTIRE message once
+    # fences were removed, so any preamble ("Here is my verdict:"), any trailing
+    # remark, or a reasoning block before the answer degraded the gate to the
+    # LLM-free path. Those are ordinary open-weight output shapes, not edge
+    # cases; extract_json handles all four and still refuses genuine non-JSON.
+    decoded = extract_json(result.text, on_failure="none")
+    if decoded is None:
         logger.warning("advise gate verdict unparseable; degrading to LLM-free path")
+        return GateOutcome(None, "parse_error")
+    try:
+        decision = AdviseGateDecision.model_validate(decoded)
+    except ValidationError:
+        logger.warning("advise gate verdict failed schema validation; degrading to LLM-free path")
         return GateOutcome(None, "parse_error")
     return GateOutcome(decision, "")

--- a/autocontext/src/autocontext/ambient/advise_gate.py
+++ b/autocontext/src/autocontext/ambient/advise_gate.py
@@ -75,9 +75,16 @@ def run_advise_gate(
     # remark, or a reasoning block before the answer degraded the gate to the
     # LLM-free path. Those are ordinary open-weight output shapes, not edge
     # cases; extract_json handles all four and still refuses genuine non-JSON.
-    decoded = extract_json(result.text, on_failure="none")
+    # This gate must also fail open on ambiguous or unexpectedly pathological
+    # output: a parser exception must never escape into the ambient stage
+    # breaker, and competing verdict objects are not a decision we can trust.
+    try:
+        decoded = extract_json(result.text, on_failure="none", require_unique=True)
+    except Exception:
+        logger.warning("advise gate verdict extraction failed; degrading to LLM-free path", exc_info=True)
+        return GateOutcome(None, "parse_error")
     if decoded is None:
-        logger.warning("advise gate verdict unparseable; degrading to LLM-free path")
+        logger.warning("advise gate verdict unparseable or ambiguous; degrading to LLM-free path")
         return GateOutcome(None, "parse_error")
     try:
         decision = AdviseGateDecision.model_validate(decoded)

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -125,7 +125,7 @@ def _top_level_object_spans(text: str) -> list[str]:
         start = min(starts)
         try:
             _value, end = decoder.raw_decode(text, start)
-        except ValueError:
+        except (ValueError, RecursionError):
             failed_attempts += 1
             if text[start] == "[" and _plausible_json_array_start(text, start):
                 # A truncated array can still contain complete object values.
@@ -204,7 +204,36 @@ def _fenced_payload_scopes(text: str) -> list[str] | None:
     return plausible or None
 
 
-def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | None:
+def _has_multiple_mapping_candidates(text: str) -> bool:
+    """Return whether an LLM response contains competing JSON objects.
+
+    A tagged JSON fence is authoritative, matching ``extract_json``'s normal
+    fence-selection rule. Without one, scan the whole response so an object in
+    an untagged reasoning fence cannot hide a different final object outside
+    that fence. Callers that must fail closed on ambiguity can opt into this
+    check without changing the established first-object behavior elsewhere.
+    """
+    tagged = next((match for match in _JSON_FENCE_RE.finditer(text) if match.group("tag")), None)
+    scope = _scope_text(tagged.group("body")) if tagged is not None else _scope_text(text)
+    mapping_count = 0
+    for span in _top_level_object_spans(scope):
+        try:
+            decoded = json.loads(span)
+        except (json.JSONDecodeError, RecursionError):
+            continue
+        if isinstance(decoded, Mapping):
+            mapping_count += 1
+            if mapping_count > 1:
+                return True
+    return False
+
+
+def extract_json(
+    text: str,
+    *,
+    on_failure: str = "raise",
+    require_unique: bool = False,
+) -> dict[str, Any] | None:
     """Extract a JSON object from LLM text.
 
     Tries fenced code blocks first. WHICH fence is not "the first one":
@@ -245,6 +274,11 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     ``on_failure`` controls what happens when no JSON object is found:
     ``"raise"`` (default) re-raises the underlying parse error; ``"none"``
     returns ``None`` instead.
+
+    ``require_unique`` rejects responses with more than one top-level JSON
+    object candidate. A tagged JSON fence remains authoritative, so JSON-shaped
+    scratch work in an earlier untagged fence cannot invalidate an explicitly
+    designated answer.
     """
     fenced_scopes = _fenced_payload_scopes(text)
     has_fence = fenced_scopes is not None
@@ -315,10 +349,19 @@ def extract_json(text: str, *, on_failure: str = "raise") -> dict[str, Any] | No
     for candidate in candidates:
         try:
             decoded = json.loads(candidate)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, RecursionError) as exc:
             last_exc = exc
             continue
         if isinstance(decoded, Mapping):
+            if require_unique:
+                try:
+                    has_multiple = _has_multiple_mapping_candidates(text)
+                except (ValueError, RecursionError) as exc:
+                    last_exc = exc
+                    break
+                if has_multiple:
+                    last_exc = ValueError("Expected one unambiguous JSON object, got multiple candidates")
+                    break
             return dict(decoded)
         # A candidate that PARSES but isn't a Mapping (e.g. a JSON array) is a
         # decisive answer about what the model produced, not a parse failure

--- a/autocontext/tests/test_advise_gate_parsing.py
+++ b/autocontext/tests/test_advise_gate_parsing.py
@@ -52,6 +52,14 @@ def _run(text: str) -> Any:
         ("preamble then json", f"Here is my verdict:\n\n{json.dumps(VERDICT)}"),
         ("preamble then fence", f"Sure!\n```json\n{json.dumps(VERDICT)}\n```\nHope that helps."),
         ("reasoning fence first", f"```\nthinking out loud\n```\n```json\n{json.dumps(VERDICT)}\n```"),
+        (
+            "tagged answer after JSON-shaped reasoning",
+            "```\n"
+            + json.dumps({"should_propose": False, "rationale": "draft"})
+            + "\n```\n```json\n"
+            + json.dumps(VERDICT)
+            + "\n```",
+        ),
         ("trailing prose", f"{json.dumps(VERDICT)}\n\nLet me know if you want more."),
     ],
 )
@@ -82,5 +90,43 @@ def test_schema_violation_is_reported_as_a_parse_failure() -> None:
     deciding on a payload it does not understand.
     """
     outcome = _run(json.dumps({"unrelated": "object"}))
+    assert outcome.decision is None
+    assert outcome.failure == "parse_error"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        (
+            "Draft: "
+            + json.dumps({"should_propose": False, "rationale": "draft"})
+            + "\nFinal: "
+            + json.dumps(VERDICT)
+        ),
+        (
+            "```\n"
+            + json.dumps({"should_propose": False, "rationale": "scratch"})
+            + "\n```\nFinal: "
+            + json.dumps(VERDICT)
+        ),
+    ],
+)
+def test_competing_verdict_objects_degrade_instead_of_guessing(text: str) -> None:
+    outcome = _run(text)
+    assert outcome.decision is None
+    assert outcome.failure == "parse_error"
+
+
+def test_unexpected_extraction_exception_degrades_instead_of_escaping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import autocontext.ambient.advise_gate as advise_gate
+
+    def fail_extraction(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise RecursionError("decoder recursion limit")
+
+    monkeypatch.setattr(advise_gate, "extract_json", fail_extraction)
+    outcome = _run(json.dumps(VERDICT))
     assert outcome.decision is None
     assert outcome.failure == "parse_error"

--- a/autocontext/tests/test_advise_gate_parsing.py
+++ b/autocontext/tests/test_advise_gate_parsing.py
@@ -1,0 +1,86 @@
+"""AC-926: the advise gate reads model JSON with the shared parser.
+
+It was the last site still using a hand-rolled fence stripper after the AC-910
+consolidation. That version required the payload to be the ENTIRE message once
+fences were removed, so a preamble, a trailing remark, or a reasoning block
+before the answer all degraded the gate to its LLM-free path -- ordinary
+open-weight output shapes, not edge cases.
+
+These pin the shapes that used to fail, so the migration cannot be quietly
+reverted, and the one that must still fail.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from autocontext.providers.base import CompletionResult, LLMProvider
+
+VERDICT = {"should_propose": True, "rationale": "the evidence supports it"}
+
+
+class _StubProvider(LLMProvider):
+    """Returns one fixed response, so the test varies output shape only."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def complete(self, *args: Any, **kwargs: Any) -> CompletionResult:
+        del args, kwargs
+        return CompletionResult(text=self._text, model="stub")
+
+    def default_model(self) -> str:
+        return "stub"
+
+
+def _run(text: str) -> Any:
+    from autocontext.ambient.advise_gate import run_advise_gate
+
+    return run_advise_gate(_StubProvider(text), "stub", "evidence", max_output_tokens=256)
+
+
+@pytest.mark.parametrize(
+    "label,text",
+    [
+        ("bare json", json.dumps(VERDICT)),
+        ("json fence", f"```json\n{json.dumps(VERDICT)}\n```"),
+        ("untagged fence", f"```\n{json.dumps(VERDICT)}\n```"),
+        # The four below all failed before this migration.
+        ("preamble then json", f"Here is my verdict:\n\n{json.dumps(VERDICT)}"),
+        ("preamble then fence", f"Sure!\n```json\n{json.dumps(VERDICT)}\n```\nHope that helps."),
+        ("reasoning fence first", f"```\nthinking out loud\n```\n```json\n{json.dumps(VERDICT)}\n```"),
+        ("trailing prose", f"{json.dumps(VERDICT)}\n\nLet me know if you want more."),
+    ],
+)
+def test_gate_decides_across_realistic_output_shapes(label: str, text: str) -> None:
+    outcome = _run(text)
+    assert outcome.failure == "", f"{label} degraded the gate"
+    assert outcome.decision is not None
+    assert outcome.decision.should_propose is True
+
+
+def test_genuine_non_json_still_degrades_rather_than_guessing() -> None:
+    """The parser got more tolerant, not credulous.
+
+    A gate that invented a decision from prose would be worse than one that
+    declines: the caller must permit when the gate cannot decide, and that only
+    stays safe if "cannot decide" is still reachable.
+    """
+    outcome = _run("I think you should propose it.")
+    assert outcome.decision is None
+    assert outcome.failure == "parse_error"
+
+
+def test_schema_violation_is_reported_as_a_parse_failure() -> None:
+    """Valid JSON of the wrong shape must not become a decision.
+
+    Separated from the extraction failure above because they are different
+    faults with the same required outcome -- the gate declines rather than
+    deciding on a payload it does not understand.
+    """
+    outcome = _run(json.dumps({"unrelated": "object"}))
+    assert outcome.decision is None
+    assert outcome.failure == "parse_error"

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -1708,3 +1708,34 @@ def test_no_new_markdown_fence_regex_outside_output_parser() -> None:
        file still offends -> fails. Restored -> passes.
     """
     assert _fence_regex_offenders() == _KNOWN_OFFENDERS
+
+
+def test_degenerate_repetition_stays_linear() -> None:
+    """AC-922: the failed-decode cap is load-bearing, so pin it.
+
+    `_MAX_FAILED_DECODE_ATTEMPTS` is what keeps a model stuck in a repetition
+    loop from costing quadratic time. It was measured at ~4x per 2x input
+    before the cap (1.07s for 46KB) and ~2x after (0.017s). Nothing guarded it,
+    so a later "simplification" of the retry loop could reintroduce the
+    quadratic without any test objecting.
+
+    Asserts the shape of the curve rather than absolute timings, which would be
+    machine-dependent and flaky. Quadratic gives ~4x; linear gives ~2x; the
+    threshold sits between them with room for noise.
+    """
+    import time
+
+    from autocontext.harness.core.output_parser import extract_json
+
+    def elapsed(n: int) -> float:
+        text = '{"a": ' * n
+        start = time.perf_counter()
+        extract_json(text, on_failure="none")
+        return time.perf_counter() - start
+
+    elapsed(2000)  # warm any lazy imports so the first sample is not inflated
+    small = elapsed(2000)
+    large = elapsed(8000)
+
+    # 4x the input. Linear predicts ~4x time, quadratic ~16x.
+    assert large < small * 8, f"scaling looks superlinear: {small:.4f}s -> {large:.4f}s for 4x input"

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -627,7 +627,11 @@ def test_extract_json_skips_bracket_prose_before_object(text: str) -> None:
     assert extract_json(text) == {"a": 1}
 
 
-def test_extract_json_bounds_failed_structural_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("decoder_error", (ValueError, RecursionError))
+def test_extract_json_bounds_failed_structural_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    decoder_error: type[Exception],
+) -> None:
     from autocontext.harness.core import output_parser
 
     class AlwaysFailDecoder:
@@ -635,13 +639,28 @@ def test_extract_json_bounds_failed_structural_recovery(monkeypatch: pytest.Monk
 
         def raw_decode(self, text: str, start: int):  # type: ignore[no-untyped-def]
             self.calls += 1
-            raise ValueError
+            raise decoder_error
 
     decoder = AlwaysFailDecoder()
     monkeypatch.setattr(output_parser.json, "JSONDecoder", lambda: decoder)
 
     assert output_parser._top_level_object_spans('{"a": ' * 1000) == []
     assert decoder.calls == output_parser._MAX_FAILED_DECODE_ATTEMPTS
+
+
+def test_extract_json_require_unique_rejects_competing_objects() -> None:
+    text = 'Draft: {"answer": 1}\nFinal: {"answer": 2}'
+
+    assert extract_json(text) == {"answer": 1}
+    assert extract_json(text, on_failure="none", require_unique=True) is None
+    with pytest.raises(ValueError, match="unambiguous"):
+        extract_json(text, require_unique=True)
+
+
+def test_extract_json_require_unique_trusts_tagged_answer() -> None:
+    text = '```\n{"answer": 1}\n```\n```json\n{"answer": 2}\n```'
+
+    assert extract_json(text, require_unique=True) == {"answer": 2}
 
 
 def test_extract_json_uppercase_json_fence_tag_is_recognized() -> None:
@@ -1710,32 +1729,9 @@ def test_no_new_markdown_fence_regex_outside_output_parser() -> None:
     assert _fence_regex_offenders() == _KNOWN_OFFENDERS
 
 
-def test_degenerate_repetition_stays_linear() -> None:
-    """AC-922: the failed-decode cap is load-bearing, so pin it.
-
-    `_MAX_FAILED_DECODE_ATTEMPTS` is what keeps a model stuck in a repetition
-    loop from costing quadratic time. It was measured at ~4x per 2x input
-    before the cap (1.07s for 46KB) and ~2x after (0.017s). Nothing guarded it,
-    so a later "simplification" of the retry loop could reintroduce the
-    quadratic without any test objecting.
-
-    Asserts the shape of the curve rather than absolute timings, which would be
-    machine-dependent and flaky. Quadratic gives ~4x; linear gives ~2x; the
-    threshold sits between them with room for noise.
-    """
-    import time
-
+def test_degenerate_repetition_honors_none_failure_policy() -> None:
+    """Deep malformed output is a parse failure on every supported Python."""
     from autocontext.harness.core.output_parser import extract_json
 
-    def elapsed(n: int) -> float:
-        text = '{"a": ' * n
-        start = time.perf_counter()
-        extract_json(text, on_failure="none")
-        return time.perf_counter() - start
-
-    elapsed(2000)  # warm any lazy imports so the first sample is not inflated
-    small = elapsed(2000)
-    large = elapsed(8000)
-
-    # 4x the input. Linear predicts ~4x time, quadratic ~16x.
-    assert large < small * 8, f"scaling looks superlinear: {small:.4f}s -> {large:.4f}s for 4x input"
+    text = "Here is my verdict:\n" + '{"a": ' * 2000
+    assert extract_json(text, on_failure="none") is None


### PR DESCRIPTION
Closes AC-926, and closes AC-922 on a re-measurement.

## AC-926 — migrate the advise gate to the shared parser

`advise_gate._strip_fences` was the last site still hand-rolling fence stripping after the AC-910 consolidation. The old version required the payload to be the entire message once fences were removed, so ordinary open-weight output shapes degraded the gate to its LLM-free path.

| shape | old | new |
|---|---|---|
| bare JSON | OK | OK |
| JSON fence | OK | OK |
| untagged fence | OK | OK |
| preamble then JSON | **FAIL** | OK |
| preamble then fence | **FAIL** | OK |
| reasoning fence first | **FAIL** | OK |
| trailing prose | **FAIL** | OK |
| not JSON at all | FAIL | FAIL *(correctly)* |

The gate now uses `extract_json`, while keeping its fail-open contract:

- extraction errors, including unexpected decoder recursion, return `parse_error` instead of escaping into the ambient stage breaker;
- competing verdict objects are rejected as ambiguous rather than silently choosing the first;
- an explicitly tagged JSON fence remains authoritative over earlier JSON-shaped scratch work;
- schema violations remain distinct from extraction failures in the log.

Regression coverage pins realistic response shapes, ambiguous draft/final verdicts, tagged-answer priority, and unexpected parser exceptions.

## AC-922 — already fixed and now re-measured

The filed benchmark is linear on current code:

| n | filed | now |
|---|---|---|
| 1000 | 0.017s | 0.0023s |
| 2000 | 0.068s (4.0×) | 0.0042s (1.8×) |
| 4000 | 0.263s (3.9×) | 0.0088s (2.1×) |
| 8000 | 1.070s (4.1×) | **0.0174s (2.0×)** |

The underlying fix remains `a1ce8229` (#1255), which capped failed decode attempts at 64. The existing deterministic call-count test already pinned that cap; this PR extends it to `RecursionError` and adds a cross-version behavioral regression proving deep malformed output honors `on_failure="none"`. The wall-clock ratio assertion was removed because it crashed on supported Python 3.11 before measuring and would remain machine-sensitive.

## Verification

- complete Python 3.11 test suite
- focused parser and advise-gate suites on Python 3.13
- Ruff across `src` and `tests`
- mypy clean across 742 source files
- clean prospective merge with current `main`
- `uv.lock` untouched

The remaining performance and behavior issues in this epic should be re-measured before scheduling; several have already been fixed by intervening work.