### PR TITLE
Collect deep thinking streams across providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ All notable changes to this project will be documented in this file.
   native OpenAI-compatible and Anthropic tool loops. Both runtimes force the first scratchpad
   call, disable parallel tool use, keep ordered tool payloads separate from final answer text,
   aggregate multi-turn usage, and fail closed when the tool contract is ignored or never
-  terminates. Retry and Python hook wrappers preserve the capability. Python teacher collection
+  terminates. OpenAI-compatible calls request native reasoning off, use the advertised lowest
+  gateway level only when `none` is rejected, and pass GPT 5.6+ external-thinking budgets through
+  the numeric system-prompt hint. Tool arguments are strict and acknowledgements do not re-inject
+  or steer the scratchpad. Retry and Python hook wrappers preserve the capability. Python teacher collection
   now requires a real tool stream by default and records capture provenance; local, deterministic,
   callable, and CLI/runtime transports report unsupported unless a caller explicitly opts into
   visible-preamble fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Python `autoctx run` now performs preflight checks against each distinct OpenAI-compatible agent, explicit role, automatically routed role, and judge endpoint before spending generation tokens. It blocks on confirmed dead endpoints, rejected credentials, and unavailable models; transient/indeterminate failures remain advisory, structured-output support is verified against the requested schema, persisted custom scenarios resolve through their configured knowledge root, and `--skip-preflight` provides an explicit escape hatch (AC-914).
+- Python and TypeScript provider contracts now support bounded `deep_think` collection with
+  native OpenAI-compatible and Anthropic tool loops. Both runtimes force the first scratchpad
+  call, disable parallel tool use, keep ordered tool payloads separate from final answer text,
+  aggregate multi-turn usage, and fail closed when the tool contract is ignored or never
+  terminates. Retry and Python hook wrappers preserve the capability. Python teacher collection
+  now requires a real tool stream by default and records capture provenance; local, deterministic,
+  callable, and CLI/runtime transports report unsupported unless a caller explicitly opts into
+  visible-preamble fallback.
 - Schema-constrained role output now has an explicit, default-on escape hatch: Python users can set `AUTOCONTEXT_CONSTRAINED_OUTPUT=false`, including with dedicated role providers, and TypeScript `AgentOrchestrator` users can pass `constrainedOutput: false` to retain Markdown generation and parsing (AC-931).
 - TypeScript interactive runs now advertise `agent_progress_notes_v1` to transcript clients and emit concise, strict `agent_progress_note` updates for intent, discovery, decisions, verification, and blockers. Notes are safety-redacted and bounded before emission, may cite only earlier same-run durable action/artifact IDs, and replay with exact ordering and identity across reconnects and server restarts within the transcript's finite retention horizon. Python parity is deferred until it can provide the same durable transcript guarantees (AC-897).
 - Role routing now separates endpoint hosting from capability in both runtimes. Default and role-specific endpoints can declare `local`/`remote` hosting and a local maximum capability (`fast`, `mid_tier`, or `frontier`); routing cost and automatic model tiers honor those declarations, while unset values retain conservative transport inference (AC-911).

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -80,6 +80,14 @@ default. If that changes output quality for a backend, set
 and use the existing Markdown parsers instead. The setting also applies to
 roles with dedicated provider overrides.
 
+Build-time teacher trace collection supports native `deep_think` tool loops on
+Anthropic and OpenAI-compatible providers. The collector requires a structured
+tool stream by default and keeps it separate from the final answer. Local and
+CLI/runtime providers report the capability as unsupported; visible-preamble
+fallback is available only through the collector's explicit
+`require_thinking_stream=False` option. Thinking payloads may contain sensitive
+prompt-derived data and should be redacted before persistence or export.
+
 ## Common commands
 
 | Command                                                                                | Purpose                                                                                                |

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -85,7 +85,10 @@ Anthropic and OpenAI-compatible providers. The collector requires a structured
 tool stream by default and keeps it separate from the final answer. Local and
 CLI/runtime providers report the capability as unsupported; visible-preamble
 fallback is available only through the collector's explicit
-`require_thinking_stream=False` option. Thinking payloads may contain sensitive
+`require_thinking_stream=False` option. For GPT 5.6+ models,
+`reasoning_effort` selects the external numeric prompt budget while native
+reasoning is requested off; a compatible gateway that rejects `none` is clamped
+to its lowest advertised level. Thinking payloads may contain sensitive
 prompt-derived data and should be redacted before persistence or export.
 
 ## Common commands

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -276,8 +276,16 @@ Notes:
 - Models are HuggingFace repo ids (e.g. `Qwen/Qwen2.5-1.5B-Instruct`), not the MLX 4-bit
   community repos. `--base-model` is the student; `--teacher-model` (gkd) must share the
   student's tokenizer. LoRA (PEFT) is applied automatically. API/hosted teachers are supported
-  for build-time trace collection via `trace_collector.collect()`; token-level GKD/OPD still
-  requires local/open-weights teacher logits.
+  for build-time trace collection via `trace_collector.collect()`. Anthropic and
+  OpenAI-compatible teachers use a bounded `deep_think` function-call loop: the first turn
+  requires the private scratchpad, later turns may add entries or finish, and ordered calls are
+  stored as `thinking_stream` while their joined text becomes the record's `reasoning`.
+  Collection requires a real tool stream by default. Local, callable, and CLI/runtime providers
+  report `thinking_capture=unsupported` and are skipped; pass
+  `require_thinking_stream=False` only when a visible-preamble rationale is an acceptable,
+  explicitly marked fallback. Treat collected scratchpads as sensitive training data and apply
+  the same access controls and redaction policy as prompts. Token-level GKD/OPD still requires
+  local/open-weights teacher logits.
 - `--scale-profile cuda_qlora_7b_rlvr` selects TRL GRPO with `Qwen/Qwen2.5-7B-Instruct`,
   NF4 QLoRA loading, and 24 GB target VRAM metadata. `cuda_sharded_32b_distill` selects
   TRL GKD with a 32B student, 72B teacher, NF4 loading, and a generated DeepSpeed ZeRO-3

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -280,6 +280,8 @@ Notes:
   OpenAI-compatible teachers use a bounded `deep_think` function-call loop: the first turn
   requires the private scratchpad, later turns may add entries or finish, and ordered calls are
   stored as `thinking_stream` while their joined text becomes the record's `reasoning`.
+  `reasoning_effort` controls the GPT 5.6+ external scratchpad budget while native reasoning is
+  requested off, keeping the explicit tool stream as the observable reasoning surface.
   Collection requires a real tool stream by default. Local, callable, and CLI/runtime providers
   report `thinking_capture=unsupported` and are skipped; pass
   `require_thinking_stream=False` only when a visible-preamble rationale is an acceptable,

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -163,6 +163,9 @@ class HookedLLMProvider(LLMProvider):
         self.provider_name = provider_name or inner.name
         self.role = role
         self._supports_output_schema = _accepts_output_schema(inner.complete)
+        thinking_complete = getattr(inner, "complete_with_thinking", None)
+        self._thinking_complete = thinking_complete if callable(thinking_complete) else None
+        self._thinking_supports_output_schema = _accepts_output_schema(thinking_complete)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.inner, name)
@@ -209,6 +212,9 @@ class HookedLLMProvider(LLMProvider):
         response_cost = getattr(response, "cost_usd", None)
         response_stop_reason = getattr(response, "stop_reason", None)
         response_constrained = bool(getattr(response, "constrained", False))
+        response_thinking_stream = _thinking_stream(getattr(response, "thinking_stream", []))
+        response_thinking_tool = _optional_str(getattr(response, "thinking_tool", None))
+        response_thinking_capture = str(getattr(response, "thinking_capture", "none"))
         response_payload = {
             "provider": self.provider_name,
             "role": request.get("role", self.role),
@@ -219,6 +225,9 @@ class HookedLLMProvider(LLMProvider):
             "cost_usd": response_cost,
             "stop_reason": response_stop_reason,
             "constrained": response_constrained,
+            "thinking_stream": response_thinking_stream,
+            "thinking_tool": response_thinking_tool,
+            "thinking_capture": response_thinking_capture,
         }
         after = self.hook_bus.emit(HookEvents.AFTER_PROVIDER_RESPONSE, response_payload)
         after.raise_if_blocked()
@@ -229,10 +238,108 @@ class HookedLLMProvider(LLMProvider):
             cost_usd=_optional_float(after.payload.get("cost_usd", response_cost)),
             stop_reason=response_stop_reason,
             constrained=response_constrained,
+            thinking_stream=_thinking_stream(after.payload.get("thinking_stream", response_thinking_stream)),
+            thinking_tool=_optional_str(after.payload.get("thinking_tool", response_thinking_tool)),
+            thinking_capture=str(after.payload.get("thinking_capture", response_thinking_capture)),
+        )
+
+    def complete_with_thinking(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
+        reasoning_effort: str = "none",
+        max_tool_turns: int = 8,
+    ) -> CompletionResult:
+        """Preserve hooks around the inner provider's full thinking loop."""
+        if self._thinking_complete is None:
+            result = self.complete(
+                system_prompt,
+                user_prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                output_schema=output_schema,
+            )
+            result.thinking_capture = "unsupported"
+            return result
+        payload = {
+            "provider": self.provider_name,
+            "role": self.role,
+            "model": model,
+            "system_prompt": system_prompt,
+            "user_prompt": user_prompt,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "output_schema": _schema_payload(output_schema),
+            "reasoning_effort": reasoning_effort,
+            "max_tool_turns": max_tool_turns,
+            "multiturn": True,
+        }
+        before = self.hook_bus.emit(HookEvents.BEFORE_PROVIDER_REQUEST, payload)
+        before.raise_if_blocked()
+        request = before.payload
+        requested_schema = _optional_output_schema(request.get("output_schema", output_schema))
+        extra = (
+            {"output_schema": requested_schema}
+            if requested_schema is not None and self._thinking_supports_output_schema
+            else {}
+        )
+        response = self._thinking_complete(
+            system_prompt=str(request.get("system_prompt", system_prompt)),
+            user_prompt=str(request.get("user_prompt", user_prompt)),
+            model=_optional_str(request.get("model", model)),
+            temperature=float(request.get("temperature", temperature)),
+            max_tokens=int(request.get("max_tokens", max_tokens)),
+            reasoning_effort=str(request.get("reasoning_effort", reasoning_effort)),
+            max_tool_turns=int(request.get("max_tool_turns", max_tool_turns)),
+            **extra,
+        )
+        response_model = getattr(response, "model", None)
+        response_usage = getattr(response, "usage", {})
+        response_cost = getattr(response, "cost_usd", None)
+        response_stop_reason = getattr(response, "stop_reason", None)
+        response_constrained = bool(getattr(response, "constrained", False))
+        response_thinking_stream = _thinking_stream(getattr(response, "thinking_stream", []))
+        response_thinking_tool = _optional_str(getattr(response, "thinking_tool", None))
+        response_thinking_capture = str(getattr(response, "thinking_capture", "none"))
+        response_payload = {
+            "provider": self.provider_name,
+            "role": request.get("role", self.role),
+            "model": response_model or request.get("model") or model or self.default_model(),
+            "request": dict(request),
+            "text": response.text,
+            "usage": dict(response_usage) if isinstance(response_usage, dict) else {},
+            "cost_usd": response_cost,
+            "stop_reason": response_stop_reason,
+            "constrained": response_constrained,
+            "thinking_stream": response_thinking_stream,
+            "thinking_tool": response_thinking_tool,
+            "thinking_capture": response_thinking_capture,
+        }
+        after = self.hook_bus.emit(HookEvents.AFTER_PROVIDER_RESPONSE, response_payload)
+        after.raise_if_blocked()
+        return CompletionResult(
+            text=str(after.payload.get("text", response.text)),
+            model=_optional_str(after.payload.get("model", response_model)),
+            usage=_usage_dict(after.payload.get("usage", response_usage)),
+            cost_usd=_optional_float(after.payload.get("cost_usd", response_cost)),
+            stop_reason=response_stop_reason,
+            constrained=response_constrained,
+            thinking_stream=_thinking_stream(after.payload.get("thinking_stream", response_thinking_stream)),
+            thinking_tool=_optional_str(after.payload.get("thinking_tool", response_thinking_tool)),
+            thinking_capture=str(after.payload.get("thinking_capture", response_thinking_capture)),
         )
 
     def default_model(self) -> str:
         return self.inner.default_model()
+
+    @property
+    def supports_thinking_stream(self) -> bool:
+        return bool(getattr(self.inner, "supports_thinking_stream", False))
 
     @property
     def name(self) -> str:
@@ -296,6 +403,12 @@ def _usage_dict(value: Any) -> dict[str, int]:
     if not isinstance(value, dict):
         return {}
     return {str(key): int(item) for key, item in value.items() if isinstance(item, (int, float))}
+
+
+def _thinking_stream(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
 
 
 def _usage_from_payload(default: RoleUsage, value: Any) -> RoleUsage:

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -251,7 +251,7 @@ class HookedLLMProvider(LLMProvider):
         temperature: float = 0.0,
         max_tokens: int = 4096,
         output_schema: OutputSchema | None = None,
-        reasoning_effort: str = "none",
+        reasoning_effort: str = "medium",
         max_tool_turns: int = 8,
     ) -> CompletionResult:
         """Preserve hooks around the inner provider's full thinking loop."""

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -6,7 +6,13 @@ from typing import Any
 
 import anthropic
 
-from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
+from autocontext.providers.base import (
+    CompletionResult,
+    LLMProvider,
+    OutputSchema,
+    ProviderError,
+    ThinkingUnsupportedError,
+)
 from autocontext.providers.thinking import (
     DEEP_THINK_DESCRIPTION,
     DEEP_THINK_PARAMETERS,
@@ -97,7 +103,9 @@ class AnthropicProvider(LLMProvider):
         thinking_stream: list[str] = []
         total_usage = {"input_tokens": 0, "output_tokens": 0}
 
-        for turn in range(max_tool_turns):
+        # ``max_tool_turns`` bounds tool-bearing responses, not all requests;
+        # allow one final request after the last permitted scratchpad turn.
+        for turn in range(max_tool_turns + 1):
             tool_choice: dict[str, Any]
             if turn == 0:
                 tool_choice = {
@@ -119,7 +127,10 @@ class AnthropicProvider(LLMProvider):
                     tool_choice=tool_choice,
                 )
             except anthropic.APIError as exc:
-                raise ProviderError(f"Anthropic API error: {exc}") from exc
+                raise ProviderError(
+                    f"Anthropic API error: {exc}",
+                    usage=total_usage,
+                ) from exc
 
             usage = getattr(response, "usage", None)
             if usage is not None:
@@ -130,7 +141,10 @@ class AnthropicProvider(LLMProvider):
             tool_blocks = [block for block in blocks if getattr(block, "type", "") == "tool_use"]
             if not tool_blocks:
                 if turn == 0:
-                    raise ProviderError("Anthropic API did not honor required deep_think tool choice")
+                    raise ThinkingUnsupportedError(
+                        "Anthropic API did not honor required deep_think tool choice",
+                        usage=total_usage,
+                    )
                 text = "".join(
                     str(getattr(block, "text", "") or "")
                     for block in blocks
@@ -146,16 +160,28 @@ class AnthropicProvider(LLMProvider):
                     thinking_capture="tool",
                 )
 
+            if turn == max_tool_turns:
+                raise ProviderError(
+                    f"Model exceeded {max_tool_turns} deep_think tool turns",
+                    usage=total_usage,
+                )
+
             messages.append({"role": "assistant", "content": blocks})
             tool_results: list[dict[str, Any]] = []
             for block in tool_blocks:
                 name = str(getattr(block, "name", "") or "")
                 if name != DEEP_THINK_TOOL_NAME:
-                    raise ProviderError(f"Unexpected thinking tool call: {name or '<missing>'}")
+                    raise ProviderError(
+                        f"Unexpected thinking tool call: {name or '<missing>'}",
+                        usage=total_usage,
+                    )
                 try:
                     thinking_stream.append(extract_deep_thought(getattr(block, "input", None)))
                 except ValueError as exc:
-                    raise ProviderError(f"Invalid deep_think arguments: {exc}") from exc
+                    raise ProviderError(
+                        f"Invalid deep_think arguments: {exc}",
+                        usage=total_usage,
+                    ) from exc
                 tool_results.append(
                     {
                         "type": "tool_result",
@@ -165,7 +191,7 @@ class AnthropicProvider(LLMProvider):
                 )
             messages.append({"role": "user", "content": tool_results})
 
-        raise ProviderError(f"Model exceeded {max_tool_turns} deep_think tool turns")
+        raise AssertionError("deep_think loop exhausted without returning or raising")
 
     def default_model(self) -> str:
         return self._default_model

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -84,7 +84,7 @@ class AnthropicProvider(LLMProvider):
         temperature: float = 0.0,
         max_tokens: int = 4096,
         output_schema: OutputSchema | None = None,
-        reasoning_effort: str = "none",
+        reasoning_effort: str = "medium",
         max_tool_turns: int = 8,
     ) -> CompletionResult:
         """Collect ordered scratchpad entries with Anthropic client tools."""
@@ -152,7 +152,10 @@ class AnthropicProvider(LLMProvider):
                 name = str(getattr(block, "name", "") or "")
                 if name != DEEP_THINK_TOOL_NAME:
                     raise ProviderError(f"Unexpected thinking tool call: {name or '<missing>'}")
-                thinking_stream.append(extract_deep_thought(getattr(block, "input", None)))
+                try:
+                    thinking_stream.append(extract_deep_thought(getattr(block, "input", None)))
+                except ValueError as exc:
+                    raise ProviderError(f"Invalid deep_think arguments: {exc}") from exc
                 tool_results.append(
                     {
                         "type": "tool_result",

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -2,10 +2,26 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import anthropic
 
 from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
+from autocontext.providers.thinking import (
+    DEEP_THINK_DESCRIPTION,
+    DEEP_THINK_PARAMETERS,
+    DEEP_THINK_TOOL_NAME,
+    deep_think_acknowledgement,
+    extract_deep_thought,
+    with_deep_think_instruction,
+)
 from autocontext.providers.token_caps import clamp_output_tokens
+
+_DEEP_THINK_TOOL: dict[str, Any] = {
+    "name": DEEP_THINK_TOOL_NAME,
+    "description": DEEP_THINK_DESCRIPTION,
+    "input_schema": DEEP_THINK_PARAMETERS,
+}
 
 
 class AnthropicProvider(LLMProvider):
@@ -60,5 +76,97 @@ class AnthropicProvider(LLMProvider):
             stop_reason=getattr(response, "stop_reason", None),
         )
 
+    def complete_with_thinking(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
+        reasoning_effort: str = "none",
+        max_tool_turns: int = 8,
+    ) -> CompletionResult:
+        """Collect ordered scratchpad entries with Anthropic client tools."""
+        del output_schema, reasoning_effort  # Neither maps to this Messages API path.
+        if max_tool_turns < 1:
+            raise ValueError("max_tool_turns must be at least 1")
+
+        model_id = model or self._default_model
+        messages: Any = [{"role": "user", "content": user_prompt}]
+        thinking_stream: list[str] = []
+        total_usage = {"input_tokens": 0, "output_tokens": 0}
+
+        for turn in range(max_tool_turns):
+            tool_choice: dict[str, Any]
+            if turn == 0:
+                tool_choice = {
+                    "type": "tool",
+                    "name": DEEP_THINK_TOOL_NAME,
+                    "disable_parallel_tool_use": True,
+                }
+            else:
+                tool_choice = {"type": "auto", "disable_parallel_tool_use": True}
+            try:
+                create_message: Any = self._client.messages.create
+                response = create_message(
+                    model=model_id,
+                    max_tokens=clamp_output_tokens(max_tokens, model_id),
+                    temperature=temperature,
+                    system=with_deep_think_instruction(system_prompt),
+                    messages=messages,
+                    tools=[_DEEP_THINK_TOOL],
+                    tool_choice=tool_choice,
+                )
+            except anthropic.APIError as exc:
+                raise ProviderError(f"Anthropic API error: {exc}") from exc
+
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                total_usage["input_tokens"] += int(getattr(usage, "input_tokens", 0) or 0)
+                total_usage["output_tokens"] += int(getattr(usage, "output_tokens", 0) or 0)
+
+            blocks = list(getattr(response, "content", None) or [])
+            tool_blocks = [block for block in blocks if getattr(block, "type", "") == "tool_use"]
+            if not tool_blocks:
+                if turn == 0:
+                    raise ProviderError("Anthropic API did not honor required deep_think tool choice")
+                text = "".join(
+                    str(getattr(block, "text", "") or "")
+                    for block in blocks
+                    if getattr(block, "type", "") == "text"
+                )
+                return CompletionResult(
+                    text=text,
+                    model=str(getattr(response, "model", model_id) or model_id),
+                    usage=total_usage,
+                    stop_reason=getattr(response, "stop_reason", None),
+                    thinking_stream=thinking_stream,
+                    thinking_tool=DEEP_THINK_TOOL_NAME,
+                    thinking_capture="tool",
+                )
+
+            messages.append({"role": "assistant", "content": blocks})
+            tool_results: list[dict[str, Any]] = []
+            for block in tool_blocks:
+                name = str(getattr(block, "name", "") or "")
+                if name != DEEP_THINK_TOOL_NAME:
+                    raise ProviderError(f"Unexpected thinking tool call: {name or '<missing>'}")
+                thinking_stream.append(extract_deep_thought(getattr(block, "input", None)))
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": str(getattr(block, "id", "") or ""),
+                        "content": deep_think_acknowledgement(len(thinking_stream)),
+                    }
+                )
+            messages.append({"role": "user", "content": tool_results})
+
+        raise ProviderError(f"Model exceeded {max_tool_turns} deep_think tool turns")
+
     def default_model(self) -> str:
         return self._default_model
+
+    @property
+    def supports_thinking_stream(self) -> bool:
+        return True

--- a/autocontext/src/autocontext/providers/base.py
+++ b/autocontext/src/autocontext/providers/base.py
@@ -104,13 +104,15 @@ class LLMProvider(ABC):
         temperature: float = 0.0,
         max_tokens: int = 4096,
         output_schema: OutputSchema | None = None,
-        reasoning_effort: str = "none",
+        reasoning_effort: str = "medium",
         max_tool_turns: int = 8,
     ) -> CompletionResult:
         """Complete while requesting an application-captured thinking stream.
 
         Providers without a tool-loop implementation fall back to ``complete``,
         return an empty ``thinking_stream``, and mark capture as unsupported.
+        ``reasoning_effort`` selects the external scratchpad budget; native
+        provider reasoning is disabled where the transport supports doing so.
         This method is intentionally non-abstract so existing third-party
         ``LLMProvider`` implementations remain compatible.
         """

--- a/autocontext/src/autocontext/providers/base.py
+++ b/autocontext/src/autocontext/providers/base.py
@@ -10,6 +10,17 @@ from typing import Any
 class ProviderError(Exception):
     """Raised when an LLM provider call fails."""
 
+    def __init__(self, message: str, *, usage: dict[str, int] | None = None) -> None:
+        super().__init__(message)
+        # Successful requests earlier in a multi-turn operation may already be
+        # billable even when a later request fails. Retry wrappers aggregate
+        # this partial usage into the eventual successful result.
+        self.usage = dict(usage or {})
+
+
+class ThinkingUnsupportedError(ProviderError):
+    """Raised when an endpoint cannot honor structured thinking capture."""
+
 
 @dataclass(frozen=True, slots=True)
 class OutputSchema:

--- a/autocontext/src/autocontext/providers/base.py
+++ b/autocontext/src/autocontext/providers/base.py
@@ -41,6 +41,15 @@ class CompletionResult:
     # request, or one written before this existed, reports the truth rather
     # than claiming an enforcement it never performed.
     constrained: bool = False
+    # Ordered scratchpad entries captured from an explicit ``deep_think``
+    # tool. Keeping them separate from ``text`` prevents a captured thinking
+    # stream from becoming the user-visible answer by accident.
+    thinking_stream: list[str] = field(default_factory=list)
+    thinking_tool: str | None = None
+    # ``tool`` means the stream came from structured tool calls. ``unsupported``
+    # means the provider could only perform an ordinary completion. The default
+    # preserves compatibility with providers written before thinking capture.
+    thinking_capture: str = "none"
 
 
 class LLMProvider(ABC):
@@ -86,6 +95,54 @@ class LLMProvider(ABC):
     def default_model(self) -> str:
         """Return the default model identifier for this provider."""
         ...
+
+    def complete_with_thinking(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
+        reasoning_effort: str = "none",
+        max_tool_turns: int = 8,
+    ) -> CompletionResult:
+        """Complete while requesting an application-captured thinking stream.
+
+        Providers without a tool-loop implementation fall back to ``complete``,
+        return an empty ``thinking_stream``, and mark capture as unsupported.
+        This method is intentionally non-abstract so existing third-party
+        ``LLMProvider`` implementations remain compatible.
+        """
+        del reasoning_effort, max_tool_turns
+        if output_schema is None:
+            # Older third-party providers may predate the optional schema
+            # keyword even though they still satisfy the core completion
+            # contract. Do not make thinking fallback less compatible.
+            result = self.complete(
+                system_prompt,
+                user_prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        else:
+            result = self.complete(
+                system_prompt,
+                user_prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                output_schema=output_schema,
+            )
+        if not result.thinking_stream:
+            result.thinking_capture = "unsupported"
+        return result
+
+    @property
+    def supports_thinking_stream(self) -> bool:
+        """Whether this provider has a native structured thinking-tool loop."""
+        return False
 
     @property
     def name(self) -> str:

--- a/autocontext/src/autocontext/providers/openai_compat.py
+++ b/autocontext/src/autocontext/providers/openai_compat.py
@@ -11,9 +11,26 @@ import os
 from typing import Any
 
 from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
+from autocontext.providers.thinking import (
+    DEEP_THINK_DESCRIPTION,
+    DEEP_THINK_PARAMETERS,
+    DEEP_THINK_TOOL_NAME,
+    deep_think_acknowledgement,
+    extract_deep_thought,
+    with_deep_think_instruction,
+)
 from autocontext.providers.token_caps import clamp_output_tokens
 
 logger = logging.getLogger(__name__)
+
+DEEP_THINK_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": DEEP_THINK_TOOL_NAME,
+        "description": DEEP_THINK_DESCRIPTION,
+        "parameters": DEEP_THINK_PARAMETERS,
+    },
+}
 
 try:
     import openai  # type: ignore[import-not-found]
@@ -87,30 +104,11 @@ class OpenAICompatibleProvider(LLMProvider):
             }
             constrained = True
 
-        try:
-            response = self._client.chat.completions.create(**request)
-        except Exception as exc:
-            if not constrained or not _is_unsupported_response_format_error(exc):
-                logger.debug("providers.openai_compat: caught Exception", exc_info=True)
-                raise ProviderError(f"OpenAI-compatible API error: {exc}") from exc
-            # This endpoint does not understand response_format. Retry once
-            # without it rather than failing the run: AC-913 requires that a
-            # backend with no constrained-decoding support still works. The
-            # result is then reported as unconstrained, so a caller can tell
-            # "the schema was enforced" from "the schema was requested and
-            # silently not applied" -- which is the distinction that makes an
-            # unconstrained run visible instead of assumed.
-            logger.info(
-                "providers.openai_compat: %s rejected response_format; retrying unconstrained",
-                model_id,
-            )
-            request.pop("response_format", None)
-            constrained = False
-            try:
-                response = self._client.chat.completions.create(**request)
-            except Exception as retry_exc:
-                logger.debug("providers.openai_compat: caught Exception", exc_info=True)
-                raise ProviderError(f"OpenAI-compatible API error: {retry_exc}") from retry_exc
+        response, constrained = self._create_chat_completion(
+            request,
+            model_id=model_id,
+            constrained=constrained,
+        )
 
         choice = response.choices[0] if response.choices else None
         text = choice.message.content or "" if choice else ""
@@ -130,8 +128,145 @@ class OpenAICompatibleProvider(LLMProvider):
             constrained=constrained,
         )
 
+    def complete_with_thinking(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
+        reasoning_effort: str = "none",
+        max_tool_turns: int = 8,
+    ) -> CompletionResult:
+        """Collect an ordered ``deep_think`` scratchpad via function calls.
+
+        The first turn requires the tool, later turns allow either another
+        scratchpad entry or the final answer. Tool arguments stay separate from
+        response text, and exceeding the bounded tool loop fails closed rather
+        than returning an incomplete answer as a successful trace.
+        """
+        if max_tool_turns < 1:
+            raise ValueError("max_tool_turns must be at least 1")
+
+        model_id = model or self._default_model
+        system_with_tool = with_deep_think_instruction(system_prompt)
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": system_with_tool},
+            {"role": "user", "content": user_prompt},
+        ]
+        thinking_stream: list[str] = []
+        total_usage = {"input_tokens": 0, "output_tokens": 0}
+        constrained = output_schema is not None
+        reasoning_effort_supported = True
+
+        for turn in range(max_tool_turns):
+            request: dict[str, Any] = {
+                "model": model_id,
+                "temperature": temperature,
+                "max_tokens": clamp_output_tokens(max_tokens, model_id),
+                "messages": messages,
+                "tools": [DEEP_THINK_TOOL],
+                "tool_choice": "required" if turn == 0 else "auto",
+                "parallel_tool_calls": False,
+            }
+            if reasoning_effort_supported:
+                request["reasoning_effort"] = reasoning_effort
+            if constrained and output_schema is not None:
+                request["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": output_schema.name,
+                        "strict": True,
+                        "schema": output_schema.schema,
+                    },
+                }
+
+            response, constrained = self._create_chat_completion(
+                request,
+                model_id=model_id,
+                constrained=constrained,
+            )
+            reasoning_effort_supported = "reasoning_effort" in request
+            _add_usage(total_usage, response)
+            choice = response.choices[0] if response.choices else None
+            if choice is None:
+                raise ProviderError("OpenAI-compatible API returned no completion choices")
+            message = choice.message
+            tool_calls = list(getattr(message, "tool_calls", None) or [])
+
+            if not tool_calls:
+                if turn == 0:
+                    raise ProviderError("OpenAI-compatible endpoint did not honor required deep_think tool choice")
+                return CompletionResult(
+                    text=getattr(message, "content", None) or "",
+                    model=model_id,
+                    usage=total_usage,
+                    stop_reason=getattr(choice, "finish_reason", None),
+                    constrained=constrained,
+                    thinking_stream=thinking_stream,
+                    thinking_tool=DEEP_THINK_TOOL_NAME,
+                    thinking_capture="tool",
+                )
+
+            messages.append(_assistant_tool_message(message, tool_calls))
+            for call in tool_calls:
+                function = getattr(call, "function", None)
+                name = getattr(function, "name", "")
+                if name != DEEP_THINK_TOOL_NAME:
+                    raise ProviderError(f"Unexpected thinking tool call: {name or '<missing>'}")
+                arguments = str(getattr(function, "arguments", "") or "")
+                thinking_stream.append(extract_deep_thought(arguments))
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": str(getattr(call, "id", "")),
+                        "content": deep_think_acknowledgement(len(thinking_stream)),
+                    }
+                )
+
+        raise ProviderError(f"Model exceeded {max_tool_turns} deep_think tool turns")
+
+    def _create_chat_completion(
+        self,
+        request: dict[str, Any],
+        *,
+        model_id: str,
+        constrained: bool,
+    ) -> tuple[Any, bool]:
+        while True:
+            try:
+                return self._client.chat.completions.create(**request), constrained
+            except Exception as exc:
+                if constrained and _is_unsupported_response_format_error(exc):
+                    # AC-913: a backend without constrained decoding should
+                    # still answer, but the result must report the truth.
+                    logger.info(
+                        "providers.openai_compat: %s rejected response_format; retrying unconstrained",
+                        model_id,
+                    )
+                    request.pop("response_format", None)
+                    constrained = False
+                    continue
+                if "reasoning_effort" in request and _is_unsupported_reasoning_effort_error(exc):
+                    # OpenAI-compatible servers frequently support tools but
+                    # not OpenAI's native-reasoning control. Keep the required
+                    # deep_think contract and negotiate away only this field.
+                    logger.info(
+                        "providers.openai_compat: %s rejected reasoning_effort; retrying without it",
+                        model_id,
+                    )
+                    request.pop("reasoning_effort", None)
+                    continue
+                logger.debug("providers.openai_compat: caught Exception", exc_info=True)
+                raise ProviderError(f"OpenAI-compatible API error: {exc}") from exc
+
     def default_model(self) -> str:
         return self._default_model
+
+    @property
+    def supports_thinking_stream(self) -> bool:
+        return True
 
 
 def _is_unsupported_response_format_error(exc: Exception) -> bool:
@@ -151,3 +286,43 @@ def _is_unsupported_response_format_error(exc: Exception) -> bool:
         for token in ("unsupported", "not supported", "unknown", "unrecognized", "invalid")
     )
     return mentions_schema and rejection
+
+
+def _is_unsupported_reasoning_effort_error(exc: Exception) -> bool:
+    """Identify only endpoint rejections of the optional reasoning control."""
+    status_code = getattr(exc, "status_code", None)
+    if status_code not in {400, 404, 422}:
+        return False
+    message = str(exc).lower()
+    mentions_field = "reasoning_effort" in message or "reasoning effort" in message
+    rejection = any(
+        token in message
+        for token in ("unsupported", "not supported", "unknown", "unrecognized", "invalid")
+    )
+    return mentions_field and rejection
+
+
+def _assistant_tool_message(message: Any, tool_calls: list[Any]) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": getattr(message, "content", None),
+        "tool_calls": [
+            {
+                "id": str(getattr(call, "id", "")),
+                "type": str(getattr(call, "type", "function") or "function"),
+                "function": {
+                    "name": str(getattr(getattr(call, "function", None), "name", "")),
+                    "arguments": str(getattr(getattr(call, "function", None), "arguments", "") or ""),
+                },
+            }
+            for call in tool_calls
+        ],
+    }
+
+
+def _add_usage(total: dict[str, int], response: Any) -> None:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return
+    total["input_tokens"] += int(getattr(usage, "prompt_tokens", 0) or 0)
+    total["output_tokens"] += int(getattr(usage, "completion_tokens", 0) or 0)

--- a/autocontext/src/autocontext/providers/openai_compat.py
+++ b/autocontext/src/autocontext/providers/openai_compat.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
@@ -16,6 +17,7 @@ from autocontext.providers.thinking import (
     DEEP_THINK_PARAMETERS,
     DEEP_THINK_TOOL_NAME,
     deep_think_acknowledgement,
+    deep_think_juice,
     extract_deep_thought,
     with_deep_think_instruction,
 )
@@ -23,14 +25,18 @@ from autocontext.providers.token_caps import clamp_output_tokens
 
 logger = logging.getLogger(__name__)
 
-DEEP_THINK_TOOL: dict[str, Any] = {
-    "type": "function",
-    "function": {
+def _deep_think_tool(*, strict: bool = True) -> dict[str, Any]:
+    function: dict[str, Any] = {
         "name": DEEP_THINK_TOOL_NAME,
         "description": DEEP_THINK_DESCRIPTION,
         "parameters": DEEP_THINK_PARAMETERS,
-    },
-}
+    }
+    if strict:
+        function["strict"] = True
+    return {"type": "function", "function": function}
+
+
+DEEP_THINK_TOOL = _deep_think_tool()
 
 try:
     import openai  # type: ignore[import-not-found]
@@ -136,7 +142,7 @@ class OpenAICompatibleProvider(LLMProvider):
         temperature: float = 0.0,
         max_tokens: int = 4096,
         output_schema: OutputSchema | None = None,
-        reasoning_effort: str = "none",
+        reasoning_effort: str = "medium",
         max_tool_turns: int = 8,
     ) -> CompletionResult:
         """Collect an ordered ``deep_think`` scratchpad via function calls.
@@ -150,7 +156,8 @@ class OpenAICompatibleProvider(LLMProvider):
             raise ValueError("max_tool_turns must be at least 1")
 
         model_id = model or self._default_model
-        system_with_tool = with_deep_think_instruction(system_prompt)
+        juice = deep_think_juice(reasoning_effort) if _is_gpt_56_plus(model_id) else None
+        system_with_tool = with_deep_think_instruction(system_prompt, juice=juice)
         messages: list[dict[str, Any]] = [
             {"role": "system", "content": system_with_tool},
             {"role": "user", "content": user_prompt},
@@ -158,7 +165,12 @@ class OpenAICompatibleProvider(LLMProvider):
         thinking_stream: list[str] = []
         total_usage = {"input_tokens": 0, "output_tokens": 0}
         constrained = output_schema is not None
-        reasoning_effort_supported = True
+        # The public option controls the external scratchpad budget. Native
+        # hidden reasoning is disabled so the captured tool stream is the
+        # reasoning surface; compatible gateways may negotiate ``none`` down
+        # to their lowest supported level.
+        wire_reasoning_effort: str | None = "none"
+        strict_tools = True
 
         for turn in range(max_tool_turns):
             request: dict[str, Any] = {
@@ -166,12 +178,12 @@ class OpenAICompatibleProvider(LLMProvider):
                 "temperature": temperature,
                 "max_tokens": clamp_output_tokens(max_tokens, model_id),
                 "messages": messages,
-                "tools": [DEEP_THINK_TOOL],
+                "tools": [_deep_think_tool(strict=strict_tools)],
                 "tool_choice": "required" if turn == 0 else "auto",
                 "parallel_tool_calls": False,
             }
-            if reasoning_effort_supported:
-                request["reasoning_effort"] = reasoning_effort
+            if wire_reasoning_effort is not None:
+                request["reasoning_effort"] = wire_reasoning_effort
             if constrained and output_schema is not None:
                 request["response_format"] = {
                     "type": "json_schema",
@@ -187,7 +199,9 @@ class OpenAICompatibleProvider(LLMProvider):
                 model_id=model_id,
                 constrained=constrained,
             )
-            reasoning_effort_supported = "reasoning_effort" in request
+            effective_effort = request.get("reasoning_effort")
+            wire_reasoning_effort = effective_effort if isinstance(effective_effort, str) else None
+            strict_tools = _request_uses_strict_tools(request)
             _add_usage(total_usage, response)
             choice = response.choices[0] if response.choices else None
             if choice is None:
@@ -216,7 +230,10 @@ class OpenAICompatibleProvider(LLMProvider):
                 if name != DEEP_THINK_TOOL_NAME:
                     raise ProviderError(f"Unexpected thinking tool call: {name or '<missing>'}")
                 arguments = str(getattr(function, "arguments", "") or "")
-                thinking_stream.append(extract_deep_thought(arguments))
+                try:
+                    thinking_stream.append(extract_deep_thought(arguments))
+                except ValueError as exc:
+                    raise ProviderError(f"Invalid deep_think arguments: {exc}") from exc
                 messages.append(
                     {
                         "role": "tool",
@@ -248,15 +265,33 @@ class OpenAICompatibleProvider(LLMProvider):
                     request.pop("response_format", None)
                     constrained = False
                     continue
+                if _request_uses_strict_tools(request) and _is_unsupported_strict_tools_error(exc):
+                    logger.info(
+                        "providers.openai_compat: %s rejected strict tools; retrying with manual validation",
+                        model_id,
+                    )
+                    _disable_strict_tools(request)
+                    continue
                 if "reasoning_effort" in request and _is_unsupported_reasoning_effort_error(exc):
                     # OpenAI-compatible servers frequently support tools but
                     # not OpenAI's native-reasoning control. Keep the required
                     # deep_think contract and negotiate away only this field.
-                    logger.info(
-                        "providers.openai_compat: %s rejected reasoning_effort; retrying without it",
-                        model_id,
-                    )
-                    request.pop("reasoning_effort", None)
+                    current_effort = str(request["reasoning_effort"])
+                    fallback_effort = _lowest_supported_reasoning_effort(exc, current_effort)
+                    if fallback_effort is None:
+                        logger.info(
+                            "providers.openai_compat: %s rejected reasoning_effort; retrying without it",
+                            model_id,
+                        )
+                        request.pop("reasoning_effort", None)
+                    else:
+                        logger.info(
+                            "providers.openai_compat: %s rejected reasoning_effort=%s; retrying with %s",
+                            model_id,
+                            current_effort,
+                            fallback_effort,
+                        )
+                        request["reasoning_effort"] = fallback_effort
                     continue
                 logger.debug("providers.openai_compat: caught Exception", exc_info=True)
                 raise ProviderError(f"OpenAI-compatible API error: {exc}") from exc
@@ -294,12 +329,70 @@ def _is_unsupported_reasoning_effort_error(exc: Exception) -> bool:
     if status_code not in {400, 404, 422}:
         return False
     message = str(exc).lower()
-    mentions_field = "reasoning_effort" in message or "reasoning effort" in message
+    mentions_field = (
+        "reasoning_effort" in message
+        or "reasoning effort" in message
+        or re.search(r"(?:valid|supported|allowed) levels?", message) is not None
+    )
     rejection = any(
         token in message
         for token in ("unsupported", "not supported", "unknown", "unrecognized", "invalid")
     )
     return mentions_field and rejection
+
+
+def _is_unsupported_strict_tools_error(exc: Exception) -> bool:
+    """Identify compatible endpoints that reject the optional strict flag."""
+    status_code = getattr(exc, "status_code", None)
+    if status_code not in {400, 404, 422}:
+        return False
+    message = str(exc).lower()
+    mentions_field = "strict" in message and ("tool" in message or "function" in message)
+    rejection = any(
+        token in message
+        for token in ("unsupported", "not supported", "unknown", "unrecognized", "unexpected", "invalid")
+    )
+    return mentions_field and rejection
+
+
+def _request_uses_strict_tools(request: dict[str, Any]) -> bool:
+    tools = request.get("tools")
+    if not isinstance(tools, list) or not tools or not isinstance(tools[0], dict):
+        return False
+    function = tools[0].get("function")
+    return isinstance(function, dict) and function.get("strict") is True
+
+
+def _disable_strict_tools(request: dict[str, Any]) -> None:
+    tools = request.get("tools")
+    if not isinstance(tools, list):
+        return
+    for tool in tools:
+        if isinstance(tool, dict) and isinstance(tool.get("function"), dict):
+            tool["function"].pop("strict", None)
+
+
+_REASONING_EFFORT_ORDER = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+
+
+def _lowest_supported_reasoning_effort(exc: Exception, current: str) -> str | None:
+    """Return the lowest advertised level after a gateway rejects ``none``."""
+    message = str(exc).lower()
+    if re.search(r"(?:valid|supported|allowed) levels?", message) is None:
+        return None
+    advertised = set(re.findall(r"\b(?:none|minimal|low|medium|high|xhigh|max)\b", message))
+    advertised.discard(current.lower())
+    return next((effort for effort in _REASONING_EFFORT_ORDER if effort in advertised), None)
+
+
+def _is_gpt_56_plus(model_id: str) -> bool:
+    """Identify GPT 5.6+ ids that consume the numeric prompt budget."""
+    match = re.search(r"(?:^|[/:-])gpt-(\d+)(?:\.(\d+))?", model_id.lower())
+    if match is None:
+        return False
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    return major > 5 or (major == 5 and minor >= 6)
 
 
 def _assistant_tool_message(message: Any, tool_calls: list[Any]) -> dict[str, Any]:

--- a/autocontext/src/autocontext/providers/openai_compat.py
+++ b/autocontext/src/autocontext/providers/openai_compat.py
@@ -11,7 +11,13 @@ import os
 import re
 from typing import Any
 
-from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
+from autocontext.providers.base import (
+    CompletionResult,
+    LLMProvider,
+    OutputSchema,
+    ProviderError,
+    ThinkingUnsupportedError,
+)
 from autocontext.providers.thinking import (
     DEEP_THINK_DESCRIPTION,
     DEEP_THINK_PARAMETERS,
@@ -172,7 +178,10 @@ class OpenAICompatibleProvider(LLMProvider):
         wire_reasoning_effort: str | None = "none"
         strict_tools = True
 
-        for turn in range(max_tool_turns):
+        # ``max_tool_turns`` bounds tool-bearing responses. A model that uses
+        # the final allowed tool turn still needs one more request in which to
+        # return its answer.
+        for turn in range(max_tool_turns + 1):
             request: dict[str, Any] = {
                 "model": model_id,
                 "temperature": temperature,
@@ -198,6 +207,7 @@ class OpenAICompatibleProvider(LLMProvider):
                 request,
                 model_id=model_id,
                 constrained=constrained,
+                partial_usage=total_usage,
             )
             effective_effort = request.get("reasoning_effort")
             wire_reasoning_effort = effective_effort if isinstance(effective_effort, str) else None
@@ -205,13 +215,19 @@ class OpenAICompatibleProvider(LLMProvider):
             _add_usage(total_usage, response)
             choice = response.choices[0] if response.choices else None
             if choice is None:
-                raise ProviderError("OpenAI-compatible API returned no completion choices")
+                raise ProviderError(
+                    "OpenAI-compatible API returned no completion choices",
+                    usage=total_usage,
+                )
             message = choice.message
             tool_calls = list(getattr(message, "tool_calls", None) or [])
 
             if not tool_calls:
                 if turn == 0:
-                    raise ProviderError("OpenAI-compatible endpoint did not honor required deep_think tool choice")
+                    raise ThinkingUnsupportedError(
+                        "OpenAI-compatible endpoint did not honor required deep_think tool choice",
+                        usage=total_usage,
+                    )
                 return CompletionResult(
                     text=getattr(message, "content", None) or "",
                     model=model_id,
@@ -223,17 +239,29 @@ class OpenAICompatibleProvider(LLMProvider):
                     thinking_capture="tool",
                 )
 
+            if turn == max_tool_turns:
+                raise ProviderError(
+                    f"Model exceeded {max_tool_turns} deep_think tool turns",
+                    usage=total_usage,
+                )
+
             messages.append(_assistant_tool_message(message, tool_calls))
             for call in tool_calls:
                 function = getattr(call, "function", None)
                 name = getattr(function, "name", "")
                 if name != DEEP_THINK_TOOL_NAME:
-                    raise ProviderError(f"Unexpected thinking tool call: {name or '<missing>'}")
+                    raise ProviderError(
+                        f"Unexpected thinking tool call: {name or '<missing>'}",
+                        usage=total_usage,
+                    )
                 arguments = str(getattr(function, "arguments", "") or "")
                 try:
                     thinking_stream.append(extract_deep_thought(arguments))
                 except ValueError as exc:
-                    raise ProviderError(f"Invalid deep_think arguments: {exc}") from exc
+                    raise ProviderError(
+                        f"Invalid deep_think arguments: {exc}",
+                        usage=total_usage,
+                    ) from exc
                 messages.append(
                     {
                         "role": "tool",
@@ -242,7 +270,7 @@ class OpenAICompatibleProvider(LLMProvider):
                     }
                 )
 
-        raise ProviderError(f"Model exceeded {max_tool_turns} deep_think tool turns")
+        raise AssertionError("deep_think loop exhausted without returning or raising")
 
     def _create_chat_completion(
         self,
@@ -250,6 +278,7 @@ class OpenAICompatibleProvider(LLMProvider):
         *,
         model_id: str,
         constrained: bool,
+        partial_usage: dict[str, int] | None = None,
     ) -> tuple[Any, bool]:
         while True:
             try:
@@ -293,8 +322,16 @@ class OpenAICompatibleProvider(LLMProvider):
                         )
                         request["reasoning_effort"] = fallback_effort
                     continue
+                if _is_unsupported_tools_error(exc):
+                    raise ThinkingUnsupportedError(
+                        f"OpenAI-compatible endpoint does not support thinking tools: {exc}",
+                        usage=partial_usage,
+                    ) from exc
                 logger.debug("providers.openai_compat: caught Exception", exc_info=True)
-                raise ProviderError(f"OpenAI-compatible API error: {exc}") from exc
+                raise ProviderError(
+                    f"OpenAI-compatible API error: {exc}",
+                    usage=partial_usage,
+                ) from exc
 
     def default_model(self) -> str:
         return self._default_model
@@ -353,6 +390,23 @@ def _is_unsupported_strict_tools_error(exc: Exception) -> bool:
         for token in ("unsupported", "not supported", "unknown", "unrecognized", "unexpected", "invalid")
     )
     return mentions_field and rejection
+
+
+def _is_unsupported_tools_error(exc: Exception) -> bool:
+    """Identify endpoints that reject function/tool calling altogether."""
+    status_code = getattr(exc, "status_code", None)
+    if status_code not in {400, 404, 422}:
+        return False
+    message = str(exc).lower()
+    mentions_tools = any(
+        token in message
+        for token in ("tools", "tool_choice", "tool choice", "function calling", "function_call")
+    )
+    rejection = any(
+        token in message
+        for token in ("unsupported", "not supported", "unknown", "unrecognized", "invalid")
+    )
+    return mentions_tools and rejection
 
 
 def _request_uses_strict_tools(request: dict[str, Any]) -> bool:

--- a/autocontext/src/autocontext/providers/retry.py
+++ b/autocontext/src/autocontext/providers/retry.py
@@ -97,7 +97,7 @@ class RetryProvider(LLMProvider):
         temperature: float = 0.0,
         max_tokens: int = 4096,
         output_schema: OutputSchema | None = None,
-        reasoning_effort: str = "none",
+        reasoning_effort: str = "medium",
         max_tool_turns: int = 8,
     ) -> CompletionResult:
         """Retry the entire bounded thinking-tool conversation as one call."""

--- a/autocontext/src/autocontext/providers/retry.py
+++ b/autocontext/src/autocontext/providers/retry.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 
 from autocontext.providers.base import CompletionResult, LLMProvider, OutputSchema, ProviderError
 
@@ -77,16 +78,49 @@ class RetryProvider(LLMProvider):
         output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
         """Call the underlying provider with retry on transient errors."""
+        return self._call_with_retry(
+            lambda: self._provider.complete(
+                system_prompt,
+                user_prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                output_schema=output_schema,
+            )
+        )
+
+    def complete_with_thinking(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        output_schema: OutputSchema | None = None,
+        reasoning_effort: str = "none",
+        max_tool_turns: int = 8,
+    ) -> CompletionResult:
+        """Retry the entire bounded thinking-tool conversation as one call."""
+        return self._call_with_retry(
+            lambda: self._provider.complete_with_thinking(
+                system_prompt,
+                user_prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                output_schema=output_schema,
+                reasoning_effort=reasoning_effort,
+                max_tool_turns=max_tool_turns,
+            )
+        )
+
+    def _call_with_retry(self, operation: Callable[[], CompletionResult]) -> CompletionResult:
         last_error: Exception | None = None
         delay = self.base_delay
 
         for attempt in range(1 + self.max_retries):
             try:
-                return self._provider.complete(
-                    system_prompt, user_prompt,
-                    model=model, temperature=temperature, max_tokens=max_tokens,
-                    output_schema=output_schema,
-                )
+                return operation()
             except ProviderError as e:
                 last_error = e
                 if attempt == self.max_retries:
@@ -109,6 +143,10 @@ class RetryProvider(LLMProvider):
 
     def default_model(self) -> str:
         return self._provider.default_model()
+
+    @property
+    def supports_thinking_stream(self) -> bool:
+        return self._provider.supports_thinking_stream
 
     @property
     def name(self) -> str:

--- a/autocontext/src/autocontext/providers/retry.py
+++ b/autocontext/src/autocontext/providers/retry.py
@@ -117,12 +117,16 @@ class RetryProvider(LLMProvider):
     def _call_with_retry(self, operation: Callable[[], CompletionResult]) -> CompletionResult:
         last_error: Exception | None = None
         delay = self.base_delay
+        retry_usage: dict[str, int] = {}
 
         for attempt in range(1 + self.max_retries):
             try:
-                return operation()
+                result = operation()
+                _add_usage(result.usage, retry_usage)
+                return result
             except ProviderError as e:
                 last_error = e
+                _add_usage(retry_usage, e.usage)
                 if attempt == self.max_retries:
                     break
                 if not self.retry_all and not _is_transient(e):
@@ -139,6 +143,8 @@ class RetryProvider(LLMProvider):
                 time.sleep(delay)
                 delay = min(delay * self.backoff_factor, self.max_delay)
 
+        if isinstance(last_error, ProviderError):
+            last_error.usage = retry_usage
         raise last_error  # type: ignore[misc]
 
     def default_model(self) -> str:
@@ -151,3 +157,8 @@ class RetryProvider(LLMProvider):
     @property
     def name(self) -> str:
         return f"Retry({self._provider.name})"
+
+
+def _add_usage(total: dict[str, int], usage: dict[str, int]) -> None:
+    for key, value in usage.items():
+        total[key] = total.get(key, 0) + value

--- a/autocontext/src/autocontext/providers/thinking.py
+++ b/autocontext/src/autocontext/providers/thinking.py
@@ -13,38 +13,54 @@ DEEP_THINK_PARAMETERS: dict[str, Any] = {
     "required": ["thoughts"],
     "additionalProperties": False,
 }
+DEEP_THINK_JUICE_BY_EFFORT: dict[str, int] = {
+    "none": 0,
+    "minimal": 2,
+    "low": 4,
+    "medium": 8,
+    "high": 48,
+    "xhigh": 112,
+    "max": 960,
+}
 DEEP_THINK_SYSTEM_SUFFIX = (
-    "Use the deep_think tool as a private scratchpad before answering. Its arguments are captured "
-    "separately and are not part of the final answer. Call it again only for materially new reasoning, "
-    "then put only the requested deliverable in the final response."
+    "Use the deep_think tool as a private scratchpad before drafting the final answer. Restate the task "
+    "and constraints, resolve the work in ordered steps, and check likely errors or boundary cases there. "
+    "Its arguments are captured separately and are not part of the final answer. Call it again only for "
+    "materially new reasoning, never to narrate progress, then put only the requested deliverable in the "
+    "final response."
 )
 
 
-def with_deep_think_instruction(system_prompt: str) -> str:
+def deep_think_juice(reasoning_effort: str) -> int:
+    """Map an external-reasoning level to its prompt budget."""
+    return DEEP_THINK_JUICE_BY_EFFORT.get(reasoning_effort.lower().strip(), 8)
+
+
+def with_deep_think_instruction(system_prompt: str, *, juice: int | None = None) -> str:
     """Append the cross-provider thinking-tool instruction once."""
-    return f"{system_prompt.rstrip()}\n\n{DEEP_THINK_SYSTEM_SUFFIX}".strip()
+    instruction = f"{system_prompt.rstrip()}\n\n{DEEP_THINK_SYSTEM_SUFFIX}".strip()
+    if juice is not None:
+        instruction = f"{instruction}\n\n# Juice: {juice} !important"
+    return instruction
 
 
 def extract_deep_thought(payload: Any) -> str:
-    """Normalize tool input while preserving malformed/nonstandard payloads."""
+    """Validate and extract one strict ``deep_think`` payload."""
     if isinstance(payload, str):
         try:
             return extract_deep_thought(json.loads(payload))
-        except (TypeError, json.JSONDecodeError):
-            return payload.strip() or "<empty deep_think arguments>"
-    if isinstance(payload, dict):
-        thoughts = payload.get("thoughts")
-        if isinstance(thoughts, str):
-            return thoughts
-    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError("arguments must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("arguments must be an object")
+    if set(payload) != {"thoughts"}:
+        raise ValueError("arguments must contain only the required thoughts field")
+    thoughts = payload.get("thoughts")
+    if not isinstance(thoughts, str):
+        raise ValueError("thoughts must be a string")
+    return thoughts
 
 
 def deep_think_acknowledgement(index: int) -> str:
     """Return a content-free result so captured scratchpads are not re-injected."""
-    return json.dumps(
-        {
-            "recorded": index,
-            "next": "Resolve another material reasoning step with deep_think, or provide the final answer now.",
-        },
-        separators=(",", ":"),
-    )
+    return json.dumps({"recorded": index}, separators=(",", ":"))

--- a/autocontext/src/autocontext/providers/thinking.py
+++ b/autocontext/src/autocontext/providers/thinking.py
@@ -1,0 +1,50 @@
+"""Shared contract helpers for explicit provider thinking-tool capture."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+DEEP_THINK_TOOL_NAME = "deep_think"
+DEEP_THINK_DESCRIPTION = "Record private scratchpad reasoning before producing the final answer."
+DEEP_THINK_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {"thoughts": {"type": "string"}},
+    "required": ["thoughts"],
+    "additionalProperties": False,
+}
+DEEP_THINK_SYSTEM_SUFFIX = (
+    "Use the deep_think tool as a private scratchpad before answering. Its arguments are captured "
+    "separately and are not part of the final answer. Call it again only for materially new reasoning, "
+    "then put only the requested deliverable in the final response."
+)
+
+
+def with_deep_think_instruction(system_prompt: str) -> str:
+    """Append the cross-provider thinking-tool instruction once."""
+    return f"{system_prompt.rstrip()}\n\n{DEEP_THINK_SYSTEM_SUFFIX}".strip()
+
+
+def extract_deep_thought(payload: Any) -> str:
+    """Normalize tool input while preserving malformed/nonstandard payloads."""
+    if isinstance(payload, str):
+        try:
+            return extract_deep_thought(json.loads(payload))
+        except (TypeError, json.JSONDecodeError):
+            return payload.strip() or "<empty deep_think arguments>"
+    if isinstance(payload, dict):
+        thoughts = payload.get("thoughts")
+        if isinstance(thoughts, str):
+            return thoughts
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def deep_think_acknowledgement(index: int) -> str:
+    """Return a content-free result so captured scratchpads are not re-injected."""
+    return json.dumps(
+        {
+            "recorded": index,
+            "next": "Resolve another material reasoning step with deep_think, or provide the final answer now.",
+        },
+        separators=(",", ":"),
+    )

--- a/autocontext/src/autocontext/training/autoresearch/trace_collector.py
+++ b/autocontext/src/autocontext/training/autoresearch/trace_collector.py
@@ -11,6 +11,11 @@ This is the teacher-distillation counterpart to self-distillation: instead of
 bootstrapping from a student's own best samples, the small student inherits reasoning
 from a stronger teacher (a higher cold-start), and the two compose.
 
+Providers with thinking-tool support capture ordered ``deep_think`` calls separately
+from the final answer. The collector uses that stream as the training rationale and
+retains the individual calls for provenance; providers without that capability keep
+the existing visible-preamble fallback only when a caller explicitly opts into it.
+
 Pure helpers (prompt building, output parsing, record building) have no provider or
 scenario dependency and are unit-tested directly; ``collect`` wires them to a provider
 and a scenario.
@@ -89,9 +94,12 @@ def build_record(
     strategy: dict[str, Any],
     score: float,
     run_id: str,
+    thinking_stream: list[str] | None = None,
+    thinking_tool: str | None = None,
+    thinking_capture: str | None = None,
 ) -> dict[str, Any]:
     """Build one training record carrying the teacher's rationale + verified score."""
-    return {
+    record: dict[str, Any] = {
         "run_id": run_id,
         "scenario": scenario,
         "context": context,
@@ -99,6 +107,14 @@ def build_record(
         "strategy": strategy,
         "score": score,
     }
+    if thinking_stream:
+        record["thinking_stream"] = list(thinking_stream)
+        record["reasoning_source"] = thinking_tool or "deep_think"
+        record["thinking_capture"] = thinking_capture or "tool"
+    elif thinking_capture:
+        record["reasoning_source"] = "visible_preamble"
+        record["thinking_capture"] = thinking_capture
+    return record
 
 
 def collect(
@@ -110,13 +126,20 @@ def collect(
     temperature: float = 1.0,
     score_threshold: float = 0.0,
     run_id: str = "teacher",
+    reasoning_effort: str = "none",
+    max_tool_turns: int = 8,
+    require_thinking_stream: bool = True,
 ) -> list[dict[str, Any]]:
     """Collect verified teacher reasoning traces as training records.
 
     For each of ``n_traces`` attempts: prompt the teacher provider, parse its
     reasoning + construction, score the construction in-scenario, and keep it as a
     record only if the verified score is at least ``score_threshold``. Unparseable
-    outputs and provider errors are skipped (never pollute the dataset).
+    outputs and provider errors are skipped (never pollute the dataset). Providers
+    that support thinking collection force ``deep_think`` on the first turn and
+    may emit more scratchpad calls before the final answer. By default, providers
+    without a real structured stream are skipped; callers may explicitly set
+    ``require_thinking_stream=False`` to retain the visible-preamble fallback.
     """
     system, user = build_teacher_prompt(scenario)
     context = teacher_task_prompt(scenario)
@@ -128,13 +151,24 @@ def collect(
     records: list[dict[str, Any]] = []
     for i in range(max(0, n_traces)):
         try:
-            result = provider.complete(system, user, model=model, temperature=temperature)
+            result = provider.complete_with_thinking(
+                system,
+                user,
+                model=model,
+                temperature=temperature,
+                reasoning_effort=reasoning_effort,
+                max_tool_turns=max_tool_turns,
+            )
         except Exception:
             continue
         parsed = parse_teacher_output(result.text)
         if parsed is None:
             continue
-        reasoning, strategy = parsed
+        visible_reasoning, strategy = parsed
+        thinking_stream = [entry for entry in result.thinking_stream if entry.strip()]
+        if require_thinking_stream and not thinking_stream:
+            continue
+        reasoning = "\n\n".join(thinking_stream) if thinking_stream else visible_reasoning
         try:
             if is_game:
                 score = float(scenario.execute_match(strategy, seed=i).score)
@@ -152,6 +186,13 @@ def collect(
                 strategy=strategy,
                 score=score,
                 run_id=run_id,
+                thinking_stream=thinking_stream,
+                thinking_tool=result.thinking_tool,
+                thinking_capture=(
+                    result.thinking_capture
+                    if result.thinking_capture != "none"
+                    else ("tool" if thinking_stream else "unsupported")
+                ),
             )
         )
     return records

--- a/autocontext/src/autocontext/training/autoresearch/trace_collector.py
+++ b/autocontext/src/autocontext/training/autoresearch/trace_collector.py
@@ -126,7 +126,7 @@ def collect(
     temperature: float = 1.0,
     score_threshold: float = 0.0,
     run_id: str = "teacher",
-    reasoning_effort: str = "none",
+    reasoning_effort: str = "medium",
     max_tool_turns: int = 8,
     require_thinking_stream: bool = True,
 ) -> list[dict[str, Any]]:

--- a/autocontext/src/autocontext/training/autoresearch/trace_collector.py
+++ b/autocontext/src/autocontext/training/autoresearch/trace_collector.py
@@ -27,7 +27,7 @@ import json
 import re
 from typing import Any
 
-from autocontext.providers.base import LLMProvider
+from autocontext.providers.base import LLMProvider, ThinkingUnsupportedError
 from autocontext.training.autoresearch.sequence_format import resolve_scenario_context, resolve_scenario_name
 
 _TEACHER_SYSTEM = (
@@ -159,6 +159,21 @@ def collect(
                 reasoning_effort=reasoning_effort,
                 max_tool_turns=max_tool_turns,
             )
+        except ThinkingUnsupportedError:
+            if require_thinking_stream:
+                continue
+            try:
+                result = provider.complete(
+                    system,
+                    user,
+                    model=model,
+                    temperature=temperature,
+                )
+            except Exception:
+                continue
+            result.thinking_stream = []
+            result.thinking_tool = None
+            result.thinking_capture = "unsupported"
         except Exception:
             continue
         parsed = parse_teacher_output(result.text)

--- a/autocontext/tests/test_anthropic_deep_think.py
+++ b/autocontext/tests/test_anthropic_deep_think.py
@@ -64,6 +64,14 @@ def test_anthropic_deep_think_is_ordered_and_separate_from_final_text() -> None:
     tool_result = messages.calls[1]["messages"][-1]["content"][0]
     assert tool_result["type"] == "tool_result"
     assert "establish invariant" not in tool_result["content"]
+    assert tool_result["content"] == '{"recorded":1}'
+
+
+def test_anthropic_deep_think_fails_closed_on_invalid_tool_input() -> None:
+    provider, _ = _provider([_response(_tool_block({"unexpected": "shape"}))])
+
+    with pytest.raises(ProviderError, match="Invalid deep_think arguments"):
+        provider.complete_with_thinking("system", "user")
 
 
 def test_anthropic_deep_think_fails_when_required_call_is_ignored() -> None:

--- a/autocontext/tests/test_anthropic_deep_think.py
+++ b/autocontext/tests/test_anthropic_deep_think.py
@@ -82,10 +82,30 @@ def test_anthropic_deep_think_fails_when_required_call_is_ignored() -> None:
 
 
 def test_anthropic_deep_think_fails_closed_at_turn_limit() -> None:
-    provider, _ = _provider([_response(_tool_block({"thoughts": "still working"}))])
+    provider, _ = _provider(
+        [
+            _response(_tool_block({"thoughts": "first turn"}, "toolu-1")),
+            _response(_tool_block({"thoughts": "still working"}, "toolu-2")),
+        ]
+    )
 
     with pytest.raises(ProviderError, match="exceeded 1 deep_think tool turns"):
         provider.complete_with_thinking("system", "user", max_tool_turns=1)
+
+
+def test_anthropic_allows_final_answer_after_last_tool_turn() -> None:
+    provider, messages = _provider(
+        [
+            _response(_tool_block({"thoughts": "bounded thought"})),
+            _response(SimpleNamespace(type="text", text="final")),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user", max_tool_turns=1)
+
+    assert result.text == "final"
+    assert result.thinking_stream == ["bounded thought"]
+    assert len(messages.calls) == 2
 
 
 def test_anthropic_advertises_native_thinking_support() -> None:

--- a/autocontext/tests/test_anthropic_deep_think.py
+++ b/autocontext/tests/test_anthropic_deep_think.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from autocontext.providers.anthropic import AnthropicProvider
+from autocontext.providers.base import ProviderError
+
+
+class _Messages:
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **request: Any) -> Any:
+        self.calls.append(request)
+        return self.outcomes.pop(0)
+
+
+def _tool_block(thoughts: Any, call_id: str = "toolu-1") -> Any:
+    return SimpleNamespace(type="tool_use", id=call_id, name="deep_think", input=thoughts)
+
+
+def _response(*blocks: Any, tokens: tuple[int, int] = (3, 2), stop_reason: str = "end_turn") -> Any:
+    return SimpleNamespace(
+        content=list(blocks),
+        model="claude-stub",
+        usage=SimpleNamespace(input_tokens=tokens[0], output_tokens=tokens[1]),
+        stop_reason=stop_reason,
+    )
+
+
+def _provider(outcomes: list[Any]) -> tuple[AnthropicProvider, _Messages]:
+    messages = _Messages(outcomes)
+    provider = object.__new__(AnthropicProvider)
+    provider._default_model = "claude-stub"
+    provider._client = SimpleNamespace(messages=messages)
+    return provider, messages
+
+
+def test_anthropic_deep_think_is_ordered_and_separate_from_final_text() -> None:
+    provider, messages = _provider(
+        [
+            _response(_tool_block({"thoughts": "establish invariant"}), tokens=(5, 7), stop_reason="tool_use"),
+            _response(SimpleNamespace(type="text", text='{"answer":"done"}'), tokens=(11, 13)),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user")
+
+    assert result.text == '{"answer":"done"}'
+    assert result.thinking_stream == ["establish invariant"]
+    assert result.thinking_tool == "deep_think"
+    assert result.thinking_capture == "tool"
+    assert result.usage == {"input_tokens": 16, "output_tokens": 20}
+    assert messages.calls[0]["tool_choice"] == {
+        "type": "tool",
+        "name": "deep_think",
+        "disable_parallel_tool_use": True,
+    }
+    assert messages.calls[1]["tool_choice"] == {"type": "auto", "disable_parallel_tool_use": True}
+    tool_result = messages.calls[1]["messages"][-1]["content"][0]
+    assert tool_result["type"] == "tool_result"
+    assert "establish invariant" not in tool_result["content"]
+
+
+def test_anthropic_deep_think_fails_when_required_call_is_ignored() -> None:
+    provider, _ = _provider([_response(SimpleNamespace(type="text", text="uncaptured"))])
+
+    with pytest.raises(ProviderError, match="did not honor required deep_think"):
+        provider.complete_with_thinking("system", "user")
+
+
+def test_anthropic_deep_think_fails_closed_at_turn_limit() -> None:
+    provider, _ = _provider([_response(_tool_block({"thoughts": "still working"}))])
+
+    with pytest.raises(ProviderError, match="exceeded 1 deep_think tool turns"):
+        provider.complete_with_thinking("system", "user", max_tool_turns=1)
+
+
+def test_anthropic_advertises_native_thinking_support() -> None:
+    provider, _ = _provider([])
+    assert provider.supports_thinking_stream is True

--- a/autocontext/tests/test_extension_hooks.py
+++ b/autocontext/tests/test_extension_hooks.py
@@ -70,6 +70,21 @@ class _SchemaProvider(LLMProvider):
         return "stub"
 
 
+class _ThinkingProvider(_SchemaProvider):
+    def complete_with_thinking(self, *args: Any, **kwargs: Any) -> CompletionResult:
+        return CompletionResult(
+            text="final",
+            model="thinking-stub",
+            thinking_stream=["captured"],
+            thinking_tool="deep_think",
+            thinking_capture="tool",
+        )
+
+    @property
+    def supports_thinking_stream(self) -> bool:
+        return True
+
+
 class _Client(LanguageModelClient):
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
@@ -240,6 +255,20 @@ def test_provider_hooks_forward_schema_and_preserve_completion_metadata() -> Non
     assert inner.schemas == [schema]
     assert response.constrained is True
     assert response.stop_reason == "stop"
+
+
+def test_provider_hooks_preserve_native_thinking_capture() -> None:
+    from autocontext.extensions import HookBus, HookedLLMProvider
+
+    provider = HookedLLMProvider(_ThinkingProvider(), HookBus())
+
+    response = provider.complete_with_thinking("system", "user")
+
+    assert provider.supports_thinking_stream is True
+    assert response.text == "final"
+    assert response.thinking_stream == ["captured"]
+    assert response.thinking_tool == "deep_think"
+    assert response.thinking_capture == "tool"
 
 
 def test_prompt_hooks_transform_components_prompts_and_compaction() -> None:

--- a/autocontext/tests/test_openai_compat_deep_think.py
+++ b/autocontext/tests/test_openai_compat_deep_think.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from autocontext.providers.base import ProviderError
+from autocontext.providers.openai_compat import DEEP_THINK_TOOL_NAME, OpenAICompatibleProvider
+
+
+class _Completions:
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **request: Any) -> Any:
+        self.calls.append(request)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class _BadRequest(Exception):
+    status_code = 400
+
+
+def _tool_call(arguments: str, call_id: str = "call-1") -> Any:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=DEEP_THINK_TOOL_NAME, arguments=arguments),
+    )
+
+
+def _response(*, text: str | None = None, tool_calls: list[Any] | None = None, tokens: tuple[int, int] = (3, 2)) -> Any:
+    choice = SimpleNamespace(
+        message=SimpleNamespace(content=text, tool_calls=tool_calls),
+        finish_reason="tool_calls" if tool_calls else "stop",
+    )
+    usage = SimpleNamespace(prompt_tokens=tokens[0], completion_tokens=tokens[1])
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _provider(outcomes: list[Any]) -> tuple[OpenAICompatibleProvider, _Completions]:
+    completions = _Completions(outcomes)
+    provider = object.__new__(OpenAICompatibleProvider)
+    provider._default_model = "stub"
+    provider._client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    return provider, completions
+
+
+def test_deep_think_calls_are_ordered_and_separate_from_final_text() -> None:
+    provider, completions = _provider(
+        [
+            _response(tool_calls=[_tool_call('{"thoughts":"check the invariant"}')], tokens=(5, 7)),
+            _response(text='{"answer":"done"}', tokens=(11, 13)),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user", reasoning_effort="none")
+
+    assert result.text == '{"answer":"done"}'
+    assert result.thinking_stream == ["check the invariant"]
+    assert result.thinking_tool == "deep_think"
+    assert result.thinking_capture == "tool"
+    assert result.usage == {"input_tokens": 16, "output_tokens": 20}
+    assert completions.calls[0]["tool_choice"] == "required"
+    assert completions.calls[1]["tool_choice"] == "auto"
+    assert completions.calls[0]["parallel_tool_calls"] is False
+    assert completions.calls[0]["reasoning_effort"] == "none"
+    assert completions.calls[0]["tools"][0]["function"]["name"] == "deep_think"
+    assert completions.calls[1]["messages"][-1]["role"] == "tool"
+    assert "check the invariant" not in completions.calls[1]["messages"][-1]["content"]
+
+
+def test_deep_think_preserves_malformed_arguments_instead_of_dropping_them() -> None:
+    provider, _ = _provider(
+        [
+            _response(tool_calls=[_tool_call("unparseable scratchpad")]),
+            _response(text="final"),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user")
+
+    assert result.thinking_stream == ["unparseable scratchpad"]
+
+
+def test_deep_think_fails_when_required_first_call_is_ignored() -> None:
+    provider, _ = _provider([_response(text="uncaptured final")])
+
+    with pytest.raises(ProviderError, match="did not honor required deep_think"):
+        provider.complete_with_thinking("system", "user")
+
+
+def test_deep_think_fails_closed_at_tool_turn_limit() -> None:
+    provider, _ = _provider([_response(tool_calls=[_tool_call('{"thoughts":"still working"}')])])
+
+    with pytest.raises(ProviderError, match="exceeded 1 deep_think tool turns"):
+        provider.complete_with_thinking("system", "user", max_tool_turns=1)
+
+
+def test_deep_think_negotiates_only_unsupported_reasoning_effort() -> None:
+    provider, completions = _provider(
+        [
+            _BadRequest("unknown parameter reasoning_effort"),
+            _response(tool_calls=[_tool_call('{"thoughts":"portable tools"}')]),
+            _response(text="final"),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user")
+
+    assert result.thinking_stream == ["portable tools"]
+    assert completions.calls[0]["reasoning_effort"] == "none"
+    assert "reasoning_effort" not in completions.calls[1]
+    assert "reasoning_effort" not in completions.calls[2]
+
+
+def test_openai_compat_advertises_native_thinking_support() -> None:
+    provider, _ = _provider([])
+    assert provider.supports_thinking_stream is True

--- a/autocontext/tests/test_openai_compat_deep_think.py
+++ b/autocontext/tests/test_openai_compat_deep_think.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
 
@@ -15,7 +16,7 @@ class _Completions:
         self.calls: list[dict[str, Any]] = []
 
     def create(self, **request: Any) -> Any:
-        self.calls.append(request)
+        self.calls.append(deepcopy(request))
         outcome = self.outcomes.pop(0)
         if isinstance(outcome, Exception):
             raise outcome
@@ -43,10 +44,12 @@ def _response(*, text: str | None = None, tool_calls: list[Any] | None = None, t
     return SimpleNamespace(choices=[choice], usage=usage)
 
 
-def _provider(outcomes: list[Any]) -> tuple[OpenAICompatibleProvider, _Completions]:
+def _provider(
+    outcomes: list[Any], *, model: str = "stub"
+) -> tuple[OpenAICompatibleProvider, _Completions]:
     completions = _Completions(outcomes)
     provider = object.__new__(OpenAICompatibleProvider)
-    provider._default_model = "stub"
+    provider._default_model = model
     provider._client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
     return provider, completions
 
@@ -71,21 +74,21 @@ def test_deep_think_calls_are_ordered_and_separate_from_final_text() -> None:
     assert completions.calls[0]["parallel_tool_calls"] is False
     assert completions.calls[0]["reasoning_effort"] == "none"
     assert completions.calls[0]["tools"][0]["function"]["name"] == "deep_think"
+    assert completions.calls[0]["tools"][0]["function"]["strict"] is True
     assert completions.calls[1]["messages"][-1]["role"] == "tool"
     assert "check the invariant" not in completions.calls[1]["messages"][-1]["content"]
+    assert completions.calls[1]["messages"][-1]["content"] == '{"recorded":1}'
 
 
-def test_deep_think_preserves_malformed_arguments_instead_of_dropping_them() -> None:
+def test_deep_think_fails_closed_on_malformed_arguments() -> None:
     provider, _ = _provider(
         [
             _response(tool_calls=[_tool_call("unparseable scratchpad")]),
-            _response(text="final"),
         ]
     )
 
-    result = provider.complete_with_thinking("system", "user")
-
-    assert result.thinking_stream == ["unparseable scratchpad"]
+    with pytest.raises(ProviderError, match="Invalid deep_think arguments"):
+        provider.complete_with_thinking("system", "user")
 
 
 def test_deep_think_fails_when_required_first_call_is_ignored() -> None:
@@ -117,6 +120,55 @@ def test_deep_think_negotiates_only_unsupported_reasoning_effort() -> None:
     assert completions.calls[0]["reasoning_effort"] == "none"
     assert "reasoning_effort" not in completions.calls[1]
     assert "reasoning_effort" not in completions.calls[2]
+
+
+def test_deep_think_uses_lowest_gateway_level_when_none_is_rejected() -> None:
+    provider, completions = _provider(
+        [
+            _BadRequest('level "none" not supported, valid levels: low, medium, high'),
+            _response(tool_calls=[_tool_call('{"thoughts":"portable scratchpad"}')]),
+            _response(text="final"),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user", reasoning_effort="high")
+
+    assert result.thinking_stream == ["portable scratchpad"]
+    assert completions.calls[0]["reasoning_effort"] == "none"
+    assert completions.calls[1]["reasoning_effort"] == "low"
+    assert completions.calls[2]["reasoning_effort"] == "low"
+
+
+def test_deep_think_negotiates_strict_flag_but_validates_arguments_locally() -> None:
+    provider, completions = _provider(
+        [
+            _BadRequest("unknown field tools[0].function.strict"),
+            _response(tool_calls=[_tool_call('{"thoughts":"portable schema"}')]),
+            _response(text="final"),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user")
+
+    assert result.thinking_stream == ["portable schema"]
+    assert completions.calls[0]["tools"][0]["function"]["strict"] is True
+    assert "strict" not in completions.calls[1]["tools"][0]["function"]
+    assert "strict" not in completions.calls[2]["tools"][0]["function"]
+
+
+def test_deep_think_maps_gpt_56_external_effort_to_numeric_juice() -> None:
+    provider, completions = _provider(
+        [
+            _response(tool_calls=[_tool_call('{"thoughts":"budgeted scratchpad"}')]),
+            _response(text="final"),
+        ],
+        model="openai-codex/gpt-5.6-sol",
+    )
+
+    provider.complete_with_thinking("system", "user", reasoning_effort="high")
+
+    assert completions.calls[0]["reasoning_effort"] == "none"
+    assert completions.calls[0]["messages"][0]["content"].endswith("# Juice: 48 !important")
 
 
 def test_openai_compat_advertises_native_thinking_support() -> None:

--- a/autocontext/tests/test_openai_compat_deep_think.py
+++ b/autocontext/tests/test_openai_compat_deep_think.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import pytest
 
-from autocontext.providers.base import ProviderError
+from autocontext.providers.base import ProviderError, ThinkingUnsupportedError
 from autocontext.providers.openai_compat import DEEP_THINK_TOOL_NAME, OpenAICompatibleProvider
+from autocontext.providers.retry import RetryProvider
 
 
 class _Completions:
@@ -98,11 +99,55 @@ def test_deep_think_fails_when_required_first_call_is_ignored() -> None:
         provider.complete_with_thinking("system", "user")
 
 
+def test_deep_think_reports_endpoint_level_tool_rejection_as_unsupported() -> None:
+    provider, _ = _provider([_BadRequest("tools are not supported")])
+
+    with pytest.raises(ThinkingUnsupportedError, match="does not support thinking tools"):
+        provider.complete_with_thinking("system", "user")
+
+
 def test_deep_think_fails_closed_at_tool_turn_limit() -> None:
-    provider, _ = _provider([_response(tool_calls=[_tool_call('{"thoughts":"still working"}')])])
+    provider, _ = _provider(
+        [
+            _response(tool_calls=[_tool_call('{"thoughts":"first turn"}', "call-1")]),
+            _response(tool_calls=[_tool_call('{"thoughts":"still working"}', "call-2")]),
+        ]
+    )
 
     with pytest.raises(ProviderError, match="exceeded 1 deep_think tool turns"):
         provider.complete_with_thinking("system", "user", max_tool_turns=1)
+
+
+def test_deep_think_allows_final_answer_after_last_tool_turn() -> None:
+    provider, completions = _provider(
+        [
+            _response(tool_calls=[_tool_call('{"thoughts":"bounded thought"}')]),
+            _response(text="final"),
+        ]
+    )
+
+    result = provider.complete_with_thinking("system", "user", max_tool_turns=1)
+
+    assert result.text == "final"
+    assert result.thinking_stream == ["bounded thought"]
+    assert len(completions.calls) == 2
+
+
+def test_retry_preserves_usage_from_successful_turns_before_transient_failure() -> None:
+    provider, _ = _provider(
+        [
+            _response(tool_calls=[_tool_call('{"thoughts":"first attempt"}')], tokens=(5, 7)),
+            ProviderError("connection reset"),
+            _response(tool_calls=[_tool_call('{"thoughts":"retry"}')], tokens=(11, 13)),
+            _response(text="final", tokens=(17, 19)),
+        ]
+    )
+    retrying = RetryProvider(provider, max_retries=1, base_delay=0)
+
+    result = retrying.complete_with_thinking("system", "user")
+
+    assert result.text == "final"
+    assert result.usage == {"input_tokens": 33, "output_tokens": 39}
 
 
 def test_deep_think_negotiates_only_unsupported_reasoning_effort() -> None:

--- a/autocontext/tests/test_providers.py
+++ b/autocontext/tests/test_providers.py
@@ -72,6 +72,19 @@ class TestLLMProviderInterface:
         assert r.model is None
         assert r.usage == {}
         assert r.cost_usd is None
+        assert r.thinking_stream == []
+        assert r.thinking_tool is None
+        assert r.thinking_capture == "none"
+
+    def test_thinking_completion_falls_back_for_legacy_provider(self):
+        p = _DummyProvider("legacy")
+
+        result = p.complete_with_thinking("sys", "usr")
+
+        assert result.text == "legacy"
+        assert result.thinking_stream == []
+        assert result.thinking_capture == "unsupported"
+        assert p.supports_thinking_stream is False
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_retry_provider.py
+++ b/autocontext/tests/test_retry_provider.py
@@ -155,3 +155,23 @@ class TestRetryProvider:
         assert calls[0]["model"] == "custom"
         assert calls[0]["temperature"] == 0.5
         assert calls[0]["max_tokens"] == 100
+
+    def test_thinking_completion_delegates_through_retry_wrapper(self):
+        class ThinkingProvider(FakeProvider):
+            def complete_with_thinking(self, *args, **kwargs):
+                return CompletionResult(
+                    text="final",
+                    thinking_stream=["captured"],
+                    thinking_tool="deep_think",
+                )
+
+            @property
+            def supports_thinking_stream(self):
+                return True
+
+        provider = RetryProvider(ThinkingProvider(), max_retries=0)
+
+        result = provider.complete_with_thinking("s", "u", reasoning_effort="none")
+
+        assert result.thinking_stream == ["captured"]
+        assert provider.supports_thinking_stream is True

--- a/autocontext/tests/test_retry_provider.py
+++ b/autocontext/tests/test_retry_provider.py
@@ -75,6 +75,26 @@ class TestRetryProvider:
         assert result.text == "success"
         assert inner.call_count == 3  # 2 failures + 1 success
 
+    def test_retry_aggregates_partial_usage_into_success(self):
+        class PartialUsageProvider(FakeProvider):
+            def complete(self, system_prompt, user_prompt, **kwargs):
+                self.call_count += 1
+                if self.call_count == 1:
+                    raise ProviderError(
+                        "connection reset",
+                        usage={"input_tokens": 5, "output_tokens": 7},
+                    )
+                return CompletionResult(
+                    text="success",
+                    usage={"input_tokens": 11, "output_tokens": 13},
+                )
+
+        provider = RetryProvider(PartialUsageProvider(), max_retries=1, base_delay=0)
+
+        result = provider.complete("sys", "user")
+
+        assert result.usage == {"input_tokens": 16, "output_tokens": 20}
+
     def test_exhaust_retries(self):
         inner = FakeProvider(fail_count=10, error_msg="rate limit exceeded")
         provider = RetryProvider(inner, max_retries=2, base_delay=0.001)

--- a/autocontext/tests/test_trace_collector.py
+++ b/autocontext/tests/test_trace_collector.py
@@ -8,6 +8,7 @@ records carrying the rationale. Nothing here is tied to a specific model or vend
 
 from __future__ import annotations
 
+from autocontext.providers.base import CompletionResult, LLMProvider
 from autocontext.providers.callable_wrapper import CallableProvider
 from autocontext.scenarios.agent_task import AgentTaskResult
 
@@ -68,6 +69,35 @@ def test_build_record_carries_reasoning_and_score() -> None:
     assert rec["strategy"] == {"points": [1]}
     assert rec["score"] == 0.5
     assert rec["run_id"] == "t0"
+    assert "thinking_stream" not in rec
+    assert "reasoning_source" not in rec
+
+
+class _ThinkingProvider(LLMProvider):
+    def complete(self, system_prompt, user_prompt, model=None, temperature=0.0, max_tokens=4096, output_schema=None):
+        return CompletionResult(text='visible fallback\n{"points": [1, 2, 3, 4, 5]}')
+
+    def complete_with_thinking(self, *args, **kwargs):
+        return CompletionResult(
+            text='{"points": [1, 2, 3, 4, 5]}',
+            thinking_stream=["establish the invariant", "check the boundary case"],
+            thinking_tool="deep_think",
+        )
+
+    def default_model(self):
+        return "thinking-test"
+
+
+def test_collect_prefers_tool_captured_thinking_and_preserves_call_boundaries() -> None:
+    from autocontext.training.autoresearch.trace_collector import collect
+
+    records = collect(_FakeScenario(), _ThinkingProvider(), n_traces=1)
+
+    assert len(records) == 1
+    assert records[0]["reasoning"] == "establish the invariant\n\ncheck the boundary case"
+    assert records[0]["thinking_stream"] == ["establish the invariant", "check the boundary case"]
+    assert records[0]["reasoning_source"] == "deep_think"
+    assert records[0]["thinking_capture"] == "tool"
 
 
 def test_collect_is_provider_agnostic_and_verifies_in_scenario() -> None:
@@ -76,12 +106,28 @@ def test_collect_is_provider_agnostic_and_verifies_in_scenario() -> None:
 
     # teacher always returns a 5-point construction -> scenario scores it 0.5
     provider = CallableProvider(lambda system, user: 'use a wide spread\n{"points": [1,2,3,4,5]}')
-    records = collect(_FakeScenario(), provider, n_traces=3, score_threshold=0.0)
+    records = collect(
+        _FakeScenario(),
+        provider,
+        n_traces=3,
+        score_threshold=0.0,
+        require_thinking_stream=False,
+    )
 
     assert len(records) == 3
     assert all(r["reasoning"] == "use a wide spread" for r in records)
     assert all(r["score"] == 0.5 for r in records)  # verified in-scenario, not from the teacher
     assert all(r["scenario"] == "toy" for r in records)
+    assert all(r["reasoning_source"] == "visible_preamble" for r in records)
+    assert all(r["thinking_capture"] == "unsupported" for r in records)
+
+
+def test_collect_requires_real_thinking_stream_by_default() -> None:
+    from autocontext.training.autoresearch.trace_collector import collect
+
+    provider = CallableProvider(lambda system, user: 'visible only\n{"points": [1,2,3,4,5]}')
+
+    assert collect(_FakeScenario(), provider, n_traces=1) == []
 
 
 def test_collect_gates_by_verified_score_threshold() -> None:
@@ -89,7 +135,13 @@ def test_collect_gates_by_verified_score_threshold() -> None:
     from autocontext.training.autoresearch.trace_collector import collect
 
     provider = CallableProvider(lambda system, user: 'thin\n{"points": [1]}')  # scenario scores 0.1
-    records = collect(_FakeScenario(), provider, n_traces=4, score_threshold=0.5)
+    records = collect(
+        _FakeScenario(),
+        provider,
+        n_traces=4,
+        score_threshold=0.5,
+        require_thinking_stream=False,
+    )
     assert records == []
 
 
@@ -97,7 +149,13 @@ def test_collect_skips_unparseable_teacher_output() -> None:
     from autocontext.training.autoresearch.trace_collector import collect
 
     provider = CallableProvider(lambda system, user: "I refuse to produce JSON")
-    records = collect(_FakeScenario(), provider, n_traces=3, score_threshold=0.0)
+    records = collect(
+        _FakeScenario(),
+        provider,
+        n_traces=3,
+        score_threshold=0.0,
+        require_thinking_stream=False,
+    )
     assert records == []
 
 
@@ -126,7 +184,13 @@ def test_collect_supports_game_scenarios_via_execute_match() -> None:
     from autocontext.training.autoresearch.trace_collector import collect
 
     provider = CallableProvider(lambda system, user: 'spread out\n{"points": [1,2,3,4,5]}')
-    records = collect(_FakeGameScenario(), provider, n_traces=2, score_threshold=0.0)
+    records = collect(
+        _FakeGameScenario(),
+        provider,
+        n_traces=2,
+        score_threshold=0.0,
+        require_thinking_stream=False,
+    )
     assert len(records) == 2  # not dropped
     assert all(r["score"] == 0.5 for r in records)  # scored via execute_match
     assert all(r["reasoning"] == "spread out" for r in records)

--- a/autocontext/tests/test_trace_collector.py
+++ b/autocontext/tests/test_trace_collector.py
@@ -8,7 +8,12 @@ records carrying the rationale. Nothing here is tied to a specific model or vend
 
 from __future__ import annotations
 
-from autocontext.providers.base import CompletionResult, LLMProvider
+from autocontext.providers.base import (
+    CompletionResult,
+    LLMProvider,
+    ProviderError,
+    ThinkingUnsupportedError,
+)
 from autocontext.providers.callable_wrapper import CallableProvider
 from autocontext.scenarios.agent_task import AgentTaskResult
 
@@ -88,6 +93,26 @@ class _ThinkingProvider(LLMProvider):
         return "thinking-test"
 
 
+class _UnsupportedThinkingProvider(LLMProvider):
+    def __init__(self) -> None:
+        self.complete_calls = 0
+
+    def complete(self, system_prompt, user_prompt, **kwargs):
+        self.complete_calls += 1
+        return CompletionResult(text='visible fallback\n{"points": [1, 2, 3, 4, 5]}')
+
+    def complete_with_thinking(self, *args, **kwargs):
+        raise ThinkingUnsupportedError("tools are not supported")
+
+    def default_model(self):
+        return "unsupported-thinking-test"
+
+
+class _BrokenThinkingProvider(_UnsupportedThinkingProvider):
+    def complete_with_thinking(self, *args, **kwargs):
+        raise ProviderError("connection reset")
+
+
 def test_collect_prefers_tool_captured_thinking_and_preserves_call_boundaries() -> None:
     from autocontext.training.autoresearch.trace_collector import collect
 
@@ -128,6 +153,48 @@ def test_collect_requires_real_thinking_stream_by_default() -> None:
     provider = CallableProvider(lambda system, user: 'visible only\n{"points": [1,2,3,4,5]}')
 
     assert collect(_FakeScenario(), provider, n_traces=1) == []
+
+
+def test_collect_uses_explicit_visible_fallback_when_native_tools_are_unsupported() -> None:
+    from autocontext.training.autoresearch.trace_collector import collect
+
+    provider = _UnsupportedThinkingProvider()
+
+    records = collect(
+        _FakeScenario(),
+        provider,
+        n_traces=1,
+        require_thinking_stream=False,
+    )
+
+    assert len(records) == 1
+    assert records[0]["reasoning"] == "visible fallback"
+    assert records[0]["reasoning_source"] == "visible_preamble"
+    assert records[0]["thinking_capture"] == "unsupported"
+    assert provider.complete_calls == 1
+
+
+def test_collect_does_not_fallback_when_structured_stream_is_required() -> None:
+    from autocontext.training.autoresearch.trace_collector import collect
+
+    provider = _UnsupportedThinkingProvider()
+
+    assert collect(_FakeScenario(), provider, n_traces=1) == []
+    assert provider.complete_calls == 0
+
+
+def test_collect_does_not_convert_provider_failures_into_visible_fallbacks() -> None:
+    from autocontext.training.autoresearch.trace_collector import collect
+
+    provider = _BrokenThinkingProvider()
+
+    assert collect(
+        _FakeScenario(),
+        provider,
+        n_traces=1,
+        require_thinking_stream=False,
+    ) == []
+    assert provider.complete_calls == 0
 
 
 def test_collect_gates_by_verified_score_threshold() -> None:

--- a/ts/README.md
+++ b/ts/README.md
@@ -58,7 +58,10 @@ tool collection through the optional `LLMProvider.completeWithThinking` method.
 Use `completeWithThinkingFallback(provider, options)` for arbitrary providers:
 it calls the native loop when available and otherwise returns an empty
 `thinkingStream` with `thinkingCapture: "unsupported"`. Tool payloads never
-become `text`; treat them as sensitive data and apply trace redaction before
+become `text`. For GPT 5.6+ models, `reasoningEffort` selects the external
+numeric prompt budget while native reasoning is requested off; compatible
+gateways that reject `none` use their lowest advertised level. Treat tool
+payloads as sensitive data and apply trace redaction before
 persistence or export. Local CLI/runtime and deterministic providers do not
 currently expose a structured tool channel.
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -53,6 +53,15 @@ AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_PI_COMMAND=pi autoctx solve "..." --it
 
 Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mistral`, `groq`, `openrouter`, `azure-openai`, `ollama`, `vllm`, `hermes`, `claude-cli`, `codex`, `pi`, `pi-rpc`, `deterministic`.
 
+Anthropic and OpenAI-compatible providers expose native, bounded `deep_think`
+tool collection through the optional `LLMProvider.completeWithThinking` method.
+Use `completeWithThinkingFallback(provider, options)` for arbitrary providers:
+it calls the native loop when available and otherwise returns an empty
+`thinkingStream` with `thinkingCapture: "unsupported"`. Tool payloads never
+become `text`; treat them as sensitive data and apply trace redaction before
+persistence or export. Local CLI/runtime and deterministic providers do not
+currently expose a structured tool channel.
+
 Provider routing details live in [../autocontext/docs/agent-integration.md](../autocontext/docs/agent-integration.md).
 Use `AUTOCONTEXT_PROVIDER_HOSTING=local|remote` to override transport-based
 hosting inference and `AUTOCONTEXT_PROVIDER_CAPABILITY=fast|mid_tier|frontier`

--- a/ts/src/agents/provider-bridge.ts
+++ b/ts/src/agents/provider-bridge.ts
@@ -8,7 +8,11 @@ import type {
   LLMProvider,
   ThinkingCompletionOptions,
 } from "../types/index.js";
-import { completeWithThinkingFallback } from "../providers/thinking.js";
+import { ProviderError } from "../types/index.js";
+import {
+  addCompletionUsage,
+  completeWithThinkingFallback,
+} from "../providers/thinking.js";
 import type { AgentRuntime } from "../runtimes/base.js";
 import { RuntimeSessionAgentRuntime } from "../runtimes/runtime-session-agent.js";
 import type { RuntimeCommandGrant } from "../runtimes/workspace-env.js";
@@ -135,17 +139,23 @@ export class RetryProvider implements LLMProvider {
 
   async #withRetry(operation: () => Promise<CompletionResult>): Promise<CompletionResult> {
     let lastError: Error | undefined;
+    const retryUsage: Record<string, number> = {};
     for (let attempt = 0; attempt <= this.#maxRetries; attempt++) {
       try {
-        return await operation();
+        const result = await operation();
+        const usage = { ...result.usage };
+        addCompletionUsage(usage, retryUsage);
+        return { ...result, usage };
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
+        if (err instanceof ProviderError) addCompletionUsage(retryUsage, err.usage);
         if (attempt < this.#maxRetries) {
           const delay = Math.min(this.#baseDelay * 2 ** attempt, this.#maxDelay);
           await new Promise((r) => setTimeout(r, delay));
         }
       }
     }
+    if (lastError instanceof ProviderError) lastError.usage = retryUsage;
     throw lastError!;
   }
 }

--- a/ts/src/agents/provider-bridge.ts
+++ b/ts/src/agents/provider-bridge.ts
@@ -3,7 +3,12 @@
  * Adapts AgentRuntime into LLMProvider interface with retry support.
  */
 
-import type { CompletionResult, LLMProvider } from "../types/index.js";
+import type {
+  CompletionResult,
+  LLMProvider,
+  ThinkingCompletionOptions,
+} from "../types/index.js";
+import { completeWithThinkingFallback } from "../providers/thinking.js";
 import type { AgentRuntime } from "../runtimes/base.js";
 import { RuntimeSessionAgentRuntime } from "../runtimes/runtime-session-agent.js";
 import type { RuntimeCommandGrant } from "../runtimes/workspace-env.js";
@@ -33,6 +38,10 @@ export class RuntimeBridgeProvider implements LLMProvider {
 
   get supportsConcurrentRequests() {
     return this.#runtime.supportsConcurrentRequests !== false;
+  }
+
+  get supportsThinkingStream() {
+    return false;
   }
 
   defaultModel() {
@@ -98,6 +107,10 @@ export class RetryProvider implements LLMProvider {
     return this.#inner.supportsConcurrentRequests !== false;
   }
 
+  get supportsThinkingStream() {
+    return this.#inner.supportsThinkingStream === true;
+  }
+
   defaultModel() {
     return this.#inner.defaultModel();
   }
@@ -113,10 +126,18 @@ export class RetryProvider implements LLMProvider {
     temperature?: number;
     maxTokens?: number;
   }): Promise<CompletionResult> {
+    return this.#withRetry(() => this.#inner.complete(opts));
+  }
+
+  async completeWithThinking(opts: ThinkingCompletionOptions): Promise<CompletionResult> {
+    return this.#withRetry(() => completeWithThinkingFallback(this.#inner, opts));
+  }
+
+  async #withRetry(operation: () => Promise<CompletionResult>): Promise<CompletionResult> {
     let lastError: Error | undefined;
     for (let attempt = 0; attempt <= this.#maxRetries; attempt++) {
       try {
-        return await this.#inner.complete(opts);
+        return await operation();
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
         if (attempt < this.#maxRetries) {

--- a/ts/src/providers/deterministic.ts
+++ b/ts/src/providers/deterministic.ts
@@ -7,6 +7,7 @@ import type { CompletionResult, LLMProvider } from "../types/index.js";
 
 export class DeterministicProvider implements LLMProvider {
   readonly name = "deterministic";
+  readonly supportsThinkingStream = false;
 
   defaultModel(): string {
     return "deterministic-dev";

--- a/ts/src/providers/index.ts
+++ b/ts/src/providers/index.ts
@@ -59,3 +59,10 @@ export {
   type RoleRoutingSettings,
   type RoutedProviderConfig,
 } from "./role-routing.js";
+
+export {
+  DEEP_THINK_DESCRIPTION,
+  DEEP_THINK_PARAMETERS,
+  DEEP_THINK_TOOL_NAME,
+  completeWithThinkingFallback,
+} from "./thinking.js";

--- a/ts/src/providers/panel-runtime.ts
+++ b/ts/src/providers/panel-runtime.ts
@@ -62,6 +62,7 @@ export function parsePanelConfigForRole(settings: PanelSettings, role: string): 
 
 export class PanelProvider implements LLMProvider {
   readonly name: string;
+  readonly supportsThinkingStream = false;
 
   constructor(
     private readonly opts: {

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -1,7 +1,20 @@
 import { ProviderError } from "../types/index.js";
 import { clampOutputTokens } from "./token-caps.js";
-import type { CompletionResult, LLMProvider } from "../types/index.js";
+import type {
+  CompletionResult,
+  LLMProvider,
+} from "../types/index.js";
 import { DeterministicProvider } from "./deterministic.js";
+import {
+  DEEP_THINK_DESCRIPTION,
+  DEEP_THINK_PARAMETERS,
+  DEEP_THINK_TOOL_NAME,
+  addCompletionUsage,
+  deepThinkAcknowledgement,
+  extractDeepThought,
+  isRecord,
+  withDeepThinkInstruction,
+} from "./thinking.js";
 import { ClaudeCLIRuntime } from "../runtimes/claude-cli.js";
 import { CodexCLIRuntime, CodexCLIConfig } from "../runtimes/codex-cli.js";
 import { PiCLIRuntime, PiCLIConfig } from "../runtimes/pi-cli.js";
@@ -25,41 +38,41 @@ export interface AnthropicProviderOpts {
 export function createAnthropicProvider(opts: AnthropicProviderOpts): LLMProvider {
   const defaultModel = opts.model || "claude-sonnet-4-20250514";
 
+  const post = async (body: Record<string, unknown>): Promise<AnthropicMessageResponse> => {
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": opts.apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text();
+      throw new ProviderError(`Anthropic API error ${res.status}: ${errorBody.slice(0, 200)}`);
+    }
+    return parseAnthropicMessageResponse(await res.json());
+  };
+
   return {
     name: "anthropic",
+    supportsThinkingStream: true,
     defaultModel: () => defaultModel,
     complete: async (callOpts) => {
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": opts.apiKey,
-          "anthropic-version": "2023-06-01",
-        },
-        body: JSON.stringify({
-          model: callOpts.model || defaultModel,
-          max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, callOpts.model || defaultModel),
-          temperature: callOpts.temperature ?? 0,
-          system: callOpts.systemPrompt,
-          messages: [{ role: "user", content: callOpts.userPrompt }],
-        }),
+      const model = callOpts.model || defaultModel;
+      const data = await post({
+        model,
+        max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, model),
+        temperature: callOpts.temperature ?? 0,
+        system: callOpts.systemPrompt,
+        messages: [{ role: "user", content: callOpts.userPrompt }],
       });
-
-      if (!res.ok) {
-        const body = await res.text();
-        throw new ProviderError(`Anthropic API error ${res.status}: ${body.slice(0, 200)}`);
-      }
-
-      const data = (await res.json()) as {
-        content: Array<{ type: string; text: string }>;
-        model: string;
-        usage: { input_tokens: number; output_tokens: number };
-        stop_reason?: string;
-      };
 
       const text = data.content
         .filter((c) => c.type === "text")
-        .map((c) => c.text)
+        .map((c) => c.text ?? "")
         .join("");
 
       return {
@@ -69,6 +82,131 @@ export function createAnthropicProvider(opts: AnthropicProviderOpts): LLMProvide
         stopReason: data.stop_reason,
       } satisfies CompletionResult;
     },
+    completeWithThinking: async (callOpts) => {
+      const maxToolTurns = callOpts.maxToolTurns ?? 8;
+      if (maxToolTurns < 1) throw new RangeError("maxToolTurns must be at least 1");
+
+      const model = callOpts.model || defaultModel;
+      const messages: Array<Record<string, unknown>> = [
+        { role: "user", content: callOpts.userPrompt },
+      ];
+      const thinkingStream: string[] = [];
+      const usage: Record<string, number> = {};
+
+      for (let turn = 0; turn < maxToolTurns; turn++) {
+        const toolChoice =
+          turn === 0
+            ? { type: "tool", name: DEEP_THINK_TOOL_NAME, disable_parallel_tool_use: true }
+            : { type: "auto", disable_parallel_tool_use: true };
+        const data = await post({
+          model,
+          max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, model),
+          temperature: callOpts.temperature ?? 0,
+          system: withDeepThinkInstruction(callOpts.systemPrompt),
+          messages,
+          tools: [
+            {
+              name: DEEP_THINK_TOOL_NAME,
+              description: DEEP_THINK_DESCRIPTION,
+              input_schema: DEEP_THINK_PARAMETERS,
+            },
+          ],
+          tool_choice: toolChoice,
+        });
+        addCompletionUsage(usage, {
+          input: data.usage.input_tokens,
+          output: data.usage.output_tokens,
+        });
+
+        const toolBlocks = data.content.filter((block) => block.type === "tool_use");
+        if (toolBlocks.length === 0) {
+          if (turn === 0) {
+            throw new ProviderError("Anthropic API did not honor required deep_think tool choice");
+          }
+          return {
+            text: data.content
+              .filter((block) => block.type === "text")
+              .map((block) => block.text ?? "")
+              .join(""),
+            model: data.model,
+            usage,
+            stopReason: data.stop_reason,
+            constrained: false,
+            thinkingStream,
+            thinkingTool: DEEP_THINK_TOOL_NAME,
+            thinkingCapture: "tool",
+          } satisfies CompletionResult;
+        }
+
+        messages.push({ role: "assistant", content: data.content });
+        const toolResults: Array<Record<string, unknown>> = [];
+        for (const block of toolBlocks) {
+          if (block.name !== DEEP_THINK_TOOL_NAME) {
+            throw new ProviderError(
+              `Unexpected thinking tool call: ${block.name || "<missing>"}`,
+            );
+          }
+          thinkingStream.push(extractDeepThought(block.input));
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: block.id ?? "",
+            content: deepThinkAcknowledgement(thinkingStream.length),
+          });
+        }
+        messages.push({ role: "user", content: toolResults });
+      }
+      throw new ProviderError(`Model exceeded ${maxToolTurns} deep_think tool turns`);
+    },
+  };
+}
+
+interface AnthropicContentBlock {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+}
+
+interface AnthropicMessageResponse {
+  content: AnthropicContentBlock[];
+  model: string;
+  usage: { input_tokens: number; output_tokens: number };
+  stop_reason?: string;
+}
+
+function parseAnthropicMessageResponse(value: unknown): AnthropicMessageResponse {
+  if (!isRecord(value) || !Array.isArray(value["content"])) {
+    throw new ProviderError("Anthropic API returned a malformed message response");
+  }
+  const usage = value["usage"];
+  if (
+    typeof value["model"] !== "string" ||
+    !isRecord(usage) ||
+    typeof usage["input_tokens"] !== "number" ||
+    typeof usage["output_tokens"] !== "number"
+  ) {
+    throw new ProviderError("Anthropic API returned malformed model or usage metadata");
+  }
+  const content = value["content"].map((raw): AnthropicContentBlock => {
+    if (!isRecord(raw) || typeof raw["type"] !== "string") {
+      throw new ProviderError("Anthropic API returned a malformed content block");
+    }
+    const block: AnthropicContentBlock = { type: raw["type"] };
+    if (typeof raw["text"] === "string") block.text = raw["text"];
+    if (typeof raw["id"] === "string") block.id = raw["id"];
+    if (typeof raw["name"] === "string") block.name = raw["name"];
+    if ("input" in raw) block.input = raw["input"];
+    return block;
+  });
+  return {
+    content,
+    model: value["model"],
+    usage: {
+      input_tokens: usage["input_tokens"],
+      output_tokens: usage["output_tokens"],
+    },
+    ...(typeof value["stop_reason"] === "string" ? { stop_reason: value["stop_reason"] } : {}),
   };
 }
 
@@ -93,6 +231,21 @@ function isUnsupportedResponseFormatError(status: number, body: string): boolean
   return mentionsSchema && rejectsSchema;
 }
 
+function isUnsupportedReasoningEffortError(status: number, body: string): boolean {
+  if (![400, 404, 422].includes(status)) return false;
+  const message = body.toLowerCase();
+  const mentionsField =
+    message.includes("reasoning_effort") || message.includes("reasoning effort");
+  const rejectsField = [
+    "unsupported",
+    "not supported",
+    "unknown",
+    "unrecognized",
+    "invalid",
+  ].some((token) => message.includes(token));
+  return mentionsField && rejectsField;
+}
+
 export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpts): LLMProvider {
   const defaultModel = opts.model || "gpt-4o";
   const baseUrl = (opts.baseUrl ?? "https://api.openai.com/v1").replace(/\/+$/, "");
@@ -100,6 +253,7 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
 
   return {
     name: "openai-compatible",
+    supportsThinkingStream: true,
     defaultModel: () => defaultModel,
     complete: async (callOpts) => {
       const buildBody = (withSchema: boolean) =>
@@ -156,11 +310,7 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
         throw new ProviderError(`OpenAI API error ${res.status}: ${body.slice(0, 200)}`);
       }
 
-      const data = (await res.json()) as {
-        choices: Array<{ message: { content: string }; finish_reason?: string }>;
-        model: string;
-        usage: { prompt_tokens: number; completion_tokens: number };
-      };
+      const data = parseOpenAIChatResponse(await res.json());
 
       const text = data.choices[0]?.message?.content ?? "";
       return {
@@ -170,6 +320,203 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
         stopReason: data.choices[0]?.finish_reason,
         constrained,
       } satisfies CompletionResult;
+    },
+    completeWithThinking: async (callOpts) => {
+      const maxToolTurns = callOpts.maxToolTurns ?? 8;
+      if (maxToolTurns < 1) throw new RangeError("maxToolTurns must be at least 1");
+
+      const model = callOpts.model || defaultModel;
+      const messages: Array<Record<string, unknown>> = [
+        { role: "system", content: withDeepThinkInstruction(callOpts.systemPrompt) },
+        { role: "user", content: callOpts.userPrompt },
+      ];
+      const thinkingStream: string[] = [];
+      const usage: Record<string, number> = {};
+      let constrained = Boolean(callOpts.outputSchema);
+      let reasoningEffortSupported = true;
+
+      for (let turn = 0; turn < maxToolTurns; turn++) {
+        const body: Record<string, unknown> = {
+          model,
+          max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, model),
+          temperature: callOpts.temperature ?? 0,
+          messages,
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: DEEP_THINK_TOOL_NAME,
+                description: DEEP_THINK_DESCRIPTION,
+                parameters: DEEP_THINK_PARAMETERS,
+              },
+            },
+          ],
+          tool_choice: turn === 0 ? "required" : "auto",
+          parallel_tool_calls: false,
+        };
+        if (reasoningEffortSupported) {
+          body["reasoning_effort"] = callOpts.reasoningEffort ?? "none";
+        }
+        if (constrained && callOpts.outputSchema) {
+          body["response_format"] = {
+            type: "json_schema",
+            json_schema: {
+              name: callOpts.outputSchema.name,
+              strict: true,
+              schema: callOpts.outputSchema.schema,
+            },
+          };
+        }
+
+        let data: OpenAIChatResponse;
+        while (true) {
+          const res = await fetch(`${baseUrl}/chat/completions`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify(body),
+          });
+          if (res.ok) {
+            data = parseOpenAIChatResponse(await res.json());
+            break;
+          }
+
+          const errorBody = await res.text();
+          if (constrained && isUnsupportedResponseFormatError(res.status, errorBody)) {
+            constrained = false;
+            delete body["response_format"];
+            continue;
+          }
+          if (
+            "reasoning_effort" in body &&
+            isUnsupportedReasoningEffortError(res.status, errorBody)
+          ) {
+            reasoningEffortSupported = false;
+            delete body["reasoning_effort"];
+            continue;
+          }
+          throw new ProviderError(`OpenAI API error ${res.status}: ${errorBody.slice(0, 200)}`);
+        }
+
+        addCompletionUsage(usage, {
+          input: data.usage.prompt_tokens,
+          output: data.usage.completion_tokens,
+        });
+        const choice = data.choices[0];
+        if (!choice) throw new ProviderError("OpenAI-compatible API returned no completion choices");
+        const toolCalls = choice.message.tool_calls ?? [];
+        if (toolCalls.length === 0) {
+          if (turn === 0) {
+            throw new ProviderError(
+              "OpenAI-compatible endpoint did not honor required deep_think tool choice",
+            );
+          }
+          return {
+            text: choice.message.content ?? "",
+            model: data.model,
+            usage,
+            stopReason: choice.finish_reason,
+            constrained,
+            thinkingStream,
+            thinkingTool: DEEP_THINK_TOOL_NAME,
+            thinkingCapture: "tool",
+          } satisfies CompletionResult;
+        }
+
+        messages.push({
+          role: "assistant",
+          content: choice.message.content ?? null,
+          tool_calls: toolCalls,
+        });
+        for (const toolCall of toolCalls) {
+          const name = toolCall.function?.name ?? "";
+          if (name !== DEEP_THINK_TOOL_NAME) {
+            throw new ProviderError(`Unexpected thinking tool call: ${name || "<missing>"}`);
+          }
+          thinkingStream.push(extractDeepThought(toolCall.function?.arguments));
+          messages.push({
+            role: "tool",
+            tool_call_id: toolCall.id ?? "",
+            content: deepThinkAcknowledgement(thinkingStream.length),
+          });
+        }
+      }
+      throw new ProviderError(`Model exceeded ${maxToolTurns} deep_think tool turns`);
+    },
+  };
+}
+
+interface OpenAIToolCall {
+  id?: string;
+  type?: string;
+  function?: { name?: string; arguments?: unknown };
+}
+
+interface OpenAIChatResponse {
+  choices: Array<{
+    message: { content: string | null; tool_calls?: OpenAIToolCall[] };
+    finish_reason?: string;
+  }>;
+  model: string;
+  usage: { prompt_tokens: number; completion_tokens: number };
+}
+
+function parseOpenAIChatResponse(value: unknown): OpenAIChatResponse {
+  if (!isRecord(value) || !Array.isArray(value["choices"])) {
+    throw new ProviderError("OpenAI-compatible API returned a malformed chat response");
+  }
+  const usage = value["usage"];
+  if (
+    typeof value["model"] !== "string" ||
+    !isRecord(usage) ||
+    typeof usage["prompt_tokens"] !== "number" ||
+    typeof usage["completion_tokens"] !== "number"
+  ) {
+    throw new ProviderError("OpenAI-compatible API returned malformed model or usage metadata");
+  }
+  const choices = value["choices"].map((rawChoice) => {
+    if (!isRecord(rawChoice) || !isRecord(rawChoice["message"])) {
+      throw new ProviderError("OpenAI-compatible API returned a malformed completion choice");
+    }
+    const rawMessage = rawChoice["message"];
+    let toolCalls: OpenAIToolCall[] | undefined;
+    if (Array.isArray(rawMessage["tool_calls"])) {
+      toolCalls = rawMessage["tool_calls"].map((rawToolCall): OpenAIToolCall => {
+        if (!isRecord(rawToolCall)) {
+          throw new ProviderError("OpenAI-compatible API returned a malformed tool call");
+        }
+        const rawFunction = rawToolCall["function"];
+        const toolCall: OpenAIToolCall = {};
+        if (typeof rawToolCall["id"] === "string") toolCall.id = rawToolCall["id"];
+        if (typeof rawToolCall["type"] === "string") toolCall.type = rawToolCall["type"];
+        if (isRecord(rawFunction)) {
+          toolCall.function = {};
+          if (typeof rawFunction["name"] === "string") {
+            toolCall.function.name = rawFunction["name"];
+          }
+          if ("arguments" in rawFunction) toolCall.function.arguments = rawFunction["arguments"];
+        }
+        return toolCall;
+      });
+    }
+    return {
+      message: {
+        content: typeof rawMessage["content"] === "string" ? rawMessage["content"] : null,
+        ...(toolCalls ? { tool_calls: toolCalls } : {}),
+      },
+      ...(typeof rawChoice["finish_reason"] === "string"
+        ? { finish_reason: rawChoice["finish_reason"] }
+        : {}),
+    };
+  });
+  return {
+    choices,
+    model: value["model"],
+    usage: {
+      prompt_tokens: usage["prompt_tokens"],
+      completion_tokens: usage["completion_tokens"],
     },
   };
 }

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "../types/index.js";
+import { ProviderError, ThinkingUnsupportedError } from "../types/index.js";
 import { clampOutputTokens } from "./token-caps.js";
 import type {
   CompletionResult,
@@ -94,26 +94,34 @@ export function createAnthropicProvider(opts: AnthropicProviderOpts): LLMProvide
       const thinkingStream: string[] = [];
       const usage: Record<string, number> = {};
 
-      for (let turn = 0; turn < maxToolTurns; turn++) {
+      // maxToolTurns bounds tool-bearing responses. The final permitted tool
+      // turn still needs one subsequent request for the answer.
+      for (let turn = 0; turn <= maxToolTurns; turn++) {
         const toolChoice =
           turn === 0
             ? { type: "tool", name: DEEP_THINK_TOOL_NAME, disable_parallel_tool_use: true }
             : { type: "auto", disable_parallel_tool_use: true };
-        const data = await post({
-          model,
-          max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, model),
-          temperature: callOpts.temperature ?? 0,
-          system: withDeepThinkInstruction(callOpts.systemPrompt),
-          messages,
-          tools: [
-            {
-              name: DEEP_THINK_TOOL_NAME,
-              description: DEEP_THINK_DESCRIPTION,
-              input_schema: DEEP_THINK_PARAMETERS,
-            },
-          ],
-          tool_choice: toolChoice,
-        });
+        let data: AnthropicMessageResponse;
+        try {
+          data = await post({
+            model,
+            max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, model),
+            temperature: callOpts.temperature ?? 0,
+            system: withDeepThinkInstruction(callOpts.systemPrompt),
+            messages,
+            tools: [
+              {
+                name: DEEP_THINK_TOOL_NAME,
+                description: DEEP_THINK_DESCRIPTION,
+                input_schema: DEEP_THINK_PARAMETERS,
+              },
+            ],
+            tool_choice: toolChoice,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new ProviderError(message, usage);
+        }
         addCompletionUsage(usage, {
           input: data.usage.input_tokens,
           output: data.usage.output_tokens,
@@ -122,7 +130,10 @@ export function createAnthropicProvider(opts: AnthropicProviderOpts): LLMProvide
         const toolBlocks = data.content.filter((block) => block.type === "tool_use");
         if (toolBlocks.length === 0) {
           if (turn === 0) {
-            throw new ProviderError("Anthropic API did not honor required deep_think tool choice");
+            throw new ThinkingUnsupportedError(
+              "Anthropic API did not honor required deep_think tool choice",
+              usage,
+            );
           }
           return {
             text: data.content
@@ -139,15 +150,25 @@ export function createAnthropicProvider(opts: AnthropicProviderOpts): LLMProvide
           } satisfies CompletionResult;
         }
 
+        if (turn === maxToolTurns) {
+          throw new ProviderError(`Model exceeded ${maxToolTurns} deep_think tool turns`, usage);
+        }
+
         messages.push({ role: "assistant", content: data.content });
         const toolResults: Array<Record<string, unknown>> = [];
         for (const block of toolBlocks) {
           if (block.name !== DEEP_THINK_TOOL_NAME) {
             throw new ProviderError(
               `Unexpected thinking tool call: ${block.name || "<missing>"}`,
+              usage,
             );
           }
-          thinkingStream.push(extractDeepThought(block.input));
+          try {
+            thinkingStream.push(extractDeepThought(block.input));
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new ProviderError(message, usage);
+          }
           toolResults.push({
             type: "tool_result",
             tool_use_id: block.id ?? "",
@@ -156,7 +177,7 @@ export function createAnthropicProvider(opts: AnthropicProviderOpts): LLMProvide
         }
         messages.push({ role: "user", content: toolResults });
       }
-      throw new ProviderError(`Model exceeded ${maxToolTurns} deep_think tool turns`);
+      throw new Error("deep_think loop exhausted without returning or raising");
     },
   };
 }
@@ -263,6 +284,26 @@ function isUnsupportedStrictToolsError(status: number, body: string): boolean {
     "invalid",
   ].some((token) => message.includes(token));
   return mentionsField && rejectsField;
+}
+
+function isUnsupportedToolsError(status: number, body: string): boolean {
+  if (![400, 404, 422].includes(status)) return false;
+  const message = body.toLowerCase();
+  const mentionsTools = [
+    "tools",
+    "tool_choice",
+    "tool choice",
+    "function calling",
+    "function_call",
+  ].some((token) => message.includes(token));
+  const rejectsTools = [
+    "unsupported",
+    "not supported",
+    "unknown",
+    "unrecognized",
+    "invalid",
+  ].some((token) => message.includes(token));
+  return mentionsTools && rejectsTools;
 }
 
 const REASONING_EFFORT_ORDER = [
@@ -387,7 +428,9 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
       let wireReasoningEffort: string | undefined = "none";
       let strictTools = true;
 
-      for (let turn = 0; turn < maxToolTurns; turn++) {
+      // maxToolTurns bounds tool-bearing responses, with one extra request
+      // available for the model to return its final answer.
+      for (let turn = 0; turn <= maxToolTurns; turn++) {
         const body: Record<string, unknown> = {
           model,
           max_tokens: clampOutputTokens(callOpts.maxTokens ?? 4096, model),
@@ -423,16 +466,27 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
 
         let data: OpenAIChatResponse;
         while (true) {
-          const res = await fetch(`${baseUrl}/chat/completions`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${apiKey}`,
-            },
-            body: JSON.stringify(body),
-          });
+          let res: Response;
+          try {
+            res = await fetch(`${baseUrl}/chat/completions`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${apiKey}`,
+              },
+              body: JSON.stringify(body),
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new ProviderError(`OpenAI API error: ${message}`, usage);
+          }
           if (res.ok) {
-            data = parseOpenAIChatResponse(await res.json());
+            try {
+              data = parseOpenAIChatResponse(await res.json());
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              throw new ProviderError(message, usage);
+            }
             break;
           }
 
@@ -465,7 +519,16 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
             }
             continue;
           }
-          throw new ProviderError(`OpenAI API error ${res.status}: ${errorBody.slice(0, 200)}`);
+          if (isUnsupportedToolsError(res.status, errorBody)) {
+            throw new ThinkingUnsupportedError(
+              `OpenAI-compatible endpoint does not support thinking tools: ${errorBody.slice(0, 200)}`,
+              usage,
+            );
+          }
+          throw new ProviderError(
+            `OpenAI API error ${res.status}: ${errorBody.slice(0, 200)}`,
+            usage,
+          );
         }
 
         addCompletionUsage(usage, {
@@ -473,12 +536,15 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
           output: data.usage.completion_tokens,
         });
         const choice = data.choices[0];
-        if (!choice) throw new ProviderError("OpenAI-compatible API returned no completion choices");
+        if (!choice) {
+          throw new ProviderError("OpenAI-compatible API returned no completion choices", usage);
+        }
         const toolCalls = choice.message.tool_calls ?? [];
         if (toolCalls.length === 0) {
           if (turn === 0) {
-            throw new ProviderError(
+            throw new ThinkingUnsupportedError(
               "OpenAI-compatible endpoint did not honor required deep_think tool choice",
+              usage,
             );
           }
           return {
@@ -493,6 +559,10 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
           } satisfies CompletionResult;
         }
 
+        if (turn === maxToolTurns) {
+          throw new ProviderError(`Model exceeded ${maxToolTurns} deep_think tool turns`, usage);
+        }
+
         messages.push({
           role: "assistant",
           content: choice.message.content ?? null,
@@ -501,9 +571,17 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
         for (const toolCall of toolCalls) {
           const name = toolCall.function?.name ?? "";
           if (name !== DEEP_THINK_TOOL_NAME) {
-            throw new ProviderError(`Unexpected thinking tool call: ${name || "<missing>"}`);
+            throw new ProviderError(
+              `Unexpected thinking tool call: ${name || "<missing>"}`,
+              usage,
+            );
           }
-          thinkingStream.push(extractDeepThought(toolCall.function?.arguments));
+          try {
+            thinkingStream.push(extractDeepThought(toolCall.function?.arguments));
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new ProviderError(message, usage);
+          }
           messages.push({
             role: "tool",
             tool_call_id: toolCall.id ?? "",
@@ -511,7 +589,7 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
           });
         }
       }
-      throw new ProviderError(`Model exceeded ${maxToolTurns} deep_think tool turns`);
+      throw new Error("deep_think loop exhausted without returning or raising");
     },
   };
 }

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -10,6 +10,7 @@ import {
   DEEP_THINK_PARAMETERS,
   DEEP_THINK_TOOL_NAME,
   addCompletionUsage,
+  deepThinkJuice,
   deepThinkAcknowledgement,
   extractDeepThought,
   isRecord,
@@ -235,7 +236,9 @@ function isUnsupportedReasoningEffortError(status: number, body: string): boolea
   if (![400, 404, 422].includes(status)) return false;
   const message = body.toLowerCase();
   const mentionsField =
-    message.includes("reasoning_effort") || message.includes("reasoning effort");
+    message.includes("reasoning_effort") ||
+    message.includes("reasoning effort") ||
+    /(?:valid|supported|allowed) levels?/.test(message);
   const rejectsField = [
     "unsupported",
     "not supported",
@@ -244,6 +247,48 @@ function isUnsupportedReasoningEffortError(status: number, body: string): boolea
     "invalid",
   ].some((token) => message.includes(token));
   return mentionsField && rejectsField;
+}
+
+function isUnsupportedStrictToolsError(status: number, body: string): boolean {
+  if (![400, 404, 422].includes(status)) return false;
+  const message = body.toLowerCase();
+  const mentionsField =
+    message.includes("strict") && (message.includes("tool") || message.includes("function"));
+  const rejectsField = [
+    "unsupported",
+    "not supported",
+    "unknown",
+    "unrecognized",
+    "unexpected",
+    "invalid",
+  ].some((token) => message.includes(token));
+  return mentionsField && rejectsField;
+}
+
+const REASONING_EFFORT_ORDER = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+function lowestSupportedReasoningEffort(body: string, current: string): string | undefined {
+  const message = body.toLowerCase();
+  if (!/(?:valid|supported|allowed) levels?/.test(message)) return undefined;
+  const advertised = new Set(message.match(/\b(?:none|minimal|low|medium|high|xhigh|max)\b/g) ?? []);
+  advertised.delete(current.toLowerCase());
+  return REASONING_EFFORT_ORDER.find((effort) => advertised.has(effort));
+}
+
+function isGpt56Plus(model: string): boolean {
+  const match = /(?:^|[/:-])gpt-(\d+)(?:\.(\d+))?/i.exec(model);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2] ?? 0);
+  return major > 5 || (major === 5 && minor >= 6);
 }
 
 export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpts): LLMProvider {
@@ -326,14 +371,21 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
       if (maxToolTurns < 1) throw new RangeError("maxToolTurns must be at least 1");
 
       const model = callOpts.model || defaultModel;
+      const juice = isGpt56Plus(model)
+        ? deepThinkJuice(callOpts.reasoningEffort ?? "medium")
+        : undefined;
       const messages: Array<Record<string, unknown>> = [
-        { role: "system", content: withDeepThinkInstruction(callOpts.systemPrompt) },
+        { role: "system", content: withDeepThinkInstruction(callOpts.systemPrompt, juice) },
         { role: "user", content: callOpts.userPrompt },
       ];
       const thinkingStream: string[] = [];
       const usage: Record<string, number> = {};
       let constrained = Boolean(callOpts.outputSchema);
-      let reasoningEffortSupported = true;
+      // reasoningEffort controls the external prompt budget. Keep native
+      // hidden reasoning off so the explicit tool payload is what callers
+      // collect; gateways that reject `none` may advertise a lowest level.
+      let wireReasoningEffort: string | undefined = "none";
+      let strictTools = true;
 
       for (let turn = 0; turn < maxToolTurns; turn++) {
         const body: Record<string, unknown> = {
@@ -348,14 +400,15 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
                 name: DEEP_THINK_TOOL_NAME,
                 description: DEEP_THINK_DESCRIPTION,
                 parameters: DEEP_THINK_PARAMETERS,
+                ...(strictTools ? { strict: true } : {}),
               },
             },
           ],
           tool_choice: turn === 0 ? "required" : "auto",
           parallel_tool_calls: false,
         };
-        if (reasoningEffortSupported) {
-          body["reasoning_effort"] = callOpts.reasoningEffort ?? "none";
+        if (wireReasoningEffort !== undefined) {
+          body["reasoning_effort"] = wireReasoningEffort;
         }
         if (constrained && callOpts.outputSchema) {
           body["response_format"] = {
@@ -389,12 +442,27 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
             delete body["response_format"];
             continue;
           }
+          if (strictTools && isUnsupportedStrictToolsError(res.status, errorBody)) {
+            strictTools = false;
+            const tools = body["tools"];
+            const firstTool = Array.isArray(tools) ? tools[0] : undefined;
+            const toolFunction = isRecord(firstTool) ? firstTool["function"] : undefined;
+            if (isRecord(toolFunction)) delete toolFunction["strict"];
+            continue;
+          }
           if (
             "reasoning_effort" in body &&
             isUnsupportedReasoningEffortError(res.status, errorBody)
           ) {
-            reasoningEffortSupported = false;
-            delete body["reasoning_effort"];
+            const currentEffort = String(body["reasoning_effort"]);
+            const fallbackEffort = lowestSupportedReasoningEffort(errorBody, currentEffort);
+            if (fallbackEffort === undefined) {
+              wireReasoningEffort = undefined;
+              delete body["reasoning_effort"];
+            } else {
+              wireReasoningEffort = fallbackEffort;
+              body["reasoning_effort"] = fallbackEffort;
+            }
             continue;
           }
           throw new ProviderError(`OpenAI API error ${res.status}: ${errorBody.slice(0, 200)}`);

--- a/ts/src/providers/thinking.ts
+++ b/ts/src/providers/thinking.ts
@@ -3,7 +3,7 @@ import type {
   LLMProvider,
   ThinkingCompletionOptions,
 } from "../types/index.js";
-import { ProviderError } from "../types/index.js";
+import { ProviderError, ThinkingUnsupportedError } from "../types/index.js";
 
 export const DEEP_THINK_TOOL_NAME = "deep_think";
 export const DEEP_THINK_DESCRIPTION =
@@ -87,10 +87,21 @@ export async function completeWithThinkingFallback(
   provider: LLMProvider,
   opts: ThinkingCompletionOptions,
 ): Promise<CompletionResult> {
-  if (provider.completeWithThinking) return provider.completeWithThinking(opts);
+  let unsupportedUsage: Record<string, number> = {};
+  if (provider.completeWithThinking) {
+    try {
+      return await provider.completeWithThinking(opts);
+    } catch (error) {
+      if (!(error instanceof ThinkingUnsupportedError)) throw error;
+      unsupportedUsage = error.usage;
+    }
+  }
   const result = await provider.complete(opts);
+  const usage = { ...result.usage };
+  addCompletionUsage(usage, unsupportedUsage);
   return {
     ...result,
+    usage,
     thinkingStream: [],
     thinkingCapture: "unsupported",
   };

--- a/ts/src/providers/thinking.ts
+++ b/ts/src/providers/thinking.ts
@@ -1,0 +1,83 @@
+import type {
+  CompletionResult,
+  LLMProvider,
+  ThinkingCompletionOptions,
+} from "../types/index.js";
+
+export const DEEP_THINK_TOOL_NAME = "deep_think";
+export const DEEP_THINK_DESCRIPTION =
+  "Record private scratchpad reasoning before producing the final answer.";
+export const DEEP_THINK_PARAMETERS: Record<string, unknown> = {
+  type: "object",
+  properties: { thoughts: { type: "string" } },
+  required: ["thoughts"],
+  additionalProperties: false,
+};
+
+const DEEP_THINK_SYSTEM_SUFFIX =
+  "Use the deep_think tool as a private scratchpad before answering. Its arguments are captured " +
+  "separately and are not part of the final answer. Call it again only for materially new reasoning, " +
+  "then put only the requested deliverable in the final response.";
+
+export function withDeepThinkInstruction(systemPrompt: string): string {
+  return `${systemPrompt.trimEnd()}\n\n${DEEP_THINK_SYSTEM_SUFFIX}`.trim();
+}
+
+export function extractDeepThought(payload: unknown): string {
+  if (typeof payload === "string") {
+    try {
+      return extractDeepThought(JSON.parse(payload));
+    } catch {
+      return payload.trim() || "<empty deep_think arguments>";
+    }
+  }
+  if (isRecord(payload) && typeof payload["thoughts"] === "string") {
+    return payload["thoughts"];
+  }
+  return stableJson(payload);
+}
+
+export function deepThinkAcknowledgement(index: number): string {
+  return JSON.stringify({
+    recorded: index,
+    next: "Resolve another material reasoning step with deep_think, or provide the final answer now.",
+  });
+}
+
+export function addCompletionUsage(
+  total: Record<string, number>,
+  usage: Record<string, number> | null | undefined,
+): void {
+  if (!usage) return;
+  for (const [key, value] of Object.entries(usage)) {
+    if (Number.isFinite(value)) total[key] = (total[key] ?? 0) + value;
+  }
+}
+
+/**
+ * Invoke native thinking collection when available and otherwise report an
+ * honest unsupported fallback without manufacturing a tool stream.
+ */
+export async function completeWithThinkingFallback(
+  provider: LLMProvider,
+  opts: ThinkingCompletionOptions,
+): Promise<CompletionResult> {
+  if (provider.completeWithThinking) return provider.completeWithThinking(opts);
+  const result = await provider.complete(opts);
+  return {
+    ...result,
+    thinkingStream: [],
+    thinkingCapture: "unsupported",
+  };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stableJson(value: unknown): string {
+  if (!isRecord(value)) return JSON.stringify(value) ?? String(value);
+  return JSON.stringify(
+    Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right))),
+  );
+}

--- a/ts/src/providers/thinking.ts
+++ b/ts/src/providers/thinking.ts
@@ -3,6 +3,7 @@ import type {
   LLMProvider,
   ThinkingCompletionOptions,
 } from "../types/index.js";
+import { ProviderError } from "../types/index.js";
 
 export const DEEP_THINK_TOOL_NAME = "deep_think";
 export const DEEP_THINK_DESCRIPTION =
@@ -14,34 +15,58 @@ export const DEEP_THINK_PARAMETERS: Record<string, unknown> = {
   additionalProperties: false,
 };
 
-const DEEP_THINK_SYSTEM_SUFFIX =
-  "Use the deep_think tool as a private scratchpad before answering. Its arguments are captured " +
-  "separately and are not part of the final answer. Call it again only for materially new reasoning, " +
-  "then put only the requested deliverable in the final response.";
+export const DEEP_THINK_JUICE_BY_EFFORT: Readonly<Record<string, number>> = {
+  none: 0,
+  minimal: 2,
+  low: 4,
+  medium: 8,
+  high: 48,
+  xhigh: 112,
+  max: 960,
+};
 
-export function withDeepThinkInstruction(systemPrompt: string): string {
-  return `${systemPrompt.trimEnd()}\n\n${DEEP_THINK_SYSTEM_SUFFIX}`.trim();
+const DEEP_THINK_SYSTEM_SUFFIX =
+  "Use the deep_think tool as a private scratchpad before drafting the final answer. Restate the task " +
+  "and constraints, resolve the work in ordered steps, and check likely errors or boundary cases there. " +
+  "Its arguments are captured separately and are not part of the final answer. Call it again only for " +
+  "materially new reasoning, never to narrate progress, then put only the requested deliverable in the " +
+  "final response.";
+
+export function deepThinkJuice(reasoningEffort: string): number {
+  return DEEP_THINK_JUICE_BY_EFFORT[reasoningEffort.trim().toLowerCase()] ?? 8;
+}
+
+export function withDeepThinkInstruction(systemPrompt: string, juice?: number): string {
+  const instruction = `${systemPrompt.trimEnd()}\n\n${DEEP_THINK_SYSTEM_SUFFIX}`.trim();
+  return juice === undefined ? instruction : `${instruction}\n\n# Juice: ${juice} !important`;
 }
 
 export function extractDeepThought(payload: unknown): string {
   if (typeof payload === "string") {
+    let parsed: unknown;
     try {
-      return extractDeepThought(JSON.parse(payload));
+      parsed = JSON.parse(payload);
     } catch {
-      return payload.trim() || "<empty deep_think arguments>";
+      throw new ProviderError("Invalid deep_think arguments: arguments must be valid JSON");
     }
+    return extractDeepThought(parsed);
   }
-  if (isRecord(payload) && typeof payload["thoughts"] === "string") {
-    return payload["thoughts"];
+  if (!isRecord(payload)) {
+    throw new ProviderError("Invalid deep_think arguments: arguments must be an object");
   }
-  return stableJson(payload);
+  if (Object.keys(payload).length !== 1 || !("thoughts" in payload)) {
+    throw new ProviderError(
+      "Invalid deep_think arguments: arguments must contain only the required thoughts field",
+    );
+  }
+  if (typeof payload["thoughts"] !== "string") {
+    throw new ProviderError("Invalid deep_think arguments: thoughts must be a string");
+  }
+  return payload["thoughts"];
 }
 
 export function deepThinkAcknowledgement(index: number): string {
-  return JSON.stringify({
-    recorded: index,
-    next: "Resolve another material reasoning step with deep_think, or provide the final answer now.",
-  });
+  return JSON.stringify({ recorded: index });
 }
 
 export function addCompletionUsage(
@@ -73,11 +98,4 @@ export async function completeWithThinkingFallback(
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stableJson(value: unknown): string {
-  if (!isRecord(value)) return JSON.stringify(value) ?? String(value);
-  return JSON.stringify(
-    Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right))),
-  );
 }

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -71,6 +71,7 @@ export interface CompletionOptions {
 }
 
 export interface ThinkingCompletionOptions extends CompletionOptions {
+  /** External scratchpad budget; native provider reasoning is disabled when supported. */
   reasoningEffort?: string;
   maxToolTurns?: number;
 }

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -38,9 +38,19 @@ export const CompletionResultSchema = z.object({
 export type CompletionResult = z.infer<typeof CompletionResultSchema>;
 
 export class ProviderError extends Error {
-  constructor(message: string) {
+  usage: Record<string, number>;
+
+  constructor(message: string, usage: Record<string, number> = {}) {
     super(message);
     this.name = "ProviderError";
+    this.usage = { ...usage };
+  }
+}
+
+export class ThinkingUnsupportedError extends ProviderError {
+  constructor(message: string, usage: Record<string, number> = {}) {
+    super(message, usage);
+    this.name = "ThinkingUnsupportedError";
   }
 }
 

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -27,6 +27,12 @@ export const CompletionResultSchema = z.object({
   // read it through wasConstrained() in agents/role-schemas.ts, which keeps
   // the `=== true` comparison in exactly one place.
   constrained: z.boolean().optional(),
+  // Explicit model-authored scratchpad entries captured from structured
+  // deep_think tool calls. They are deliberately separate from user-visible
+  // text and optional for backward compatibility with third-party providers.
+  thinkingStream: z.array(z.string()).optional(),
+  thinkingTool: z.string().nullish(),
+  thinkingCapture: z.enum(["tool", "unsupported"]).optional(),
 });
 
 export type CompletionResult = z.infer<typeof CompletionResultSchema>;
@@ -51,27 +57,41 @@ export interface OutputSchema {
   schema: Record<string, unknown>;
 }
 
+export interface CompletionOptions {
+  systemPrompt: string;
+  userPrompt: string;
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  /**
+   * Optional and best-effort. An implementation that cannot honor it must
+   * still answer and must leave `constrained` false.
+   */
+  outputSchema?: OutputSchema;
+}
+
+export interface ThinkingCompletionOptions extends CompletionOptions {
+  reasoningEffort?: string;
+  maxToolTurns?: number;
+}
+
 export interface LLMProvider {
-  complete(opts: {
-    systemPrompt: string;
-    userPrompt: string;
-    model?: string;
-    temperature?: number;
-    maxTokens?: number;
-    /**
-     * Optional and best-effort. An implementation that cannot honor it must
-     * still answer and must leave `constrained` false. Optional on purpose:
-     * LLMProvider is public API, so a provider written outside this repo keeps
-     * compiling and keeps working.
-     */
-    outputSchema?: OutputSchema;
-  }): Promise<CompletionResult>;
+  complete(opts: CompletionOptions): Promise<CompletionResult>;
+
+  /**
+   * Optional on purpose: existing third-party providers remain source
+   * compatible. Callers use completeWithThinkingFallback() to receive honest
+   * `unsupported` provenance when this operation is absent.
+   */
+  completeWithThinking?(opts: ThinkingCompletionOptions): Promise<CompletionResult>;
 
   defaultModel(): string;
 
   close?(): void;
 
   readonly supportsConcurrentRequests?: boolean;
+
+  readonly supportsThinkingStream?: boolean;
 
   readonly name: string;
 }

--- a/ts/tests/thinking-providers.test.ts
+++ b/ts/tests/thinking-providers.test.ts
@@ -7,6 +7,7 @@ import {
   createOpenAICompatibleProvider,
 } from "../src/providers/index.js";
 import type { LLMProvider } from "../src/types/index.js";
+import { ProviderError, ThinkingUnsupportedError } from "../src/types/index.js";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -61,6 +62,46 @@ describe("thinking provider contract", () => {
     expect(result.thinkingCapture).toBe("unsupported");
   });
 
+  it("falls back when a nominally native endpoint rejects thinking tools", async () => {
+    const provider: LLMProvider = {
+      name: "dynamic-capability",
+      supportsThinkingStream: true,
+      defaultModel: () => "dynamic-capability",
+      complete: async () => ({ text: "visible only", usage: { input: 11, output: 13 } }),
+      completeWithThinking: async () => {
+        throw new ThinkingUnsupportedError("tools unsupported", { input: 5, output: 7 });
+      },
+    };
+
+    const result = await completeWithThinkingFallback(provider, {
+      systemPrompt: "system",
+      userPrompt: "user",
+    });
+
+    expect(result.text).toBe("visible only");
+    expect(result.thinkingStream).toEqual([]);
+    expect(result.thinkingCapture).toBe("unsupported");
+    expect(result.usage).toEqual({ input: 16, output: 20 });
+  });
+
+  it("does not convert unrelated provider failures into ordinary completions", async () => {
+    const complete = vi.fn(async () => ({ text: "must not run", usage: {} }));
+    const provider: LLMProvider = {
+      name: "broken-native",
+      supportsThinkingStream: true,
+      defaultModel: () => "broken-native",
+      complete,
+      completeWithThinking: async () => {
+        throw new ProviderError("connection reset");
+      },
+    };
+
+    await expect(
+      completeWithThinkingFallback(provider, { systemPrompt: "system", userPrompt: "user" }),
+    ).rejects.toThrow("connection reset");
+    expect(complete).not.toHaveBeenCalled();
+  });
+
   it("retries the whole native thinking operation through RetryProvider", async () => {
     let attempts = 0;
     const inner: LLMProvider = {
@@ -86,6 +127,33 @@ describe("thinking provider contract", () => {
     expect(provider.supportsThinkingStream).toBe(true);
     expect(attempts).toBe(2);
     expect(result.thinkingStream).toEqual(["captured"]);
+  });
+
+  it("preserves partial usage when retrying a thinking operation", async () => {
+    let attempts = 0;
+    const inner: LLMProvider = {
+      name: "native",
+      supportsThinkingStream: true,
+      defaultModel: () => "native",
+      complete: async () => ({ text: "unused", usage: {} }),
+      completeWithThinking: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new ProviderError("temporary", { input: 5, output: 7 });
+        }
+        return {
+          text: "final",
+          thinkingStream: ["captured"],
+          thinkingCapture: "tool",
+          usage: { input: 11, output: 13 },
+        };
+      },
+    };
+    const provider = new RetryProvider(inner, { maxRetries: 1, baseDelay: 0 });
+
+    const result = await provider.completeWithThinking({ systemPrompt: "s", userPrompt: "u" });
+
+    expect(result.usage).toEqual({ input: 16, output: 20 });
   });
 });
 
@@ -251,6 +319,22 @@ describe("OpenAI-compatible deep_think", () => {
     ).rejects.toThrow("did not honor required deep_think");
   });
 
+  it("reports endpoint-level tool rejection as unsupported", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => "tools are not supported",
+      }),
+    );
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    await expect(
+      provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" }),
+    ).rejects.toBeInstanceOf(ThinkingUnsupportedError);
+  });
+
   it("fails closed at the configured tool-turn bound", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(openAIToolResponse("still thinking")));
     const provider = createOpenAICompatibleProvider({ apiKey: "test" });
@@ -258,6 +342,25 @@ describe("OpenAI-compatible deep_think", () => {
     await expect(
       provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u", maxToolTurns: 2 }),
     ).rejects.toThrow("exceeded 2 deep_think tool turns");
+  });
+
+  it("allows a final answer after the last permitted tool turn", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(openAIToolResponse("bounded thought"))
+      .mockResolvedValueOnce(openAIFinalResponse("final"));
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    const result = await provider.completeWithThinking!({
+      systemPrompt: "s",
+      userPrompt: "u",
+      maxToolTurns: 1,
+    });
+
+    expect(result.text).toBe("final");
+    expect(result.thinkingStream).toEqual(["bounded thought"]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -381,5 +484,45 @@ describe("Anthropic deep_think", () => {
     await expect(
       provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u", maxToolTurns: 2 }),
     ).rejects.toThrow("exceeded 2 deep_think tool turns");
+  });
+
+  it("allows a final answer after the last permitted tool turn", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okJson({
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-bounded",
+              name: "deep_think",
+              input: { thoughts: "bounded thought" },
+            },
+          ],
+          model: "claude-stub",
+          usage: { input_tokens: 3, output_tokens: 2 },
+          stop_reason: "tool_use",
+        }),
+      )
+      .mockResolvedValueOnce(
+        okJson({
+          content: [{ type: "text", text: "final" }],
+          model: "claude-stub",
+          usage: { input_tokens: 3, output_tokens: 2 },
+          stop_reason: "end_turn",
+        }),
+      );
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createAnthropicProvider({ apiKey: "test" });
+
+    const result = await provider.completeWithThinking!({
+      systemPrompt: "s",
+      userPrompt: "u",
+      maxToolTurns: 1,
+    });
+
+    expect(result.text).toBe("final");
+    expect(result.thinkingStream).toEqual(["bounded thought"]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/ts/tests/thinking-providers.test.ts
+++ b/ts/tests/thinking-providers.test.ts
@@ -115,8 +115,10 @@ describe("OpenAI-compatible deep_think", () => {
     expect(firstBody.parallel_tool_calls).toBe(false);
     expect(firstBody.reasoning_effort).toBe("none");
     expect(firstBody.tools[0].function.name).toBe("deep_think");
+    expect(firstBody.tools[0].function.strict).toBe(true);
     expect(secondBody.messages.at(-1).role).toBe("tool");
     expect(secondBody.messages.at(-1).content).not.toContain("check invariant");
+    expect(secondBody.messages.at(-1).content).toBe('{"recorded":1}');
   });
 
   it("negotiates away only an unsupported reasoning_effort field", async () => {
@@ -138,6 +140,106 @@ describe("OpenAI-compatible deep_think", () => {
     expect(JSON.parse(mockFetch.mock.calls[0][1].body).reasoning_effort).toBe("none");
     expect(JSON.parse(mockFetch.mock.calls[1][1].body).reasoning_effort).toBeUndefined();
     expect(JSON.parse(mockFetch.mock.calls[2][1].body).reasoning_effort).toBeUndefined();
+  });
+
+  it("uses the lowest advertised gateway level when none is rejected", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => 'level "none" not supported, valid levels: low, medium, high',
+      })
+      .mockResolvedValueOnce(openAIToolResponse("portable scratchpad"))
+      .mockResolvedValueOnce(openAIFinalResponse("final"));
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    const result = await provider.completeWithThinking!({
+      systemPrompt: "s",
+      userPrompt: "u",
+      reasoningEffort: "high",
+    });
+
+    expect(result.thinkingStream).toEqual(["portable scratchpad"]);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).reasoning_effort).toBe("none");
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body).reasoning_effort).toBe("low");
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body).reasoning_effort).toBe("low");
+  });
+
+  it("negotiates the strict flag while retaining local argument validation", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => "unknown field tools[0].function.strict",
+      })
+      .mockResolvedValueOnce(openAIToolResponse("portable schema"))
+      .mockResolvedValueOnce(openAIFinalResponse("final"));
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    const result = await provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" });
+
+    expect(result.thinkingStream).toEqual(["portable schema"]);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).tools[0].function.strict).toBe(true);
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body).tools[0].function.strict).toBeUndefined();
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body).tools[0].function.strict).toBeUndefined();
+  });
+
+  it("maps GPT 5.6 external effort to the numeric prompt budget", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(openAIToolResponse("budgeted scratchpad"))
+      .mockResolvedValueOnce(openAIFinalResponse("final"));
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "test",
+      model: "openai-codex/gpt-5.6-sol",
+    });
+
+    await provider.completeWithThinking!({
+      systemPrompt: "s",
+      userPrompt: "u",
+      reasoningEffort: "high",
+    });
+
+    const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(firstBody.reasoning_effort).toBe("none");
+    expect(firstBody.messages[0].content).toMatch(/# Juice: 48 !important$/);
+  });
+
+  it("fails closed on malformed tool arguments", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        okJson({
+          choices: [
+            {
+              message: {
+                content: null,
+                tool_calls: [
+                  {
+                    id: "call-invalid",
+                    type: "function",
+                    function: { name: "deep_think", arguments: "not-json" },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          model: "gpt-stub",
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        }),
+      ),
+    );
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    await expect(
+      provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" }),
+    ).rejects.toThrow("Invalid deep_think arguments");
   });
 
   it("fails closed when the required first tool call is ignored", async () => {
@@ -207,6 +309,33 @@ describe("Anthropic deep_think", () => {
     expect(secondBody.tool_choice).toEqual({ type: "auto", disable_parallel_tool_use: true });
     expect(secondBody.messages.at(-1).content[0].type).toBe("tool_result");
     expect(secondBody.messages.at(-1).content[0].content).not.toContain("establish invariant");
+    expect(secondBody.messages.at(-1).content[0].content).toBe('{"recorded":1}');
+  });
+
+  it("fails closed on malformed tool input", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        okJson({
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-invalid",
+              name: "deep_think",
+              input: { unexpected: "shape" },
+            },
+          ],
+          model: "claude-stub",
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "tool_use",
+        }),
+      ),
+    );
+    const provider = createAnthropicProvider({ apiKey: "test" });
+
+    await expect(
+      provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" }),
+    ).rejects.toThrow("Invalid deep_think arguments");
   });
 
   it("fails closed when the required first tool call is ignored", async () => {

--- a/ts/tests/thinking-providers.test.ts
+++ b/ts/tests/thinking-providers.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RetryProvider } from "../src/agents/provider-bridge.js";
+import {
+  completeWithThinkingFallback,
+  createAnthropicProvider,
+  createOpenAICompatibleProvider,
+} from "../src/providers/index.js";
+import type { LLMProvider } from "../src/types/index.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function okJson(payload: unknown) {
+  return { ok: true, json: async () => payload };
+}
+
+function openAIToolResponse(thoughts: string, input = 3, output = 2) {
+  return okJson({
+    choices: [
+      {
+        message: {
+          content: null,
+          tool_calls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: { name: "deep_think", arguments: JSON.stringify({ thoughts }) },
+            },
+          ],
+        },
+        finish_reason: "tool_calls",
+      },
+    ],
+    model: "gpt-stub",
+    usage: { prompt_tokens: input, completion_tokens: output },
+  });
+}
+
+function openAIFinalResponse(text: string, input = 3, output = 2) {
+  return okJson({
+    choices: [{ message: { content: text }, finish_reason: "stop" }],
+    model: "gpt-stub",
+    usage: { prompt_tokens: input, completion_tokens: output },
+  });
+}
+
+describe("thinking provider contract", () => {
+  it("reports an honest unsupported fallback for legacy providers", async () => {
+    const provider: LLMProvider = {
+      name: "legacy",
+      defaultModel: () => "legacy",
+      complete: async () => ({ text: "visible only", model: "legacy", usage: {} }),
+    };
+
+    const result = await completeWithThinkingFallback(provider, {
+      systemPrompt: "system",
+      userPrompt: "user",
+    });
+
+    expect(result.thinkingStream).toEqual([]);
+    expect(result.thinkingCapture).toBe("unsupported");
+  });
+
+  it("retries the whole native thinking operation through RetryProvider", async () => {
+    let attempts = 0;
+    const inner: LLMProvider = {
+      name: "native",
+      supportsThinkingStream: true,
+      defaultModel: () => "native",
+      complete: async () => ({ text: "unused", model: "native", usage: {} }),
+      completeWithThinking: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("temporary");
+        return {
+          text: "final",
+          thinkingStream: ["captured"],
+          thinkingCapture: "tool",
+          usage: {},
+        };
+      },
+    };
+    const provider = new RetryProvider(inner, { maxRetries: 1, baseDelay: 0 });
+
+    const result = await provider.completeWithThinking({ systemPrompt: "s", userPrompt: "u" });
+
+    expect(provider.supportsThinkingStream).toBe(true);
+    expect(attempts).toBe(2);
+    expect(result.thinkingStream).toEqual(["captured"]);
+  });
+});
+
+describe("OpenAI-compatible deep_think", () => {
+  it("captures ordered tool payloads separately from final text", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(openAIToolResponse("check invariant", 5, 7))
+      .mockResolvedValueOnce(openAIFinalResponse('{"answer":"done"}', 11, 13));
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+    expect(provider.completeWithThinking).toBeDefined();
+
+    const result = await provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" });
+
+    expect(result.text).toBe('{"answer":"done"}');
+    expect(result.thinkingStream).toEqual(["check invariant"]);
+    expect(result.thinkingTool).toBe("deep_think");
+    expect(result.thinkingCapture).toBe("tool");
+    expect(result.usage).toEqual({ input: 16, output: 20 });
+    expect(provider.supportsThinkingStream).toBe(true);
+
+    const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(firstBody.tool_choice).toBe("required");
+    expect(secondBody.tool_choice).toBe("auto");
+    expect(firstBody.parallel_tool_calls).toBe(false);
+    expect(firstBody.reasoning_effort).toBe("none");
+    expect(firstBody.tools[0].function.name).toBe("deep_think");
+    expect(secondBody.messages.at(-1).role).toBe("tool");
+    expect(secondBody.messages.at(-1).content).not.toContain("check invariant");
+  });
+
+  it("negotiates away only an unsupported reasoning_effort field", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => "unknown parameter reasoning_effort",
+      })
+      .mockResolvedValueOnce(openAIToolResponse("portable tool"))
+      .mockResolvedValueOnce(openAIFinalResponse("final"));
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    const result = await provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" });
+
+    expect(result.thinkingStream).toEqual(["portable tool"]);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).reasoning_effort).toBe("none");
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body).reasoning_effort).toBeUndefined();
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body).reasoning_effort).toBeUndefined();
+  });
+
+  it("fails closed when the required first tool call is ignored", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(openAIFinalResponse("uncaptured answer")));
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    await expect(
+      provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" }),
+    ).rejects.toThrow("did not honor required deep_think");
+  });
+
+  it("fails closed at the configured tool-turn bound", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(openAIToolResponse("still thinking")));
+    const provider = createOpenAICompatibleProvider({ apiKey: "test" });
+
+    await expect(
+      provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u", maxToolTurns: 2 }),
+    ).rejects.toThrow("exceeded 2 deep_think tool turns");
+  });
+});
+
+describe("Anthropic deep_think", () => {
+  it("uses native client-tool blocks and returns a separate stream", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okJson({
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-1",
+              name: "deep_think",
+              input: { thoughts: "establish invariant" },
+            },
+          ],
+          model: "claude-stub",
+          usage: { input_tokens: 5, output_tokens: 7 },
+          stop_reason: "tool_use",
+        }),
+      )
+      .mockResolvedValueOnce(
+        okJson({
+          content: [{ type: "text", text: "final" }],
+          model: "claude-stub",
+          usage: { input_tokens: 11, output_tokens: 13 },
+          stop_reason: "end_turn",
+        }),
+      );
+    vi.stubGlobal("fetch", mockFetch);
+    const provider = createAnthropicProvider({ apiKey: "test" });
+
+    const result = await provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" });
+
+    expect(result.text).toBe("final");
+    expect(result.thinkingStream).toEqual(["establish invariant"]);
+    expect(result.thinkingCapture).toBe("tool");
+    expect(result.usage).toEqual({ input: 16, output: 20 });
+    expect(provider.supportsThinkingStream).toBe(true);
+
+    const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(firstBody.tool_choice).toEqual({
+      type: "tool",
+      name: "deep_think",
+      disable_parallel_tool_use: true,
+    });
+    expect(secondBody.tool_choice).toEqual({ type: "auto", disable_parallel_tool_use: true });
+    expect(secondBody.messages.at(-1).content[0].type).toBe("tool_result");
+    expect(secondBody.messages.at(-1).content[0].content).not.toContain("establish invariant");
+  });
+
+  it("fails closed when the required first tool call is ignored", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        okJson({
+          content: [{ type: "text", text: "uncaptured answer" }],
+          model: "claude-stub",
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        }),
+      ),
+    );
+    const provider = createAnthropicProvider({ apiKey: "test" });
+
+    await expect(
+      provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u" }),
+    ).rejects.toThrow("did not honor required deep_think");
+  });
+
+  it("fails closed at the configured tool-turn bound", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        okJson({
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-repeat",
+              name: "deep_think",
+              input: { thoughts: "still thinking" },
+            },
+          ],
+          model: "claude-stub",
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "tool_use",
+        }),
+      ),
+    );
+    const provider = createAnthropicProvider({ apiKey: "test" });
+
+    await expect(
+      provider.completeWithThinking!({ systemPrompt: "s", userPrompt: "u", maxToolTurns: 2 }),
+    ).rejects.toThrow("exceeded 2 deep_think tool turns");
+  });
+});


### PR DESCRIPTION
## Summary

- add cross-runtime `deep_think` completion contracts and provenance metadata
- implement bounded native tool loops for Anthropic and OpenAI-compatible providers in Python and TypeScript
- disable native OpenAI reasoning while external capture is active and map GPT 5.6+ effort levels to numeric prompt budgets
- validate strict tool payloads locally, with targeted compatibility fallback for gateways that reject the strict flag or `reasoning_effort: none`
- preserve capture through retry and hook wrappers while marking local, deterministic, panel, callable, and CLI/runtime transports unsupported
- make Python teacher-trace collection require a structured stream by default, with an explicit visible-preamble fallback
- document sensitive-data handling and provider coverage

## Why

Teacher trace collection previously relied on visible response preambles and the initial implementation only covered the Python OpenAI-compatible path. That could silently treat uncaptured prose as reasoning and left TypeScript and Anthropic without parity.

This change captures explicit model-authored tool payloads separately from final answer text, forces the first tool call, bounds subsequent turns, aggregates usage, and fails closed when the tool contract is ignored, malformed, or does not terminate.

The external-thinking controls were cross-checked against oh-my-pi v17.2.14. In particular, the implementation now separates the external reasoning budget from native hidden reasoning, uses a neutral tool acknowledgement, and supports gateways whose lowest available native level is above `none`.

## Validation

- Python Ruff passed across `src` and `tests`
- Python mypy passed across all 743 source files
- 97 focused Python provider, collector, retry, and hook tests passed
- TypeScript lint and both source/test type checks passed
- 81 focused TypeScript provider tests passed, including 14 `deep_think` tests
- prior full-suite validation: Python 9,106 passed with host-only reruns green; TypeScript 6,150 passed
- `git diff --check` passed