### PR TITLE
fix(AC-927, AC-936): decide what a blank routing setting means; declare thinking-schema support

### DIFF
--- a/autocontext/src/autocontext/agents/role_router.py
+++ b/autocontext/src/autocontext/agents/role_router.py
@@ -124,6 +124,27 @@ def _inferred_hosting(provider_type: str) -> str:
     return _INFERRED_PROVIDER_HOSTING.get(provider_type.strip().lower(), "remote")
 
 
+# The shipped default for `agent_provider`; kept next to its only consumer so
+# the fallback cannot drift from settings.py without this line being read.
+_DEFAULT_AGENT_PROVIDER = "anthropic"
+# The artifact slot has its own setting and never falls back to a role or
+# tier default, so a blank one resolves to this literal rather than to a
+# model id. Matches TypeScript's `clean(settings.mlxModelPath) ?? "local"`.
+_DEFAULT_LOCAL_ARTIFACT = "local"
+
+
+def _clean_setting(value: str | None, fallback: str) -> str:
+    """Treat an empty or whitespace-only setting as unset (AC-927).
+
+    Mirrors TypeScript's `clean()`. The decision is recorded once here: a blank
+    value means "I did not set this", not "send an empty transport name". An
+    empty provider type cannot be constructed at all, so passing it through
+    turned a config mistake into a runtime failure far from its cause.
+    """
+    cleaned = (value or "").strip()
+    return cleaned or fallback
+
+
 class RoleRouter:
     """Routes agent roles to providers based on capability, cost, and available artifacts."""
 
@@ -406,7 +427,10 @@ class RoleRouter:
         if provider_class == ProviderClass.LOCAL:
             return ProviderConfig(
                 provider_type="mlx",
-                model=local_model_path or self._settings.mlx_model_path or None,
+                model=(
+                    _clean_setting(local_model_path, "")
+                    or _clean_setting(self._settings.mlx_model_path, _DEFAULT_LOCAL_ARTIFACT)
+                ),
                 provider_class=ProviderClass.LOCAL,
                 estimated_cost_per_1k_tokens=self._cost_for(
                     ProviderClass.LOCAL,
@@ -414,7 +438,7 @@ class RoleRouter:
                     declared_hosting="local",
                 ),
             )
-        provider_type = self._settings.agent_provider
+        provider_type = _clean_setting(self._settings.agent_provider, _DEFAULT_AGENT_PROVIDER)
         # A role asks for a capability; an endpoint has one. Asking for frontier
         # from an endpoint declared mid_tier does not make it frontier, so the
         # request is clamped down to what the endpoint actually offers and both
@@ -462,7 +486,7 @@ class RoleRouter:
         return ProviderConfig(
             provider_type=provider_type,
             model=(
-                self._settings.mlx_model_path
+                _clean_setting(self._settings.mlx_model_path, _DEFAULT_LOCAL_ARTIFACT)
                 if provider_class == ProviderClass.LOCAL
                 else self._resolve_role_model(role, provider_type)
             ),
@@ -476,7 +500,7 @@ class RoleRouter:
 
     def _config_for_default(self, role: str) -> ProviderConfig:
         """Build config when routing is disabled — use default provider + model."""
-        provider_type = self._settings.agent_provider
+        provider_type = _clean_setting(self._settings.agent_provider, _DEFAULT_AGENT_PROVIDER)
         inferred = _EXPLICIT_PROVIDER_CLASS.get(
             provider_type.lower(),
             ProviderClass.MID_TIER,
@@ -490,7 +514,7 @@ class RoleRouter:
         return ProviderConfig(
             provider_type=provider_type,
             model=(
-                self._settings.mlx_model_path
+                _clean_setting(self._settings.mlx_model_path, _DEFAULT_LOCAL_ARTIFACT)
                 if provider_class == ProviderClass.LOCAL
                 else self._resolve_role_model(role, provider_type)
             ),

--- a/autocontext/src/autocontext/config/provider_model_defaults.py
+++ b/autocontext/src/autocontext/config/provider_model_defaults.py
@@ -37,12 +37,16 @@ so asking it for three tiers is meaningless.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Protocol
 
 from autocontext.agents import role_routing_contract_generated as _contract
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from collections.abc import Set as AbstractSet
+
+
+logger = logging.getLogger(__name__)
 
 
 class _SupportsFieldsSet(Protocol):
@@ -87,8 +91,24 @@ def resolve_model_default(
     better-informed answer, so every caller can substitute it for a direct
     settings read without changing Anthropic behavior.
     """
-    if field_name in settings.model_fields_set:
+    if field_name in settings.model_fields_set and (configured or "").strip():
         return configured
+
+    # AC-927: a field the user set to "" (or whitespace) is treated as UNSET,
+    # not as a request to send an empty model id. That matches TypeScript's
+    # `clean()`, and it matches this project's own config convention -- the
+    # shipped .env.example carries 20 empty-valued AUTOCONTEXT_* keys, so
+    # failing closed on a blank value would break the template we publish.
+    #
+    # The blank is dropped here so the shipped field default takes over
+    # downstream; passing it through reached an endpoint as `model: ""`, which
+    # is a malformed request rather than a routing preference.
+    if configured is not None and not configured.strip():
+        configured = shipped_default(field_name)
+        logger.debug(
+            "config.provider_model_defaults: %s was set to an empty value; treating it as unset",
+            field_name,
+        )
 
     normalized = provider.strip().lower()
     if normalized in _PRESERVED_PROVIDERS:
@@ -99,3 +119,24 @@ def resolve_model_default(
         return local_model
 
     return PROVIDER_DEFAULT_MODEL.get(normalized, configured)
+
+
+def shipped_default(field_name: str) -> str | None:
+    """The default declared on ``AppSettings`` for ``field_name``.
+
+    Read off the CLASS, not off the settings object a caller passed. The
+    parity harness drives routing with a ``MagicMock(spec=...)`` on purpose, so
+    instance introspection returns nothing there -- and the shipped default is
+    a property of the model either way. TypeScript's counterpart is the
+    ``DEFAULT_ROLE_MODELS`` literal in ``role-routing.ts``; both are the same
+    values, and the parity fixture is what holds them together.
+
+    Imported lazily to keep this module free of a settings import at module
+    scope, which is what lets ``backends.py`` load it without pulling in the
+    heavy config graph.
+    """
+    from autocontext.config.settings import AppSettings
+
+    field = AppSettings.model_fields.get(field_name)
+    default = getattr(field, "default", None)
+    return default if isinstance(default, str) and default.strip() else None

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -16,6 +16,8 @@ from autocontext.runtimes.pi_defaults import PI_DEFAULT_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_AGENT_PROVIDER = "anthropic"
+
 _ENV_ALIASES: dict[str, tuple[str, ...]] = {
     "agent_provider": ("AUTOCONTEXT_AGENT_PROVIDER", "AUTOCONTEXT_PROVIDER"),
     "anthropic_api_key": ("ANTHROPIC_API_KEY", "AUTOCONTEXT_ANTHROPIC_API_KEY"),
@@ -50,7 +52,7 @@ class AppSettings(RoleRoutingFields, WorkspaceInterpreterFields, OutputBudgetFie
     skills_root: Path = Field(default=Path("skills"))
     claude_skills_path: Path = Field(default=Path(".claude/skills"))
     executor_mode: str = Field(default="local")
-    agent_provider: str = Field(default="anthropic")
+    agent_provider: str = Field(default=_DEFAULT_AGENT_PROVIDER)
     anthropic_api_key: str | None = Field(default=None)
     # AC-912: fills unset role/tier slots. See config/provider_model_defaults.py.
     local_model: str = Field(default="", description="Model id for every unset non-Anthropic role/tier slot")
@@ -797,6 +799,11 @@ class AppSettings(RoleRoutingFields, WorkspaceInterpreterFields, OutputBudgetFie
         f = float(v) if isinstance(v, (int, float, str)) else 0.0
         return f if f > 0 else None
 
+    @field_validator("agent_provider", mode="before")
+    @classmethod
+    def _blank_agent_provider_uses_default(cls, v: object) -> object:
+        return _DEFAULT_AGENT_PROVIDER if isinstance(v, str) and not v.strip() else v
+
 
 def load_settings() -> AppSettings:
     """Load settings from env vars and preset overrides.
@@ -810,7 +817,13 @@ def load_settings() -> AppSettings:
     kwargs: dict[str, Any] = {}
     for field_name in AppSettings.model_fields:
         env_keys = setting_env_keys(field_name)
-        env_val = next((value for key in env_keys if (value := os.getenv(key)) is not None), None)
+        env_val = next(
+            (
+                value for key in env_keys if (value := os.getenv(key)) is not None
+                and (field_name != "agent_provider" or bool(value.strip()))
+            ),
+            None,
+        )
         if env_val is not None:
             kwargs[field_name] = env_val
         elif field_name in preset:

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -165,7 +165,15 @@ class HookedLLMProvider(LLMProvider):
         self._supports_output_schema = _accepts_output_schema(inner.complete)
         thinking_complete = getattr(inner, "complete_with_thinking", None)
         self._thinking_complete = thinking_complete if callable(thinking_complete) else None
-        self._thinking_supports_output_schema = _accepts_output_schema(thinking_complete)
+        # Ask the provider before falling back to signature inspection
+        # (AC-936). A signature cannot distinguish a parameter that is honored
+        # from one that is accepted and discarded, and Anthropic's thinking loop
+        # does the latter, so the probe used to report support that did not
+        # exist. The declaration wins wherever a provider makes one.
+        declared = getattr(inner, "supports_thinking_output_schema", None)
+        self._thinking_supports_output_schema = (
+            bool(declared) if isinstance(declared, bool) else _accepts_output_schema(thinking_complete)
+        )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.inner, name)

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -350,6 +350,11 @@ class HookedLLMProvider(LLMProvider):
         return bool(getattr(self.inner, "supports_thinking_stream", False))
 
     @property
+    def supports_thinking_output_schema(self) -> bool:
+        """Forward the resolved capability instead of answering for the wrapper."""
+        return self._thinking_supports_output_schema
+
+    @property
     def name(self) -> str:
         return self.provider_name
 

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -251,6 +251,18 @@ class AnthropicProvider(LLMProvider):
         return self._default_model
 
     @property
+    def supports_thinking_output_schema(self) -> bool:
+        """False: ``complete_with_thinking`` discards ``output_schema`` (AC-936).
+
+        Not an oversight. The loop forces the ``deep_think`` tool on the first
+        turn, and ``tool_choice`` cannot pin two tools at once, so a forced
+        schema tool has nowhere to go. Honoring both means declaring both tools
+        and expecting the output tool on the final turn instead of forcing it,
+        which is a design change rather than a parameter pass-through.
+        """
+        return False
+
+    @property
     def supports_thinking_stream(self) -> bool:
         return True
 

--- a/autocontext/src/autocontext/providers/base.py
+++ b/autocontext/src/autocontext/providers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -167,10 +168,23 @@ class LLMProvider(ABC):
         does the latter, because its thinking loop already pins ``tool_choice``
         to the scratchpad tool and cannot force a second one.
 
-        Defaults to following ``supports_thinking_stream``: a provider with no
-        thinking loop has nothing to honor a schema on, and one that implements
-        the loop is assumed to have wired the schema unless it says otherwise.
+        Defaults to following ``supports_thinking_stream`` when the provider
+        inherits the standard thinking fallback. For compatibility, an older
+        provider that overrides ``complete_with_thinking`` but predates this
+        declaration is inferred from that override's signature. New providers
+        whose signature accepts but discards the schema must override this
+        declaration, as Anthropic does.
         """
+        implementation = inspect.getattr_static(type(self), "complete_with_thinking", None)
+        if implementation is not LLMProvider.complete_with_thinking:
+            try:
+                parameters = inspect.signature(self.complete_with_thinking).parameters.values()
+            except (TypeError, ValueError):
+                return False
+            return any(
+                parameter.name == "output_schema" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters
+            )
         return self.supports_thinking_stream
 
     @property

--- a/autocontext/src/autocontext/providers/base.py
+++ b/autocontext/src/autocontext/providers/base.py
@@ -158,6 +158,22 @@ class LLMProvider(ABC):
         return False
 
     @property
+    def supports_thinking_output_schema(self) -> bool:
+        """Whether ``complete_with_thinking`` actually honors ``output_schema``.
+
+        Declared rather than inferred (AC-936). The extension layer used to
+        decide this by inspecting the signature, which cannot tell a parameter
+        that is honored from one that is accepted and discarded -- and Anthropic
+        does the latter, because its thinking loop already pins ``tool_choice``
+        to the scratchpad tool and cannot force a second one.
+
+        Defaults to following ``supports_thinking_stream``: a provider with no
+        thinking loop has nothing to honor a schema on, and one that implements
+        the loop is assumed to have wired the schema unless it says otherwise.
+        """
+        return self.supports_thinking_stream
+
+    @property
     def name(self) -> str:
         """Human-readable provider name."""
         return self.__class__.__name__

--- a/autocontext/src/autocontext/providers/retry.py
+++ b/autocontext/src/autocontext/providers/retry.py
@@ -155,6 +155,13 @@ class RetryProvider(LLMProvider):
         return self._provider.supports_thinking_stream
 
     @property
+    def supports_thinking_output_schema(self) -> bool:
+        # Must be forwarded, not inherited from the base default: this wrapper
+        # has no thinking loop of its own, so the base would answer for the
+        # wrapper rather than for the provider actually doing the work.
+        return self._provider.supports_thinking_output_schema
+
+    @property
     def name(self) -> str:
         return f"Retry({self._provider.name})"
 

--- a/autocontext/tests/test_role_routing_parity.py
+++ b/autocontext/tests/test_role_routing_parity.py
@@ -62,21 +62,32 @@ _EXPECTED_CASE_IDS: dict[str, frozenset[str]] = {
             "local_artifact_ignored_when_routing_off",
         },
     ),
+    # AC-927. These five were `known_divergences` until both languages agreed
+    # that a blank routing setting means unset. Moved here rather than deleted:
+    # dropping them would have removed the only coverage of the empty-value
+    # layer at the exact moment it started working.
+    "unset_settings": frozenset(
+        {
+            "agent_provider_empty",
+            "blank_local_artifact",
+            "mlx_model_path_empty",
+            "role_model_empty_routing_off",
+            "tier_model_empty",
+        },
+    ),
 }
 
 _EXPECTED_DIVERGENCE_CASE_IDS = {
     "explicit_override.mixed_case_provider_name",
     "explicit_override.whitespace_only_provider_name",
     "routing_off.unknown_role_model",
-    # AC-919 item 2. Every other fixture case supplies all 16 settings fields
-    # non-empty, so nothing reached the unset/empty layer -- the exact layer
-    # AC-912 rewrites. These five pin its before-state so that rewrite can be
-    # diffed rather than trusted.
-    "unset_settings.agent_provider_empty",
-    "unset_settings.blank_local_artifact",
-    "unset_settings.mlx_model_path_empty",
-    "unset_settings.role_model_empty_routing_off",
-    "unset_settings.tier_model_empty",
+    # The five unset_settings entries that used to sit here are GONE, not
+    # updated (AC-927). They recorded the two languages disagreeing about what
+    # an empty routing setting means; both now treat blank as unset, so there is
+    # no divergence left to pin. The inputs moved into the `unset_settings`
+    # FIXTURE group above, where they are replayed as agreeing cases -- deleting
+    # them outright would have dropped the only coverage of the empty-value
+    # layer at the moment it started working.
 }
 
 # Every fixture group is a set of single route() calls compared field by field.

--- a/autocontext/tests/test_settings_cleanup.py
+++ b/autocontext/tests/test_settings_cleanup.py
@@ -1,6 +1,9 @@
 """Tests for settings simplification (AC-25)."""
 from __future__ import annotations
 
+import pytest
+
+from autocontext.agents.llm_client import AnthropicClient, build_client_from_settings
 from autocontext.config.settings import AppSettings, load_settings
 
 
@@ -46,3 +49,20 @@ def test_load_settings_without_removed_env_vars() -> None:
     settings = load_settings()
     assert settings.agent_provider == "anthropic"
     assert settings.curator_enabled is True
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_blank_agent_provider_uses_default_before_client_construction(blank: str) -> None:
+    settings = AppSettings(agent_provider=blank, anthropic_api_key="test-key")
+
+    assert settings.agent_provider == "anthropic"
+    assert isinstance(build_client_from_settings(settings), AnthropicClient)
+
+
+def test_blank_primary_provider_env_falls_through_to_compatibility_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_AGENT_PROVIDER", "   ")
+    monkeypatch.setenv("AUTOCONTEXT_PROVIDER", "deterministic")
+
+    assert load_settings().agent_provider == "deterministic"

--- a/autocontext/tests/test_thinking_schema_capability.py
+++ b/autocontext/tests/test_thinking_schema_capability.py
@@ -43,6 +43,27 @@ class _ThinkingDiscardsSchema(_ThinkingHonorsSchema):
         return False
 
 
+class _LegacyThinkingWithoutSchema(_NoThinking):
+    """A pre-declaration provider using the old thinking signature."""
+
+    def complete_with_thinking(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        reasoning_effort: str = "medium",
+        max_tool_turns: int = 8,
+    ) -> CompletionResult:
+        del system_prompt, user_prompt, model, temperature, max_tokens, reasoning_effort, max_tool_turns
+        return CompletionResult(text="legacy", model="legacy")
+
+    @property
+    def supports_thinking_stream(self) -> bool:
+        return True
+
+
 def test_default_follows_whether_a_thinking_loop_exists() -> None:
     """A provider with no thinking loop has nothing to honor a schema on."""
     assert _NoThinking().supports_thinking_output_schema is False
@@ -51,6 +72,11 @@ def test_default_follows_whether_a_thinking_loop_exists() -> None:
 
 def test_a_provider_can_declare_that_it_discards_the_schema() -> None:
     assert _ThinkingDiscardsSchema().supports_thinking_output_schema is False
+
+
+def test_legacy_subclass_falls_back_to_its_thinking_signature() -> None:
+    """An inherited base property must not turn an old method into a declaration."""
+    assert _LegacyThinkingWithoutSchema().supports_thinking_output_schema is False
 
 
 def test_anthropic_declares_it_does_not_honor_the_schema() -> None:
@@ -81,6 +107,24 @@ def test_the_extension_probe_believes_the_declaration_over_the_signature() -> No
 
     assert signature_says is True, "signature inspection no longer over-reports; this test is out of date"
     assert hooked._thinking_supports_output_schema is False
+    assert hooked.supports_thinking_output_schema is False
+
+
+def test_hooked_legacy_subclass_does_not_receive_a_new_schema_keyword() -> None:
+    from autocontext.extensions import HookBus
+    from autocontext.extensions.llm import HookedLLMProvider
+    from autocontext.providers.base import OutputSchema
+
+    hooked = HookedLLMProvider(_LegacyThinkingWithoutSchema(), HookBus())
+
+    result = hooked.complete_with_thinking(
+        "system",
+        "user",
+        output_schema=OutputSchema(name="answer", schema={"type": "object"}),
+    )
+
+    assert result.text == "legacy"
+    assert hooked.supports_thinking_output_schema is False
 
 
 def test_a_provider_with_no_declaration_still_falls_back_to_the_signature() -> None:

--- a/autocontext/tests/test_thinking_schema_capability.py
+++ b/autocontext/tests/test_thinking_schema_capability.py
@@ -1,0 +1,121 @@
+"""AC-936: the thinking path declares whether it honors output_schema.
+
+The extension layer used to infer this from the method signature. A signature
+cannot tell a parameter that is honored from one that is accepted and then
+discarded, and Anthropic's `complete_with_thinking` does the latter -- it opens
+with `del output_schema` because its loop already pins `tool_choice` to the
+scratchpad tool and cannot force a second one.
+
+So the probe reported support that did not exist. Nothing broke, because
+`CompletionResult.constrained` still told the truth and callers read that. The
+danger is a capability probe that disagrees with behavior: the next feature
+builds on the probe, not on the flag.
+
+Declared rather than inferred, which is the same correction AC-911 made for
+provider capability.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.providers.base import CompletionResult, LLMProvider
+
+
+class _NoThinking(LLMProvider):
+    def complete(self, *args: Any, **kwargs: Any) -> CompletionResult:
+        del args, kwargs
+        return CompletionResult(text="", model="stub")
+
+    def default_model(self) -> str:
+        return "stub"
+
+
+class _ThinkingHonorsSchema(_NoThinking):
+    @property
+    def supports_thinking_stream(self) -> bool:
+        return True
+
+
+class _ThinkingDiscardsSchema(_ThinkingHonorsSchema):
+    @property
+    def supports_thinking_output_schema(self) -> bool:
+        return False
+
+
+def test_default_follows_whether_a_thinking_loop_exists() -> None:
+    """A provider with no thinking loop has nothing to honor a schema on."""
+    assert _NoThinking().supports_thinking_output_schema is False
+    assert _ThinkingHonorsSchema().supports_thinking_output_schema is True
+
+
+def test_a_provider_can_declare_that_it_discards_the_schema() -> None:
+    assert _ThinkingDiscardsSchema().supports_thinking_output_schema is False
+
+
+def test_anthropic_declares_it_does_not_honor_the_schema() -> None:
+    """The concrete case, asserted against the real provider.
+
+    Pinned to the class rather than an instance so it needs no API key, and
+    tied to the `del output_schema` in `complete_with_thinking`: if that line
+    ever goes away, this test is the reminder that the declaration must move
+    with it.
+    """
+    from autocontext.providers.anthropic import AnthropicProvider
+
+    assert AnthropicProvider.supports_thinking_output_schema.fget(object.__new__(AnthropicProvider)) is False
+
+
+def test_the_extension_probe_believes_the_declaration_over_the_signature() -> None:
+    """The defect, stated as the behavior that was wrong.
+
+    `_ThinkingDiscardsSchema.complete_with_thinking` inherits a signature that
+    accepts `output_schema`, so signature inspection alone answers True here.
+    """
+    from autocontext.extensions import HookBus
+    from autocontext.extensions.llm import HookedLLMProvider, _accepts_output_schema
+
+    provider = _ThinkingDiscardsSchema()
+    signature_says = _accepts_output_schema(getattr(provider, "complete_with_thinking", None))
+    hooked = HookedLLMProvider(provider, HookBus())
+
+    assert signature_says is True, "signature inspection no longer over-reports; this test is out of date"
+    assert hooked._thinking_supports_output_schema is False
+
+
+def test_a_provider_with_no_declaration_still_falls_back_to_the_signature() -> None:
+    """Third-party providers predate this attribute and must keep working."""
+    from autocontext.extensions import HookBus
+    from autocontext.extensions.llm import HookedLLMProvider
+
+    class _Legacy:
+        def complete(self, *args: Any, **kwargs: Any) -> CompletionResult:
+            del args, kwargs
+            return CompletionResult(text="", model="legacy")
+
+        def complete_with_thinking(
+            self,
+            system_prompt: str,
+            user_prompt: str,
+            output_schema: Any = None,
+        ) -> CompletionResult:
+            del system_prompt, user_prompt, output_schema
+            return CompletionResult(text="", model="legacy")
+
+        @property
+        def name(self) -> str:
+            return "legacy"
+
+    hooked = HookedLLMProvider(_Legacy(), HookBus())
+    assert hooked._thinking_supports_output_schema is True
+
+
+def test_the_retry_wrapper_forwards_the_declaration() -> None:
+    """Otherwise the wrapper answers for itself and the declaration is lost."""
+    from autocontext.providers.retry import RetryProvider
+
+    wrapped = RetryProvider(_ThinkingDiscardsSchema())
+    assert wrapped.supports_thinking_output_schema is False
+
+    honest = RetryProvider(_ThinkingHonorsSchema())
+    assert honest.supports_thinking_output_schema is True

--- a/docs/role-routing-parity-fixtures.json
+++ b/docs/role-routing-parity-fixtures.json
@@ -263,7 +263,9 @@
         "role": "competitor",
         "settings": {},
         "context": {
-          "availableLocalModels": ["/models/distilled-competitor"]
+          "availableLocalModels": [
+            "/models/distilled-competitor"
+          ]
         },
         "expected": {
           "provider_type": "mlx",
@@ -276,7 +278,9 @@
         "role": "architect",
         "settings": {},
         "context": {
-          "availableLocalModels": ["/models/distilled-architect"]
+          "availableLocalModels": [
+            "/models/distilled-architect"
+          ]
         },
         "expected": {
           "provider_type": "mlx",
@@ -289,7 +293,9 @@
         "role": "curator",
         "settings": {},
         "context": {
-          "availableLocalModels": ["/models/distilled-curator"]
+          "availableLocalModels": [
+            "/models/distilled-curator"
+          ]
         },
         "expected": {
           "provider_type": "mlx",
@@ -304,11 +310,79 @@
           "role_routing": "off"
         },
         "context": {
-          "availableLocalModels": ["/models/distilled-competitor"]
+          "availableLocalModels": [
+            "/models/distilled-competitor"
+          ]
         },
         "expected": {
           "provider_type": "anthropic",
           "model": "competitor-role-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      }
+    },
+    "unset_settings": {
+      "agent_provider_empty": {
+        "settings": {
+          "agent_provider": ""
+        },
+        "role": "competitor",
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "opus-tier-model",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "blank_local_artifact": {
+        "context": {
+          "availableLocalModels": [
+            "  "
+          ]
+        },
+        "role": "competitor",
+        "expected": {
+          "provider_type": "mlx",
+          "model": "/models/default-local",
+          "provider_class": "local",
+          "cost_per_1k_tokens": 0.0
+        }
+      },
+      "mlx_model_path_empty": {
+        "settings": {
+          "competitor_provider": "mlx",
+          "mlx_model_path": ""
+        },
+        "role": "competitor",
+        "expected": {
+          "provider_type": "mlx",
+          "model": "local",
+          "provider_class": "local",
+          "cost_per_1k_tokens": 0.0
+        }
+      },
+      "role_model_empty_routing_off": {
+        "settings": {
+          "model_competitor": "",
+          "role_routing": "off"
+        },
+        "role": "competitor",
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "claude-sonnet-5",
+          "provider_class": "frontier",
+          "cost_per_1k_tokens": 0.015
+        }
+      },
+      "tier_model_empty": {
+        "settings": {
+          "tier_opus_model": ""
+        },
+        "role": "competitor",
+        "expected": {
+          "provider_type": "anthropic",
+          "model": "claude-opus-5",
           "provider_class": "frontier",
           "cost_per_1k_tokens": 0.015
         }
@@ -381,118 +455,6 @@
       },
       "reason": "Python has no fallback for an unregistered role under routing_off and returns None for the model, while TypeScript's roleSpecificModel falls back to the sonnet tier model. provider_type ('anthropic') and provider_class ('frontier') agree in both; only model differs.",
       "resolution": "AC-911: the RoleAssignment work must decide one behavior for an unregistered role under routing_off, rather than inheriting Python's None and TypeScript's tier-default fallback as two separate defaults."
-    },
-    {
-      "case": "unset_settings.agent_provider_empty",
-      "role": "competitor",
-      "settings": {
-        "agent_provider": ""
-      },
-      "context": {},
-      "python": {
-        "provider_type": "",
-        "model": "opus-tier-model",
-        "provider_class": "frontier",
-        "cost_per_1k_tokens": 0.015
-      },
-      "typescript": {
-        "provider_type": "anthropic",
-        "model": "opus-tier-model",
-        "provider_class": "frontier",
-        "cost_per_1k_tokens": 0.015
-      },
-      "reason": "An empty default provider is returned verbatim by Python but coerced to 'anthropic' by TypeScript's normalizeProvider fallback. The model and class agree; only the transport name differs.",
-      "resolution": "Still open after AC-911. This entry was previously attributed to AC-912's per-provider default layer, which was wrong: the disagreement is about how each language treats an explicitly EMPTY setting, not about which model a provider defaults to. Python returns the empty value verbatim; TypeScript trims it away and falls back. AC-912 and AC-911 both landed and both languages still disagree here, so the attribution is corrected rather than the entry deleted. Resolving it means deciding, once, whether an empty setting means \"unset\" or \"deliberately blank\"."
-    },
-    {
-      "case": "unset_settings.blank_local_artifact",
-      "role": "competitor",
-      "settings": {},
-      "context": {
-        "availableLocalModels": ["  "]
-      },
-      "python": {
-        "provider_type": "mlx",
-        "model": "  ",
-        "provider_class": "local",
-        "cost_per_1k_tokens": 0.0
-      },
-      "typescript": {
-        "provider_type": "mlx",
-        "model": "/models/default-local",
-        "provider_class": "local",
-        "cost_per_1k_tokens": 0.0
-      },
-      "reason": "A whitespace-only local artifact is treated as a usable model id by Python and returned verbatim, while TypeScript trims it away and falls back to the configured mlx model path.",
-      "resolution": "Still open after AC-911. This entry was previously attributed to AC-912's per-provider default layer, which was wrong: the disagreement is about how each language treats an explicitly EMPTY setting, not about which model a provider defaults to. Python returns the empty value verbatim; TypeScript trims it away and falls back. AC-912 and AC-911 both landed and both languages still disagree here, so the attribution is corrected rather than the entry deleted. Resolving it means deciding, once, whether an empty setting means \"unset\" or \"deliberately blank\"."
-    },
-    {
-      "case": "unset_settings.mlx_model_path_empty",
-      "role": "competitor",
-      "settings": {
-        "competitor_provider": "mlx",
-        "mlx_model_path": ""
-      },
-      "context": {},
-      "python": {
-        "provider_type": "mlx",
-        "model": "",
-        "provider_class": "local",
-        "cost_per_1k_tokens": 0.0
-      },
-      "typescript": {
-        "provider_type": "mlx",
-        "model": "local",
-        "provider_class": "local",
-        "cost_per_1k_tokens": 0.0
-      },
-      "reason": "For a local provider with an empty model path Python returns the empty string, while TypeScript's tierModel('local', ...) falls back to the literal 'local'.",
-      "resolution": "Still open after AC-911. This entry was previously attributed to AC-912's per-provider default layer, which was wrong: the disagreement is about how each language treats an explicitly EMPTY setting, not about which model a provider defaults to. Python returns the empty value verbatim; TypeScript trims it away and falls back. AC-912 and AC-911 both landed and both languages still disagree here, so the attribution is corrected rather than the entry deleted. Resolving it means deciding, once, whether an empty setting means \"unset\" or \"deliberately blank\"."
-    },
-    {
-      "case": "unset_settings.role_model_empty_routing_off",
-      "role": "competitor",
-      "settings": {
-        "model_competitor": "",
-        "role_routing": "off"
-      },
-      "context": {},
-      "python": {
-        "provider_type": "anthropic",
-        "model": "",
-        "provider_class": "frontier",
-        "cost_per_1k_tokens": 0.015
-      },
-      "typescript": {
-        "provider_type": "anthropic",
-        "model": "claude-sonnet-5",
-        "provider_class": "frontier",
-        "cost_per_1k_tokens": 0.015
-      },
-      "reason": "With routing off and an empty role model Python returns the empty string, while TypeScript falls back to its hardcoded DEFAULT_ROLE_MODELS entry for the role.",
-      "resolution": "Still open after AC-911. This entry was previously attributed to AC-912's per-provider default layer, which was wrong: the disagreement is about how each language treats an explicitly EMPTY setting, not about which model a provider defaults to. Python returns the empty value verbatim; TypeScript trims it away and falls back. AC-912 and AC-911 both landed and both languages still disagree here, so the attribution is corrected rather than the entry deleted. Resolving it means deciding, once, whether an empty setting means \"unset\" or \"deliberately blank\"."
-    },
-    {
-      "case": "unset_settings.tier_model_empty",
-      "role": "competitor",
-      "settings": {
-        "tier_opus_model": ""
-      },
-      "context": {},
-      "python": {
-        "provider_type": "anthropic",
-        "model": "",
-        "provider_class": "frontier",
-        "cost_per_1k_tokens": 0.015
-      },
-      "typescript": {
-        "provider_type": "anthropic",
-        "model": "claude-opus-5",
-        "provider_class": "frontier",
-        "cost_per_1k_tokens": 0.015
-      },
-      "reason": "With an empty tier model Python returns the empty string as the model, while TypeScript falls back to its hardcoded tierModel default. Python has no equivalent fallback table.",
-      "resolution": "Still open after AC-911. This entry was previously attributed to AC-912's per-provider default layer, which was wrong: the disagreement is about how each language treats an explicitly EMPTY setting, not about which model a provider defaults to. Python returns the empty value verbatim; TypeScript trims it away and falls back. AC-912 and AC-911 both landed and both languages still disagree here, so the attribution is corrected rather than the entry deleted. Resolving it means deciding, once, whether an empty setting means \"unset\" or \"deliberately blank\"."
     }
   ]
 }

--- a/ts/src/providers/provider-config-resolution.ts
+++ b/ts/src/providers/provider-config-resolution.ts
@@ -16,6 +16,11 @@ export interface ResolveProviderConfigOpts {
   preferBaseUrlOverride?: boolean;
 }
 
+function nonBlank(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 export function resolveProviderConfig(
   overrides: Partial<ProviderConfig> = {},
   opts: ResolveProviderConfigOpts = {},
@@ -23,8 +28,8 @@ export function resolveProviderConfig(
   const projectConfig = loadProjectConfig();
   const defaultPersistedCredentials = loadPersistedCredentials();
   const envProviderType =
-    process.env.AUTOCONTEXT_AGENT_PROVIDER ??
-    process.env.AUTOCONTEXT_PROVIDER;
+    nonBlank(process.env.AUTOCONTEXT_AGENT_PROVIDER) ??
+    nonBlank(process.env.AUTOCONTEXT_PROVIDER);
   const envModel =
     process.env.AUTOCONTEXT_AGENT_DEFAULT_MODEL ??
     process.env.AUTOCONTEXT_MODEL;
@@ -36,11 +41,11 @@ export function resolveProviderConfig(
     process.env.AUTOCONTEXT_API_KEY;
 
   const providerType =
-    (opts.preferProviderOverride ? overrides.providerType : undefined) ??
+    nonBlank(opts.preferProviderOverride ? overrides.providerType : undefined) ??
     envProviderType ??
-    overrides.providerType ??
-    projectConfig?.provider ??
-    defaultPersistedCredentials?.provider ??
+    nonBlank(overrides.providerType) ??
+    nonBlank(projectConfig?.provider) ??
+    nonBlank(defaultPersistedCredentials?.provider) ??
     "anthropic";
   const persistedCredentials = loadPersistedCredentials(undefined, providerType);
   const model =

--- a/ts/src/providers/role-provider-bundle.ts
+++ b/ts/src/providers/role-provider-bundle.ts
@@ -327,11 +327,12 @@ export function buildRoleProviderBundle(
 ): RoleProviderBundle {
   // Only actually prefer the override when there is one to prefer — an empty overrides.providerType
   // with preferProviderOverride:true must fall through to the usual env/settings precedence.
-  const preferOverride = Boolean(opts.preferProviderOverride) && Boolean(overrides.providerType);
+  const providerOverride = normalizeOptionalOverride(overrides.providerType);
+  const preferOverride = Boolean(opts.preferProviderOverride) && Boolean(providerOverride);
   const defaultConfig = resolveProviderConfig(
     {
       ...overrides,
-      providerType: overrides.providerType ?? settings.agentProvider,
+      providerType: providerOverride ?? settings.agentProvider,
     },
     { preferProviderOverride: preferOverride },
   );

--- a/ts/tests/provider-config-resolution-workflow.test.ts
+++ b/ts/tests/provider-config-resolution-workflow.test.ts
@@ -61,6 +61,23 @@ describe("provider config resolution workflow", () => {
     });
   });
 
+  it.each(["", "   ", "\t"])("treats blank provider env %j as unset", (blank) => {
+    saveAndClear();
+    process.env.AUTOCONTEXT_AGENT_PROVIDER = blank;
+    process.env.AUTOCONTEXT_PROVIDER = "deterministic";
+
+    expect(resolveProviderConfig()).toMatchObject({ providerType: "deterministic" });
+  });
+
+  it("treats a blank explicit provider override as unset", () => {
+    saveAndClear();
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+
+    expect(
+      resolveProviderConfig({ providerType: "   " }, { preferProviderOverride: true }),
+    ).toMatchObject({ providerType: "anthropic" });
+  });
+
   it("preserves keyless provider families and anthropic guardrails", () => {
     saveAndClear();
     process.env.AUTOCONTEXT_AGENT_PROVIDER = "pi";

--- a/ts/tests/role-provider-bundle-workflow.test.ts
+++ b/ts/tests/role-provider-bundle-workflow.test.ts
@@ -80,6 +80,36 @@ describe("role provider bundle workflow", () => {
     }
   });
 
+  it("treats a blank default provider setting as unset", () => {
+    saveAndClear();
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+
+    const bundle = buildRoleProviderBundle({ agentProvider: "   " });
+    try {
+      expect(bundle.defaultConfig.providerType).toBe("anthropic");
+      expect(bundle.defaultProvider.name).toBe("anthropic");
+      expect(bundle.roleRoutes?.competitor?.providerType).toBe("anthropic");
+    } finally {
+      closeProviderBundle(bundle);
+    }
+  });
+
+  it("lets a blank CLI provider override fall back to the settings provider", () => {
+    saveAndClear();
+
+    const bundle = buildRoleProviderBundle(
+      { agentProvider: "deterministic" },
+      { providerType: "   " },
+      { preferProviderOverride: true },
+    );
+    try {
+      expect(bundle.defaultConfig.providerType).toBe("deterministic");
+      expect(bundle.defaultProvider.name).toBe("deterministic");
+    } finally {
+      closeProviderBundle(bundle);
+    }
+  });
+
   it("wraps configured roles with the experimental panel provider", async () => {
     saveAndClear();
 

--- a/ts/tests/role-routing-parity.test.ts
+++ b/ts/tests/role-routing-parity.test.ts
@@ -91,6 +91,17 @@ const EXPECTED_CASE_IDS = {
     "curator_uses_local_artifact",
     "local_artifact_ignored_when_routing_off",
   ],
+  // AC-927. These five were known_divergences until both languages agreed that
+  // a blank routing setting means unset. Moved here rather than deleted:
+  // dropping them would have removed the only coverage of the empty-value layer
+  // at the exact moment it started working.
+  unset_settings: [
+    "agent_provider_empty",
+    "blank_local_artifact",
+    "mlx_model_path_empty",
+    "role_model_empty_routing_off",
+    "tier_model_empty",
+  ],
 } as const satisfies Record<string, readonly string[]>;
 
 // Compared with .sort(), so this list must stay in sorted order.
@@ -98,15 +109,10 @@ const EXPECTED_DIVERGENCE_CASE_IDS = [
   "explicit_override.mixed_case_provider_name",
   "explicit_override.whitespace_only_provider_name",
   "routing_off.unknown_role_model",
-  // AC-919 item 2. Every other fixture case supplies all 16 settings fields
-  // non-empty, so nothing reached the unset/empty layer -- the exact layer
-  // AC-912 rewrites. These five pin its before-state so that rewrite can be
-  // diffed rather than trusted.
-  "unset_settings.agent_provider_empty",
-  "unset_settings.blank_local_artifact",
-  "unset_settings.mlx_model_path_empty",
-  "unset_settings.role_model_empty_routing_off",
-  "unset_settings.tier_model_empty",
+  // The five unset_settings entries that used to sit here are GONE, not
+  // updated (AC-927). Both languages now treat a blank routing setting as
+  // unset, so there is no divergence left to pin; the inputs moved into the
+  // unset_settings FIXTURE group above and are replayed as agreeing cases.
 ];
 
 const EXPECTED_ASSIGNMENT_KEYS = ["cost_per_1k_tokens", "model", "provider_class", "provider_type"];


### PR DESCRIPTION
Two 900s issues in the same area: a value the code accepted but did not honor, and a capability the code claimed but did not have.

## AC-927 — blank means unset, in both languages

Python passed empty and whitespace-only routing settings straight through; TypeScript trimmed them and took a fallback. Nothing had ever decided between them, so five `unset_settings` entries sat in `known_divergences`.

**Decided by evidence rather than taste:** the shipped `.env.example` carries **20 empty-valued `AUTOCONTEXT_*` keys**, so an empty value already means "not set" in this project's own config convention. Failing closed on blank would break the template we publish. TypeScript was right; Python now matches.

| setting | was | now |
| --- | --- | --- |
| `agent_provider=""` | `""` | `"anthropic"` |
| `model_coach=""` | `""` | shipped role default |
| `tier_opus_model=""` | `""` | shipped tier default |
| `mlx_model_path=""` | `""` | `"local"` |
| local artifact `"  "` | `"  "` | falls back to `mlx_model_path` |

The empty transport is the sharp end: **`provider_type: ""` cannot be constructed at all**, so passing it through turned a config typo into a runtime failure far from its cause.

Two things the implementation had to get right, both caught by the replay rather than by reasoning:

- **Fallback order.** TypeScript is `clean(artifact) ?? clean(mlxModelPath)`, so a blank *artifact* falls back to the mlx setting, not straight to the literal. My first attempt collapsed both steps and produced `"local"`.
- **Where the default is read from.** Off the `AppSettings` *class*, not the instance — the parity harness drives routing with a `MagicMock(spec=...)` on purpose, so instance introspection returns nothing there.

### The five divergences moved rather than being deleted

They existed **only** in `known_divergences`. Deleting them would have dropped the only coverage of the empty-value layer at the exact moment it started working — narrowing the regression surface while looking green.

They are now a real `unset_settings` **fixture** group, replayed by both languages as *agreeing*, with both inventories explaining why. An earlier revision of this branch deleted them and left a comment claiming they lived on; that comment was false and is corrected.

## AC-936 — declare the capability instead of sniffing the signature

`extensions/llm.py` decided whether a provider's thinking path honors `output_schema` by inspecting the method signature. A signature cannot tell a parameter that is *honored* from one that is *accepted and discarded*, and Anthropic's `complete_with_thinking` does the latter — it opens with `del output_schema` because its loop already pins `tool_choice` to the scratchpad tool and cannot force a second one.

Nothing broke, because `CompletionResult.constrained` still told the truth and callers read that. The hazard is a probe that disagrees with behavior: the next feature builds on the probe, not on the flag.

`supports_thinking_output_schema` is now **declared** — defaulting to `supports_thinking_stream`, forwarded through `RetryProvider` (otherwise the wrapper answers for itself), and falling back to signature inference when a provider makes no declaration, so third-party implementations keep working.

Same correction AC-911 made for provider capability: declare it, don't infer it.

## Mutation testing

| Mutation | Caught by |
| --- | --- |
| revert the probe to signature-only | probe test |
| drop the `RetryProvider` forward | wrapper test |
| stop cleaning the transport | `unset_settings.agent_provider_empty` |
| treat a blank configured model as configured | `role_model_empty_routing_off`, `tier_model_empty` |

## Verification

| Check | Result |
| --- | --- |
| Python suite | pass |
| `ruff check src tests` | pass |
| TS suite | 6235 tests / 841 files pass |
| `npm run lint` | pass |

`uv.lock` not committed.