### PR TITLE
fix(AC-924): migrate the judge score parser onto the shared extractor

### DIFF
--- a/autocontext/src/autocontext/execution/judge.py
+++ b/autocontext/src/autocontext/execution/judge.py
@@ -574,10 +574,11 @@ class LLMJudge:
         every one of those callers carry judge semantics they do not want.
 
         Depth is unbounded now. The old regexes handled at most one level of
-        nesting, so a judge returning nested per-dimension scores fell through
-        to the plaintext tier and lost every dimension silently.
+        nesting, so a verdict carrying valid flat dimensions plus unrelated
+        deeply nested metadata fell through to the plaintext tier and lost
+        every dimension silently.
         """
-        data = extract_json(response, on_failure="none")
+        data = extract_json(response, on_failure="none", required_keys=("score",))
         if isinstance(data, dict) and "score" in data:
             return data
         return None

--- a/autocontext/src/autocontext/execution/judge.py
+++ b/autocontext/src/autocontext/execution/judge.py
@@ -12,6 +12,7 @@ from autocontext.agents.types import LlmFn
 from autocontext.execution.rubric_coherence import check_rubric_coherence
 from autocontext.execution.rubric_spec import RubricSpec, compile_rubric_spec
 from autocontext.extensions import HookBus, HookEvents, get_current_hook_bus
+from autocontext.harness.core.output_parser import extract_json
 from autocontext.providers.base import LLMProvider
 from autocontext.providers.callable_wrapper import CallableProvider
 
@@ -363,8 +364,7 @@ class LLMJudge:
             all_dims = [all_dims[i] for i in valid_indices]
         elif not valid_indices and last_stop_reason in ("max_tokens", "length"):
             reasonings = [
-                f"Failed to parse judge response: output truncated (stop_reason={last_stop_reason}); "
-                "no parseable score found"
+                f"Failed to parse judge response: output truncated (stop_reason={last_stop_reason}); no parseable score found"
             ]
 
         avg_score = sum(scores) / len(scores)
@@ -507,26 +507,36 @@ class LLMJudge:
 
         Strategies (tried in order):
         1. Marker-based: extract JSON between <!-- JUDGE_RESULT_START/END -->
-        2. Raw JSON: find a JSON object with "score" key anywhere in response
-        3. Code block: extract JSON from ```json ... ``` blocks
-        4. Plain text: regex for "score": X.XX or "Score: X.XX" patterns
+        2. Shared model-JSON extraction, accepted only if it carries a "score"
+        3. Plain text: regex for "score": X.XX or "Score: X.XX" patterns
+
+        AC-924 collapsed what used to be two separate middle tiers. A
+        hand-rolled `re.finditer(r'\\{[^{}]*"score"[^{}]*\\}', ...)` ran ahead of
+        a hand-rolled fence regex, and because it scanned the whole response and
+        took the FIRST match, it read inside fences and reasoning blocks and won
+        before the fence-aware tier was ever reached. Measured before the
+        change: a reasoning block containing a discarded draft scored the run
+        0.05 where the fenced answer said 0.88. That is ordinary open-weight
+        output shape, and the failure is silent -- a wrong number entering the
+        ranking, not an error.
+
+        `extract_json` already prefers the answer over the scratchpad, so
+        replacing both tiers with it fixes that rather than only deduplicating
+        a regex. The "score" requirement stays here, at the call site, because
+        it is judge semantics: the shared parser is a general model-JSON
+        extractor and has no business knowing about scores.
         """
         # Strategy 1: Marker-based (preferred — matches our system prompt format)
         data = self._try_marker_parse(response)
         if data is not None:
             return self._extract_from_dict(data, "markers")
 
-        # Strategy 2: Raw JSON object with "score" key
-        data = self._try_raw_json_parse(response)
+        # Strategy 2: Shared extraction, gated on judge semantics.
+        data = self._try_model_json_parse(response)
         if data is not None:
             return self._extract_from_dict(data, "raw_json")
 
-        # Strategy 3: JSON code block
-        data = self._try_code_block_parse(response)
-        if data is not None:
-            return self._extract_from_dict(data, "code_block")
-
-        # Strategy 4: Plain text score extraction
+        # Strategy 3: Plain text score extraction
         result = self._try_plaintext_parse(response)
         if result is not None:
             return (*result, "plaintext")
@@ -550,37 +560,26 @@ class LLMJudge:
             return None
 
     @staticmethod
-    def _try_code_block_parse(response: str) -> dict | None:
-        """Strategy 2: Extract JSON from ```json ... ``` code blocks."""
-        pattern = re.compile(r"```(?:json)?\s*\n?(.*?)\n?```", re.DOTALL)
-        for match in pattern.finditer(response):
-            try:
-                data = json.loads(match.group(1).strip())
-                if isinstance(data, dict) and "score" in data:
-                    return data
-            except (json.JSONDecodeError, TypeError):
-                continue
-        return None
+    def _try_model_json_parse(response: str) -> dict | None:
+        """Strategy 2: shared model-JSON extraction, gated on judge semantics.
 
-    @staticmethod
-    def _try_raw_json_parse(response: str) -> dict | None:
-        """Strategy 3: Find a JSON object containing 'score' key."""
-        # Look for JSON objects in the response
-        for match in re.finditer(r'\{[^{}]*"score"[^{}]*\}', response):
-            try:
-                data = json.loads(match.group(0))
-                if isinstance(data, dict) and "score" in data:
-                    return data
-            except (json.JSONDecodeError, TypeError):
-                continue
-        # Try nested objects (with dimensions)
-        for match in re.finditer(r'\{(?:[^{}]|\{[^{}]*\})*"score"(?:[^{}]|\{[^{}]*\})*\}', response):
-            try:
-                data = json.loads(match.group(0))
-                if isinstance(data, dict) and "score" in data:
-                    return data
-            except (json.JSONDecodeError, TypeError):
-                continue
+        Replaces the two hand-rolled middle tiers (AC-924). Both are gone: a
+        fence regex duplicating the shared one, and a whole-response
+        ``"score"``-shaped scan that ran ahead of it and took the first match
+        wherever it appeared -- including inside a reasoning block.
+
+        The ``"score"`` check stays here rather than moving into ``extract_json``.
+        That function is a general model-JSON parser used by the roles, the
+        advise gate and the strategy path; teaching it about scores would make
+        every one of those callers carry judge semantics they do not want.
+
+        Depth is unbounded now. The old regexes handled at most one level of
+        nesting, so a judge returning nested per-dimension scores fell through
+        to the plaintext tier and lost every dimension silently.
+        """
+        data = extract_json(response, on_failure="none")
+        if isinstance(data, dict) and "score" in data:
+            return data
         return None
 
     @staticmethod

--- a/autocontext/src/autocontext/harness/core/output_parser.py
+++ b/autocontext/src/autocontext/harness/core/output_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from typing import Any
 
 # The `tag` group is what makes a ```json fence distinguishable from a bare
@@ -204,14 +204,16 @@ def _fenced_payload_scopes(text: str) -> list[str] | None:
     return plausible or None
 
 
-def _has_multiple_mapping_candidates(text: str) -> bool:
-    """Return whether an LLM response contains competing JSON objects.
+def _has_multiple_mapping_candidates(text: str, required_keys: frozenset[str]) -> bool:
+    """Return whether an LLM response contains competing eligible JSON objects.
 
     A tagged JSON fence is authoritative, matching ``extract_json``'s normal
     fence-selection rule. Without one, scan the whole response so an object in
     an untagged reasoning fence cannot hide a different final object outside
     that fence. Callers that must fail closed on ambiguity can opt into this
     check without changing the established first-object behavior elsewhere.
+    Mappings missing ``required_keys`` are not competitors because the caller
+    could not accept them as its result.
     """
     tagged = next((match for match in _JSON_FENCE_RE.finditer(text) if match.group("tag")), None)
     scope = _scope_text(tagged.group("body")) if tagged is not None else _scope_text(text)
@@ -221,7 +223,7 @@ def _has_multiple_mapping_candidates(text: str) -> bool:
             decoded = json.loads(span)
         except (json.JSONDecodeError, RecursionError):
             continue
-        if isinstance(decoded, Mapping):
+        if isinstance(decoded, Mapping) and required_keys.issubset(decoded):
             mapping_count += 1
             if mapping_count > 1:
                 return True
@@ -233,6 +235,7 @@ def extract_json(
     *,
     on_failure: str = "raise",
     require_unique: bool = False,
+    required_keys: Collection[str] = (),
 ) -> dict[str, Any] | None:
     """Extract a JSON object from LLM text.
 
@@ -257,12 +260,12 @@ def extract_json(
     brace-free ones that cannot be holding an object -- does the scan fall
     back to the whole text. There, unlike the fenced case, multiple candidate top-level
     values are tried in the order they appear, returning the first Mapping
-    that parses -- this is what lets bare, unfenced JSON embedded in prose
-    still be recovered, including when a competitor lists more than one
-    option (e.g. "Option A: {...} Option B: {...}"): loose prose makes no
-    claim to a single payload the way a fence does, so picking the first
-    valid one is the closest match to what a human reader would take as the
-    answer.
+    that parses and satisfies ``required_keys`` -- this is what lets bare,
+    unfenced JSON embedded in prose still be recovered, including when a
+    competitor lists more than one option (e.g. "Option A: {...} Option B:
+    {...}"): loose prose makes no claim to a single payload the way a fence
+    does, so picking the first valid one is the closest match to what a human
+    reader would take as the answer.
 
     A scope whose first plausible JSON container is ``[`` -- fenced or not,
     and even when prose precedes it -- is exempt from object rescue. If it
@@ -279,7 +282,14 @@ def extract_json(
     object candidate. A tagged JSON fence remains authoritative, so JSON-shaped
     scratch work in an earlier untagged fence cannot invalidate an explicitly
     designated answer.
+
+    ``required_keys`` filters Mapping candidates without assigning domain
+    semantics to this shared parser. A Mapping that does not contain every
+    required key is skipped so a later candidate can satisfy the caller's
+    schema. ``require_unique`` likewise counts only candidates that satisfy
+    the key requirement.
     """
+    required_key_set = frozenset(required_keys)
     fenced_scopes = _fenced_payload_scopes(text)
     has_fence = fenced_scopes is not None
     scopes = fenced_scopes if fenced_scopes is not None else [_scope_text(text)]
@@ -353,9 +363,13 @@ def extract_json(
             last_exc = exc
             continue
         if isinstance(decoded, Mapping):
+            if not required_key_set.issubset(decoded):
+                missing = sorted(required_key_set.difference(decoded))
+                last_exc = ValueError(f"Expected JSON object containing required keys: {missing}")
+                continue
             if require_unique:
                 try:
-                    has_multiple = _has_multiple_mapping_candidates(text)
+                    has_multiple = _has_multiple_mapping_candidates(text, required_key_set)
                 except (ValueError, RecursionError) as exc:
                     last_exc = exc
                     break

--- a/autocontext/tests/test_judge_score_parsing.py
+++ b/autocontext/tests/test_judge_score_parsing.py
@@ -6,19 +6,21 @@ turned up two behaviors that matter more than the duplication, because a
 mis-parsed judge score is not a crash. It is a wrong number entering the loop's
 ranking, so the run keeps going and reports a result nobody can tell is wrong.
 
-**Tier order is not what the method docstrings say.** `_parse_judge_response`
-calls markers, then raw_json, then code_block, then plaintext. The individual
-methods label themselves "Strategy 2: code block" and "Strategy 3: raw JSON",
-i.e. the reverse of the order they run in. The class docstring has it right.
-AC-924's own description inherited the wrong version.
+**The tier order was not what the method docstrings said.** The parser ran
+markers, raw_json, code_block, plaintext, while the methods labelled themselves
+"Strategy 2: code block" and "Strategy 3: raw JSON" -- the reverse. Only the
+class docstring was right, and AC-924's own description inherited the wrong
+version.
 
-That inversion is what causes the first defect: `_try_raw_json_parse` scans the
-WHOLE response with `re.finditer(r'\\{[^{}]*"score"[^{}]*\\}', ...)` and takes
-the first match, so it reaches inside fences and reasoning blocks and wins
-before the fence-aware tier is ever tried.
+That inversion is what caused the first defect. `_try_raw_json_parse` scanned
+the WHOLE response with `re.finditer(r'\\{[^{}]*"score"[^{}]*\\}', ...)` and took
+the first match, so it reached inside fences and reasoning blocks and won before
+the fence-aware tier was ever tried.
 
-These tests pin today's behavior including both defects. The fix commit changes
-the recorded values, so the diff is the evidence.
+The fix replaces both middle tiers with the shared `extract_json`, which already
+preferred the answer over the scratchpad. These values were recorded against the
+old parser first and then re-recorded, so the diff in this file is the evidence
+that the behavior moved.
 """
 
 from __future__ import annotations
@@ -47,7 +49,7 @@ def _parse(response: str) -> tuple[float, str, dict[str, float], str]:
             "markers",
         ),
         ("bare object", '{"score": 0.6}', 0.6, "raw_json"),
-        ("fenced object is read by the RAW tier", '```json\n{"score": 0.8}\n```', 0.8, "raw_json"),
+        ("fenced object", '```json\n{"score": 0.8}\n```', 0.8, "raw_json"),
         ("untagged fence, same", '```\n{"score": 0.7}\n```', 0.7, "raw_json"),
         ("prose then object", 'Verdict:\n{"score": 0.55}', 0.55, "raw_json"),
         ("plain text score", "Overall score: 0.45", 0.45, "plaintext"),
@@ -61,77 +63,58 @@ def test_uncontested_responses_parse_as_recorded(label: str, response: str, scor
     assert (got_score, got_method) == (score, method), label
 
 
-def test_code_block_tier_is_only_reachable_past_two_nesting_levels() -> None:
-    """Why `code_block` almost never fires, which the tier order hides.
+def test_arbitrary_nesting_depth_is_read_as_json() -> None:
+    """FIXED by AC-924. Was: fell to the plaintext tier and lost its dimensions.
 
-    `raw_json` runs first and its regex handles at most one level of nesting.
-    A fenced payload nested deeper falls through to the fence-aware tier -- the
-    only routine way to reach it at all.
+    The old raw regex handled one level of nesting and the fence tier could not
+    help an unfenced payload, so a well-formed object was scraped by a plaintext
+    regex. The score survived by luck; every per-dimension score was dropped.
     """
-    score, _reasoning, _dims, method = _parse('```json\n{"score": 0.65, "dimensions": {"a": {"b": 1}}}\n```')
-    assert (score, method) == (0.65, "code_block")
-
-
-def test_deeply_nested_unfenced_payload_falls_all_the_way_to_plaintext() -> None:
-    """DEFECT (recorded, not endorsed): dimensions are silently dropped.
-
-    Two levels of nesting defeats the raw tier, there is no fence for the fence
-    tier, so a well-formed JSON object is scraped by a plaintext regex. The
-    score survives by luck because the regex finds `"score": 0.64`; every
-    per-dimension score in the same object is lost without a signal.
-    """
-    score, _reasoning, dims, method = _parse('{"score": 0.64, "dimensions": {"a": {"b": 1}}}')
-    assert (score, method) == (0.64, "plaintext")
-    assert dims == {}, "dimensions survived; this test is out of date"
+    score, _reasoning, _dims, method = _parse('{"score": 0.64, "dimensions": {"a": {"b": 1}}}')
+    assert (score, method) == (0.64, "raw_json")
 
 
 @pytest.mark.parametrize(
-    "label,response,wrong,right",
+    "label,response,expected,was",
     [
         (
-            "a discarded draft beats the final answer",
-            'I considered {"score": 0.2} but settled on {"score": 0.9}',
-            0.2,
-            0.9,
-        ),
-        (
-            "prose draft beats the fenced answer",
+            "prose draft loses to the fenced answer",
             'Draft thought {"score": 0.1}\n```json\n{"score": 0.95}\n```',
-            0.1,
             0.95,
+            0.1,
         ),
         (
-            "a reasoning block beats the answer",
+            "a reasoning block loses to the answer",
             '```\nthinking out loud, maybe {"score": 0.05}\n```\n```json\n{"score": 0.88}\n```',
-            0.05,
             0.88,
+            0.05,
         ),
     ],
 )
-def test_first_score_shaped_object_anywhere_wins(label: str, response: str, wrong: float, right: float) -> None:
-    """DEFECT (recorded, not endorsed): the earliest match wins, wherever it is.
+def test_a_discarded_draft_no_longer_outranks_the_answer(label: str, response: str, expected: float, was: float) -> None:
+    """FIXED by AC-924, and the reason the issue was worth more than a dedupe.
 
-    The third case is the one that matters in practice. Emitting a reasoning
-    block before the answer is ordinary open-weight behavior -- it is the exact
-    shape AC-926 fixed for the advise gate -- and here it scores the run 0.05
-    instead of 0.88. Nothing errors; a wrong number just enters the ranking.
+    The old middle tier scanned the whole response for a `"score"`-shaped
+    object and took the first hit, so a draft in prose or a reasoning block beat
+    the real answer. Emitting a reasoning block before the answer is ordinary
+    open-weight output -- the exact shape AC-926 fixed for the advise gate --
+    and it scored the run 0.05 where the judge said 0.88. Silently: a wrong
+    number entered the ranking and the run carried on.
     """
     score, _reasoning, _dims, _method = _parse(response)
-    assert score == wrong, f"{label}: expected the recorded (wrong) value"
-    assert score != right, f"{label}: behavior improved; re-record this file"
+    assert score == expected, label
+    assert score != was, f"{label}: regressed to the pre-AC-924 value"
 
 
-def test_tier_order_contradicts_the_method_docstrings() -> None:
-    """Pins the naming inversion so the fix has to resolve it deliberately.
+def test_two_bare_objects_in_prose_still_take_the_first() -> None:
+    """NOT fixed, and deliberately so.
 
-    `_try_code_block_parse` documents itself as Strategy 2 and `_try_raw_json_parse`
-    as Strategy 3, while `_parse_judge_response` runs raw_json second and
-    code_block third. Asserted on observable behavior rather than on docstring
-    text: a fenced, singly-nested payload is reported as `raw_json`, which is
-    only possible if the raw tier runs first.
+    With no fence and no markers there is nothing to distinguish a draft from a
+    verdict; both parsers take the first object. Recorded so the limit is known
+    rather than assumed away by the cases above.
     """
-    _score, _reasoning, _dims, method = _parse('```json\n{"score": 0.5, "dimensions": {"a": 1}}\n```')
-    assert method == "raw_json"
+    score, _reasoning, _dims, method = _parse('I considered {"score": 0.2} but settled on {"score": 0.9}')
+    assert (score, method) == (0.2, "raw_json")
 
 
 def test_dimensions_survive_a_single_nesting_level() -> None:

--- a/autocontext/tests/test_judge_score_parsing.py
+++ b/autocontext/tests/test_judge_score_parsing.py
@@ -67,11 +67,29 @@ def test_arbitrary_nesting_depth_is_read_as_json() -> None:
     """FIXED by AC-924. Was: fell to the plaintext tier and lost its dimensions.
 
     The old raw regex handled one level of nesting and the fence tier could not
-    help an unfenced payload, so a well-formed object was scraped by a plaintext
-    regex. The score survived by luck; every per-dimension score was dropped.
+    help an unfenced payload with deeply nested metadata, so a well-formed
+    object was scraped by a plaintext regex. The score survived by luck; every
+    otherwise-valid per-dimension score was dropped.
     """
-    score, _reasoning, _dims, method = _parse('{"score": 0.64, "dimensions": {"a": {"b": 1}}}')
+    response = '{"score": 0.64, "dimensions": {"quality": 0.7}, "metadata": {"a": {"b": 1}}}'
+    score, _reasoning, dims, method = _parse(response)
     assert (score, method) == (0.64, "raw_json")
+    assert dims == {"quality": 0.7}
+
+
+def test_unrelated_json_object_does_not_hide_the_scored_verdict() -> None:
+    """A schema-mismatched object must not force the lossy plaintext tier.
+
+    Without caller-aware candidate filtering, ``extract_json`` returned the
+    metadata object and the judge rejected it only after extraction had ended.
+    Plaintext fallback then read the ``1`` prefix of the valid JSON number
+    ``1e-1`` as 1.0 and discarded the verdict's reasoning and dimensions.
+    """
+    response = (
+        '{"metadata": {"request_id": "abc"}}\n'
+        '{"score": 1e-1, "reasoning": "final", "dimensions": {"quality": 0.77}}'
+    )
+    assert _parse(response) == (0.1, "final", {"quality": 0.77}, "raw_json")
 
 
 @pytest.mark.parametrize(

--- a/autocontext/tests/test_judge_score_parsing.py
+++ b/autocontext/tests/test_judge_score_parsing.py
@@ -1,0 +1,148 @@
+"""AC-924: what the judge's 4-tier score parser actually does, pinned by execution.
+
+The issue framed this as consolidating a duplicate fence regex. Characterizing
+first -- the same discipline that found five defects in the Plan 3 extractors --
+turned up two behaviors that matter more than the duplication, because a
+mis-parsed judge score is not a crash. It is a wrong number entering the loop's
+ranking, so the run keeps going and reports a result nobody can tell is wrong.
+
+**Tier order is not what the method docstrings say.** `_parse_judge_response`
+calls markers, then raw_json, then code_block, then plaintext. The individual
+methods label themselves "Strategy 2: code block" and "Strategy 3: raw JSON",
+i.e. the reverse of the order they run in. The class docstring has it right.
+AC-924's own description inherited the wrong version.
+
+That inversion is what causes the first defect: `_try_raw_json_parse` scans the
+WHOLE response with `re.finditer(r'\\{[^{}]*"score"[^{}]*\\}', ...)` and takes
+the first match, so it reaches inside fences and reasoning blocks and wins
+before the fence-aware tier is ever tried.
+
+These tests pin today's behavior including both defects. The fix commit changes
+the recorded values, so the diff is the evidence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from autocontext.execution.judge import _RESULT_END, _RESULT_START, LLMJudge
+
+
+def _parse(response: str) -> tuple[float, str, dict[str, float], str]:
+    """Drive the real parser without constructing a judge (no provider needed)."""
+    judge = object.__new__(LLMJudge)
+    return judge._parse_judge_response(response)
+
+
+@pytest.mark.parametrize(
+    "label,response,score,method",
+    [
+        ("markers win outright", f'{_RESULT_START}\n{{"score":0.9}}\n{_RESULT_END}', 0.9, "markers"),
+        (
+            "markers beat stray prose JSON",
+            f'Aside {{"score":0.15}}\n{_RESULT_START}\n{{"score":0.85}}\n{_RESULT_END}',
+            0.85,
+            "markers",
+        ),
+        ("bare object", '{"score": 0.6}', 0.6, "raw_json"),
+        ("fenced object is read by the RAW tier", '```json\n{"score": 0.8}\n```', 0.8, "raw_json"),
+        ("untagged fence, same", '```\n{"score": 0.7}\n```', 0.7, "raw_json"),
+        ("prose then object", 'Verdict:\n{"score": 0.55}', 0.55, "raw_json"),
+        ("plain text score", "Overall score: 0.45", 0.45, "plaintext"),
+        ("x / 1.0 form", "I would rate this 0.35 / 1.0", 0.35, "plaintext"),
+        ("nothing scoreable", "This response cannot be scored.", 0.0, "none"),
+    ],
+)
+def test_uncontested_responses_parse_as_recorded(label: str, response: str, score: float, method: str) -> None:
+    """The cases where every tier would agree. These must not move."""
+    got_score, _reasoning, _dims, got_method = _parse(response)
+    assert (got_score, got_method) == (score, method), label
+
+
+def test_code_block_tier_is_only_reachable_past_two_nesting_levels() -> None:
+    """Why `code_block` almost never fires, which the tier order hides.
+
+    `raw_json` runs first and its regex handles at most one level of nesting.
+    A fenced payload nested deeper falls through to the fence-aware tier -- the
+    only routine way to reach it at all.
+    """
+    score, _reasoning, _dims, method = _parse('```json\n{"score": 0.65, "dimensions": {"a": {"b": 1}}}\n```')
+    assert (score, method) == (0.65, "code_block")
+
+
+def test_deeply_nested_unfenced_payload_falls_all_the_way_to_plaintext() -> None:
+    """DEFECT (recorded, not endorsed): dimensions are silently dropped.
+
+    Two levels of nesting defeats the raw tier, there is no fence for the fence
+    tier, so a well-formed JSON object is scraped by a plaintext regex. The
+    score survives by luck because the regex finds `"score": 0.64`; every
+    per-dimension score in the same object is lost without a signal.
+    """
+    score, _reasoning, dims, method = _parse('{"score": 0.64, "dimensions": {"a": {"b": 1}}}')
+    assert (score, method) == (0.64, "plaintext")
+    assert dims == {}, "dimensions survived; this test is out of date"
+
+
+@pytest.mark.parametrize(
+    "label,response,wrong,right",
+    [
+        (
+            "a discarded draft beats the final answer",
+            'I considered {"score": 0.2} but settled on {"score": 0.9}',
+            0.2,
+            0.9,
+        ),
+        (
+            "prose draft beats the fenced answer",
+            'Draft thought {"score": 0.1}\n```json\n{"score": 0.95}\n```',
+            0.1,
+            0.95,
+        ),
+        (
+            "a reasoning block beats the answer",
+            '```\nthinking out loud, maybe {"score": 0.05}\n```\n```json\n{"score": 0.88}\n```',
+            0.05,
+            0.88,
+        ),
+    ],
+)
+def test_first_score_shaped_object_anywhere_wins(label: str, response: str, wrong: float, right: float) -> None:
+    """DEFECT (recorded, not endorsed): the earliest match wins, wherever it is.
+
+    The third case is the one that matters in practice. Emitting a reasoning
+    block before the answer is ordinary open-weight behavior -- it is the exact
+    shape AC-926 fixed for the advise gate -- and here it scores the run 0.05
+    instead of 0.88. Nothing errors; a wrong number just enters the ranking.
+    """
+    score, _reasoning, _dims, _method = _parse(response)
+    assert score == wrong, f"{label}: expected the recorded (wrong) value"
+    assert score != right, f"{label}: behavior improved; re-record this file"
+
+
+def test_tier_order_contradicts_the_method_docstrings() -> None:
+    """Pins the naming inversion so the fix has to resolve it deliberately.
+
+    `_try_code_block_parse` documents itself as Strategy 2 and `_try_raw_json_parse`
+    as Strategy 3, while `_parse_judge_response` runs raw_json second and
+    code_block third. Asserted on observable behavior rather than on docstring
+    text: a fenced, singly-nested payload is reported as `raw_json`, which is
+    only possible if the raw tier runs first.
+    """
+    _score, _reasoning, _dims, method = _parse('```json\n{"score": 0.5, "dimensions": {"a": 1}}\n```')
+    assert method == "raw_json"
+
+
+def test_dimensions_survive_a_single_nesting_level() -> None:
+    """The one path that delivers per-dimension scores today."""
+    _score, _reasoning, dims, method = _parse('{"score": 0.75, "dimensions": {"a": 1}}')
+    assert method == "raw_json"
+    assert dims == {"a": 1.0}
+
+
+def test_marker_tier_ignores_malformed_json_and_falls_through() -> None:
+    """Markers are preferred but not trusted blindly."""
+    response: Any = f'{_RESULT_START}\nnot json\n{_RESULT_END}\n{{"score": 0.42}}'
+    score, _reasoning, _dims, method = _parse(response)
+    assert (score, method) == (0.42, "raw_json")

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -1524,8 +1524,6 @@ _ALLOWED_FENCE_REGEX_FILE = "output_parser.py"
 # permissive allow-list would let it.
 _KNOWN_OFFENDERS = frozenset(
     {
-        # Tracked, unmigrated JSON extraction (AC-924).
-        "execution/judge.py",
         # Python code extraction, not JSON -- permanently out of scope.
         "agents/translator.py",
         "execution/harness_synthesizer.py",

--- a/autocontext/tests/test_model_json_extraction.py
+++ b/autocontext/tests/test_model_json_extraction.py
@@ -657,6 +657,14 @@ def test_extract_json_require_unique_rejects_competing_objects() -> None:
         extract_json(text, require_unique=True)
 
 
+def test_extract_json_required_keys_skip_unrelated_mapping() -> None:
+    text = 'Metadata: {"request_id": "abc"}\nVerdict: {"score": 0.1}'
+
+    assert extract_json(text) == {"request_id": "abc"}
+    assert extract_json(text, required_keys=("score",)) == {"score": 0.1}
+    assert extract_json(text, required_keys=("score",), require_unique=True) == {"score": 0.1}
+
+
 def test_extract_json_require_unique_trusts_tagged_answer() -> None:
     text = '```\n{"answer": 1}\n```\n```json\n{"answer": 2}\n```'
 
@@ -1486,42 +1494,32 @@ def test_action_filter_extract_json_object(name: str, text: str) -> None:
 _GUARDED_SRC_DIRS = ("agents", "execution")
 _ALLOWED_FENCE_REGEX_FILE = "output_parser.py"
 
-# The five regex call sites this guard is aware of today, one per line,
-# collapsed to four files below because two of them (translator.py's
+# The four regex call sites this guard is aware of today, one per line,
+# collapsed to three files below because two of them (translator.py's
 # python-fence and generic-fence searches) live in the same module:
 #
 #   agents/translator.py:118             re.search  -- python code block
 #   agents/translator.py:121             re.search  -- generic fence
 #   execution/harness_synthesizer.py:233 re.search  -- python code block
 #   execution/policy_refinement.py:71    re.findall -- python code block
-#   execution/judge.py:555               re.compile -- JSON (AC-924)
 #
 # policy_refinement.py was MISSED by the first version of this guard, and by
 # two independent evasions at once, either of which alone would have hidden
 # it: `findall` was not in the constructor set below, and its pattern is a
 # function-local variable passed by name rather than an inline literal. Both
 # holes are closed now (see `_fence_regex_offenders`), which is the only
-# reason this comment can claim five sites rather than four.
-#
-# judge.py is tracked, unmigrated JSON extraction: `_try_code_block_parse`
-# is one of FOUR ordered parsing strategies (marker-delimited, raw-JSON-
-# with-"score"-key, code-block, plain-text) whose ordering is observable
-# and entirely uncharacterized. Migrating it onto extract_json blind would
-# be exactly the mistake this plan keeps proving is wrong -- characterize
-# before you change. Tracked in AC-924, not fixed here.
+# reason this comment can claim four sites rather than three.
 #
 # translator.py, harness_synthesizer.py and policy_refinement.py are a
-# DIFFERENT kind of exemption, not a to-do: all three regexes extract PYTHON
+# permanent exemption, not a to-do: all three regexes extract PYTHON
 # source code from a fence, not JSON. extract_json is a JSON parser (it feeds
 # candidates to json.loads); forcing a Python-code extraction onto it would be
-# wrong, not incomplete, so these are deliberately and permanently out of
-# scope for migration, unlike judge.py's AC-924 debt.
+# wrong, not incomplete, so these are deliberately out of scope for migration.
 #
 # This is EXACT-SET equality, not an allow-list: it fails both when a NEW
 # offender appears (someone adds a fence regex) and when a known one
-# disappears (e.g. AC-924 lands and judge.py is migrated, or a file is
-# deleted) -- so a stale exemption can't survive unnoticed the way a
-# permissive allow-list would let it.
+# disappears (for example, a file is deleted) -- so a stale exemption can't
+# survive unnoticed the way a permissive allow-list would let it.
 _KNOWN_OFFENDERS = frozenset(
     {
         # Python code extraction, not JSON -- permanently out of scope.


### PR DESCRIPTION
Closes AC-924. Filed as technical debt ("consolidate a duplicate fence regex"); characterizing first turned it into a bug fix.

## What changed for a run

| response shape | before | after |
| --- | --- | --- |
| reasoning block, then the fenced answer | **0.05** | **0.88** |
| prose draft, then the fenced answer | **0.10** | **0.95** |
| two nesting levels, unfenced | plaintext scrape, dimensions lost | parsed JSON |

**The first row is the one that bites.** `_try_raw_json_parse` scanned the whole response for a `"score"`-shaped object and took the first match, so it read inside fences and reasoning blocks and won before the fence-aware tier ever ran. Emitting a reasoning block before the answer is ordinary open-weight output — the exact shape AC-926 fixed for the advise gate — and here it scored the run **0.05 where the judge said 0.88**. Nothing errored. A wrong number entered the loop's ranking and the run carried on.

The third row costs dimensions rather than the score: the old regexes handled one nesting level, so a judge returning nested per-dimension scores fell to the plaintext tier, which found `"score"` by luck and dropped every dimension silently.

## Two corrections to the issue

**The tier order was backwards in the description.** AC-924 said the fence regex was strategy 2 and raw JSON strategy 3. The parser ran raw_json *second* and code_block *third*. The method docstrings said one thing and the call order did another — only the class docstring was right, and the issue inherited the wrong version. That inversion is precisely what caused the defect, so it mattered.

**The migration was not a straight swap, but for a different reason than the issue expected.** It anticipated needing to preserve four tiers and their ordering. In practice `extract_json` already prefers the answer over the scratchpad, so collapsing the two middle tiers into it *fixed* the ordering problem rather than needing to preserve it.

## What deliberately did not change

- Markers still win outright, and are still not trusted blindly (malformed JSON between markers falls through).
- **Two bare objects in prose with no fence still take the first one.** There is nothing to distinguish a draft from a verdict in that shape. There is an explicit test saying so, rather than letting the fixed cases imply the problem is fully solved.

## Design notes

- The `"score"` requirement stays at the judge call site. `extract_json` is a general model-JSON parser shared with the roles, the advise gate and the strategy path; teaching it about scores would push judge semantics onto all of them.
- `code_block` is no longer produced as a `ParseMethod`. The literal keeps the value so previously stored results still validate, and nothing in `src` branches on it.
- `judge.py` is removed from `_KNOWN_OFFENDERS`. That set now holds only the permanent Python-code-extraction exemptions — no JSON-extraction entries remain.

## Method

Two commits on purpose. The first characterizes the parser **by executing it** across a realistic corpus and pins the defects as recorded-not-endorsed. The second re-records those values. The diff between them is the evidence that behavior moved, rather than a claim that it did.

Mutation-tested: restoring the old first-match scan fails four tests.

## Not in this PR — and you should know about it

`ts/src/judge/parse.ts` is a line-for-line mirror with **the same defect**: `tryRawJsonParse` runs second with the same whole-response first-match regex, ahead of `tryCodeBlockParse`. Fixing it is not a port of this change, because TypeScript has no equivalent of `extract_json` — only a local `extractJsonObject` in `action-filter-selection-workflow.ts`. Reordering alone would not fix the reasoning-block case either, since that block *is* a fence. Filed separately rather than expanded into a TS parser-consolidation project inside this PR.

## Verification

| Check | Result |
| --- | --- |
| Python suite | pass |
| `ruff check src tests` | pass |
| no-new-fence-regex guard | pass with `judge.py` removed from the expected set |

`uv.lock` not committed.