### PR TITLE
fix(AC-930): preserve TypeScript architect proposal contracts

### DIFF
--- a/ts/src/agents/role-schemas.ts
+++ b/ts/src/agents/role-schemas.ts
@@ -190,31 +190,25 @@ export function parseCoachConstrained(rawText: string): CoachOutput {
 
 /**
  * NOT wired into the orchestrator. The Python payload carries nine channels and
- * a legacy-format renderer; this maps only tools and the changelog entry, so
- * wiring it would silently drop the rest. Exercised by tests so it cannot rot.
+ * a legacy-format renderer; this maps tools, harness proposals, and the
+ * changelog entry, so wiring it would still silently drop the remaining
+ * channels. Exercised by tests so it cannot rot.
  *
- * AC-930 investigated finishing the port and concluded it is not worth doing on
- * the current shape: the only class that would consume the extra channels here
- * is `AgentOrchestrator`, which is referenced solely by tests and is not public
- * API -- production runs `loop/generation-runner.ts`. If the full payload is
- * ever needed on the production path, that is an issue against generation-runner,
- * not a port into this function.
+ * `AgentOrchestrator` and these parsers are public package exports. Harness code
+ * remains opaque because this engine cannot execute Python validators, but the
+ * public `ArchitectOutput` contract preserves the proposal instead of silently
+ * erasing it. Wiring the full constrained payload remains separate work.
  */
 export function parseArchitectConstrained(rawText: string): ArchitectOutput {
   const payload = parsePayload<{
     tools: Array<{ name: string; description: string; code: string }>;
+    harness: Array<{ name: string; description: string; code: string }>;
     changelog_entry: string;
   }>("architect", ARCHITECT_SCHEMA, rawText);
   return {
     rawMarkdown: rawText,
     toolSpecs: payload.tools.map((tool) => ({ ...tool })),
-    // Dropped on purpose, and unlike the markdown path the data IS here:
-    // ARCHITECT_SCHEMA declares a `harness` channel, so a constrained response
-    // can carry validator specs that this line discards (AC-930). The specs are
-    // Python source for the Python harness; ts/src has no consumer of them and
-    // nothing that could execute one. Surfacing them would hand callers values
-    // whose only correct use on this engine is to ignore them.
-    harnessSpecs: [],
+    harnessSpecs: payload.harness.map((spec) => ({ ...spec })),
     changelogEntry: payload.changelog_entry,
     parseSuccess: true,
   };

--- a/ts/src/agents/role-schemas.ts
+++ b/ts/src/agents/role-schemas.ts
@@ -189,10 +189,16 @@ export function parseCoachConstrained(rawText: string): CoachOutput {
 }
 
 /**
- * NOT wired into the orchestrator yet. The Python payload carries nine channels
- * and a legacy-format renderer; this maps only tools and the changelog entry,
- * so wiring it would silently drop the rest. Kept as the starting point for
- * that port (tracked as AC-930), and exercised by tests so it cannot rot.
+ * NOT wired into the orchestrator. The Python payload carries nine channels and
+ * a legacy-format renderer; this maps only tools and the changelog entry, so
+ * wiring it would silently drop the rest. Exercised by tests so it cannot rot.
+ *
+ * AC-930 investigated finishing the port and concluded it is not worth doing on
+ * the current shape: the only class that would consume the extra channels here
+ * is `AgentOrchestrator`, which is referenced solely by tests and is not public
+ * API -- production runs `loop/generation-runner.ts`. If the full payload is
+ * ever needed on the production path, that is an issue against generation-runner,
+ * not a port into this function.
  */
 export function parseArchitectConstrained(rawText: string): ArchitectOutput {
   const payload = parsePayload<{
@@ -202,6 +208,12 @@ export function parseArchitectConstrained(rawText: string): ArchitectOutput {
   return {
     rawMarkdown: rawText,
     toolSpecs: payload.tools.map((tool) => ({ ...tool })),
+    // Dropped on purpose, and unlike the markdown path the data IS here:
+    // ARCHITECT_SCHEMA declares a `harness` channel, so a constrained response
+    // can carry validator specs that this line discards (AC-930). The specs are
+    // Python source for the Python harness; ts/src has no consumer of them and
+    // nothing that could execute one. Surfacing them would hand callers values
+    // whose only correct use on this engine is to ignore them.
     harnessSpecs: [],
     changelogEntry: payload.changelog_entry,
     parseSuccess: true,

--- a/ts/src/agents/roles.ts
+++ b/ts/src/agents/roles.ts
@@ -167,15 +167,43 @@ export function parseArchitectOutput(rawMarkdown: string): ArchitectOutput {
     return {
       rawMarkdown,
       toolSpecs,
+      // Always empty by design, not by omission (AC-930). The architect's
+      // harness channel carries Python source, executed by the Python harness;
+      // this engine has nothing that could run it, and no consumer of harness
+      // specs exists anywhere in ts/src. Parsing it here would produce a value
+      // whose only possible use is to be discarded.
       harnessSpecs: [],
       changelogEntry: "",
       parseSuccess: true,
     };
   } catch {
-    return { rawMarkdown, toolSpecs: [], harnessSpecs: [], changelogEntry: "", parseSuccess: false };
+    return {
+      rawMarkdown,
+      toolSpecs: [],
+      harnessSpecs: [],
+      changelogEntry: "",
+      parseSuccess: false,
+    };
   }
 }
 
+/**
+ * Extract proposed tool specs. Deliberately does NOT syntax-check `code`.
+ *
+ * AC-930 was filed believing this was laxer than Python. It is not: Python's
+ * `parse_architect_tool_specs` type-checks name/description/code and stops
+ * there too. Python's `ast.parse` on tool code runs at the persistence
+ * boundary (`storage/artifacts.py`, on the `kind="tool"` path), immediately
+ * before the source is written to a `.py` file that something will import.
+ *
+ * That is the right place for it, and it is why there is nothing to mirror
+ * here. TypeScript has no persistence path for tool code -- nothing in ts/src
+ * consumes `toolSpecs` at all. Adding a syntax check to this parser would make
+ * TypeScript *stricter* than Python rather than aligned with it, and would
+ * reject a proposal at a stage where nobody is about to execute it. If this
+ * engine ever grows a path that writes or runs proposed tool code, the check
+ * belongs at that boundary.
+ */
 function parseArchitectToolSpecs(markdown: string): Array<Record<string, unknown>> {
   const codeBlockPattern = /```json\s*\n([\s\S]*?)\n```/g;
   let match: RegExpExecArray | null;

--- a/ts/src/agents/roles.ts
+++ b/ts/src/agents/roles.ts
@@ -3,6 +3,8 @@
  * Mirrors Python's autocontext/agents/contracts.py + parsers.py.
  */
 
+import { parseArchitectHarnessSpecs } from "../execution/harness-loader.js";
+
 // ---------------------------------------------------------------------------
 // Role constants
 // ---------------------------------------------------------------------------
@@ -164,15 +166,14 @@ export function parseCoachOutput(rawMarkdown: string): CoachOutput {
 export function parseArchitectOutput(rawMarkdown: string): ArchitectOutput {
   try {
     const toolSpecs = parseArchitectToolSpecs(rawMarkdown);
+    const harnessSpecs = parseArchitectHarnessSpecs(rawMarkdown).map((spec) => ({ ...spec }));
     return {
       rawMarkdown,
       toolSpecs,
-      // Always empty by design, not by omission (AC-930). The architect's
-      // harness channel carries Python source, executed by the Python harness;
-      // this engine has nothing that could run it, and no consumer of harness
-      // specs exists anywhere in ts/src. Parsing it here would produce a value
-      // whose only possible use is to be discarded.
-      harnessSpecs: [],
+      // TypeScript does not execute the proposed Python validators, but this is
+      // a public parser contract. Keep the validated specs as opaque proposal
+      // data so callers can inspect, persist, or forward them without loss.
+      harnessSpecs,
       changelogEntry: "",
       parseSuccess: true,
     };
@@ -190,32 +191,53 @@ export function parseArchitectOutput(rawMarkdown: string): ArchitectOutput {
 /**
  * Extract proposed tool specs. Deliberately does NOT syntax-check `code`.
  *
- * AC-930 was filed believing this was laxer than Python. It is not: Python's
- * `parse_architect_tool_specs` type-checks name/description/code and stops
- * there too. Python's `ast.parse` on tool code runs at the persistence
- * boundary (`storage/artifacts.py`, on the `kind="tool"` path), immediately
- * before the source is written to a `.py` file that something will import.
+ * Like Python's `parse_architect_tool_specs`, this filters malformed entries
+ * and keeps only string name/description/code fields. Python's `ast.parse` on
+ * tool code runs later at the persistence boundary (`storage/artifacts.py`, on
+ * the `kind="tool"` path), immediately before the source is written to a `.py`
+ * file that something will import.
  *
- * That is the right place for it, and it is why there is nothing to mirror
- * here. TypeScript has no persistence path for tool code -- nothing in ts/src
- * consumes `toolSpecs` at all. Adding a syntax check to this parser would make
- * TypeScript *stricter* than Python rather than aligned with it, and would
- * reject a proposal at a stage where nobody is about to execute it. If this
- * engine ever grows a path that writes or runs proposed tool code, the check
- * belongs at that boundary.
+ * TypeScript has no internal persistence or execution path for proposed tool
+ * code. Adding a syntax check here would therefore make this parser stricter
+ * than Python's equivalent stage. If such a path is added, validate syntax at
+ * that boundary.
  */
 function parseArchitectToolSpecs(markdown: string): Array<Record<string, unknown>> {
   const codeBlockPattern = /```json\s*\n([\s\S]*?)\n```/g;
   let match: RegExpExecArray | null;
   while ((match = codeBlockPattern.exec(markdown)) !== null) {
     try {
-      const parsed = JSON.parse(match[1]);
-      if (parsed && Array.isArray(parsed.tools)) {
-        return parsed.tools;
+      const parsed: unknown = JSON.parse(match[1]);
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "tools" in parsed &&
+        Array.isArray(parsed.tools)
+      ) {
+        const tools: unknown[] = parsed.tools;
+        return tools
+          .filter(isArchitectToolSpec)
+          .map(({ name, description, code }) => ({ name, description, code }));
       }
     } catch {
       continue;
     }
   }
   return [];
+}
+
+function isArchitectToolSpec(
+  value: unknown,
+): value is { name: string; description: string; code: string } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return (
+    "name" in value &&
+    typeof value.name === "string" &&
+    "description" in value &&
+    typeof value.description === "string" &&
+    "code" in value &&
+    typeof value.code === "string"
+  );
 }

--- a/ts/tests/architect-harness-boundary.test.ts
+++ b/ts/tests/architect-harness-boundary.test.ts
@@ -1,0 +1,84 @@
+/**
+ * AC-930: the TypeScript engine drops the architect's harness channel on purpose.
+ *
+ * Both parsers hardcode `harnessSpecs: []`. Read cold that looks like an
+ * unfinished port, and the previous fix for "looks unfinished" is what this
+ * suite exists to prevent: someone wires the channel through, and the loop
+ * starts handing callers Python source that this engine cannot execute.
+ *
+ * The boundary is real. Harness specs are Python validator source run by the
+ * Python harness, and no consumer of harness specs exists anywhere in ts/src.
+ * A comment alone rots; these assert the drop so restoring it is a deliberate,
+ * visible act rather than an edit that quietly passes.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseArchitectOutput } from "../src/agents/roles.js";
+import { ARCHITECT_SCHEMA, parseArchitectConstrained } from "../src/agents/role-schemas.js";
+
+const HARNESS_CODE = "def validate(run):\n    return run.score > 0.5\n";
+
+describe("architect harness boundary", () => {
+  it("drops harness specs the markdown path could have parsed", () => {
+    const markdown = [
+      "## Proposal",
+      "```json",
+      JSON.stringify({
+        tools: [{ name: "t", description: "d", code: "print(1)" }],
+        harness: [{ name: "h", description: "d", code: HARNESS_CODE }],
+      }),
+      "```",
+    ].join("\n");
+
+    const parsed = parseArchitectOutput(markdown);
+
+    expect(parsed.toolSpecs).toHaveLength(1);
+    expect(parsed.harnessSpecs).toEqual([]);
+  });
+
+  it("drops harness specs the constrained path definitely received", () => {
+    // The sharper case. ARCHITECT_SCHEMA declares `harness`, so this payload is
+    // schema-valid and the specs genuinely arrive before being discarded --
+    // this is a drop, not an absence.
+    const payload = JSON.stringify({
+      tools: [{ name: "t", description: "d", code: "print(1)" }],
+      harness: [{ name: "h", description: "d", code: HARNESS_CODE }],
+      changelog_entry: "e",
+      dag_changes: [],
+      mutations: [],
+      observed_bottlenecks: [],
+      tuning_parameters: [],
+      tuning_reasoning: "",
+      impact_hypothesis: "",
+    });
+
+    const parsed = parseArchitectConstrained(payload);
+
+    expect(parsed.toolSpecs).toHaveLength(1);
+    expect(parsed.harnessSpecs).toEqual([]);
+  });
+
+  it("keeps the harness channel in the shared schema", () => {
+    // Guards the claim the comments make. If the channel were ever removed from
+    // the contract, "we deliberately drop a channel that exists" would silently
+    // become a statement about nothing, and the comments would mislead.
+    const properties = (ARCHITECT_SCHEMA.schema as { properties: Record<string, unknown> })
+      .properties;
+    expect(Object.keys(properties)).toContain("harness");
+  });
+
+  it("accepts tool code that does not parse as Python", () => {
+    // Pins the decision recorded on parseArchitectToolSpecs. Python's parser is
+    // equally permissive here; its ast.parse runs at the persistence boundary in
+    // storage/artifacts.py, right before the source is written to a .py file.
+    // TypeScript has no such boundary, so rejecting here would make this engine
+    // stricter than Python rather than aligned with it.
+    const markdown = [
+      "```json",
+      JSON.stringify({ tools: [{ name: "t", description: "d", code: "def (" }] }),
+      "```",
+    ].join("\n");
+
+    expect(parseArchitectOutput(markdown).toolSpecs).toHaveLength(1);
+  });
+});

--- a/ts/tests/architect-harness-boundary.test.ts
+++ b/ts/tests/architect-harness-boundary.test.ts
@@ -1,15 +1,11 @@
 /**
- * AC-930: the TypeScript engine drops the architect's harness channel on purpose.
+ * AC-930: preserve architect proposals at the public parser boundary.
  *
- * Both parsers hardcode `harnessSpecs: []`. Read cold that looks like an
- * unfinished port, and the previous fix for "looks unfinished" is what this
- * suite exists to prevent: someone wires the channel through, and the loop
- * starts handing callers Python source that this engine cannot execute.
- *
- * The boundary is real. Harness specs are Python validator source run by the
- * Python harness, and no consumer of harness specs exists anywhere in ts/src.
- * A comment alone rots; these assert the drop so restoring it is a deliberate,
- * visible act rather than an edit that quietly passes.
+ * Harness specs contain Python source that this engine cannot execute, but
+ * `ArchitectOutput` is a public package contract. Both parsers retain validated
+ * proposals as opaque data instead of silently discarding them. Tool proposals
+ * match Python's structural validation while remaining syntax-permissive until
+ * an execution or persistence boundary exists.
  */
 import { describe, expect, it } from "vitest";
 
@@ -19,27 +15,30 @@ import { ARCHITECT_SCHEMA, parseArchitectConstrained } from "../src/agents/role-
 const HARNESS_CODE = "def validate(run):\n    return run.score > 0.5\n";
 
 describe("architect harness boundary", () => {
-  it("drops harness specs the markdown path could have parsed", () => {
+  it("preserves harness specs from the markdown path as opaque proposals", () => {
     const markdown = [
       "## Proposal",
       "```json",
       JSON.stringify({
         tools: [{ name: "t", description: "d", code: "print(1)" }],
-        harness: [{ name: "h", description: "d", code: HARNESS_CODE }],
       }),
       "```",
+      "<!-- HARNESS_START -->",
+      JSON.stringify({
+        harness: [{ name: "h", description: "d", code: HARNESS_CODE }],
+      }),
+      "<!-- HARNESS_END -->",
     ].join("\n");
 
     const parsed = parseArchitectOutput(markdown);
 
     expect(parsed.toolSpecs).toHaveLength(1);
-    expect(parsed.harnessSpecs).toEqual([]);
+    expect(parsed.harnessSpecs).toEqual([
+      { name: "h", description: "d", code: HARNESS_CODE },
+    ]);
   });
 
-  it("drops harness specs the constrained path definitely received", () => {
-    // The sharper case. ARCHITECT_SCHEMA declares `harness`, so this payload is
-    // schema-valid and the specs genuinely arrive before being discarded --
-    // this is a drop, not an absence.
+  it("preserves harness specs from the constrained path", () => {
     const payload = JSON.stringify({
       tools: [{ name: "t", description: "d", code: "print(1)" }],
       harness: [{ name: "h", description: "d", code: HARNESS_CODE }],
@@ -55,13 +54,12 @@ describe("architect harness boundary", () => {
     const parsed = parseArchitectConstrained(payload);
 
     expect(parsed.toolSpecs).toHaveLength(1);
-    expect(parsed.harnessSpecs).toEqual([]);
+    expect(parsed.harnessSpecs).toEqual([
+      { name: "h", description: "d", code: HARNESS_CODE },
+    ]);
   });
 
   it("keeps the harness channel in the shared schema", () => {
-    // Guards the claim the comments make. If the channel were ever removed from
-    // the contract, "we deliberately drop a channel that exists" would silently
-    // become a statement about nothing, and the comments would mislead.
     const properties = (ARCHITECT_SCHEMA.schema as { properties: Record<string, unknown> })
       .properties;
     expect(Object.keys(properties)).toContain("harness");
@@ -80,5 +78,30 @@ describe("architect harness boundary", () => {
     ].join("\n");
 
     expect(parseArchitectOutput(markdown).toolSpecs).toHaveLength(1);
+  });
+
+  it("filters malformed tool entries and returns canonical fields", () => {
+    const markdown = [
+      "```json",
+      JSON.stringify({
+        tools: [
+          null,
+          "not an object",
+          { name: 7, description: "d", code: "print(1)" },
+          { name: "missing_code", description: "d" },
+          {
+            name: "valid_tool",
+            description: "d",
+            code: "print(1)",
+            ignored: "not part of Python's parsed contract",
+          },
+        ],
+      }),
+      "```",
+    ].join("\n");
+
+    expect(parseArchitectOutput(markdown).toolSpecs).toEqual([
+      { name: "valid_tool", description: "d", code: "print(1)" },
+    ]);
   });
 });


### PR DESCRIPTION
Closes AC-930.

## What changed

- Preserve architect harness proposals in the public `ArchitectOutput` contract instead of silently replacing them with `[]`.
  - The Markdown parser reuses the existing `<!-- HARNESS_START -->` parser and exposes validated specs as opaque proposal data.
  - The constrained parser maps the schema-validated `harness` channel into `harnessSpecs`.
- Match Python's structural validation for tool proposals: malformed entries are filtered, and valid entries retain only string `name`, `description`, and `code` fields.
- Keep tool-code syntax permissive at the parser boundary. Python performs `ast.parse` later, immediately before persistence; TypeScript has no equivalent persistence or execution path for proposed tool code.

## Contract boundary

`AgentOrchestrator` and the architect parsers are public package exports. TypeScript cannot execute the proposed Python harness source, but that does not make it safe to erase from a public result. Callers can now inspect, persist, or forward the opaque proposal without data loss.

The schema-constrained architect path remains unwired in `AgentOrchestrator`: it still maps only tools, harness proposals, and the changelog entry while the shared payload carries additional channels. Wiring all nine channels remains separate work.

## Regression coverage

- Markdown and constrained parsers both preserve harness proposals.
- The shared schema continues to declare the harness channel.
- Invalid Python tool syntax remains accepted at this non-execution boundary.
- Null, non-object, missing-field, and wrongly typed tool entries are filtered while valid entries are canonicalized.

## Verification

| Check | Result |
| --- | --- |
| Full TypeScript suite | 6,143 tests / 838 files passed |
| Focused architect/orchestrator suite | 75 tests passed |
| `npm run lint` | passed |
| `npm run build` | passed |
| `git diff --check` | passed |

No Python source changes.
