### PR TITLE
feat(AC-928): enforce Anthropic structured tool output

### DIFF
--- a/autocontext/scripts/measure_constrained_quality.py
+++ b/autocontext/scripts/measure_constrained_quality.py
@@ -1,10 +1,11 @@
 """AC-928: does forcing a schema make the analysis worse?
 
-AC-913 switched every OpenAI-compatible backend to constrained decoding. That
-the payload is *valid* is guaranteed by construction and not worth measuring.
-The open question is whether the analysis is as **substantive** when a model
-fills a schema instead of writing prose -- a model that emits perfectly-shaped
-empty-calorie findings steers the loop just as confidently as a good one.
+AC-913 switched every OpenAI-compatible backend to constrained decoding. This
+harness validates every candidate payload against the shipped analyst contract;
+invalid trials are rejected rather than scored. The open question is whether
+the analysis is as **substantive** when a model fills a schema instead of
+writing prose -- a model that emits perfectly-shaped empty-calorie findings
+steers the loop just as confidently as a good one.
 
 Measured with objective proxies rather than an LLM judge, so the numbers are
 reproducible and not hostage to a judge's mood or a second model's quirks:
@@ -21,17 +22,21 @@ reproducible and not hostage to a judge's mood or a second model's quirks:
 Usage:
     python scripts/measure_constrained_quality.py --base-url http://localhost:11434/v1 \
         --model llama3.1:8b --api-key ollama --trials 20
+    python scripts/measure_constrained_quality.py --base-url https://api.anthropic.com/v1 \
+        --model claude-sonnet-4-5 --api-key "$ANTHROPIC_API_KEY" --mode anthropic_tool --trials 20
 """
 
 from __future__ import annotations
 
 import argparse
-import concurrent.futures
 import json
+import multiprocessing
 import re
 import statistics
 import sys
 import urllib.request
+from collections.abc import Callable
+from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import Any
 
@@ -55,7 +60,45 @@ EVIDENCE = ("0.41", "2 of 5", "14", "40", "6 steps", "9", "0.8", "2-step")
 PARAM = re.compile(r"\b(aggression|lookahead|decoy|tiebreak|threshold|weight|step)\w*\b|\b\d+(\.\d+)?\b", re.I)
 
 
-def _post(url: str, api_key: str, payload: dict[str, Any], *, attempts: int = 3, deadline: float = 120.0) -> dict[str, Any]:
+def _post_once(
+    url: str,
+    api_key: str,
+    payload: dict[str, Any],
+    deadline: float,
+    sender: Connection,
+    anthropic_api: bool,
+) -> None:
+    """Perform one request in a child process the parent can terminate."""
+    try:
+        headers = {"Content-Type": "application/json"}
+        if anthropic_api:
+            headers.update({"x-api-key": api_key, "anthropic-version": "2023-06-01"})
+        else:
+            headers["Authorization"] = f"Bearer {api_key}"
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode(),
+            headers=headers,
+        )
+        with urllib.request.urlopen(req, timeout=deadline) as resp:  # noqa: S310 - operator-supplied endpoint
+            result = json.loads(resp.read())
+        sender.send((True, result))
+    except Exception as exc:  # noqa: BLE001 - serialize any transport failure for the parent
+        sender.send((False, type(exc).__name__, str(exc)))
+    finally:
+        sender.close()
+
+
+def _post(
+    url: str,
+    api_key: str,
+    payload: dict[str, Any],
+    *,
+    attempts: int = 3,
+    deadline: float = 120.0,
+    anthropic_api: bool = False,
+    _worker: Callable[..., None] | None = None,
+) -> dict[str, Any]:
     """POST with a bounded wait and a retry.
 
     urllib's ``timeout`` is per socket operation, not per request, so a gateway
@@ -64,31 +107,45 @@ def _post(url: str, api_key: str, payload: dict[str, Any], *, attempts: int = 3,
     18 minutes with a 120s socket timeout set, while ordinary calls to the same
     model returned in two seconds.
 
-    So the deadline is enforced from outside the socket, on a worker thread the
-    caller abandons if it overruns. The thread may linger until its own socket
-    gives up; that is deliberate. This is a measurement harness, and a leaked
-    thread is a much smaller problem than a measurement that never finishes.
+    The deadline is therefore enforced from a parent process. An overrun child
+    is terminated and joined before retrying, so neither retries nor interpreter
+    shutdown can accumulate hidden in-flight requests.
     """
 
-    def _once() -> dict[str, Any]:
-        req = urllib.request.Request(
-            url,
-            data=json.dumps(payload).encode(),
-            headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
-        )
-        with urllib.request.urlopen(req, timeout=deadline) as resp:  # noqa: S310 - operator-supplied endpoint
-            return json.loads(resp.read())
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    if deadline <= 0:
+        raise ValueError("deadline must be positive")
 
     last: Exception | None = None
     for attempt in range(attempts):
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        context = multiprocessing.get_context("spawn")
+        receiver, sender = context.Pipe(duplex=False)
+        process = context.Process(
+            target=_post_once if _worker is None else _worker,
+            args=(url, api_key, payload, deadline, sender, anthropic_api),
+            daemon=True,
+        )
+        process.start()
+        sender.close()
         try:
-            return pool.submit(_once).result(timeout=deadline)
+            if not receiver.poll(deadline):
+                raise TimeoutError(f"request exceeded {deadline:.3f}s deadline")
+            message = receiver.recv()
+            if message[0] is True:
+                return message[1]
+            raise RuntimeError(f"{message[1]}: {message[2]}")
         except Exception as exc:  # noqa: BLE001, PERF203 - any failure is a retry
             last = exc
             print(f"    retry {attempt + 1}/{attempts}: {type(exc).__name__}", flush=True)
         finally:
-            pool.shutdown(wait=False)
+            receiver.close()
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=1.0)
+            if process.is_alive():
+                process.kill()
+                process.join()
     raise RuntimeError(f"request failed after {attempts} attempts: {last}")
 
 
@@ -170,13 +227,11 @@ def _score(sections: dict[str, list[str]]) -> dict[str, float]:
 
 
 def _score_payload(payload: dict[str, Any]) -> dict[str, float]:
-    return _score(
-        {
-            "findings": payload.get("findings", []),
-            "root_causes": payload.get("root_causes", []),
-            "recommendations": payload.get("recommendations", []),
-        }
-    )
+    """Validate the real analyst contract before a payload enters the score."""
+    from autocontext.agents.role_schemas import AnalystPayload
+
+    validated = AnalystPayload.model_validate(payload)
+    return _score(validated.model_dump())
 
 
 def _constrained_request(mode: str, base: dict[str, Any], schema: Any) -> dict[str, Any]:
@@ -185,7 +240,8 @@ def _constrained_request(mode: str, base: dict[str, Any], schema: Any) -> dict[s
     Two mechanisms, because the providers differ in kind rather than in syntax:
 
     * ``response_format`` -- what AC-913 shipped for OpenAI-compatible backends.
-    * ``tool`` -- a forced tool call, which is Anthropic's only equivalent.
+    * ``tool`` -- a strict function tool through an OpenAI-compatible gateway.
+    * ``anthropic_tool`` -- the native Anthropic Messages strict-tool shape.
       AC-928's open question is whether *being made to fill a schema* costs
       analysis quality, so the forced-tool arm has to be measured on its own
       rather than assumed to behave like ``response_format``.
@@ -198,6 +254,21 @@ def _constrained_request(mode: str, base: dict[str, Any], schema: Any) -> dict[s
                 "json_schema": {"name": schema.name, "strict": True, "schema": schema.schema},
             },
         }
+    from autocontext.providers.anthropic import _anthropic_strict_schema
+
+    if mode == "anthropic_tool":
+        return {
+            **base,
+            "tools": [
+                {
+                    "name": schema.name,
+                    "description": "Return the analysis as structured data.",
+                    "input_schema": _anthropic_strict_schema(schema.schema),
+                    "strict": True,
+                }
+            ],
+            "tool_choice": {"type": "tool", "name": schema.name},
+        }
     return {
         **base,
         "tools": [
@@ -206,7 +277,8 @@ def _constrained_request(mode: str, base: dict[str, Any], schema: Any) -> dict[s
                 "function": {
                     "name": schema.name,
                     "description": "Return the analysis as structured data.",
-                    "parameters": schema.schema,
+                    "parameters": _anthropic_strict_schema(schema.schema),
+                    "strict": True,
                 },
             }
         ],
@@ -214,15 +286,38 @@ def _constrained_request(mode: str, base: dict[str, Any], schema: Any) -> dict[s
     }
 
 
-def _constrained_payload(mode: str, response: dict[str, Any]) -> dict[str, Any]:
+def _constrained_payload(
+    mode: str,
+    response: dict[str, Any],
+    *,
+    expected_tool: str = "analyst_output",
+) -> dict[str, Any]:
     """Pull the object out of whichever channel the mechanism used."""
+    if mode == "anthropic_tool":
+        for block in response.get("content", []):
+            if (
+                block.get("type") == "tool_use"
+                and block.get("name") == expected_tool
+                and isinstance(block.get("input"), dict)
+            ):
+                return block["input"]
+        raise json.JSONDecodeError("forced tool call produced no tool_use", "", 0)
     message = response["choices"][0]["message"]
     if mode == "response_format":
         return json.loads(message["content"])
     calls = message.get("tool_calls") or []
-    if not calls:
+    if not calls or calls[0].get("function", {}).get("name") != expected_tool:
         raise json.JSONDecodeError("forced tool call produced no tool_calls", "", 0)
     return json.loads(calls[0]["function"]["arguments"])
+
+
+def _prose_content(mode: str, response: dict[str, Any]) -> str:
+    if mode == "anthropic_tool":
+        for block in response.get("content", []):
+            if block.get("type") == "text" and isinstance(block.get("text"), str):
+                return block["text"]
+        raise KeyError("Anthropic response contained no text block")
+    return response["choices"][0]["message"]["content"]
 
 
 def main() -> int:
@@ -234,29 +329,48 @@ def main() -> int:
     ap.add_argument("--out", default="")
     ap.add_argument(
         "--mode",
-        choices=("response_format", "tool"),
+        choices=("response_format", "tool", "anthropic_tool"),
         default="response_format",
-        help="Constraint mechanism: response_format (OpenAI-compatible) or tool (forced tool call, Anthropic's equivalent)",
+        help=(
+            "Constraint mechanism: response_format, an OpenAI-compatible strict tool, "
+            "or a native Anthropic Messages strict tool"
+        ),
     )
     args = ap.parse_args()
 
     from autocontext.agents.role_schemas import ANALYST_SCHEMA
 
-    url = f"{args.base_url.rstrip('/')}/chat/completions"
+    anthropic_api = args.mode == "anthropic_tool"
+    resource = "messages" if anthropic_api else "chat/completions"
+    url = f"{args.base_url.rstrip('/')}/{resource}"
     prose_scores: list[dict[str, float]] = []
     schema_scores: list[dict[str, float]] = []
     schema_rejected = 0
 
     for i in range(args.trials):
-        base = {"model": args.model, "messages": _messages(), "temperature": 0.7, "max_tokens": 900}
+        messages = _messages()
+        base: dict[str, Any] = {
+            "model": args.model,
+            "messages": messages,
+            "temperature": 0.7,
+            "max_tokens": 900,
+        }
+        if anthropic_api:
+            base["system"] = messages[0]["content"]
+            base["messages"] = messages[1:]
 
-        prose = _post(url, args.api_key, base)["choices"][0]["message"]["content"]
+        prose = _prose_content(args.mode, _post(url, args.api_key, base, anthropic_api=anthropic_api))
         prose_scores.append(_score(_prose_items(prose)))
 
-        response = _post(url, args.api_key, _constrained_request(args.mode, base, ANALYST_SCHEMA))
+        response = _post(
+            url,
+            args.api_key,
+            _constrained_request(args.mode, base, ANALYST_SCHEMA),
+            anthropic_api=anthropic_api,
+        )
         try:
             schema_scores.append(_score_payload(_constrained_payload(args.mode, response)))
-        except (json.JSONDecodeError, KeyError, TypeError):
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
             schema_rejected += 1
         print(f"  trial {i + 1}/{args.trials}", flush=True)
 
@@ -288,7 +402,7 @@ def main() -> int:
         "trials": args.trials,
         "prose": agg(prose_scores),
         "schema": agg(schema_scores),
-        "schema_unparseable": schema_rejected,
+        "schema_rejected": schema_rejected,
         # Retained so a reader can re-aggregate or run a different test without
         # paying for the API calls again.
         "raw": {"prose": prose_scores, "schema": schema_scores},

--- a/autocontext/scripts/measure_constrained_quality.py
+++ b/autocontext/scripts/measure_constrained_quality.py
@@ -1,0 +1,303 @@
+"""AC-928: does forcing a schema make the analysis worse?
+
+AC-913 switched every OpenAI-compatible backend to constrained decoding. That
+the payload is *valid* is guaranteed by construction and not worth measuring.
+The open question is whether the analysis is as **substantive** when a model
+fills a schema instead of writing prose -- a model that emits perfectly-shaped
+empty-calorie findings steers the loop just as confidently as a good one.
+
+Measured with objective proxies rather than an LLM judge, so the numbers are
+reproducible and not hostage to a judge's mood or a second model's quirks:
+
+* **count** -- how many findings / root causes / recommendations came back
+* **substance** -- mean characters per item; one-word findings are the
+  degenerate case a schema could invite
+* **grounding** -- share of items citing a number that appears in the scenario
+  (14 steps, 40 steps, 0.41, 2 of 5, 6 steps, 9-step median). An analysis that
+  never touches the evidence is the failure mode worth catching
+* **actionability** -- share of recommendations naming a parameter or a
+  concrete quantity, which is what the prompt actually asks for
+
+Usage:
+    python scripts/measure_constrained_quality.py --base-url http://localhost:11434/v1 \
+        --model llama3.1:8b --api-key ollama --trials 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import re
+import statistics
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+ANALYST_TASK = "Analyze strengths/failures and return markdown with sections: Findings, Root Causes, Actionable Recommendations."
+
+CONTEXT = """Scenario: grid_ctf, generation 3.
+Competitor strategy: greedy nearest-flag with a 2-step lookahead, aggression=0.8.
+Result: score 0.41 of 1.0. Captured 2 of 5 flags.
+Failures: agent oscillated between two equidistant flags for 14 of 40 steps;
+walked into a guarded tile twice; never used the decoy action.
+Strengths: reached the first flag in 6 steps, below the 9-step median."""
+
+# Numbers that appear in the scenario. An item citing one is engaging with the
+# evidence rather than producing generic advice.
+EVIDENCE = ("0.41", "2 of 5", "14", "40", "6 steps", "9", "0.8", "2-step")
+
+# Parameter names the scenario names, plus any explicit quantity.
+PARAM = re.compile(r"\b(aggression|lookahead|decoy|tiebreak|threshold|weight|step)\w*\b|\b\d+(\.\d+)?\b", re.I)
+
+
+def _post(url: str, api_key: str, payload: dict[str, Any], *, attempts: int = 3, deadline: float = 120.0) -> dict[str, Any]:
+    """POST with a bounded wait and a retry.
+
+    urllib's ``timeout`` is per socket operation, not per request, so a gateway
+    that dribbles bytes resets it on every chunk and holds the connection open
+    indefinitely. Observed twice against OpenRouter: a run sat on one trial for
+    18 minutes with a 120s socket timeout set, while ordinary calls to the same
+    model returned in two seconds.
+
+    So the deadline is enforced from outside the socket, on a worker thread the
+    caller abandons if it overruns. The thread may linger until its own socket
+    gives up; that is deliberate. This is a measurement harness, and a leaked
+    thread is a much smaller problem than a measurement that never finishes.
+    """
+
+    def _once() -> dict[str, Any]:
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+        )
+        with urllib.request.urlopen(req, timeout=deadline) as resp:  # noqa: S310 - operator-supplied endpoint
+            return json.loads(resp.read())
+
+    last: Exception | None = None
+    for attempt in range(attempts):
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            return pool.submit(_once).result(timeout=deadline)
+        except Exception as exc:  # noqa: BLE001, PERF203 - any failure is a retry
+            last = exc
+            print(f"    retry {attempt + 1}/{attempts}: {type(exc).__name__}", flush=True)
+        finally:
+            pool.shutdown(wait=False)
+    raise RuntimeError(f"request failed after {attempts} attempts: {last}")
+
+
+def _messages() -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": "You are the analyst agent in an optimization loop."},
+        {"role": "user", "content": f"{CONTEXT}\n\n{ANALYST_TASK}"},
+    ]
+
+
+def _prose_items(markdown: str) -> dict[str, list[str]]:
+    """Every bullet the model wrote, by ANY marker, regardless of heading level.
+
+    Deliberately NOT the shipped scraper. The question here is whether the
+    model's ANALYSIS degrades when it fills a schema, not whether the parser can
+    read it -- that is AC-913 and already measured. Scoring the prose arm
+    through the strict scraper conflates the two and, on a model that drifts,
+    yields zero items and no comparison at all (observed: llama3.1:8b scores 0
+    items on every prose trial, which says nothing about its reasoning).
+    """
+    items = [
+        re.sub(r"^\s*([-*+]|\d+[.)])\s*", "", line).strip()
+        for line in markdown.splitlines()
+        if re.match(r"^\s*([-*+]|\d+[.)])\s+\S", line)
+    ]
+    # Recommendations are scored separately, so approximate the split by the
+    # last heading that mentions recommendations; everything else is analysis.
+    split = re.search(r"^#+\s*.*Recommendation", markdown, re.MULTILINE | re.IGNORECASE)
+    if split:
+        head, tail = markdown[: split.start()], markdown[split.start() :]
+        recs = [
+            re.sub(r"^\s*([-*+]|\d+[.)])\s*", "", line).strip()
+            for line in tail.splitlines()
+            if re.match(r"^\s*([-*+]|\d+[.)])\s+\S", line)
+        ]
+        others = [
+            re.sub(r"^\s*([-*+]|\d+[.)])\s*", "", line).strip()
+            for line in head.splitlines()
+            if re.match(r"^\s*([-*+]|\d+[.)])\s+\S", line)
+        ]
+        return {"analysis": others, "recommendations": recs}
+    return {"analysis": items, "recommendations": []}
+
+
+def _unused_scrape(markdown: str) -> dict[str, list[str]]:
+    """Kept for reference: the shipped scraper's exact rule."""
+    out: dict[str, list[str]] = {}
+    for key, heading in (
+        ("findings", "Findings"),
+        ("root_causes", "Root Causes"),
+        ("recommendations", "Actionable Recommendations"),
+    ):
+        match = re.search(rf"^##\s+{re.escape(heading)}\s*$", markdown, re.MULTILINE)
+        bullets: list[str] = []
+        if match:
+            for line in markdown[match.end() :].splitlines():
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    break
+                if stripped.startswith("- "):
+                    bullets.append(stripped[2:].strip())
+        out[key] = bullets
+    return out
+
+
+def _score(sections: dict[str, list[str]]) -> dict[str, float]:
+    items = [i for group in sections.values() for i in group]
+    recs = sections.get("recommendations", [])
+    if not items:
+        return {"items": 0, "mean_chars": 0.0, "grounded": 0.0, "actionable": 0.0}
+    grounded = sum(1 for i in items if any(e in i for e in EVIDENCE))
+    actionable = sum(1 for r in recs if PARAM.search(r))
+    return {
+        "items": len(items),
+        "mean_chars": statistics.mean(len(i) for i in items),
+        "grounded": grounded / len(items),
+        "actionable": (actionable / len(recs)) if recs else 0.0,
+    }
+
+
+def _score_payload(payload: dict[str, Any]) -> dict[str, float]:
+    return _score(
+        {
+            "findings": payload.get("findings", []),
+            "root_causes": payload.get("root_causes", []),
+            "recommendations": payload.get("recommendations", []),
+        }
+    )
+
+
+def _constrained_request(mode: str, base: dict[str, Any], schema: Any) -> dict[str, Any]:
+    """Build the schema-constrained arm for the mechanism under test.
+
+    Two mechanisms, because the providers differ in kind rather than in syntax:
+
+    * ``response_format`` -- what AC-913 shipped for OpenAI-compatible backends.
+    * ``tool`` -- a forced tool call, which is Anthropic's only equivalent.
+      AC-928's open question is whether *being made to fill a schema* costs
+      analysis quality, so the forced-tool arm has to be measured on its own
+      rather than assumed to behave like ``response_format``.
+    """
+    if mode == "response_format":
+        return {
+            **base,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": schema.name, "strict": True, "schema": schema.schema},
+            },
+        }
+    return {
+        **base,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": schema.name,
+                    "description": "Return the analysis as structured data.",
+                    "parameters": schema.schema,
+                },
+            }
+        ],
+        "tool_choice": {"type": "function", "function": {"name": schema.name}},
+    }
+
+
+def _constrained_payload(mode: str, response: dict[str, Any]) -> dict[str, Any]:
+    """Pull the object out of whichever channel the mechanism used."""
+    message = response["choices"][0]["message"]
+    if mode == "response_format":
+        return json.loads(message["content"])
+    calls = message.get("tool_calls") or []
+    if not calls:
+        raise json.JSONDecodeError("forced tool call produced no tool_calls", "", 0)
+    return json.loads(calls[0]["function"]["arguments"])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", required=True)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--api-key", default="no-key")
+    ap.add_argument("--trials", type=int, default=20)
+    ap.add_argument("--out", default="")
+    ap.add_argument(
+        "--mode",
+        choices=("response_format", "tool"),
+        default="response_format",
+        help="Constraint mechanism: response_format (OpenAI-compatible) or tool (forced tool call, Anthropic's equivalent)",
+    )
+    args = ap.parse_args()
+
+    from autocontext.agents.role_schemas import ANALYST_SCHEMA
+
+    url = f"{args.base_url.rstrip('/')}/chat/completions"
+    prose_scores: list[dict[str, float]] = []
+    schema_scores: list[dict[str, float]] = []
+    schema_rejected = 0
+
+    for i in range(args.trials):
+        base = {"model": args.model, "messages": _messages(), "temperature": 0.7, "max_tokens": 900}
+
+        prose = _post(url, args.api_key, base)["choices"][0]["message"]["content"]
+        prose_scores.append(_score(_prose_items(prose)))
+
+        response = _post(url, args.api_key, _constrained_request(args.mode, base, ANALYST_SCHEMA))
+        try:
+            schema_scores.append(_score_payload(_constrained_payload(args.mode, response)))
+        except (json.JSONDecodeError, KeyError, TypeError):
+            schema_rejected += 1
+        print(f"  trial {i + 1}/{args.trials}", flush=True)
+
+    def agg(rows: list[dict[str, float]]) -> dict[str, dict[str, float]]:
+        """Mean plus spread, because a mean alone cannot support the decision.
+
+        AC-928 asks whether constrained output is *worse*, and two means a few
+        percent apart say nothing without knowing how much a single trial
+        varies. Reporting sd and the standard error of the mean lets a reader
+        check whether a gap is larger than the run-to-run wobble instead of
+        taking the point estimate on faith.
+        """
+        if not rows:
+            return {}
+        out: dict[str, dict[str, float]] = {}
+        for key in rows[0]:
+            values = [r[key] for r in rows]
+            sd = statistics.stdev(values) if len(values) > 1 else 0.0
+            out[key] = {
+                "mean": round(statistics.mean(values), 3),
+                "sd": round(sd, 3),
+                "sem": round(sd / (len(values) ** 0.5), 3) if values else 0.0,
+            }
+        return out
+
+    verdict = {
+        "model": args.model,
+        "mode": args.mode,
+        "trials": args.trials,
+        "prose": agg(prose_scores),
+        "schema": agg(schema_scores),
+        "schema_unparseable": schema_rejected,
+        # Retained so a reader can re-aggregate or run a different test without
+        # paying for the API calls again.
+        "raw": {"prose": prose_scores, "schema": schema_scores},
+    }
+    print(json.dumps({k: v for k, v in verdict.items() if k != "raw"}, indent=2))
+    if args.out:
+        Path(args.out).write_text(json.dumps(verdict, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any
 
 import anthropic
@@ -28,6 +30,7 @@ _DEEP_THINK_TOOL: dict[str, Any] = {
     "description": DEEP_THINK_DESCRIPTION,
     "input_schema": DEEP_THINK_PARAMETERS,
 }
+logger = logging.getLogger(__name__)
 
 
 class AnthropicProvider(LLMProvider):
@@ -50,24 +53,51 @@ class AnthropicProvider(LLMProvider):
         max_tokens: int = 4096,
         output_schema: OutputSchema | None = None,
     ) -> CompletionResult:
-        del output_schema  # AC-913: Anthropic structured output not wired yet; reported unconstrained
         model_id = model or self._default_model
+        request: dict[str, Any] = {
+            "model": model_id,
+            "max_tokens": clamp_output_tokens(max_tokens, model_id),
+            "temperature": temperature,
+            "system": system_prompt,
+            "messages": [{"role": "user", "content": user_prompt}],
+        }
+
+        # AC-928. Anthropic has no `response_format`; a forced tool call is the
+        # equivalent. Declaring a tool whose input_schema is the role schema and
+        # pinning tool_choice to it makes the model emit a validated object in a
+        # tool_use block instead of prose.
+        constrained = False
+        if output_schema is not None:
+            request["tools"] = [
+                {
+                    "name": output_schema.name,
+                    "description": "Return the response as structured data matching the schema.",
+                    "input_schema": output_schema.schema,
+                }
+            ]
+            request["tool_choice"] = {"type": "tool", "name": output_schema.name}
+            constrained = True
+
         try:
-            response = self._client.messages.create(
-                model=model_id,
-                max_tokens=clamp_output_tokens(max_tokens, model_id),
-                temperature=temperature,
-                system=system_prompt,
-                messages=[{"role": "user", "content": user_prompt}],
-            )
+            response = self._client.messages.create(**request)
         except anthropic.APIError as exc:
             raise ProviderError(f"Anthropic API error: {exc}") from exc
 
-        text = ""
-        if response.content:
-            block = response.content[0]
-            if hasattr(block, "text"):
-                text = block.text
+        text = _text_from(response, output_schema if constrained else None)
+        if constrained and text is None:
+            # Forcing the tool did not produce a tool_use block. Rather than
+            # claim a constrained result the caller would then hand to a strict
+            # parser, fall back to whatever text came back and say it was
+            # unconstrained -- the same honesty contract openai_compat keeps
+            # when an endpoint rejects response_format.
+            logger.warning(
+                "providers.anthropic: %s returned no tool_use block for forced tool '%s'; reporting unconstrained",
+                model_id,
+                output_schema.name if output_schema else "",
+            )
+            constrained = False
+            text = _first_text_block(response)
+
         usage = {}
         if response.usage:
             usage = {
@@ -76,10 +106,11 @@ class AnthropicProvider(LLMProvider):
             }
 
         return CompletionResult(
-            text=text,
+            text=text or "",
             model=model_id,
             usage=usage,
             stop_reason=getattr(response, "stop_reason", None),
+            constrained=constrained,
         )
 
     def complete_with_thinking(
@@ -199,3 +230,29 @@ class AnthropicProvider(LLMProvider):
     @property
     def supports_thinking_stream(self) -> bool:
         return True
+
+
+def _first_text_block(response: Any) -> str:
+    for block in getattr(response, "content", None) or []:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            return text
+    return ""
+
+
+def _text_from(response: Any, output_schema: OutputSchema | None) -> str | None:
+    """Serialize the response into the text the rest of the loop parses.
+
+    Unconstrained, that is the first text block, unchanged. Constrained, the
+    payload arrives as an already-parsed dict on a tool_use block, so it is
+    re-serialized to JSON: every caller downstream of this method reads
+    ``CompletionResult.text``, and returning an object here would mean changing
+    that contract for one provider. Returns None when the forced tool produced
+    no tool_use block, which the caller reports as unconstrained.
+    """
+    if output_schema is None:
+        return _first_text_block(response)
+    for block in getattr(response, "content", None) or []:
+        if getattr(block, "type", None) == "tool_use" and getattr(block, "name", None) == output_schema.name:
+            return json.dumps(block.input)
+    return None

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 import anthropic
@@ -62,56 +63,77 @@ class AnthropicProvider(LLMProvider):
             "messages": [{"role": "user", "content": user_prompt}],
         }
 
-        # AC-928. Anthropic has no `response_format`; a forced tool call is the
-        # equivalent. Declaring a tool whose input_schema is the role schema and
-        # pinning tool_choice to it makes the model emit a validated object in a
-        # tool_use block instead of prose.
+        # AC-928. Anthropic has no `response_format`; a strict, forced tool call
+        # is the equivalent. ``strict`` is essential: forcing a non-strict tool
+        # only guarantees the channel and tool name, not the input's shape.
         constrained = False
         if output_schema is not None:
             request["tools"] = [
                 {
                     "name": output_schema.name,
                     "description": "Return the response as structured data matching the schema.",
-                    "input_schema": output_schema.schema,
+                    "input_schema": _anthropic_strict_schema(output_schema.schema),
+                    "strict": True,
                 }
             ]
             request["tool_choice"] = {"type": "tool", "name": output_schema.name}
             constrained = True
 
-        try:
-            response = self._client.messages.create(**request)
-        except anthropic.APIError as exc:
-            raise ProviderError(f"Anthropic API error: {exc}") from exc
+        response, constrained = self._create_message(request, model_id=model_id, constrained=constrained)
 
-        text = _text_from(response, output_schema if constrained else None)
-        if constrained and text is None:
-            # Forcing the tool did not produce a tool_use block. Rather than
-            # claim a constrained result the caller would then hand to a strict
-            # parser, fall back to whatever text came back and say it was
-            # unconstrained -- the same honesty contract openai_compat keeps
-            # when an endpoint rejects response_format.
-            logger.warning(
-                "providers.anthropic: %s returned no tool_use block for forced tool '%s'; reporting unconstrained",
-                model_id,
-                output_schema.name if output_schema else "",
+        stop_reason = getattr(response, "stop_reason", None)
+        text = _first_text_block(response)
+        if constrained and output_schema is not None:
+            payload = _tool_payload(response, output_schema.name)
+            constrained = (
+                stop_reason == "tool_use"
+                and payload is not None
+                and _matches_json_schema(payload, output_schema.schema)
             )
-            constrained = False
-            text = _first_text_block(response)
-
-        usage = {}
-        if response.usage:
-            usage = {
-                "input_tokens": response.usage.input_tokens,
-                "output_tokens": response.usage.output_tokens,
-            }
+            if constrained:
+                text = json.dumps(payload)
+            else:
+                # A refusal, truncated response, wrong/missing tool call, or
+                # invalid payload must never enter the strict parser under a
+                # successful constrained flag.
+                logger.warning(
+                    "providers.anthropic: %s did not return a complete, schema-valid tool '%s'; "
+                    "reporting unconstrained (stop_reason=%s)",
+                    model_id,
+                    output_schema.name,
+                    stop_reason,
+                )
 
         return CompletionResult(
-            text=text or "",
+            text=text,
             model=model_id,
-            usage=usage,
-            stop_reason=getattr(response, "stop_reason", None),
+            usage=_usage_from(response),
+            stop_reason=stop_reason,
             constrained=constrained,
         )
+
+    def _create_message(
+        self,
+        request: dict[str, Any],
+        *,
+        model_id: str,
+        constrained: bool,
+    ) -> tuple[Any, bool]:
+        """Create one message, degrading only explicit strict-schema rejection."""
+        while True:
+            try:
+                return self._client.messages.create(**request), constrained
+            except anthropic.APIError as exc:
+                if constrained and _is_unsupported_strict_schema_error(exc):
+                    logger.info(
+                        "providers.anthropic: %s rejected strict structured output; retrying unconstrained",
+                        model_id,
+                    )
+                    request.pop("tools", None)
+                    request.pop("tool_choice", None)
+                    constrained = False
+                    continue
+                raise ProviderError(f"Anthropic API error: {exc}") from exc
 
     def complete_with_thinking(
         self,
@@ -240,19 +262,223 @@ def _first_text_block(response: Any) -> str:
     return ""
 
 
-def _text_from(response: Any, output_schema: OutputSchema | None) -> str | None:
-    """Serialize the response into the text the rest of the loop parses.
-
-    Unconstrained, that is the first text block, unchanged. Constrained, the
-    payload arrives as an already-parsed dict on a tool_use block, so it is
-    re-serialized to JSON: every caller downstream of this method reads
-    ``CompletionResult.text``, and returning an object here would mean changing
-    that contract for one provider. Returns None when the forced tool produced
-    no tool_use block, which the caller reports as unconstrained.
-    """
-    if output_schema is None:
-        return _first_text_block(response)
+def _tool_payload(response: Any, name: str) -> Any | None:
     for block in getattr(response, "content", None) or []:
-        if getattr(block, "type", None) == "tool_use" and getattr(block, "name", None) == output_schema.name:
-            return json.dumps(block.input)
+        if getattr(block, "type", None) == "tool_use" and getattr(block, "name", None) == name:
+            return getattr(block, "input", None)
     return None
+
+
+def _usage_from(response: Any) -> dict[str, int]:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return {}
+    return {
+        "input_tokens": int(getattr(usage, "input_tokens", 0) or 0),
+        "output_tokens": int(getattr(usage, "output_tokens", 0) or 0),
+    }
+
+
+def _is_unsupported_strict_schema_error(exc: Exception) -> bool:
+    """Identify only endpoint rejections of strict structured tool use."""
+    if getattr(exc, "status_code", None) not in {400, 404, 422}:
+        return False
+    message = str(exc).lower()
+    mentions_feature = any(
+        token in message
+        for token in ("strict", "input_schema", "input schema", "structured output", "structured tool")
+    )
+    rejection = any(
+        token in message
+        for token in ("unsupported", "not supported", "unknown", "unrecognized", "unexpected", "invalid")
+    )
+    return mentions_feature and rejection
+
+
+def _anthropic_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Transform JSON Schema to Anthropic's strict structured-output subset.
+
+    Anthropic rejects unsupported validation keywords instead of ignoring them.
+    As its SDK's newer ``transform_schema`` helper does, keep those constraints
+    in descriptions for generation guidance. The original schema remains the
+    authority for the local validation performed before ``constrained=True``.
+    This local copy keeps compatibility with the older SDK versions in CI.
+    """
+
+    def transform(current: dict[str, Any]) -> dict[str, Any]:
+        remaining = dict(current)
+        result: dict[str, Any] = {}
+
+        definitions = remaining.pop("$defs", None)
+        if isinstance(definitions, dict):
+            result["$defs"] = {
+                str(name): transform(definition)
+                for name, definition in definitions.items()
+                if isinstance(definition, dict)
+            }
+
+        reference = remaining.pop("$ref", None)
+        if isinstance(reference, str):
+            result["$ref"] = reference
+            return result
+
+        schema_type = remaining.pop("type", None)
+        any_of = remaining.pop("anyOf", None)
+        one_of = remaining.pop("oneOf", None)
+        all_of = remaining.pop("allOf", None)
+        if isinstance(any_of, list):
+            result["anyOf"] = [transform(item) for item in any_of if isinstance(item, dict)]
+        elif isinstance(one_of, list):
+            result["anyOf"] = [transform(item) for item in one_of if isinstance(item, dict)]
+        elif isinstance(all_of, list):
+            result["allOf"] = [transform(item) for item in all_of if isinstance(item, dict)]
+        elif isinstance(schema_type, str):
+            result["type"] = schema_type
+        else:
+            raise ValueError("Anthropic structured-output schemas require type, anyOf, oneOf, or allOf")
+
+        enum = remaining.pop("enum", None)
+        if isinstance(enum, list):
+            result["enum"] = enum
+        for annotation in ("description", "title"):
+            value = remaining.pop(annotation, None)
+            if isinstance(value, str):
+                result[annotation] = value
+
+        if schema_type == "object":
+            properties = remaining.pop("properties", {})
+            if isinstance(properties, dict):
+                result["properties"] = {
+                    str(name): transform(value)
+                    for name, value in properties.items()
+                    if isinstance(value, dict)
+                }
+            remaining.pop("additionalProperties", None)
+            result["additionalProperties"] = False
+            required = remaining.pop("required", None)
+            if isinstance(required, list):
+                result["required"] = required
+        elif schema_type == "array":
+            items = remaining.pop("items", None)
+            if isinstance(items, dict):
+                result["items"] = transform(items)
+            min_items = remaining.pop("minItems", None)
+            if min_items in {0, 1}:
+                result["minItems"] = min_items
+            elif min_items is not None:
+                remaining["minItems"] = min_items
+        elif schema_type == "string":
+            string_format = remaining.pop("format", None)
+            if string_format in {"date-time", "time", "date", "duration", "email", "hostname", "uri", "ipv4", "ipv6", "uuid"}:
+                result["format"] = string_format
+            elif string_format is not None:
+                remaining["format"] = string_format
+
+        if remaining:
+            suffix = "{" + ", ".join(f"{key}: {value}" for key, value in remaining.items()) + "}"
+            description = result.get("description")
+            result["description"] = f"{description}\n\n{suffix}" if isinstance(description, str) else suffix
+        return result
+
+    return transform(schema)
+
+
+def _matches_json_schema(value: Any, schema: dict[str, Any], *, root: dict[str, Any] | None = None) -> bool:
+    """Validate the JSON Schema features emitted by autocontext role models."""
+    root = schema if root is None else root
+    reference = schema.get("$ref")
+    if isinstance(reference, str):
+        target = _local_schema_reference(root, reference)
+        return target is not None and _matches_json_schema(value, target, root=root)
+
+    if isinstance(schema.get("allOf"), list) and not all(
+        isinstance(item, dict) and _matches_json_schema(value, item, root=root) for item in schema["allOf"]
+    ):
+        return False
+    if isinstance(schema.get("anyOf"), list) and not any(
+        isinstance(item, dict) and _matches_json_schema(value, item, root=root) for item in schema["anyOf"]
+    ):
+        return False
+    if isinstance(schema.get("oneOf"), list) and sum(
+        isinstance(item, dict) and _matches_json_schema(value, item, root=root) for item in schema["oneOf"]
+    ) != 1:
+        return False
+    if "enum" in schema and value not in schema["enum"]:
+        return False
+    if "const" in schema and value != schema["const"]:
+        return False
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        if not any(_matches_json_schema(value, {**schema, "type": item}, root=root) for item in schema_type):
+            return False
+    elif isinstance(schema_type, str) and not _matches_json_type(value, schema_type):
+        return False
+
+    if schema_type == "object" and isinstance(value, dict):
+        required = schema.get("required", [])
+        if isinstance(required, list) and any(key not in value for key in required):
+            return False
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            properties = {}
+        for key, item in value.items():
+            property_schema = properties.get(key)
+            if isinstance(property_schema, dict):
+                if not _matches_json_schema(item, property_schema, root=root):
+                    return False
+            elif schema.get("additionalProperties") is False:
+                return False
+            elif isinstance(schema.get("additionalProperties"), dict) and not _matches_json_schema(
+                item, schema["additionalProperties"], root=root
+            ):
+                return False
+
+    if schema_type == "array" and isinstance(value, list):
+        if isinstance(schema.get("minItems"), int) and len(value) < schema["minItems"]:
+            return False
+        if isinstance(schema.get("maxItems"), int) and len(value) > schema["maxItems"]:
+            return False
+        items = schema.get("items")
+        if isinstance(items, dict) and any(not _matches_json_schema(item, items, root=root) for item in value):
+            return False
+
+    if schema_type == "string" and isinstance(value, str):
+        if isinstance(schema.get("minLength"), int) and len(value) < schema["minLength"]:
+            return False
+        if isinstance(schema.get("maxLength"), int) and len(value) > schema["maxLength"]:
+            return False
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str) and re.search(pattern, value) is None:
+            return False
+    return True
+
+
+def _matches_json_type(value: Any, schema_type: str) -> bool:
+    if schema_type == "object":
+        return isinstance(value, dict)
+    if schema_type == "array":
+        return isinstance(value, list)
+    if schema_type == "string":
+        return isinstance(value, str)
+    if schema_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if schema_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if schema_type == "boolean":
+        return isinstance(value, bool)
+    if schema_type == "null":
+        return value is None
+    return True
+
+
+def _local_schema_reference(root: dict[str, Any], reference: str) -> dict[str, Any] | None:
+    if not reference.startswith("#/"):
+        return None
+    current: Any = root
+    for segment in reference[2:].split("/"):
+        key = segment.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current if isinstance(current, dict) else None

--- a/autocontext/tests/test_anthropic_constrained.py
+++ b/autocontext/tests/test_anthropic_constrained.py
@@ -21,19 +21,26 @@ from typing import Any
 import pytest
 
 from autocontext.providers.anthropic import AnthropicProvider
-from autocontext.providers.base import OutputSchema
+from autocontext.providers.base import OutputSchema, ProviderError
 
 PAYLOAD = {"answer": "ok"}
 
 
 class _Messages:
-    def __init__(self, response: Any) -> None:
-        self.response = response
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
         self.calls: list[dict[str, Any]] = []
 
     def create(self, **request: Any) -> Any:
         self.calls.append(request)
-        return self.response
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class _RejectedRequest(Exception):
+    status_code = 400
 
 
 def _tool_use_block(name: str = "answer", payload: dict[str, Any] | None = None) -> Any:
@@ -52,8 +59,8 @@ def _response(blocks: list[Any], stop_reason: str = "end_turn") -> Any:
     )
 
 
-def _provider(response: Any) -> tuple[AnthropicProvider, _Messages]:
-    messages = _Messages(response)
+def _provider(*outcomes: Any) -> tuple[AnthropicProvider, _Messages]:
+    messages = _Messages(list(outcomes))
     provider = object.__new__(AnthropicProvider)
     provider._default_model = "claude-stub"
     provider._client = SimpleNamespace(messages=messages)
@@ -80,6 +87,7 @@ def test_schema_forces_the_tool_and_returns_its_payload() -> None:
     request = messages.calls[0]
     assert request["tools"][0]["name"] == "answer"
     assert request["tools"][0]["input_schema"] == _schema().schema
+    assert request["tools"][0]["strict"] is True
     # Pinned, not "auto": an unforced tool is one the model may decline to call,
     # which would silently produce prose on the path a strict parser reads.
     assert request["tool_choice"] == {"type": "tool", "name": "answer"}
@@ -117,7 +125,7 @@ def test_missing_tool_use_block_degrades_to_unconstrained(caplog: pytest.LogCapt
 
     assert result.constrained is False
     assert result.text == "I would rather explain."
-    assert any("no tool_use block" in record.message for record in caplog.records)
+    assert any("did not return a complete, schema-valid tool" in record.message for record in caplog.records)
 
 
 def test_tool_use_block_for_a_different_tool_is_not_accepted() -> None:
@@ -139,7 +147,7 @@ def test_tool_use_block_is_found_after_leading_text() -> None:
     The pre-AC-928 reader took ``content[0]`` and stopped, so a preamble would
     have hidden the payload entirely.
     """
-    provider, _ = _provider(_response([_text_block("Let me structure that."), _tool_use_block()]))
+    provider, _ = _provider(_response([_text_block("Let me structure that."), _tool_use_block()], stop_reason="tool_use"))
 
     result = provider.complete("sys", "user", output_schema=_schema())
 
@@ -154,6 +162,66 @@ def test_unconstrained_text_is_found_after_a_non_text_block() -> None:
     result = provider.complete("sys", "user")
 
     assert result.text == "the answer"
+
+
+def test_invalid_matching_tool_payload_is_not_reported_as_constrained() -> None:
+    provider, _ = _provider(
+        _response([_tool_use_block(payload={"answer": ["wrong type"]})], stop_reason="tool_use")
+    )
+
+    result = provider.complete("sys", "user", output_schema=_schema())
+
+    assert result.constrained is False
+
+
+@pytest.mark.parametrize("stop_reason", ["max_tokens", "refusal"])
+def test_incomplete_or_refused_tool_response_is_not_constrained(stop_reason: str) -> None:
+    provider, _ = _provider(_response([_tool_use_block()], stop_reason=stop_reason))
+
+    result = provider.complete("sys", "user", output_schema=_schema())
+
+    assert result.constrained is False
+    assert result.stop_reason == stop_reason
+
+
+def test_strict_schema_rejection_retries_without_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("autocontext.providers.anthropic.anthropic.APIError", _RejectedRequest)
+    provider, messages = _provider(
+        _RejectedRequest("strict structured output is not supported for this model"),
+        _response([_text_block("fallback prose")]),
+    )
+
+    result = provider.complete("sys", "user", output_schema=_schema())
+
+    assert result.text == "fallback prose"
+    assert result.constrained is False
+    assert len(messages.calls) == 2
+    assert messages.calls[0]["tools"][0]["strict"] is True
+    assert "tools" not in messages.calls[1]
+    assert "tool_choice" not in messages.calls[1]
+
+
+def test_unrelated_api_error_does_not_retry_without_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("autocontext.providers.anthropic.anthropic.APIError", _RejectedRequest)
+    provider, messages = _provider(_RejectedRequest("invalid authentication token"))
+
+    with pytest.raises(ProviderError, match="invalid authentication token"):
+        provider.complete("sys", "user", output_schema=_schema())
+
+    assert len(messages.calls) == 1
+
+
+def test_anthropic_schema_transform_keeps_original_constraints_for_local_validation() -> None:
+    schema = _schema()
+    schema.schema["properties"]["answer"]["minLength"] = 2
+    provider, messages = _provider(_response([_tool_use_block(payload={"answer": "x"})], stop_reason="tool_use"))
+
+    result = provider.complete("sys", "user", output_schema=schema)
+
+    sent = messages.calls[0]["tools"][0]["input_schema"]["properties"]["answer"]
+    assert "minLength" not in sent
+    assert "minLength: 2" in sent["description"]
+    assert result.constrained is False
 
 
 def test_a_real_analyst_run_forces_the_tool_on_the_anthropic_wire() -> None:

--- a/autocontext/tests/test_anthropic_constrained.py
+++ b/autocontext/tests/test_anthropic_constrained.py
@@ -1,0 +1,183 @@
+"""AC-928: Anthropic honors ``output_schema`` via a forced tool call.
+
+Anthropic has no ``response_format``. The equivalent is declaring a tool whose
+``input_schema`` is the role schema and pinning ``tool_choice`` to it, so the
+model fills the schema in a ``tool_use`` block instead of writing prose.
+
+The contract these pin is the same one ``openai_compat`` keeps: ``constrained``
+describes what actually happened, never what was requested. A caller reads that
+flag to decide between the strict parser and the markdown scrape, so a result
+that claims ``constrained=True`` without a validated payload behind it would
+route unvalidated text into a parser that assumes otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from autocontext.providers.anthropic import AnthropicProvider
+from autocontext.providers.base import OutputSchema
+
+PAYLOAD = {"answer": "ok"}
+
+
+class _Messages:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **request: Any) -> Any:
+        self.calls.append(request)
+        return self.response
+
+
+def _tool_use_block(name: str = "answer", payload: dict[str, Any] | None = None) -> Any:
+    return SimpleNamespace(type="tool_use", name=name, input=payload if payload is not None else PAYLOAD)
+
+
+def _text_block(text: str) -> Any:
+    return SimpleNamespace(type="text", text=text)
+
+
+def _response(blocks: list[Any], stop_reason: str = "end_turn") -> Any:
+    return SimpleNamespace(
+        content=blocks,
+        usage=SimpleNamespace(input_tokens=3, output_tokens=2),
+        stop_reason=stop_reason,
+    )
+
+
+def _provider(response: Any) -> tuple[AnthropicProvider, _Messages]:
+    messages = _Messages(response)
+    provider = object.__new__(AnthropicProvider)
+    provider._default_model = "claude-stub"
+    provider._client = SimpleNamespace(messages=messages)
+    return provider, messages
+
+
+def _schema() -> OutputSchema:
+    return OutputSchema(
+        name="answer",
+        schema={
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def test_schema_forces_the_tool_and_returns_its_payload() -> None:
+    provider, messages = _provider(_response([_tool_use_block()], stop_reason="tool_use"))
+
+    result = provider.complete("sys", "user", output_schema=_schema())
+
+    request = messages.calls[0]
+    assert request["tools"][0]["name"] == "answer"
+    assert request["tools"][0]["input_schema"] == _schema().schema
+    # Pinned, not "auto": an unforced tool is one the model may decline to call,
+    # which would silently produce prose on the path a strict parser reads.
+    assert request["tool_choice"] == {"type": "tool", "name": "answer"}
+    assert result.constrained is True
+    assert json.loads(result.text) == PAYLOAD
+
+
+def test_no_schema_sends_no_tool_and_reports_unconstrained() -> None:
+    """The default path must be byte-identical to pre-AC-928 behavior.
+
+    Anthropic is the shipped default provider, so a change that leaked into
+    unschema'd calls would alter every existing user's runs.
+    """
+    provider, messages = _provider(_response([_text_block("plain prose")]))
+
+    result = provider.complete("sys", "user")
+
+    assert "tools" not in messages.calls[0]
+    assert "tool_choice" not in messages.calls[0]
+    assert result.constrained is False
+    assert result.text == "plain prose"
+
+
+def test_missing_tool_use_block_degrades_to_unconstrained(caplog: pytest.LogCaptureFixture) -> None:
+    """The failure that would otherwise be invisible.
+
+    If the model answers in prose despite the forced tool, reporting
+    ``constrained=True`` would hand that prose to a parser that assumes JSON.
+    Fall back to the text and say so.
+    """
+    provider, _ = _provider(_response([_text_block("I would rather explain.")]))
+
+    with caplog.at_level(logging.WARNING):
+        result = provider.complete("sys", "user", output_schema=_schema())
+
+    assert result.constrained is False
+    assert result.text == "I would rather explain."
+    assert any("no tool_use block" in record.message for record in caplog.records)
+
+
+def test_tool_use_block_for_a_different_tool_is_not_accepted() -> None:
+    """Name-matched on purpose.
+
+    Taking the first tool_use block regardless of name would accept a payload
+    shaped by some other schema and label it constrained against this one.
+    """
+    provider, _ = _provider(_response([_tool_use_block(name="something_else", payload={"other": 1})]))
+
+    result = provider.complete("sys", "user", output_schema=_schema())
+
+    assert result.constrained is False
+
+
+def test_tool_use_block_is_found_after_leading_text() -> None:
+    """Anthropic may emit a text block before the tool call.
+
+    The pre-AC-928 reader took ``content[0]`` and stopped, so a preamble would
+    have hidden the payload entirely.
+    """
+    provider, _ = _provider(_response([_text_block("Let me structure that."), _tool_use_block()]))
+
+    result = provider.complete("sys", "user", output_schema=_schema())
+
+    assert result.constrained is True
+    assert json.loads(result.text) == PAYLOAD
+
+
+def test_unconstrained_text_is_found_after_a_non_text_block() -> None:
+    """Same defect on the unconstrained path, which also read only content[0]."""
+    provider, _ = _provider(_response([SimpleNamespace(type="thinking"), _text_block("the answer")]))
+
+    result = provider.complete("sys", "user")
+
+    assert result.text == "the answer"
+
+
+def test_a_real_analyst_run_forces_the_tool_on_the_anthropic_wire() -> None:
+    """The capability has to FIRE, not merely exist.
+
+    The tests above drive ``complete()`` directly, which cannot catch a role
+    path that never passes a schema down -- exactly the AC-913 near-miss where
+    constrained decoding compiled, passed, and would never have run. This goes
+    through the real AnalystRunner and asserts on the request that reached the
+    Anthropic client, so the whole chain is covered by something executable.
+    """
+    from autocontext.agents.analyst import AnalystRunner
+    from autocontext.agents.provider_bridge import ProviderBridgeClient
+    from autocontext.harness.core.subagent import SubagentRuntime
+
+    payload = {"findings": ["f"], "root_causes": ["r"], "recommendations": ["rec"]}
+    provider, messages = _provider(_response([_tool_use_block(name="analyst_output", payload=payload)], stop_reason="tool_use"))
+
+    runtime = SubagentRuntime(ProviderBridgeClient(provider))
+    execution = AnalystRunner(runtime, model="claude-stub").run("analyze this", system="you are the analyst")
+
+    request = messages.calls[0]
+    assert request["tool_choice"] == {"type": "tool", "name": "analyst_output"}
+    assert request["tools"][0]["name"] == "analyst_output"
+    # And the loop believes it, so parsing takes the strict path rather than
+    # scraping markdown out of a JSON payload.
+    assert execution.metadata.get("constrained") is True

--- a/autocontext/tests/test_measure_constrained_quality.py
+++ b/autocontext/tests/test_measure_constrained_quality.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import multiprocessing
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from autocontext.agents.role_schemas import ANALYST_SCHEMA  # noqa: E402
+from scripts.measure_constrained_quality import (  # noqa: E402
+    _constrained_payload,
+    _constrained_request,
+    _post,
+    _prose_content,
+    _score_payload,
+)
+
+
+def test_tool_measurement_requests_strict_arguments() -> None:
+    request = _constrained_request("tool", {"model": "stub"}, ANALYST_SCHEMA)
+
+    assert request["tools"][0]["function"]["strict"] is True
+
+
+def test_native_anthropic_measurement_matches_shipped_wire_shape() -> None:
+    request = _constrained_request("anthropic_tool", {"model": "stub"}, ANALYST_SCHEMA)
+
+    tool = request["tools"][0]
+    assert tool["name"] == "analyst_output"
+    assert tool["strict"] is True
+    assert tool["input_schema"]["properties"]["findings"]["minItems"] == 1
+    assert "minLength" not in tool["input_schema"]["properties"]["findings"]["items"]
+    assert request["tool_choice"] == {"type": "tool", "name": "analyst_output"}
+
+
+def test_native_anthropic_measurement_extracts_both_arms() -> None:
+    assert _prose_content("anthropic_tool", {"content": [{"type": "text", "text": "analysis"}]}) == "analysis"
+    payload = {"findings": ["f"], "root_causes": ["r"], "recommendations": ["rec"]}
+    response = {"content": [{"type": "tool_use", "name": "analyst_output", "input": payload}]}
+    assert _constrained_payload("anthropic_tool", response) == payload
+
+
+def test_measurement_rejects_wrongly_typed_schema_payload() -> None:
+    malformed = {
+        "findings": "not-a-list",
+        "root_causes": "also-not-a-list",
+        "recommendations": "x",
+    }
+
+    with pytest.raises(ValueError):
+        _score_payload(malformed)
+
+
+def test_measurement_scores_only_validated_payloads() -> None:
+    score = _score_payload(
+        {
+            "findings": ["Score was 0.41."],
+            "root_causes": ["The 2-step lookahead was too short."],
+            "recommendations": ["Raise lookahead to 4 steps."],
+        }
+    )
+
+    assert score["items"] == 3
+    assert score["grounded"] == pytest.approx(2 / 3)
+    assert score["actionable"] == 1.0
+
+
+def _blocking_worker(
+    url: str,
+    api_key: str,
+    payload: dict[str, Any],
+    deadline: float,
+    sender: Any,
+    anthropic_api: bool,
+) -> None:
+    del url, api_key, payload, deadline, sender, anthropic_api
+    time.sleep(10.0)
+
+
+def test_post_deadline_terminates_and_reaps_in_flight_request() -> None:
+    before_children = {child.pid for child in multiprocessing.active_children()}
+    before_threads = {thread.ident for thread in threading.enumerate()}
+    started = time.monotonic()
+
+    with pytest.raises(RuntimeError, match="request failed after 1 attempts"):
+        _post(
+            "http://unused.invalid/chat/completions",
+            "test-key",
+            {"model": "stub"},
+            attempts=1,
+            deadline=0.1,
+            _worker=_blocking_worker,
+        )
+
+    assert time.monotonic() - started < 2.0
+    assert {child.pid for child in multiprocessing.active_children()} <= before_children
+    leaked_threads = [
+        thread
+        for thread in threading.enumerate()
+        if thread.ident not in before_threads and not thread.daemon and thread.is_alive()
+    ]
+    assert leaked_threads == []

--- a/docs/ac928-constrained-quality-measurement.json
+++ b/docs/ac928-constrained-quality-measurement.json
@@ -1,0 +1,64 @@
+{
+  "contract": "AC-928 constrained-output quality measurement. Answers whether forcing a model to fill a schema makes its ANALYSIS worse, not whether the payload validates (that is AC-913 and already settled). Read schema_minus_prose_grounded_items with its standard_errors before quoting any ratio from this file.",
+  "measured_on": "2026-08-11",
+  "harness": "scripts/measure_constrained_quality.py",
+  "transport_caveat": "Both models were reached through OpenRouter, not the vendor APIs directly. The OpenAI key available at measurement time had no credits and no Anthropic key was available. OpenRouter normalizes both backends to the OpenAI-shaped API, so the Anthropic arm exercises a forced tool call translated by OpenRouter rather than a native Anthropic messages call. The provider code that shipped from this issue calls Anthropic natively; the largest role schema (architect_output, the only one using $defs/$ref) was separately confirmed accepted with HTTP 200 and a returned tool call.",
+  "metric_note": "The per-item ratios in the raw rows are denominator-sensitive and were nearly misread. The prose arm emits roughly twice as many, much shorter items (structural and nested bullets all count), which dilutes any per-item ratio. Absolute grounded items per response is the comparable figure and is what the verdict rests on.",
+  "arms": {
+    "prose": "no schema; the model writes markdown and the loop scrapes it",
+    "schema": "response_format json_schema (OpenAI) or a forced tool call (Anthropic)"
+  },
+  "results": {
+    "openai/gpt-4o": {
+      "mechanism": "response_format json_schema",
+      "prose": {
+        "items_per_response": 18.15,
+        "grounded_items_per_response": 3.4,
+        "grounded_items_sem": 0.2,
+        "total_chars_per_response": 2469,
+        "actionable_share_of_recommendations": 0.484
+      },
+      "schema": {
+        "items_per_response": 12,
+        "grounded_items_per_response": 2.85,
+        "grounded_items_sem": 0.25,
+        "total_chars_per_response": 1599,
+        "actionable_share_of_recommendations": 0.517
+      },
+      "schema_minus_prose_grounded_items": -0.55,
+      "standard_errors": 1.7,
+      "schema_unparseable": 0,
+      "trials": 20
+    },
+    "anthropic/claude-sonnet-4.5": {
+      "mechanism": "forced tool call",
+      "prose": {
+        "items_per_response": 41.4,
+        "grounded_items_per_response": 6.65,
+        "grounded_items_sem": 0.31,
+        "total_chars_per_response": 2402,
+        "actionable_share_of_recommendations": 0.583
+      },
+      "schema": {
+        "items_per_response": 17.95,
+        "grounded_items_per_response": 7.45,
+        "grounded_items_sem": 0.15,
+        "total_chars_per_response": 2048,
+        "actionable_share_of_recommendations": 0.71
+      },
+      "schema_minus_prose_grounded_items": 0.8,
+      "standard_errors": 2.3,
+      "schema_unparseable": 0,
+      "trials": 20
+    }
+  },
+  "replication": {
+    "anthropic/claude-sonnet-4.5": "An independent 20-trial run reproduced the direction and size (per-item grounding 0.158 -> 0.424 vs 0.161 -> 0.415).",
+    "openai/gpt-4o": "An independent 20-trial run disagreed in SIGN on per-item grounding (0.216 -> 0.210 vs 0.205 -> 0.239), which is itself the evidence that the gpt-4o difference is noise."
+  },
+  "verdict": {
+    "anthropic": "Ship constrained by default. No regression on either substance proxy; grounded content is slightly HIGHER (+0.80 items per response, 2.3 standard errors) and actionability rises 0.583 -> 0.710. 40 of 40 trials produced a valid payload.",
+    "openai": "Keep what AC-913 already shipped. Grounded content is statistically indistinguishable (-0.55 items, 1.7 standard errors, sign flips between runs). Recorded caveat: constrained responses are about 35 percent shorter in total characters, which is a real change in output shape even though the substance proxies do not move.",
+    "escape_hatch": "Neither decision is one-way. AC-931's per-role constrained_output setting already lets an operator take the prose path."
+  }
+}

--- a/docs/ac928-constrained-quality-measurement.json
+++ b/docs/ac928-constrained-quality-measurement.json
@@ -1,12 +1,14 @@
 {
-  "contract": "AC-928 constrained-output quality measurement. Answers whether forcing a model to fill a schema makes its ANALYSIS worse, not whether the payload validates (that is AC-913 and already settled). Read schema_minus_prose_grounded_items with its standard_errors before quoting any ratio from this file.",
+  "status": "pilot_only_not_release_evidence",
+  "contract": "Historical AC-928 quality pilot. The Anthropic-shaped arm forced a tool name but omitted strict=true and checked only that arguments were JSON-decodable, so it did not measure schema-constrained Anthropic output. Its quality numbers may guide a future experiment but cannot support a default-rollout decision.",
   "measured_on": "2026-08-11",
   "harness": "scripts/measure_constrained_quality.py",
-  "transport_caveat": "Both models were reached through OpenRouter, not the vendor APIs directly. The OpenAI key available at measurement time had no credits and no Anthropic key was available. OpenRouter normalizes both backends to the OpenAI-shaped API, so the Anthropic arm exercises a forced tool call translated by OpenRouter rather than a native Anthropic messages call. The provider code that shipped from this issue calls Anthropic natively; the largest role schema (architect_output, the only one using $defs/$ref) was separately confirmed accepted with HTTP 200 and a returned tool call.",
+  "required_rerun": "Use --mode anthropic_tool with https://api.anthropic.com/v1; the corrected harness sends native strict=true tools and rejects payloads that fail AnalystPayload validation.",
+  "transport_caveat": "Both models were reached through OpenRouter, not the vendor APIs directly. The Anthropic arm exercised a non-strict forced tool call translated by OpenRouter rather than a native Anthropic strict tool. The reported HTTP 200 for architect_output established only that a non-strict tool declaration was accepted; it did not establish schema enforcement.",
   "metric_note": "The per-item ratios in the raw rows are denominator-sensitive and were nearly misread. The prose arm emits roughly twice as many, much shorter items (structural and nested bullets all count), which dilutes any per-item ratio. Absolute grounded items per response is the comparable figure and is what the verdict rests on.",
   "arms": {
     "prose": "no schema; the model writes markdown and the loop scrapes it",
-    "schema": "response_format json_schema (OpenAI) or a forced tool call (Anthropic)"
+    "schema": "response_format json_schema (OpenAI) or, in the historical Anthropic pilot only, a non-strict forced tool call"
   },
   "results": {
     "openai/gpt-4o": {
@@ -28,6 +30,7 @@
       "schema_minus_prose_grounded_items": -0.55,
       "standard_errors": 1.7,
       "schema_unparseable": 0,
+      "schema_validation": "Validated by the response_format strict JSON-schema mechanism.",
       "trials": 20
     },
     "anthropic/claude-sonnet-4.5": {
@@ -49,15 +52,16 @@
       "schema_minus_prose_grounded_items": 0.8,
       "standard_errors": 2.3,
       "schema_unparseable": 0,
+      "schema_validation": "Not measured. Zero means JSON decoding succeeded, not that payloads matched analyst_output.",
       "trials": 20
     }
   },
   "replication": {
-    "anthropic/claude-sonnet-4.5": "An independent 20-trial run reproduced the direction and size (per-item grounding 0.158 -> 0.424 vs 0.161 -> 0.415).",
+    "anthropic/claude-sonnet-4.5": "An independent 20-trial run reproduced the direction and size for the same non-strict forced-tool pilot (per-item grounding 0.158 -> 0.424 vs 0.161 -> 0.415); this does not repair the missing enforcement or native-transport controls.",
     "openai/gpt-4o": "An independent 20-trial run disagreed in SIGN on per-item grounding (0.216 -> 0.210 vs 0.205 -> 0.239), which is itself the evidence that the gpt-4o difference is noise."
   },
   "verdict": {
-    "anthropic": "Ship constrained by default. No regression on either substance proxy; grounded content is slightly HIGHER (+0.80 items per response, 2.3 standard errors) and actionability rises 0.583 -> 0.710. 40 of 40 trials produced a valid payload.",
+    "anthropic": "INCONCLUSIVE. This pilot cannot support its original ship-by-default conclusion and must not be cited as rollout evidence. Rerun the corrected strict harness against the native Anthropic Messages API and require every payload to pass the AnalystPayload contract before comparing quality.",
     "openai": "Keep what AC-913 already shipped. Grounded content is statistically indistinguishable (-0.55 items, 1.7 standard errors, sign flips between runs). Recorded caveat: constrained responses are about 35 percent shorter in total characters, which is a real change in output shape even though the substance proxies do not move.",
     "escape_hatch": "Neither decision is one-way. AC-931's per-role constrained_output setting already lets an operator take the prose path."
   }


### PR DESCRIPTION
Closes AC-928.

## What changed

- Anthropic constrained role output now uses a **strict forced tool** (`strict: true`) rather than treating an ordinary forced tool call as schema enforcement.
- Provider-facing schemas are transformed to Anthropic's supported strict subset, while returned tool input is validated against the original role schema before `constrained=True` is reported.
- Refusals, truncation, missing/wrong tool calls, and malformed inputs report `constrained=False`; explicit strict/schema capability rejections retry once on the prose path. Authentication, rate-limit, timeout, and server failures are not silently downgraded.
- The pre-existing content reader fix remains: text and matching tool blocks are found after leading thinking/preamble blocks.
- The branch is rebased onto current `main`, preserving Anthropic's deep-thinking tool loop from #1267.

## Measurement correction

The original Anthropic quality run was not valid release evidence: it used an OpenRouter-translated, non-strict tool and checked only JSON decoding. The checked-in artifact now labels that run as a historical pilot and retracts its ship-by-default conclusion.

The harness now:

- sets `strict: true` for tool-mode trials;
- validates every candidate with the shipped `AnalystPayload` model before scoring;
- supports native Anthropic Messages API trials via `--mode anthropic_tool`;
- enforces deadlines in terminable child processes, preventing timed-out requests from lingering through interpreter shutdown.

A fresh paid/native experiment was not fabricated in this change. The artifact records the exact rerun required before its results can be used as rollout evidence.

## Verification

- `ruff check src tests` — pass
- targeted script lint — pass
- `mypy src` — pass (744 files)
- full Python suite — pass (9,209 collected, expected skips)
- focused Anthropic constrained/thinking/measurement suite — 25 pass

`uv.lock` is unchanged.
