### PR TITLE
feat(AC-917): AUTOCONTEXT_OFFLINE as an enforced no-egress guarantee

### DIFF
--- a/autocontext/docs/self-hosted-models.md
+++ b/autocontext/docs/self-hosted-models.md
@@ -291,6 +291,65 @@ so preflight reports no context-window result rather than guessing. If an
 endpoint has a non-standard discovery surface or the operator has independently
 validated it, `autoctx run ... --skip-preflight` bypasses these checks.
 
+## Offline mode
+
+`AUTOCONTEXT_OFFLINE=1` means one thing:
+
+> The engine never initiates an outbound connection.
+
+Scoped by **who initiates**. Control-plane sync, provider calls, webhook
+notifications and fixture downloads are engine-initiated, so they are off. An
+operator SSH-ing into the box is operator-initiated, so it is out of scope --
+airgapped does not have to mean unreachable.
+
+Anything blocked raises an error naming what it was, rather than failing as a
+timeout three layers down:
+
+```
+AUTOCONTEXT_OFFLINE is set; refusing to post a webhook notification
+(https://hooks.example/x)
+```
+
+### What becomes unavailable
+
+**The CLI runtimes** — `claude-cli`, `codex`, `pi`, `pi-rpc`, `hermes` — refuse
+to start. They shell out to a third-party binary that makes its own network
+calls, and no amount of guarding this codebase controls another program's
+sockets. They are refused rather than silently trusted, because a guarantee
+that depends on someone else's behavior is not a guarantee.
+
+Use a local endpoint instead: `ollama`, `vllm`, or `mlx`.
+
+**Configuring egress at the same time is a startup error**, not a silent
+precedence rule. Setting `AUTOCONTEXT_OFFLINE=1` alongside
+`AUTOCONTEXT_NOTIFY_WEBHOOK_URL`, or alongside a CLI runtime, fails preflight
+with both conflicts listed at once. Letting one quietly win would mean you
+either got a guarantee you did not receive or a sync you did not expect,
+decided by load order.
+
+### How it is enforced, and how far that goes
+
+Two mechanisms, and it is worth knowing which covers what.
+
+A test runs a **complete generation** with a guard installed at
+`socket.socket.connect` — below every HTTP client, SDK and transport in the
+process — and asserts zero connection attempts. Per-path checks only cover the
+paths someone remembered; this covers the path nobody remembered.
+
+A CI guard fails the build when a new `urlopen` appears without a
+`require_online` in the same function. That is the part that stops this
+decaying: without it the enforcement is a convention held up by code review.
+Its limits are written down in `tests/test_offline_mode.py` — it does not catch
+egress through an SDK client or a helper one frame down, which is what the
+socket-level test is paired with it to cover.
+
+**What this is not is proof.** The strongest assurance comes from outside the
+process: run autocontext in a network namespace with no route, or behind a
+firewall rule that drops egress. This work is what makes doing that actually
+function instead of hanging on a call you did not expect it to make. That claim
+you can verify yourself in about thirty seconds, which is worth more than
+anything the program could assert about itself.
+
 ## Not covered yet
 
 **llama.cpp.** Reachable through `openai-compatible` with

--- a/autocontext/docs/self-hosted-models.md
+++ b/autocontext/docs/self-hosted-models.md
@@ -302,6 +302,25 @@ notifications and fixture downloads are engine-initiated, so they are off. An
 operator SSH-ing into the box is operator-initiated, so it is out of scope --
 airgapped does not have to mean unreachable.
 
+Connections to an endpoint that is unambiguously on the same host are not
+outbound and remain available. The allowlist is intentionally narrow: the exact
+`localhost` name and literal loopback addresses (`127.0.0.0/8` and `::1`). A
+private-LAN address or hostname is still egress and is refused; the engine does
+not perform DNS resolution to decide whether a name happens to resolve locally.
+
+A complete local setup must configure both the agent and the judge. The normal
+`judge_provider=auto` fallback is Anthropic unless it inherits a subscription
+CLI runtime, so leaving it on `auto` is a startup conflict offline:
+
+```bash
+AUTOCONTEXT_OFFLINE=1 \
+AUTOCONTEXT_AGENT_PROVIDER=ollama \
+AUTOCONTEXT_LOCAL_MODEL=llama3.1:8b \
+AUTOCONTEXT_JUDGE_PROVIDER=ollama \
+AUTOCONTEXT_JUDGE_BASE_URL=http://localhost:11434/v1 \
+  autoctx run my_task
+```
+
 Anything blocked raises an error naming what it was, rather than failing as a
 timeout three layers down:
 
@@ -312,20 +331,24 @@ AUTOCONTEXT_OFFLINE is set; refusing to post a webhook notification
 
 ### What becomes unavailable
 
-**The CLI runtimes** — `claude-cli`, `codex`, `pi`, `pi-rpc`, `hermes` — refuse
-to start. They shell out to a third-party binary that makes its own network
-calls, and no amount of guarding this codebase controls another program's
-sockets. They are refused rather than silently trusted, because a guarantee
-that depends on someone else's behavior is not a guarantee.
+**External runtimes** — `agent_sdk`, `claude-cli`, `codex`, `pi`, `pi-rpc`,
+`hermes`, and OpenClaw CLI/factory runtimes — refuse to start. They run code
+outside the guarded provider transports, and no amount of guarding this
+codebase controls another program's sockets. They are refused rather than
+silently trusted, because a guarantee that depends on someone else's behavior
+is not a guarantee. An OpenClaw HTTP sidecar remains usable only when its URL is
+literal loopback.
 
 Use a local endpoint instead: `ollama`, `vllm`, or `mlx`.
 
 **Configuring egress at the same time is a startup error**, not a silent
 precedence rule. Setting `AUTOCONTEXT_OFFLINE=1` alongside
-`AUTOCONTEXT_NOTIFY_WEBHOOK_URL`, or alongside a CLI runtime, fails preflight
-with both conflicts listed at once. Letting one quietly win would mean you
-either got a guarantee you did not receive or a sync you did not expect,
-decided by load order.
+`AUTOCONTEXT_NOTIFY_WEBHOOK_URL`, a remote provider or per-role override, a
+remote judge or consultation provider, an SSH/PrimeIntellect executor, a
+Hugging Face blob store, or an external runtime fails preflight with every
+conflict listed at once. Letting one quietly win would mean you either got a
+guarantee you did not receive or a sync you did not expect, decided by load
+order.
 
 ### How it is enforced, and how far that goes
 

--- a/autocontext/src/autocontext/agents/agent_sdk_client.py
+++ b/autocontext/src/autocontext/agents/agent_sdk_client.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from autocontext.agents.llm_client import LanguageModelClient, ModelResponse
 from autocontext.agents.types import RoleUsage
+from autocontext.offline import require_runtime_available
 
 # Per-role tool permissions
 ROLE_TOOL_CONFIG: dict[str, list[str]] = {
@@ -78,6 +79,7 @@ class AgentSdkClient(LanguageModelClient):
         return ModelResponse(text=result_text, usage=usage)
 
     async def _query(self, prompt: str, model: str, role: str, system_prompt: str = "") -> str:
+        require_runtime_available("agent_sdk")
         from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
 
         tool_list = ROLE_TOOL_CONFIG.get(role, ROLE_TOOL_CONFIG["competitor"])

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -12,6 +12,7 @@ from anthropic import Anthropic
 from autocontext.config.settings import AppSettings
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleUsage
+from autocontext.offline import require_online, require_runtime_available
 from autocontext.providers.base import ProviderError
 from autocontext.providers.mlx_provider import MLXProvider  # type: ignore[import-untyped]
 from autocontext.providers.retry import _is_transient
@@ -44,6 +45,7 @@ class AnthropicClient(LanguageModelClient):
 
         for attempt in range(1 + self.max_retries):
             try:
+                require_online("call the Anthropic API")
                 return self._client.messages.create(**kwargs)
             except anthropic.APIError as exc:
                 last_error = exc
@@ -665,6 +667,7 @@ def build_client_from_settings(
     scenario_name: str = "",
 ) -> LanguageModelClient:
     """Construct a LanguageModelClient from AppSettings."""
+    require_runtime_available(settings.agent_provider, settings=settings)
     if settings.agent_provider == "anthropic":
         api_key = settings.anthropic_api_key or os.getenv("ANTHROPIC_API_KEY") or os.getenv("AUTOCONTEXT_ANTHROPIC_API_KEY", "")
         if not api_key:

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, cast
 from autocontext.extensions.llm import HookedLanguageModelClient
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleUsage
+from autocontext.offline import require_endpoint_available, require_runtime_available
 from autocontext.runtimes.errors import format_runtime_failure
 
 logger = logging.getLogger(__name__)
@@ -555,6 +556,7 @@ def create_role_client(
         return None
 
     provider_type = provider_type.lower().strip()
+    require_runtime_available(provider_type, settings=settings)
 
     # Native LanguageModelClient implementations
     if provider_type == "deterministic":
@@ -681,6 +683,7 @@ def _build_openclaw_agent(settings: AppSettings) -> object:
     compatibility_version = getattr(settings, "openclaw_compatibility_version", "1.0")
 
     if runtime_kind == "factory":
+        require_runtime_available("openclaw-factory", settings=settings)
         factory_path = settings.openclaw_agent_factory.strip()
         if not factory_path:
             raise ValueError(
@@ -701,6 +704,7 @@ def _build_openclaw_agent(settings: AppSettings) -> object:
         return agent
 
     if runtime_kind == "cli":
+        require_runtime_available("openclaw-cli", settings=settings)
         command_parts = shlex.split(getattr(settings, "openclaw_agent_command", ""))
         if not command_parts:
             raise ValueError(
@@ -726,6 +730,7 @@ def _build_openclaw_agent(settings: AppSettings) -> object:
             raise ValueError(
                 "OpenClaw HTTP runtime requires AUTOCONTEXT_OPENCLAW_AGENT_HTTP_ENDPOINT",
             )
+        require_endpoint_available("call an OpenClaw endpoint", endpoint, settings=settings)
         raw_headers = getattr(settings, "openclaw_agent_http_headers", "").strip()
         headers: dict[str, str] = {}
         if raw_headers:

--- a/autocontext/src/autocontext/blobstore/hf_bucket.py
+++ b/autocontext/src/autocontext/blobstore/hf_bucket.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from autocontext.blobstore.store import BlobStore, normalize_blob_key, prefix_matches, resolve_blob_path
+from autocontext.offline import require_online
 
 logger = logging.getLogger(__name__)
 _INDEX_KEY = ".autocontext/blob_index.json"
@@ -204,6 +205,7 @@ class HfBucketStore(BlobStore):
             logger.info("remote delete not available for %s in %s", key, self.repo_id)
 
     def _run_hf_command(self, cmd: list[str]) -> str:
+        require_online("synchronize Hugging Face blob storage", detail=self.repo_id)
         result = subprocess.run(
             cmd,
             capture_output=True,

--- a/autocontext/src/autocontext/config/role_routing.py
+++ b/autocontext/src/autocontext/config/role_routing.py
@@ -32,6 +32,13 @@ class RoleRoutingFields(BaseModel):
         default="",
         description="Default endpoint hosting: local or remote; empty infers from transport",
     )
+    # AC-917: when true, the engine never initiates an outbound connection.
+    # Scoped by who initiates: operator-initiated access (SSH, a tunnel) is out
+    # of scope, so "airgapped" does not have to mean "unreachable".
+    offline: bool = Field(
+        default=False,
+        description="Refuse all engine-initiated network egress (AUTOCONTEXT_OFFLINE)",
+    )
 
     competitor_provider: str = Field(default="", description="Provider override for competitor role")
     analyst_provider: str = Field(default="", description="Provider override for analyst role")

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -337,14 +337,6 @@ class AppSettings(RoleRoutingFields, WorkspaceInterpreterFields, OutputBudgetFie
         default=False,
         description="Run bias probes on judge evaluations",
     )
-    # AC-917: when true, the engine never initiates an outbound connection.
-    # Scoped by who initiates: operator-initiated access (SSH, a tunnel) is out
-    # of scope, so "airgapped" does not have to mean "unreachable".
-    offline: bool = Field(
-        default=False,
-        description="Refuse all engine-initiated network egress (AUTOCONTEXT_OFFLINE)",
-    )
-
     # Notification settings
     notify_webhook_url: str | None = Field(default=None)
     notify_on: str = Field(default="threshold_met,failure")

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -337,6 +337,14 @@ class AppSettings(RoleRoutingFields, WorkspaceInterpreterFields, OutputBudgetFie
         default=False,
         description="Run bias probes on judge evaluations",
     )
+    # AC-917: when true, the engine never initiates an outbound connection.
+    # Scoped by who initiates: operator-initiated access (SSH, a tunnel) is out
+    # of scope, so "airgapped" does not have to mean "unreachable".
+    offline: bool = Field(
+        default=False,
+        description="Refuse all engine-initiated network egress (AUTOCONTEXT_OFFLINE)",
+    )
+
     # Notification settings
     notify_webhook_url: str | None = Field(default=None)
     notify_on: str = Field(default="threshold_met,failure")

--- a/autocontext/src/autocontext/endpoint_probe.py
+++ b/autocontext/src/autocontext/endpoint_probe.py
@@ -29,7 +29,7 @@ import urllib.request
 from dataclasses import dataclass, field
 from typing import Any
 
-from autocontext.offline import require_online
+from autocontext.offline import require_endpoint_available
 
 # Long enough to survive a cold local model load, short enough that a wrong
 # base URL fails at setup instead of looking like a hang.
@@ -69,7 +69,7 @@ def _get_json(url: str, api_key: str, payload: dict[str, Any] | None = None) -> 
         data=data,
         headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
     )
-    require_online("probe an endpoint", detail=url)
+    require_endpoint_available("probe an endpoint", url)
     with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:  # noqa: S310 - operator-configured endpoint
         return json.loads(response.read())
 

--- a/autocontext/src/autocontext/endpoint_probe.py
+++ b/autocontext/src/autocontext/endpoint_probe.py
@@ -29,6 +29,8 @@ import urllib.request
 from dataclasses import dataclass, field
 from typing import Any
 
+from autocontext.offline import require_online
+
 # Long enough to survive a cold local model load, short enough that a wrong
 # base URL fails at setup instead of looking like a hang.
 _TIMEOUT_SECONDS = 20
@@ -67,6 +69,7 @@ def _get_json(url: str, api_key: str, payload: dict[str, Any] | None = None) -> 
         data=data,
         headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
     )
+    require_online("probe an endpoint", detail=url)
     with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:  # noqa: S310 - operator-configured endpoint
         return json.loads(response.read())
 

--- a/autocontext/src/autocontext/integrations/primeintellect/client.py
+++ b/autocontext/src/autocontext/integrations/primeintellect/client.py
@@ -8,6 +8,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from autocontext.offline import require_online
+
 logger = logging.getLogger(__name__)
 
 AsyncSandboxClient: Any | None = None
@@ -53,6 +55,7 @@ class PrimeIntellectClient:
 
     def warm_provision(self, environment_name: str, max_retries: int = 2, backoff_seconds: float = 0.75) -> dict[str, Any]:
         del max_retries, backoff_seconds
+        require_online("use the PrimeIntellect executor")
         try:
             asyncio.run(self._probe())
             return {"environment": environment_name, "status": "ready"}
@@ -72,6 +75,7 @@ class PrimeIntellectClient:
         max_retries: int = 2,
         backoff_seconds: float = 0.75,
     ) -> dict[str, Any]:
+        require_online("use the PrimeIntellect executor")
         attempt = 0
         while True:
             try:

--- a/autocontext/src/autocontext/integrations/ssh/client.py
+++ b/autocontext/src/autocontext/integrations/ssh/client.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from autocontext.integrations.ssh.config import SSHHostConfig
+from autocontext.offline import require_online
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,7 @@ class SSHClient:
 
     def execute_command(self, command: str, *, timeout: float | None = None) -> SSHCommandResult:
         """Execute a command on the remote host via SSH."""
+        require_online("connect to an SSH executor", detail=self.config.hostname)
         effective_timeout = timeout or self.config.command_timeout
         wrapped = self._wrap_command(command)
         args = self._ssh_base_args() + [self._ssh_target(), wrapped]
@@ -151,6 +153,7 @@ class SSHClient:
 
     def upload_file(self, local_path: Path, remote_path: str) -> None:
         """Upload a local file to the remote host via SCP."""
+        require_online("upload a file over SCP", detail=self.config.hostname)
         args = self._scp_base_args() + [str(local_path), self._scp_target(remote_path)]
         proc = subprocess.run(args, capture_output=True, text=True, timeout=self.config.command_timeout)
         if proc.returncode != 0:
@@ -158,6 +161,7 @@ class SSHClient:
 
     def download_file(self, remote_path: str, local_path: Path) -> None:
         """Download a file from the remote host via SCP."""
+        require_online("download a file over SCP", detail=self.config.hostname)
         args = self._scp_base_args() + [self._scp_target(remote_path), str(local_path)]
         proc = subprocess.run(args, capture_output=True, text=True, timeout=self.config.command_timeout)
         if proc.returncode != 0:

--- a/autocontext/src/autocontext/loop/fixture_loader.py
+++ b/autocontext/src/autocontext/loop/fixture_loader.py
@@ -33,6 +33,8 @@ from typing import Any, Protocol
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
+from autocontext.offline import require_online
+
 # --- Errors ----------------------------------------------------------------
 
 
@@ -126,6 +128,7 @@ class UrlFetcher:
             except OSError as e:
                 raise FixtureFetchError(f"could not read {source}: {e}") from e
         try:
+            require_online("download a fixture", detail=str(source))
             with urlopen(source) as response:
                 body: bytes = response.read()
                 return body

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -62,6 +62,7 @@ from autocontext.loop.runner_hooks import (
     initialize_hook_bus,
 )
 from autocontext.loop.trace_artifacts import persist_run_inspection
+from autocontext.offline import require_online
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.families import detect_family
@@ -117,6 +118,7 @@ class GenerationRunner:
             self.gate = BackpressureGate(min_delta=settings.backpressure_min_delta)
         self.remote: Any | None = None
         if settings.executor_mode == "primeintellect":
+            require_online("use the PrimeIntellect executor", settings=settings)
             from autocontext.execution.executors.primeintellect import PrimeIntellectExecutor
             from autocontext.integrations.primeintellect.client import PrimeIntellectClient
 
@@ -151,6 +153,7 @@ class GenerationRunner:
                 )
             )
         elif settings.executor_mode == "ssh":
+            require_online("use the SSH executor", settings=settings, detail=settings.ssh_host)
             if not settings.ssh_host:
                 raise ValueError("AUTOCONTEXT_SSH_HOST is required for ssh executor mode")
             from autocontext.execution.executors.ssh import SSHExecutor

--- a/autocontext/src/autocontext/notifications/http.py
+++ b/autocontext/src/autocontext/notifications/http.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 
 from autocontext.notifications.base import NotificationEvent, Notifier
+from autocontext.offline import require_online
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ class HTTPNotifier(Notifier):
                 headers={"Content-Type": "application/json", **self._headers},
                 method="POST",
             )
+            require_online("post a webhook notification", detail=self._url)
             urllib.request.urlopen(req, timeout=self._timeout)
         except Exception as exc:
             logger.warning("HTTP notification failed: %s", exc)

--- a/autocontext/src/autocontext/notifications/slack.py
+++ b/autocontext/src/autocontext/notifications/slack.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 
 from autocontext.notifications.base import EventType, NotificationEvent, Notifier
+from autocontext.offline import require_online
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class SlackWebhookNotifier(Notifier):
                 headers={"Content-Type": "application/json"},
                 method="POST",
             )
+            require_online("post a Slack notification")
             urllib.request.urlopen(req, timeout=self._timeout)
         except Exception as exc:
             logger.warning("Slack notification failed: %s", exc)

--- a/autocontext/src/autocontext/offline.py
+++ b/autocontext/src/autocontext/offline.py
@@ -1,0 +1,129 @@
+"""AC-917: ``AUTOCONTEXT_OFFLINE`` as an enforced no-egress guarantee.
+
+The rule, scoped by who initiates:
+
+    Offline mode means the ENGINE never initiates an outbound connection.
+
+Scoping it that way is what makes it decidable. Control-plane sync is
+engine-initiated, so it is off. An operator SSH-ing into the box is
+operator-initiated, so it is simply out of scope -- the guarantee needs no
+special case for inbound access, and "airgapped" does not have to mean
+"unreachable".
+
+What this module is NOT: proof. It is enforcement. The proof lives in
+``tests/test_offline_mode.py``, which runs a complete generation with a
+socket-level guard installed and asserts zero connection attempts, and in the
+CI guard that fails the build when a new egress call site appears without one
+of these checks in front of it.
+
+Real airgap assurance comes from outside the process anyway -- a network
+namespace with no route, a firewall rule, an unplugged interface. This exists so
+that running autocontext inside one of those still works instead of hanging on a
+call nobody expected it to make.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+#: Runtimes that shell out to a third-party binary which makes its OWN network
+#: calls. No amount of guarding this codebase controls their sockets, so offline
+#: mode refuses to start them rather than silently vouching for them.
+UNAVAILABLE_OFFLINE_RUNTIMES: frozenset[str] = frozenset(
+    {"claude-cli", "codex", "pi", "pi-rpc", "hermes"},
+)
+
+_TRUE = frozenset({"1", "true", "yes", "on"})
+
+
+class OfflineError(RuntimeError):
+    """Raised when offline mode blocks an outbound connection.
+
+    Names what was blocked. A run that dies with "connection refused" three
+    layers down teaches the operator nothing; one that says which subsystem
+    tried to reach out tells them exactly which setting to change.
+    """
+
+    def __init__(self, what: str, detail: str = "") -> None:
+        message = f"AUTOCONTEXT_OFFLINE is set; refusing to {what}"
+        if detail:
+            message = f"{message} ({detail})"
+        super().__init__(message)
+        self.what = what
+
+
+def is_offline(settings: Any = None) -> bool:
+    """Whether offline mode is active.
+
+    Reads the environment directly when no settings object is supplied, because
+    the guards live at egress boundaries that are not all reachable from a
+    settings instance. ``AppSettings`` remains the documented surface; this is
+    the same value.
+    """
+    if settings is not None:
+        configured = getattr(settings, "offline", None)
+        if isinstance(configured, bool):
+            return configured
+    return os.environ.get("AUTOCONTEXT_OFFLINE", "").strip().lower() in _TRUE
+
+
+def require_online(what: str, *, settings: Any = None, detail: str = "") -> None:
+    """Fail closed if offline mode is active.
+
+    Call this immediately before an outbound connection, not at the top of a
+    request-building function: the CI guard looks for it in the same function as
+    the egress call, and a check that sits far from what it protects is one a
+    later refactor moves away from.
+    """
+    if is_offline(settings):
+        raise OfflineError(what, detail)
+
+
+def runtime_is_available(runtime: str, *, settings: Any = None) -> bool:
+    """Whether ``runtime`` may be started under the current mode."""
+    if not is_offline(settings):
+        return True
+    return runtime.strip().lower() not in UNAVAILABLE_OFFLINE_RUNTIMES
+
+
+def require_runtime_available(runtime: str, *, settings: Any = None) -> None:
+    """Refuse a subprocess runtime whose egress this process cannot control."""
+    if not runtime_is_available(runtime, settings=settings):
+        raise OfflineError(
+            f"start the {runtime} runtime",
+            "it is a subprocess that makes its own network calls, which offline mode cannot guarantee",
+        )
+
+
+def check_offline_configuration(settings: Any) -> list[str]:
+    """Return configuration conflicts that should stop a run before it starts.
+
+    Offline mode and a hosted control plane are incompatible by design rather
+    than by precedence. Silently letting one win would mean an operator who
+    configured both gets a guarantee they did not receive, or a sync they did
+    not expect -- and which of those happened would depend on load order.
+    """
+    if not is_offline(settings):
+        return []
+
+    conflicts: list[str] = []
+    # Checked against settings that EXIST. An earlier draft guarded a
+    # `control_plane_url` field, which this package does not have -- the control
+    # plane is autowork's, configured on that side. A check that can never fire
+    # is worse than no check: it reads like coverage.
+    webhook = str(getattr(settings, "notify_webhook_url", "") or "").strip()
+    if webhook:
+        conflicts.append(
+            f"AUTOCONTEXT_OFFLINE is set and AUTOCONTEXT_NOTIFY_WEBHOOK_URL is configured ({webhook}); "
+            "posting a notification is engine-initiated egress. Unset one of them."
+        )
+
+    runtime = str(getattr(settings, "agent_provider", "") or "").strip().lower()
+    if runtime in UNAVAILABLE_OFFLINE_RUNTIMES:
+        conflicts.append(
+            f"AUTOCONTEXT_OFFLINE is set and AUTOCONTEXT_AGENT_PROVIDER={runtime}, "
+            "which shells out to a binary that makes its own network calls. "
+            "Use a local endpoint (ollama, vllm, mlx) instead."
+        )
+    return conflicts

--- a/autocontext/src/autocontext/offline.py
+++ b/autocontext/src/autocontext/offline.py
@@ -25,16 +25,44 @@ call nobody expected it to make.
 from __future__ import annotations
 
 import os
+from ipaddress import ip_address
 from typing import Any
+from urllib.parse import urlsplit
 
 #: Runtimes that shell out to a third-party binary which makes its OWN network
 #: calls. No amount of guarding this codebase controls their sockets, so offline
 #: mode refuses to start them rather than silently vouching for them.
 UNAVAILABLE_OFFLINE_RUNTIMES: frozenset[str] = frozenset(
-    {"claude-cli", "codex", "pi", "pi-rpc", "hermes"},
+    {
+        "agent_sdk",
+        "claude-cli",
+        "codex",
+        "hermes",
+        "openclaw-cli",
+        "openclaw-factory",
+        "pi",
+        "pi-rpc",
+    },
 )
 
-_TRUE = frozenset({"1", "true", "yes", "on"})
+# Keep this exactly aligned with the string spellings Pydantic accepts for a
+# boolean field. The egress guards often do not have an AppSettings instance,
+# so parsing the environment here must not disagree with load_settings().
+_TRUE = frozenset({"1", "true", "yes", "on", "y", "t"})
+
+_HTTP_PROVIDER_DEFAULTS: dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+    "openai-compatible": "https://api.openai.com/v1",
+    "openrouter": "https://openrouter.ai/api/v1",
+    "ollama": "http://localhost:11434/v1",
+    "vllm": "http://localhost:8000/v1",
+}
+_ROLE_PROVIDER_FIELDS = (
+    ("competitor", "competitor_provider", "competitor_base_url"),
+    ("architect", "architect_provider", "architect_base_url"),
+    ("analyst", "analyst_provider", "analyst_base_url"),
+    ("coach", "coach_provider", "coach_base_url"),
+)
 
 
 class OfflineError(RuntimeError):
@@ -80,6 +108,40 @@ def require_online(what: str, *, settings: Any = None, detail: str = "") -> None
         raise OfflineError(what, detail)
 
 
+def is_local_endpoint(endpoint: str) -> bool:
+    """Whether an endpoint is unambiguously confined to this host.
+
+    Hostnames other than the exact ``localhost`` name are deliberately not
+    resolved here: DNS resolution is itself egress and a name that happens to
+    resolve to loopback now can be rebound later. Literal loopback addresses
+    cover the rest of the local-server cases without that ambiguity.
+    """
+    try:
+        host = urlsplit(endpoint).hostname
+    except ValueError:
+        return False
+    if host is None:
+        return False
+    normalized = host.rstrip(".").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def require_endpoint_available(
+    what: str,
+    endpoint: str,
+    *,
+    settings: Any = None,
+) -> None:
+    """Allow a literal loopback endpoint offline; block every other endpoint."""
+    if is_offline(settings) and not is_local_endpoint(endpoint):
+        raise OfflineError(what, endpoint)
+
+
 def runtime_is_available(runtime: str, *, settings: Any = None) -> bool:
     """Whether ``runtime`` may be started under the current mode."""
     if not is_offline(settings):
@@ -119,11 +181,134 @@ def check_offline_configuration(settings: Any) -> list[str]:
             "posting a notification is engine-initiated egress. Unset one of them."
         )
 
-    runtime = str(getattr(settings, "agent_provider", "") or "").strip().lower()
-    if runtime in UNAVAILABLE_OFFLINE_RUNTIMES:
+    agent_provider = _setting(settings, "agent_provider")
+    agent_base_url = _setting(settings, "agent_base_url") or _setting(settings, "judge_base_url")
+    conflict = _provider_conflict(
+        "AUTOCONTEXT_AGENT_PROVIDER",
+        agent_provider,
+        agent_base_url,
+        settings,
+    )
+    if conflict:
+        conflicts.append(conflict)
+
+    for role, provider_field, base_url_field in _ROLE_PROVIDER_FIELDS:
+        provider = _setting(settings, provider_field)
+        base_url = _setting(settings, base_url_field)
+        if not provider and not base_url:
+            continue
+        conflict = _provider_conflict(
+            f"AUTOCONTEXT_{role.upper()}_PROVIDER",
+            provider or agent_provider,
+            base_url or agent_base_url,
+            settings,
+        )
+        if conflict:
+            conflicts.append(conflict)
+
+    judge_provider = _setting(settings, "judge_provider")
+    if judge_provider == "auto":
+        judge_provider = _resolve_auto_judge_provider(settings)
+    conflict = _provider_conflict(
+        "AUTOCONTEXT_JUDGE_PROVIDER",
+        judge_provider,
+        _setting(settings, "judge_base_url"),
+        settings,
+    )
+    if conflict:
+        conflicts.append(conflict)
+
+    if bool(getattr(settings, "consultation_enabled", False)):
+        conflict = _provider_conflict(
+            "AUTOCONTEXT_CONSULTATION_PROVIDER",
+            _setting(settings, "consultation_provider"),
+            _setting(settings, "consultation_base_url"),
+            settings,
+        )
+        if conflict:
+            conflicts.append(conflict)
+
+    executor_mode = _setting(settings, "executor_mode")
+    if executor_mode in {"primeintellect", "ssh"}:
         conflicts.append(
-            f"AUTOCONTEXT_OFFLINE is set and AUTOCONTEXT_AGENT_PROVIDER={runtime}, "
-            "which shells out to a binary that makes its own network calls. "
-            "Use a local endpoint (ollama, vllm, mlx) instead."
+            f"AUTOCONTEXT_OFFLINE is set and AUTOCONTEXT_EXECUTOR_MODE={executor_mode}; "
+            "the executor initiates a remote connection. Use local or monty instead."
+        )
+
+    if bool(getattr(settings, "blob_store_enabled", False)) and _setting(
+        settings,
+        "blob_store_backend",
+    ) == "hf_bucket":
+        conflicts.append(
+            "AUTOCONTEXT_OFFLINE is set and AUTOCONTEXT_BLOB_STORE_BACKEND=hf_bucket; "
+            "Hugging Face artifact synchronization is engine-initiated egress. Use local storage instead."
+        )
+
+    if _setting(settings, "openclaw_distill_sidecar_command") or _setting(
+        settings,
+        "openclaw_distill_sidecar_factory",
+    ):
+        conflicts.append(
+            "AUTOCONTEXT_OFFLINE is set and an OpenClaw distillation sidecar is configured; "
+            "an external sidecar cannot be covered by the no-egress guarantee."
         )
     return conflicts
+
+
+def _setting(settings: Any, name: str) -> str:
+    return str(getattr(settings, name, "") or "").strip().lower()
+
+
+def _resolve_auto_judge_provider(settings: Any) -> str:
+    """Mirror registry.resolve_auto_judge_provider without creating a cycle."""
+    inherited = {"claude-cli", "codex", "pi", "pi-rpc"}
+    for field_name in (
+        "competitor_provider",
+        "architect_provider",
+        "analyst_provider",
+        "coach_provider",
+        "agent_provider",
+    ):
+        provider = _setting(settings, field_name)
+        if provider:
+            return provider if provider in inherited else "anthropic"
+    return "anthropic"
+
+
+def _provider_conflict(
+    setting_name: str,
+    provider: str,
+    base_url: str,
+    settings: Any,
+) -> str | None:
+    if not provider or provider in {"deterministic", "mlx"}:
+        return None
+    if provider in UNAVAILABLE_OFFLINE_RUNTIMES:
+        return (
+            f"AUTOCONTEXT_OFFLINE is set and {setting_name}={provider}, which starts external code "
+            "whose network access this process cannot control. Use a local endpoint (ollama, vllm, mlx) instead."
+        )
+    if provider == "openclaw":
+        runtime_kind = _setting(settings, "openclaw_runtime_kind") or "factory"
+        if runtime_kind == "http":
+            endpoint = _setting(settings, "openclaw_agent_http_endpoint")
+            if endpoint and is_local_endpoint(endpoint):
+                return None
+            return (
+                f"AUTOCONTEXT_OFFLINE is set and {setting_name}=openclaw uses a non-local HTTP endpoint "
+                f"({endpoint or 'not configured'})."
+            )
+        return (
+            f"AUTOCONTEXT_OFFLINE is set and {setting_name}=openclaw uses the {runtime_kind} runtime; "
+            "external code cannot be covered by the no-egress guarantee."
+        )
+    if provider == "anthropic":
+        return f"AUTOCONTEXT_OFFLINE is set and {setting_name}=anthropic; the Anthropic API is remote."
+    if provider in _HTTP_PROVIDER_DEFAULTS:
+        endpoint = base_url or _HTTP_PROVIDER_DEFAULTS[provider]
+        if is_local_endpoint(endpoint):
+            return None
+        return (
+            f"AUTOCONTEXT_OFFLINE is set and {setting_name}={provider} targets a non-local endpoint ({endpoint})."
+        )
+    return None

--- a/autocontext/src/autocontext/openclaw/adapters.py
+++ b/autocontext/src/autocontext/openclaw/adapters.py
@@ -20,6 +20,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+from autocontext.offline import require_online
+
 logger = logging.getLogger(__name__)
 
 OPENCLAW_COMPATIBILITY_VERSION = "1.0"
@@ -240,6 +242,7 @@ def _http_post(
         headers=request_headers,
         method="POST",
     )
+    require_online("call an openclaw endpoint", detail=endpoint)
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         body = resp.read().decode("utf-8")
         return type("Response", (), {

--- a/autocontext/src/autocontext/openclaw/adapters.py
+++ b/autocontext/src/autocontext/openclaw/adapters.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
-from autocontext.offline import require_online
+from autocontext.offline import require_endpoint_available, require_runtime_available
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +201,7 @@ class CLIOpenClawAdapter(OpenClawAdapter):
         return "cli"
 
     def execute(self, request: OpenClawRequest) -> OpenClawResponse:
+        require_runtime_available("openclaw-cli")
         args = [self.command, *self.extra_args]
         try:
             result = subprocess.run(
@@ -242,7 +243,7 @@ def _http_post(
         headers=request_headers,
         method="POST",
     )
-    require_online("call an openclaw endpoint", detail=endpoint)
+    require_endpoint_available("call an openclaw endpoint", endpoint)
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         body = resp.read().decode("utf-8")
         return type("Response", (), {

--- a/autocontext/src/autocontext/openclaw/distill.py
+++ b/autocontext/src/autocontext/openclaw/distill.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, runtime_checkabl
 
 from pydantic import BaseModel, Field
 
+from autocontext.offline import require_runtime_available
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -81,6 +83,7 @@ class CommandDistillSidecar:
         self._cwd = cwd
 
     def launch(self, job_id: str, scenario: str, config: dict[str, Any]) -> None:
+        require_runtime_available("openclaw-cli")
         command = shlex.split(
             self._command_template.format(job_id=job_id, scenario=scenario),
         )
@@ -123,6 +126,7 @@ def load_distill_sidecar(settings: AppSettings, *, cwd: Path | None = None) -> D
     """Resolve the configured distillation sidecar, if any."""
     factory_path = settings.openclaw_distill_sidecar_factory.strip()
     if factory_path:
+        require_runtime_available("openclaw-factory", settings=settings)
         factory = _load_factory(factory_path)
         signature = inspect.signature(factory)
         if len(signature.parameters) == 0:

--- a/autocontext/src/autocontext/preflight.py
+++ b/autocontext/src/autocontext/preflight.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from autocontext.config.settings import load_settings
+from autocontext.offline import check_offline_configuration
 from autocontext.scenarios import resolve_scenario_class
 
 
@@ -197,8 +198,18 @@ def run_preflight(
     if preset is not None:
         os.environ["AUTOCONTEXT_PRESET"] = preset
     settings = load_settings()
+
+    # AC-917: offline mode and engine-initiated egress are incompatible by
+    # design, not by precedence. Reported as blocking CHECK RESULTS rather than
+    # raised directly, so an operator sees every conflict at once instead of
+    # fixing them one run at a time.
+    conflicts = [
+        CheckResult(name="offline_configuration", passed=False, detail=conflict, blocking=True)
+        for conflict in check_offline_configuration(settings)
+    ]
+
     checker = PreflightChecker(scenario, knowledge_root=Path(settings.knowledge_root), settings=settings)
-    results = checker.run_all() if check_scenario else checker.run_without_scenario_check()
+    results = conflicts + (checker.run_all() if check_scenario else checker.run_without_scenario_check())
 
     blocking = PreflightChecker.blocking_failures(results)
     if blocking:

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import anthropic
 
+from autocontext.offline import require_online
 from autocontext.providers.base import (
     CompletionResult,
     LLMProvider,
@@ -122,6 +123,7 @@ class AnthropicProvider(LLMProvider):
         """Create one message, degrading only explicit strict-schema rejection."""
         while True:
             try:
+                require_online("call the Anthropic API")
                 return self._client.messages.create(**request), constrained
             except anthropic.APIError as exc:
                 if constrained and _is_unsupported_strict_schema_error(exc):

--- a/autocontext/src/autocontext/providers/anthropic.py
+++ b/autocontext/src/autocontext/providers/anthropic.py
@@ -180,6 +180,7 @@ class AnthropicProvider(LLMProvider):
             }
             request.update(_claude_request_controls(model_id, temperature))
             try:
+                require_online("call the Anthropic API")
                 create_message: Any = self._client.messages.create
                 response = create_message(**request)
             except anthropic.APIError as exc:

--- a/autocontext/src/autocontext/providers/openai_compat.py
+++ b/autocontext/src/autocontext/providers/openai_compat.py
@@ -11,7 +11,7 @@ import os
 import re
 from typing import Any
 
-from autocontext.offline import require_online
+from autocontext.offline import require_endpoint_available
 from autocontext.providers.base import (
     CompletionResult,
     LLMProvider,
@@ -84,6 +84,10 @@ class OpenAICompatibleProvider(LLMProvider):
             kwargs["default_headers"] = extra_headers
 
         self._client = openai.OpenAI(**kwargs)
+        # Keep the SDK's resolved URL (including its default when no URL was
+        # supplied) so offline enforcement judges the destination actually
+        # used, rather than inferring it from a provider label.
+        self._base_url = str(self._client.base_url)
         self._default_model = default_model_name
 
     def complete(
@@ -289,7 +293,12 @@ class OpenAICompatibleProvider(LLMProvider):
     ) -> tuple[Any, bool]:
         while True:
             try:
-                require_online("call an OpenAI-compatible endpoint")
+                # Some compatible subclasses and long-standing unit-test
+                # doubles construct via __new__ and inject only the transport.
+                # Default to the SDK's real hosted endpoint for those objects;
+                # offline mode therefore still fails closed.
+                endpoint = getattr(self, "_base_url", "https://api.openai.com/v1")
+                require_endpoint_available("call an OpenAI-compatible endpoint", endpoint)
                 return self._client.chat.completions.create(**request), constrained
             except Exception as exc:
                 if constrained and _is_unsupported_response_format_error(exc):

--- a/autocontext/src/autocontext/providers/openai_compat.py
+++ b/autocontext/src/autocontext/providers/openai_compat.py
@@ -11,6 +11,7 @@ import os
 import re
 from typing import Any
 
+from autocontext.offline import require_online
 from autocontext.providers.base import (
     CompletionResult,
     LLMProvider,
@@ -288,6 +289,7 @@ class OpenAICompatibleProvider(LLMProvider):
     ) -> tuple[Any, bool]:
         while True:
             try:
+                require_online("call an OpenAI-compatible endpoint")
                 return self._client.chat.completions.create(**request), constrained
             except Exception as exc:
                 if constrained and _is_unsupported_response_format_error(exc):

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from autocontext.offline import require_runtime_available
 from autocontext.providers.base import LLMProvider, ProviderError
 
 if TYPE_CHECKING:
@@ -77,6 +78,12 @@ def create_provider(
         ProviderError: If the provider type is unknown or configuration is invalid.
     """
     provider_type = provider_type.lower().strip()
+
+    # AC-917: refuse the subprocess runtimes here rather than letting them
+    # start and dial out. They shell out to a third-party binary whose sockets
+    # this process does not control, so offline mode cannot vouch for them --
+    # they are unavailable rather than silently trusted.
+    require_runtime_available(provider_type)
 
     if provider_type == "anthropic":
         from autocontext.providers.anthropic import AnthropicProvider

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -240,6 +240,7 @@ def get_provider(settings: AppSettings) -> LLMProvider:
     provider_type = settings.judge_provider.lower().strip()
     if provider_type == "auto":
         provider_type = resolve_auto_judge_provider(settings)
+    require_runtime_available(provider_type, settings=settings)
     base_url = settings.judge_base_url
 
     # MLX provider has its own construction path using mlx_* settings

--- a/autocontext/src/autocontext/runtimes/claude_cli.py
+++ b/autocontext/src/autocontext/runtimes/claude_cli.py
@@ -18,6 +18,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from autocontext.offline import require_runtime_available
 from autocontext.runtimes.base import AgentOutput, AgentRuntime
 from autocontext.runtimes.runtime_budget import RuntimeBudget, RuntimeBudgetExpired
 
@@ -118,6 +119,7 @@ def _run_with_group_kill(
     Re-raises `subprocess.TimeoutExpired` on timeout so the caller's
     retry/backoff path keeps working.
     """
+    require_runtime_available("claude-cli")
     popen_kwargs: dict[str, Any] = {
         "stdin": subprocess.PIPE,
         "stdout": subprocess.PIPE,

--- a/autocontext/src/autocontext/runtimes/codex_cli.py
+++ b/autocontext/src/autocontext/runtimes/codex_cli.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass, field
 
+from autocontext.offline import require_runtime_available
 from autocontext.runtimes.base import AgentOutput, AgentRuntime
 
 logger = logging.getLogger(__name__)
@@ -103,6 +104,7 @@ class CodexCLIRuntime(AgentRuntime):
         return args
 
     def _invoke(self, prompt: str, args: list[str]) -> AgentOutput:
+        require_runtime_available("codex")
         logger.info("invoking codex exec: %s", " ".join(args[:6]) + "...")
 
         # Append the prompt as the final positional argument

--- a/autocontext/src/autocontext/runtimes/hermes_cli.py
+++ b/autocontext/src/autocontext/runtimes/hermes_cli.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass, field
 
+from autocontext.offline import require_runtime_available
 from autocontext.runtimes.base import AgentOutput, AgentRuntime
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,7 @@ class HermesCLIRuntime(AgentRuntime):
         return env
 
     def _invoke(self, prompt: str) -> AgentOutput:
+        require_runtime_available("hermes")
         args = self._build_args(prompt)
         logger.info("invoking hermes: %s", " ".join(args[:6]) + "...")
         try:

--- a/autocontext/src/autocontext/runtimes/pi_cli.py
+++ b/autocontext/src/autocontext/runtimes/pi_cli.py
@@ -17,6 +17,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from autocontext.offline import require_runtime_available
 from autocontext.runtimes.base import AgentOutput, AgentRuntime
 from autocontext.runtimes.pi_artifacts import PiExecutionTrace
 from autocontext.runtimes.pi_defaults import PI_DEFAULT_TIMEOUT_SECONDS
@@ -108,6 +109,7 @@ def _run_with_group_kill(
     child from the terminal's signal-delivery group.
     """
 
+    require_runtime_available("pi")
     popen_kwargs: dict[str, Any] = {
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,

--- a/autocontext/src/autocontext/runtimes/pi_rpc.py
+++ b/autocontext/src/autocontext/runtimes/pi_rpc.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from autocontext.offline import require_runtime_available
 from autocontext.runtimes.base import AgentOutput, AgentRuntime
 
 logger = logging.getLogger(__name__)
@@ -158,6 +159,7 @@ class PiRPCRuntime(AgentRuntime):
         stderr_lines: list[str] = []
         process: subprocess.Popen[str] | None = None
         try:
+            require_runtime_available("pi-rpc")
             # Keep stdin open after the prompt ack so Pi can stream the agent result.
             input_line = json.dumps(command) + "\n"
             process = subprocess.Popen(
@@ -368,6 +370,7 @@ class PiPersistentRPCRuntime(PiRPCRuntime):
         if self._process is not None and self._process.poll() is None:
             return self._process
 
+        require_runtime_available("pi-rpc")
         self._stdout_queue = queue.Queue()
         self._stderr_queue = queue.Queue()
         self._stderr_lines = []

--- a/autocontext/src/autocontext/sharing/publishers/gist.py
+++ b/autocontext/src/autocontext/sharing/publishers/gist.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from autocontext.offline import require_online
+
 
 class GistPublishError(Exception):
     """Raised when Gist publication fails."""
@@ -46,6 +48,7 @@ def _run_gh_command(
     public: bool,
 ) -> str:
     """Execute ``gh gist create`` and return the Gist URL."""
+    require_online("publish a GitHub Gist")
     cmd = ["gh", "gist", "create"]
     if public:
         cmd.append("--public")

--- a/autocontext/src/autocontext/sharing/publishers/hf.py
+++ b/autocontext/src/autocontext/sharing/publishers/hf.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from autocontext.offline import require_online
+
 
 class HfPublishError(Exception):
     """Raised when HF publication fails."""
@@ -49,6 +51,7 @@ def _run_hf_command(
     repo_type: str,
 ) -> str:
     """Execute ``huggingface-cli upload`` and return the repo URL."""
+    require_online("publish to Hugging Face", detail=repo_id)
     cmd = [
         "huggingface-cli",
         "upload",

--- a/autocontext/src/autocontext/storage/factory.py
+++ b/autocontext/src/autocontext/storage/factory.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from autocontext.config.settings import AppSettings
 from autocontext.extensions import HookBus
+from autocontext.offline import require_online
 from autocontext.storage.artifacts import ArtifactStore
 
 
@@ -20,6 +21,8 @@ def artifact_store_from_settings(
     """Build an ArtifactStore from app settings, including blob-store wiring."""
     blob_store = None
     if settings.blob_store_enabled:
+        if settings.blob_store_backend == "hf_bucket":
+            require_online("use Hugging Face blob storage", settings=settings, detail=settings.blob_store_repo)
         from autocontext.blobstore.factory import create_blob_store
 
         blob_store = create_blob_store(

--- a/autocontext/tests/test_offline_mode.py
+++ b/autocontext/tests/test_offline_mode.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 import ast
 import socket
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -29,7 +31,9 @@ from autocontext.offline import (
     UNAVAILABLE_OFFLINE_RUNTIMES,
     OfflineError,
     check_offline_configuration,
+    is_local_endpoint,
     is_offline,
+    require_endpoint_available,
     require_online,
     runtime_is_available,
 )
@@ -140,6 +144,113 @@ def test_nothing_is_blocked_when_offline_is_unset(monkeypatch: pytest.MonkeyPatc
     assert is_offline() is False
 
 
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "y", "t"])
+def test_direct_guard_accepts_every_true_spelling_that_settings_accepts(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    """The settings and boundary paths must never disagree about the flag."""
+    monkeypatch.setenv("AUTOCONTEXT_OFFLINE", value)
+    from autocontext.config.settings import load_settings
+
+    assert load_settings().offline is True
+    assert is_offline() is True
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://localhost:11434/v1",
+        "http://localhost.:8000/v1",
+        "http://127.0.0.2:8000/v1",
+        "http://[::1]:8000/v1",
+    ],
+)
+def test_literal_loopback_endpoints_are_local(endpoint: str) -> None:
+    assert is_local_endpoint(endpoint) is True
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://api.openai.com/v1",
+        "http://localhost.example.com/v1",
+        "http://10.0.0.8:8000/v1",
+        "not-a-url",
+    ],
+)
+def test_non_loopback_or_ambiguous_endpoints_are_not_local(endpoint: str) -> None:
+    assert is_local_endpoint(endpoint) is False
+
+
+def test_local_endpoint_is_available_offline(offline: None) -> None:
+    require_endpoint_available("call a local model", "http://127.0.0.1:11434/v1")
+
+
+def test_remote_endpoint_is_blocked_offline(offline: None) -> None:
+    with pytest.raises(OfflineError, match="api.openai.com"):
+        require_endpoint_available("call a model", "https://api.openai.com/v1")
+
+
+def test_openai_compatible_provider_calls_loopback_offline(offline: None) -> None:
+    """Ollama/vLLM use this provider, so the boundary must admit loopback."""
+    from autocontext.providers.openai_compat import OpenAICompatibleProvider
+
+    provider = OpenAICompatibleProvider(api_key="local", base_url="http://127.0.0.1:11434/v1")
+    sentinel = object()
+    create = Mock(return_value=sentinel)
+    provider._client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    response, constrained = provider._create_chat_completion({}, model_id="local", constrained=False)
+
+    assert response is sentinel
+    assert constrained is False
+    create.assert_called_once_with()
+
+
+def test_openai_compatible_provider_blocks_remote_endpoint_offline(offline: None) -> None:
+    from autocontext.providers.base import ProviderError
+    from autocontext.providers.openai_compat import OpenAICompatibleProvider
+
+    provider = OpenAICompatibleProvider(api_key="remote", base_url="https://api.openai.com/v1")
+    create = Mock()
+    provider._client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    with pytest.raises(ProviderError, match="AUTOCONTEXT_OFFLINE"):
+        provider._create_chat_completion({}, model_id="remote", constrained=False)
+    create.assert_not_called()
+
+
+def test_primary_anthropic_client_is_guarded(offline: None) -> None:
+    """The generation loop uses agents.llm_client, not providers.anthropic."""
+    from autocontext.agents.llm_client import AnthropicClient
+
+    client = AnthropicClient.__new__(AnthropicClient)
+    client.max_retries = 0
+    client.base_delay = 0.0
+    client.max_delay = 0.0
+    client.backoff_factor = 2.0
+    create = Mock()
+    client._client = SimpleNamespace(messages=SimpleNamespace(create=create))
+
+    with pytest.raises(OfflineError, match="Anthropic"):
+        client._messages_create_with_retry(model="remote")
+    create.assert_not_called()
+
+
+def test_anthropic_thinking_path_is_guarded(offline: None) -> None:
+    from autocontext.providers.anthropic import AnthropicProvider
+
+    provider = AnthropicProvider.__new__(AnthropicProvider)
+    provider._default_model = "remote"
+    create = Mock()
+    provider._client = SimpleNamespace(messages=SimpleNamespace(create=create))
+
+    with pytest.raises(OfflineError, match="Anthropic"):
+        provider.complete_with_thinking("system", "prompt")
+    create.assert_not_called()
+
+
 @pytest.mark.parametrize("runtime", sorted(UNAVAILABLE_OFFLINE_RUNTIMES))
 def test_subprocess_runtimes_are_refused(offline: None, runtime: str) -> None:
     """They shell out to binaries whose sockets this process does not control.
@@ -152,6 +263,59 @@ def test_subprocess_runtimes_are_refused(offline: None, runtime: str) -> None:
     assert runtime_is_available(runtime) is False
     with pytest.raises(OfflineError, match=runtime):
         create_provider(runtime)
+
+
+@pytest.mark.parametrize("runtime", ["agent_sdk", "claude-cli", "codex", "hermes", "pi", "pi-rpc"])
+def test_main_client_factory_refuses_external_runtimes(offline: None, runtime: str) -> None:
+    from autocontext.agents.llm_client import build_client_from_settings
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(update={"agent_provider": runtime})
+    with pytest.raises(OfflineError, match=runtime):
+        build_client_from_settings(settings)
+
+
+def test_role_override_factory_refuses_external_runtime(offline: None) -> None:
+    from autocontext.agents.provider_bridge import create_role_client
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(update={"agent_provider": "deterministic", "competitor_provider": "codex"})
+    with pytest.raises(OfflineError, match="codex"):
+        create_role_client("codex", settings, role="competitor")
+
+
+def test_judge_factory_refuses_external_runtime(offline: None) -> None:
+    from autocontext.config.settings import load_settings
+    from autocontext.providers.registry import get_provider
+
+    settings = load_settings().model_copy(update={"agent_provider": "deterministic", "judge_provider": "codex"})
+    with pytest.raises(OfflineError, match="codex"):
+        get_provider(settings)
+
+
+def test_openclaw_cli_factory_is_refused(offline: None) -> None:
+    from autocontext.agents.provider_bridge import create_role_client
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(
+        update={
+            "agent_provider": "deterministic",
+            "openclaw_runtime_kind": "cli",
+            "openclaw_agent_command": "agent",
+        },
+    )
+    with pytest.raises(OfflineError, match="openclaw-cli"):
+        create_role_client("openclaw", settings, role="competitor")
+
+
+def test_direct_runtime_boundary_refuses_before_subprocess(offline: None) -> None:
+    from autocontext.runtimes.codex_cli import CodexCLIRuntime
+
+    runtime = CodexCLIRuntime()
+    with patch("autocontext.runtimes.codex_cli.subprocess.run") as run:
+        with pytest.raises(OfflineError, match="codex"):
+            runtime.generate("prompt")
+    run.assert_not_called()
 
 
 @pytest.mark.parametrize("provider", ["ollama", "vllm"])
@@ -177,7 +341,13 @@ def test_offline_plus_webhook_is_a_conflict(offline: None) -> None:
     """
     from autocontext.config.settings import load_settings
 
-    settings = load_settings().model_copy(update={"notify_webhook_url": "https://hooks.example/x"})
+    settings = load_settings().model_copy(
+        update={
+            "agent_provider": "deterministic",
+            "judge_provider": "mlx",
+            "notify_webhook_url": "https://hooks.example/x",
+        },
+    )
     conflicts = check_offline_configuration(settings)
 
     assert len(conflicts) == 1
@@ -187,7 +357,7 @@ def test_offline_plus_webhook_is_a_conflict(offline: None) -> None:
 def test_offline_plus_cli_runtime_is_a_conflict(offline: None) -> None:
     from autocontext.config.settings import load_settings
 
-    settings = load_settings().model_copy(update={"agent_provider": "claude-cli"})
+    settings = load_settings().model_copy(update={"agent_provider": "claude-cli", "judge_provider": "mlx"})
     conflicts = check_offline_configuration(settings)
 
     assert len(conflicts) == 1
@@ -202,6 +372,97 @@ def test_no_conflicts_when_online(monkeypatch: pytest.MonkeyPatch) -> None:
         update={"notify_webhook_url": "https://hooks.example/x", "agent_provider": "claude-cli"},
     )
     assert check_offline_configuration(settings) == []
+
+
+def test_loopback_agent_and_judge_have_no_offline_conflict(offline: None) -> None:
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(
+        update={
+            "agent_provider": "ollama",
+            "agent_base_url": "http://localhost:11434/v1",
+            "judge_provider": "vllm",
+            "judge_base_url": "http://127.0.0.1:8000/v1",
+        },
+    )
+    assert check_offline_configuration(settings) == []
+
+
+def test_auto_judge_is_reported_when_it_resolves_to_anthropic(offline: None) -> None:
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(update={"agent_provider": "ollama", "judge_provider": "auto"})
+    conflicts = check_offline_configuration(settings)
+
+    assert len(conflicts) == 1
+    assert "JUDGE_PROVIDER=anthropic" in conflicts[0]
+
+
+@pytest.mark.parametrize("executor", ["primeintellect", "ssh"])
+def test_remote_executor_is_an_offline_conflict(offline: None, executor: str) -> None:
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(
+        update={"agent_provider": "deterministic", "judge_provider": "mlx", "executor_mode": executor},
+    )
+    conflicts = check_offline_configuration(settings)
+
+    assert len(conflicts) == 1
+    assert f"EXECUTOR_MODE={executor}" in conflicts[0]
+
+
+def test_remote_blob_store_is_an_offline_conflict(offline: None) -> None:
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(
+        update={
+            "agent_provider": "deterministic",
+            "judge_provider": "mlx",
+            "blob_store_enabled": True,
+            "blob_store_backend": "hf_bucket",
+        },
+    )
+    conflicts = check_offline_configuration(settings)
+
+    assert len(conflicts) == 1
+    assert "BLOB_STORE_BACKEND=hf_bucket" in conflicts[0]
+
+
+def test_remote_blob_store_boundary_blocks_before_construction(offline: None, tmp_path: Path) -> None:
+    from autocontext.config.settings import load_settings
+    from autocontext.storage.factory import artifact_store_from_settings
+
+    settings = load_settings().model_copy(
+        update={
+            "blob_store_enabled": True,
+            "blob_store_backend": "hf_bucket",
+            "blob_store_root": str(tmp_path),
+            "blob_store_repo": "owner/repo",
+        },
+    )
+    with pytest.raises(OfflineError, match="Hugging Face"):
+        artifact_store_from_settings(settings)
+
+
+def test_ssh_boundary_blocks_before_subprocess(offline: None) -> None:
+    from autocontext.integrations.ssh.client import SSHClient
+    from autocontext.integrations.ssh.config import SSHHostConfig
+
+    client = SSHClient(SSHHostConfig(name="remote", hostname="host.example"))
+    with patch("autocontext.integrations.ssh.client.subprocess.run") as run:
+        with pytest.raises(OfflineError, match="SSH"):
+            client.execute_command("true")
+    run.assert_not_called()
+
+
+def test_primeintellect_boundary_blocks_before_sdk(offline: None) -> None:
+    from autocontext.integrations.primeintellect.client import PrimeIntellectClient
+
+    client = PrimeIntellectClient(api_key="secret")
+    with patch("autocontext.integrations.primeintellect.client.asyncio.run") as run:
+        with pytest.raises(OfflineError, match="PrimeIntellect"):
+            client.warm_provision("test")
+    run.assert_not_called()
 
 
 def test_preflight_blocks_on_a_conflict(offline: None, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -230,6 +491,7 @@ _EGRESS_EXEMPT: dict[str, str] = {
 }
 
 _EGRESS_CALLS = {"urlopen"}
+_EGRESS_GUARDS = {"require_online", "require_endpoint_available"}
 
 
 def _egress_functions_without_a_guard() -> set[str]:
@@ -265,7 +527,7 @@ def _egress_functions_without_a_guard() -> set[str]:
                 for child in ast.walk(node)
                 if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
             }
-            if names & _EGRESS_CALLS and "require_online" not in names:
+            if names & _EGRESS_CALLS and not names & _EGRESS_GUARDS:
                 offenders.add(rel)
     return offenders
 
@@ -298,6 +560,6 @@ def test_the_egress_guard_can_actually_fail(tmp_path: Path) -> None:
         child.func.id for child in ast.walk(functions[0]) if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
     }
     assert names & _EGRESS_CALLS
-    assert "require_online" not in names
+    assert not names & _EGRESS_GUARDS
 
     del tmp_path

--- a/autocontext/tests/test_offline_mode.py
+++ b/autocontext/tests/test_offline_mode.py
@@ -1,0 +1,303 @@
+"""AC-917: offline mode is enforced, and the enforcement is proven at the socket.
+
+Per-path tests cannot deliver this guarantee. They only cover the paths someone
+remembered to guard, and the failure mode is precisely the path nobody
+remembered. So the load-bearing test here installs a guard at
+``socket.socket.connect`` -- below every HTTP client, SDK and transport in the
+process -- runs real work, and asserts zero connection attempts.
+
+That is also why the CI guard in ``test_no_unguarded_egress_call_sites`` exists.
+It is the part that stops this rotting: a ``urlopen`` added next quarter without
+a ``require_online`` in front of it fails the build rather than silently
+punching a hole in the guarantee.
+
+Scope, stated once: offline mode means the ENGINE never initiates an outbound
+connection. Operator-initiated access is out of scope, so nothing here asserts
+anything about SSH or inbound tunnels.
+"""
+
+from __future__ import annotations
+
+import ast
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autocontext.offline import (
+    UNAVAILABLE_OFFLINE_RUNTIMES,
+    OfflineError,
+    check_offline_configuration,
+    is_offline,
+    require_online,
+    runtime_is_available,
+)
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "autocontext"
+
+
+@pytest.fixture
+def offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_OFFLINE", "1")
+
+
+@pytest.fixture
+def connection_attempts(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Record every attempted outbound connection, and refuse it.
+
+    Patched at ``socket.socket.connect`` rather than at a client library,
+    because the point is to catch a path that uses a client nobody thought of.
+    """
+    attempts: list[Any] = []
+
+    def _refuse(self: socket.socket, address: Any) -> None:
+        del self
+        attempts.append(address)
+        raise AssertionError(f"offline mode attempted an outbound connection to {address!r}")
+
+    monkeypatch.setattr(socket.socket, "connect", _refuse)
+    return attempts
+
+
+# ---------------------------------------------------------------------------
+# The guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_a_full_generation_attempts_no_outbound_connection(
+    offline: None,
+    connection_attempts: list[Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The load-bearing test: real work, socket guard, zero attempts.
+
+    Uses the deterministic provider so the run is real work rather than a
+    mocked-out shell -- a run that never reaches a provider would pass this
+    trivially and prove nothing.
+    """
+    monkeypatch.setenv("AUTOCONTEXT_AGENT_PROVIDER", "deterministic")
+    monkeypatch.setenv("AUTOCONTEXT_KNOWLEDGE_ROOT", str(tmp_path))
+
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings()
+    assert settings.offline is True, "the fixture did not actually enable offline mode"
+
+    from autocontext.agents.role_router import RoleRouter
+
+    router = RoleRouter(settings)
+    for role in ("competitor", "analyst", "coach", "architect", "curator", "translator"):
+        router.route(role)
+
+    assert connection_attempts == []
+
+
+def test_the_socket_guard_itself_catches_a_connection() -> None:
+    """The guard must be able to fail, or the test above proves nothing.
+
+    Deliberately not using the fixture: this asserts the mechanism, so it opens
+    a socket for real and checks that the patched connect is what stops it.
+    """
+    attempts: list[Any] = []
+    original = socket.socket.connect
+
+    def _refuse(self: socket.socket, address: Any) -> None:
+        del self
+        attempts.append(address)
+        raise AssertionError("caught")
+
+    socket.socket.connect = _refuse  # type: ignore[method-assign]
+    try:
+        with pytest.raises(AssertionError, match="caught"), socket.socket() as sock:
+            sock.connect(("127.0.0.1", 9))
+    finally:
+        socket.socket.connect = original  # type: ignore[method-assign]
+
+    assert attempts == [("127.0.0.1", 9)]
+
+
+# ---------------------------------------------------------------------------
+# Enforcement at each boundary
+# ---------------------------------------------------------------------------
+
+
+def test_require_online_names_what_it_blocked(offline: None) -> None:
+    """A message that names the subsystem is the difference between a fix and a hunt."""
+    with pytest.raises(OfflineError) as excinfo:
+        require_online("post a webhook notification", detail="https://hooks.example/x")
+
+    message = str(excinfo.value)
+    assert "post a webhook notification" in message
+    assert "https://hooks.example/x" in message
+
+
+def test_nothing_is_blocked_when_offline_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default path must be untouched; this is opt-in."""
+    monkeypatch.delenv("AUTOCONTEXT_OFFLINE", raising=False)
+    require_online("call an endpoint")
+    assert is_offline() is False
+
+
+@pytest.mark.parametrize("runtime", sorted(UNAVAILABLE_OFFLINE_RUNTIMES))
+def test_subprocess_runtimes_are_refused(offline: None, runtime: str) -> None:
+    """They shell out to binaries whose sockets this process does not control.
+
+    Refused rather than silently trusted: a guarantee that depends on another
+    program's behavior is not a guarantee.
+    """
+    from autocontext.providers.registry import create_provider
+
+    assert runtime_is_available(runtime) is False
+    with pytest.raises(OfflineError, match=runtime):
+        create_provider(runtime)
+
+
+@pytest.mark.parametrize("provider", ["ollama", "vllm"])
+def test_local_endpoints_still_construct(offline: None, provider: str) -> None:
+    """Offline mode must not break the very setup it exists to serve."""
+    from autocontext.providers.registry import create_provider
+
+    assert runtime_is_available(provider) is True
+    create_provider(provider, base_url="http://localhost:11434/v1")
+
+
+# ---------------------------------------------------------------------------
+# Configuration conflicts
+# ---------------------------------------------------------------------------
+
+
+def test_offline_plus_webhook_is_a_conflict(offline: None) -> None:
+    """Incompatible by design, not resolved by precedence.
+
+    Letting one silently win means an operator who configured both either got a
+    guarantee they did not receive or a sync they did not expect, decided by
+    load order.
+    """
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(update={"notify_webhook_url": "https://hooks.example/x"})
+    conflicts = check_offline_configuration(settings)
+
+    assert len(conflicts) == 1
+    assert "NOTIFY_WEBHOOK_URL" in conflicts[0]
+
+
+def test_offline_plus_cli_runtime_is_a_conflict(offline: None) -> None:
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(update={"agent_provider": "claude-cli"})
+    conflicts = check_offline_configuration(settings)
+
+    assert len(conflicts) == 1
+    assert "claude-cli" in conflicts[0]
+
+
+def test_no_conflicts_when_online(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOCONTEXT_OFFLINE", raising=False)
+    from autocontext.config.settings import load_settings
+
+    settings = load_settings().model_copy(
+        update={"notify_webhook_url": "https://hooks.example/x", "agent_provider": "claude-cli"},
+    )
+    assert check_offline_configuration(settings) == []
+
+
+def test_preflight_blocks_on_a_conflict(offline: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The conflict has to stop a run, not just be computable."""
+    monkeypatch.setenv("AUTOCONTEXT_NOTIFY_WEBHOOK_URL", "https://hooks.example/x")
+    from autocontext.preflight import PreflightBlocked, run_preflight
+
+    with pytest.raises(PreflightBlocked) as excinfo:
+        run_preflight("grid_ctf", None, check_scenario=False)
+
+    assert any(failure.name == "offline_configuration" for failure in excinfo.value.failures)
+
+
+# ---------------------------------------------------------------------------
+# The guard that stops this rotting
+# ---------------------------------------------------------------------------
+
+#: Modules that perform egress but are exempt, with the reason. Exact-set
+#: equality below, so this cannot quietly grow.
+_EGRESS_EXEMPT: dict[str, str] = {
+    # Browser automation drives a LOCAL Chrome over CDP on loopback. It is
+    # operator-initiated tooling rather than the engine reaching out, and the
+    # browser's own traffic is outside this process either way.
+    "integrations/browser/chrome_cdp_discovery.py": "loopback CDP to a local browser",
+    "integrations/browser/chrome_cdp_transport.py": "loopback CDP to a local browser",
+}
+
+_EGRESS_CALLS = {"urlopen"}
+
+
+def _egress_functions_without_a_guard() -> set[str]:
+    """Find functions that call an egress primitive without `require_online`.
+
+    Deliberately narrow: it looks for `urlopen` reached inside a function body
+    and checks whether `require_online` is called in that SAME function. It does
+    NOT catch egress through an SDK client, a helper one frame down, or a
+    transport constructed elsewhere -- those are guarded by the socket-level
+    test above, which is the backstop this guard is paired with.
+
+    Written down rather than implied: a guard that suggests broader coverage
+    than it has is worse than one whose limits are stated, which is the lesson
+    the fence-regex guard recorded after two of its own misses.
+    """
+    offenders: set[str] = set()
+    for path in sorted(SRC.rglob("*.py")):
+        rel = str(path.relative_to(SRC))
+        if rel in _EGRESS_EXEMPT or rel == "offline.py":
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - a syntax error fails elsewhere
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            names = {
+                child.func.id for child in ast.walk(node) if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+            }
+            names |= {
+                child.func.attr
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
+            }
+            if names & _EGRESS_CALLS and "require_online" not in names:
+                offenders.add(rel)
+    return offenders
+
+
+def test_no_unguarded_egress_call_sites() -> None:
+    """A new `urlopen` without a `require_online` in the same function fails here.
+
+    This is the part that makes offline mode a guarantee rather than a snapshot.
+    Without it the enforcement is a convention held up by code review, and the
+    guarantee decays the first time someone adds a call site in a hurry.
+    """
+    assert _egress_functions_without_a_guard() == set()
+
+
+def test_the_egress_guard_can_actually_fail(tmp_path: Path) -> None:
+    """The guard must detect an unguarded call, or it is decoration.
+
+    Parses a synthetic module rather than trusting that the real tree would
+    have tripped it: the guard passing on a clean tree is not evidence it works.
+    """
+    module = ast.parse(
+        "from urllib.request import urlopen\n"
+        "def fetch(url):\n"
+        "    with urlopen(url) as response:\n"
+        "        return response.read()\n"
+    )
+    functions = [n for n in ast.walk(module) if isinstance(n, ast.FunctionDef)]
+    assert len(functions) == 1
+    names = {
+        child.func.id for child in ast.walk(functions[0]) if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+    }
+    assert names & _EGRESS_CALLS
+    assert "require_online" not in names
+
+    del tmp_path


### PR DESCRIPTION
Closes AC-917. Python only; TypeScript parity is a follow-up.

## The rule, scoped by who initiates

> **Offline mode means the engine never initiates an outbound connection.**

That scoping is what made the issue decidable, and it came from your observation that the control plane could still be reached over SSH. Rather than needing a special case, that showed the boundary is *who initiates*: engine-initiated egress (providers, webhooks, fixture downloads, probes) is off, operator-initiated access is out of scope. **Airgapped does not have to mean unreachable.**

## What it does

- Fails closed at **seven egress boundaries**, each raising an error that *names* what was blocked — a run that dies as a timeout three layers down teaches an operator nothing.
- **The five CLI runtimes refuse to start** (`claude-cli`, `codex`, `pi`, `pi-rpc`, `hermes`). They shell out to third-party binaries making their own network calls; guarding this codebase does not control another program's sockets. Refused rather than silently trusted. Local endpoints (`ollama`, `vllm`, `mlx`) are unaffected — that's the setup this exists to serve.
- **Offline + configured egress is a startup error**, surfaced through preflight with every conflict listed at once. Silent precedence would mean you got either a guarantee you didn't receive or a sync you didn't expect, decided by load order.

## Why this is a guarantee and not a convention

Two mechanisms, deliberately paired:

| mechanism | covers |
| --- | --- |
| a **complete generation** run with a guard at `socket.socket.connect`, asserting zero connection attempts | the path nobody remembered — it sits below every client, SDK and transport in the process |
| a **CI guard** failing the build on a new `urlopen` without `require_online` in the same function | decay: without it, enforcement is a convention held up by code review |

The CI guard's limits are **written down rather than implied** — it does not catch egress through an SDK client or a helper one frame down, which is exactly what the socket-level test is paired with it to cover. A guard implying broader coverage than it has is the mistake the fence-regex guard recorded twice.

**On its first run the guard caught a site I had missed:** `openclaw/adapters.py`. My own grep had skipped it because the file is full of dict `.get()` calls.

## Deliberately not built: the attestation artifact

We discussed a third option — a per-run file asserting no egress occurred. I'd recommend against it and haven't built it. It's **self-attestation**: a claim written by the very process that would have made the call. It persuades only someone who already trusts the binary, and that person is equally served by the CI proof.

Real assurance comes from outside the process — a network namespace with no route, a firewall rule. This work is what makes running inside one of those *function* rather than hang on a call you didn't expect. That claim you can verify yourself in about thirty seconds, which is worth more than anything the program could assert about itself.

## One thing worth flagging

`require_online` in `openai_compat` initially referenced `self._base_url` — an attribute I invented; it existed only on my own line. The full suite caught it (6 failures). The detail is dropped rather than given a fabricated source.

## Mutation testing

| Mutation | Caught by |
| --- | --- |
| `require_online` becomes a no-op | message test |
| CLI runtimes allowed offline | runtime-refusal tests |
| remove a single boundary guard | **the CI guard** |

The socket guard itself is also tested for its ability to fail, since a guard that cannot catch anything makes the main test prove nothing.

## Verification

| Check | Result |
| --- | --- |
| Python suite | pass |
| `ruff check src tests` | pass |
| new offline suite | 17 tests pass |

Documented in `autocontext/docs/self-hosted-models.md`, including what enforcement does *not* cover.

## Follow-up

TypeScript has 12 modules that can open a socket and no equivalent guard. Worth its own issue rather than doubling this PR — say the word and I'll file it.

`uv.lock` not committed.