### PR TITLE
feat(AC-934): say when a dollar budget can never fire on a local run

### DIFF
--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autocontext.agents import role_runtime_overrides
@@ -22,7 +21,7 @@ from autocontext.agents.orchestrator_helpers import (
     _run_translator_phase,
 )
 from autocontext.agents.parsers import parse_analyst_exec, parse_architect_exec, parse_coach_exec, parse_competitor_output
-from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext
+from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext, available_local_models
 from autocontext.agents.runtime_session_wiring import runtime_session_client_for_role
 from autocontext.agents.skeptic import SkepticAgent
 from autocontext.agents.subagent_runtime import SubagentRuntime
@@ -251,35 +250,11 @@ class AgentOrchestrator:
         return configured_role_provider(role, self.settings)
 
     def _available_local_models(self, scenario_name: str = "", runtime_type: str = "provider") -> list[str]:
-        model_path = self.settings.mlx_model_path.strip()
-        if not model_path:
-            if not scenario_name:
-                return []
-            try:
-                from autocontext.providers.scenario_routing import (
-                    ScenarioRoutingContext,
-                    resolve_provider_for_context,
-                )
-                from autocontext.training.model_registry import ModelRegistry
-
-                decision = resolve_provider_for_context(
-                    ScenarioRoutingContext(
-                        scenario=scenario_name,
-                        backend="mlx",
-                        runtime_type=runtime_type,
-                    ),
-                    ModelRegistry(self.settings.knowledge_root),
-                    fallback_provider="",
-                    fallback_model="",
-                )
-            except Exception:
-                logger.debug("agents.orchestrator: caught Exception", exc_info=True)
-                return []
-            if decision.fallback_used or decision.provider_type != "mlx":
-                return []
-            candidate_path = decision.model.strip()
-            return [candidate_path] if candidate_path and Path(candidate_path).exists() else []
-        return [model_path] if Path(model_path).exists() else []
+        return available_local_models(
+            self.settings,
+            scenario_name=scenario_name,
+            runtime_type=runtime_type,
+        )
 
     def _scenario_bound_runtime_client(
         self,

--- a/autocontext/src/autocontext/agents/role_router.py
+++ b/autocontext/src/autocontext/agents/role_router.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autocontext.agents import role_routing_contract_generated as _contract
@@ -49,6 +50,49 @@ class RoutingContext:
     is_plateau: bool = False
     available_local_models: list[str] = field(default_factory=list)
     scenario_name: str = ""
+
+
+def available_local_models(
+    settings: AppSettings,
+    *,
+    scenario_name: str = "",
+    runtime_type: str = "provider",
+) -> list[str]:
+    """Return local model artifacts that role routing can actually execute.
+
+    Both orchestration and preflight need the same answer. Keeping discovery
+    beside ``RoutingContext`` prevents an advisory from evaluating a different
+    route than the generation it describes.
+    """
+    model_path = settings.mlx_model_path.strip()
+    if model_path:
+        return [model_path] if Path(model_path).exists() else []
+    if not scenario_name:
+        return []
+
+    try:
+        from autocontext.providers.scenario_routing import (
+            ScenarioRoutingContext,
+            resolve_provider_for_context,
+        )
+        from autocontext.training.model_registry import ModelRegistry
+
+        decision = resolve_provider_for_context(
+            ScenarioRoutingContext(
+                scenario=scenario_name,
+                backend="mlx",
+                runtime_type=runtime_type,
+            ),
+            ModelRegistry(settings.knowledge_root),
+            fallback_provider="",
+            fallback_model="",
+        )
+    except Exception:
+        return []
+    if decision.fallback_used or decision.provider_type != "mlx":
+        return []
+    candidate_path = decision.model.strip()
+    return [candidate_path] if candidate_path and Path(candidate_path).exists() else []
 
 
 # The values below derive from docs/role-routing-contract.json via the

--- a/autocontext/src/autocontext/preflight.py
+++ b/autocontext/src/autocontext/preflight.py
@@ -124,75 +124,106 @@ class PreflightChecker:
         return results
 
     def check_budget_gates_can_fire(self) -> list[CheckResult]:
-        """Warn when a dollar budget is configured for a run that spends no dollars.
+        """Warn when a configured dollar gate cannot receive non-zero spend.
 
-        AC-934. Two gates are denominated in USD: `consultation_cost_budget`,
-        and `cost_budget_limit` / `cost_throttle_above_total` in the generation
-        pipeline. Spend accumulates from `CompletionResult.cost_usd`, which is
-        None for local providers, so on an all-local run the total stays at zero
-        and neither gate ever fires.
-
-        Deliberately NOT fixed by making a dollar budget bound something else.
-        The setting says dollars; a local run spends no dollars; not firing is
-        correct. Quietly repurposing it as a wall-clock or token bound would be
-        the silent substitution this codebase keeps removing -- the operator
-        would get a limit they never asked for, in a unit the name does not say.
-
-        What was actually missing is that nobody was told. An operator who set a
-        dollar budget as a proxy for "do not let this run forever" got no bound
-        and no signal. Advisory rather than blocking: the configuration is not
-        wrong, and refusing to start a working local run over an inert gate
-        would be worse than the gap it reports.
+        The two generation gates and the consultation gate use different
+        accumulators. Generation prices ``RoleUsage`` by model; consultation
+        sums provider-reported ``CompletionResult.cost_usd``. Reachability must
+        therefore be evaluated independently rather than inferred from one
+        provider or one routing estimate.
         """
         if self._settings is None:
             return []
 
-        budgets = {
+        generation_budgets = {
             "AUTOCONTEXT_COST_BUDGET_LIMIT": float(getattr(self._settings, "cost_budget_limit", 0.0) or 0.0),
             "AUTOCONTEXT_COST_THROTTLE_ABOVE_TOTAL": float(
                 getattr(self._settings, "cost_throttle_above_total", 0.0) or 0.0
             ),
-            "AUTOCONTEXT_CONSULTATION_COST_BUDGET": float(
-                getattr(self._settings, "consultation_cost_budget", 0.0) or 0.0
-            ),
         }
-        configured = sorted(name for name, value in budgets.items() if value > 0)
-        if not configured:
-            return []
+        configured_generation = sorted(name for name, value in generation_budgets.items() if value > 0)
+        consultation_budget = float(getattr(self._settings, "consultation_cost_budget", 0.0) or 0.0)
+        results: list[CheckResult] = []
 
-        # Asked of the router rather than inferred from the provider name: after
-        # AC-911 hosting is declared, so a self-hosted frontier endpoint and a
-        # cloud one are distinguishable, and a priced role is what makes a
-        # dollar gate reachable at all.
-        from autocontext.agents.role_router import RoleRouter
+        if configured_generation:
+            reason = self._generation_budget_inert_reason()
+            if reason is not None:
+                time_budget = int(getattr(self._settings, "generation_time_budget_seconds", 0) or 0)
+                if time_budget <= 0:
+                    hint = (
+                        "AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS can stop later stages after elapsed "
+                        "wall clock, but it does not cancel an in-flight provider call"
+                    )
+                else:
+                    hint = (
+                        f"a time budget is already set ({time_budget}s); it limits later stages after calls "
+                        "return, but it does not cancel an in-flight provider call"
+                    )
+                results.append(
+                    CheckResult(
+                        name="generation_budget_gate_inert",
+                        passed=False,
+                        detail=(
+                            f"{', '.join(configured_generation)} is set, but {reason}, so its accumulated "
+                            f"spend stays at zero and the budget cannot be reached. {hint}."
+                        ),
+                        blocking=False,
+                    )
+                )
 
-        router = RoleRouter(self._settings)
-        priced = [
-            role
-            for role in ("competitor", "analyst", "coach", "architect", "curator", "translator")
-            if router.route(role).estimated_cost_per_1k_tokens > 0
-        ]
-        if priced:
-            return []
-
-        time_budget = int(getattr(self._settings, "generation_time_budget_seconds", 0) or 0)
-        hint = (
-            "AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS bounds a local run by wall clock"
-            if time_budget <= 0
-            else f"a time budget is already set ({time_budget}s), which does bound this run"
-        )
-        return [
-            CheckResult(
-                name="budget_gate_inert",
-                passed=False,
-                detail=(
-                    f"{', '.join(configured)} is set, but every role on this run routes to a "
-                    "locally hosted endpoint priced at zero, so accumulated spend stays at zero "
-                    f"and the budget can never be reached. {hint}."
-                ),
-                blocking=False,
+        if consultation_budget > 0:
+            provider = str(getattr(self._settings, "consultation_provider", "") or "configured provider")
+            if not bool(getattr(self._settings, "consultation_enabled", False)):
+                reason = "consultation is disabled"
+            else:
+                # ConsultationRunner persists CompletionResult.cost_usd exactly
+                # as returned. None of the providers constructible by the
+                # consultation path currently populate that field.
+                reason = f"the {provider} consultation path does not report CompletionResult.cost_usd"
+            results.append(
+                CheckResult(
+                    name="consultation_budget_gate_inert",
+                    passed=False,
+                    detail=(
+                        "AUTOCONTEXT_CONSULTATION_COST_BUDGET is set, but "
+                        f"{reason}, so new consultations add no recorded spend and the budget cannot be reached."
+                    ),
+                    blocking=False,
+                )
             )
-        ]
+
+        return results
+
+    def _generation_budget_inert_reason(self) -> str | None:
+        """Explain why generation's model-priced accumulator cannot advance."""
+        assert self._settings is not None
+        if not bool(getattr(self._settings, "cost_tracking_enabled", False)):
+            return "generation cost tracking is disabled"
+        if getattr(self._settings, "exploration_mode", "linear") == "tree":
+            return "tree exploration bypasses generation cost accounting"
+
+        from autocontext.agents.role_router import (
+            DEFAULT_ROUTING_TABLE,
+            RoleRouter,
+            RoutingContext,
+            available_local_models,
+        )
+
+        context = RoutingContext(
+            available_local_models=available_local_models(
+                self._settings,
+                scenario_name=self._scenario,
+            ),
+            scenario_name=self._scenario,
+        )
+        router = RoleRouter(self._settings)
+        # Generation gates price RoleUsage via CostCalculator. MLX completions
+        # currently expose no token usage, so their calculated contribution is
+        # zero. Other routes can contribute through model-based estimation even
+        # when their endpoint is locally hosted (for example Ollama or vLLM).
+        if all(router.route(role, context=context).provider_type == "mlx" for role in DEFAULT_ROUTING_TABLE):
+            return "every generation role uses MLX, whose completions expose no token usage to the cost tracker"
+        return None
 
     def run_without_scenario_check(self) -> list[CheckResult]:
         """Everything except the registry lookup.

--- a/autocontext/src/autocontext/preflight.py
+++ b/autocontext/src/autocontext/preflight.py
@@ -123,13 +123,88 @@ class PreflightChecker:
             )
         return results
 
+    def check_budget_gates_can_fire(self) -> list[CheckResult]:
+        """Warn when a dollar budget is configured for a run that spends no dollars.
+
+        AC-934. Two gates are denominated in USD: `consultation_cost_budget`,
+        and `cost_budget_limit` / `cost_throttle_above_total` in the generation
+        pipeline. Spend accumulates from `CompletionResult.cost_usd`, which is
+        None for local providers, so on an all-local run the total stays at zero
+        and neither gate ever fires.
+
+        Deliberately NOT fixed by making a dollar budget bound something else.
+        The setting says dollars; a local run spends no dollars; not firing is
+        correct. Quietly repurposing it as a wall-clock or token bound would be
+        the silent substitution this codebase keeps removing -- the operator
+        would get a limit they never asked for, in a unit the name does not say.
+
+        What was actually missing is that nobody was told. An operator who set a
+        dollar budget as a proxy for "do not let this run forever" got no bound
+        and no signal. Advisory rather than blocking: the configuration is not
+        wrong, and refusing to start a working local run over an inert gate
+        would be worse than the gap it reports.
+        """
+        if self._settings is None:
+            return []
+
+        budgets = {
+            "AUTOCONTEXT_COST_BUDGET_LIMIT": float(getattr(self._settings, "cost_budget_limit", 0.0) or 0.0),
+            "AUTOCONTEXT_COST_THROTTLE_ABOVE_TOTAL": float(
+                getattr(self._settings, "cost_throttle_above_total", 0.0) or 0.0
+            ),
+            "AUTOCONTEXT_CONSULTATION_COST_BUDGET": float(
+                getattr(self._settings, "consultation_cost_budget", 0.0) or 0.0
+            ),
+        }
+        configured = sorted(name for name, value in budgets.items() if value > 0)
+        if not configured:
+            return []
+
+        # Asked of the router rather than inferred from the provider name: after
+        # AC-911 hosting is declared, so a self-hosted frontier endpoint and a
+        # cloud one are distinguishable, and a priced role is what makes a
+        # dollar gate reachable at all.
+        from autocontext.agents.role_router import RoleRouter
+
+        router = RoleRouter(self._settings)
+        priced = [
+            role
+            for role in ("competitor", "analyst", "coach", "architect", "curator", "translator")
+            if router.route(role).estimated_cost_per_1k_tokens > 0
+        ]
+        if priced:
+            return []
+
+        time_budget = int(getattr(self._settings, "generation_time_budget_seconds", 0) or 0)
+        hint = (
+            "AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS bounds a local run by wall clock"
+            if time_budget <= 0
+            else f"a time budget is already set ({time_budget}s), which does bound this run"
+        )
+        return [
+            CheckResult(
+                name="budget_gate_inert",
+                passed=False,
+                detail=(
+                    f"{', '.join(configured)} is set, but every role on this run routes to a "
+                    "locally hosted endpoint priced at zero, so accumulated spend stays at zero "
+                    f"and the budget can never be reached. {hint}."
+                ),
+                blocking=False,
+            )
+        ]
+
     def run_without_scenario_check(self) -> list[CheckResult]:
         """Everything except the registry lookup.
 
         Agent-task scenarios are resolved outside SCENARIO_REGISTRY, so that
         check would reject them; the endpoint checks apply just the same.
         """
-        return [self.check_knowledge_writable(), *self.check_endpoint()]
+        return [
+            self.check_knowledge_writable(),
+            *self.check_endpoint(),
+            *self.check_budget_gates_can_fire(),
+        ]
 
     def run_all(self) -> list[CheckResult]:
         """Run all preflight checks."""
@@ -137,6 +212,7 @@ class PreflightChecker:
             self.check_scenario_exists(),
             self.check_knowledge_writable(),
             *self.check_endpoint(),
+            *self.check_budget_gates_can_fire(),
         ]
 
     @staticmethod

--- a/autocontext/tests/test_budget_gate_visibility.py
+++ b/autocontext/tests/test_budget_gate_visibility.py
@@ -1,21 +1,9 @@
-"""AC-934: a dollar budget that can never fire says so.
+"""AC-934: a dollar budget that cannot accumulate spend says so.
 
-Two gates are denominated in USD -- `consultation_cost_budget`, and
-`cost_budget_limit` / `cost_throttle_above_total` in the generation pipeline.
-Spend accumulates from `CompletionResult.cost_usd`, which is None for local
-providers, so on an all-local run the total stays at zero and neither gate ever
-fires.
-
-**Not fixed by making a dollar budget bound something else.** The setting says
-dollars, a local run spends no dollars, and not firing is correct. Quietly
-repurposing it as a wall-clock or token bound would hand the operator a limit
-they never asked for in a unit the name does not say -- the silent substitution
-this codebase keeps removing.
-
-What was missing is that nobody was told. These pin that the advisory fires
-exactly when the gate is genuinely unreachable, and stays quiet otherwise: a
-warning on a working cloud run is one operators learn to ignore, which would put
-us back where we started.
+Generation and consultation do not share a cost accumulator. Generation prices
+``RoleUsage`` by model, while consultation persists provider-reported
+``CompletionResult.cost_usd``. These tests pin each path independently so a
+route's hosting label is never mistaken for the value a live gate consumes.
 """
 
 from __future__ import annotations
@@ -25,38 +13,65 @@ from pathlib import Path
 import pytest
 
 from autocontext.config.settings import load_settings
+from autocontext.harness.core.types import RoleUsage
+from autocontext.harness.meta_optimizer import MetaOptimizer
 from autocontext.preflight import PreflightChecker
 
 
-def _advisories(monkeypatch: pytest.MonkeyPatch, **env: str) -> list:
+def _advisories(monkeypatch: pytest.MonkeyPatch, *, knowledge_root: Path | None = None, **env: str) -> list:
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     settings = load_settings()
-    checker = PreflightChecker("grid_ctf", knowledge_root=Path("/tmp"), settings=settings)
+    checker = PreflightChecker(
+        "grid_ctf",
+        knowledge_root=knowledge_root or Path("/tmp"),
+        settings=settings,
+    )
     return checker.check_budget_gates_can_fire()
 
 
-def test_local_run_with_a_dollar_budget_is_warned(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_mlx_run_with_a_generation_dollar_budget_is_warned(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "model"
+    model_path.mkdir()
     results = _advisories(
         monkeypatch,
-        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        knowledge_root=tmp_path,
+        AUTOCONTEXT_AGENT_PROVIDER="mlx",
+        AUTOCONTEXT_MLX_MODEL_PATH=str(model_path),
         AUTOCONTEXT_ROLE_ROUTING="auto",
         AUTOCONTEXT_COST_BUDGET_LIMIT="5",
     )
     assert len(results) == 1
-    assert results[0].name == "budget_gate_inert"
+    assert results[0].name == "generation_budget_gate_inert"
     assert "AUTOCONTEXT_COST_BUDGET_LIMIT" in results[0].detail
+    assert "MLX" in results[0].detail
+
+
+def test_discovered_local_artifact_uses_the_same_route_as_orchestration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results = _advisories(
+        monkeypatch,
+        knowledge_root=tmp_path,
+        AUTOCONTEXT_AGENT_PROVIDER="anthropic",
+        AUTOCONTEXT_MLX_MODEL_PATH=str(model_path),
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+    )
+    assert len(results) == 1
+    assert "every generation role uses MLX" in results[0].detail
 
 
 def test_the_warning_is_advisory_not_blocking(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A working local run must not be refused over an inert gate.
-
-    The configuration is not wrong -- it is merely unreachable -- and blocking
-    would be worse than the gap being reported.
-    """
     results = _advisories(
         monkeypatch,
-        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        AUTOCONTEXT_AGENT_PROVIDER="mlx",
         AUTOCONTEXT_ROLE_ROUTING="auto",
         AUTOCONTEXT_COST_BUDGET_LIMIT="5",
     )
@@ -65,25 +80,19 @@ def test_the_warning_is_advisory_not_blocking(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_no_warning_without_a_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _advisories(monkeypatch, AUTOCONTEXT_AGENT_PROVIDER="mlx", AUTOCONTEXT_ROLE_ROUTING="auto") == []
+
+
+@pytest.mark.parametrize("provider", ["anthropic", "ollama", "vllm"])
+def test_model_priced_generation_routes_are_not_called_inert(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    """These routes can advance CostCalculator even when locally hosted."""
     assert (
         _advisories(
             monkeypatch,
-            AUTOCONTEXT_AGENT_PROVIDER="ollama",
-            AUTOCONTEXT_ROLE_ROUTING="auto",
-        )
-        == []
-    )
-
-
-def test_no_warning_on_a_priced_run(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The gate is reachable here, so there is nothing to report.
-
-    This is the case that keeps the warning worth reading.
-    """
-    assert (
-        _advisories(
-            monkeypatch,
-            AUTOCONTEXT_AGENT_PROVIDER="anthropic",
+            AUTOCONTEXT_AGENT_PROVIDER=provider,
             AUTOCONTEXT_ROLE_ROUTING="auto",
             AUTOCONTEXT_COST_BUDGET_LIMIT="5",
         )
@@ -91,19 +100,37 @@ def test_no_warning_on_a_priced_run(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def test_ollama_advisory_matches_the_live_generation_accumulator(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOCONTEXT_AGENT_PROVIDER", "ollama")
+    monkeypatch.setenv("AUTOCONTEXT_ROLE_ROUTING", "auto")
+    monkeypatch.setenv("AUTOCONTEXT_COST_BUDGET_LIMIT", "0.001")
+    settings = load_settings()
+
+    assert PreflightChecker("grid_ctf", settings=settings).check_budget_gates_can_fire() == []
+
+    optimizer = MetaOptimizer.from_settings(settings)
+    optimizer.record_llm_call(
+        "competitor",
+        RoleUsage(input_tokens=1_000, output_tokens=0, latency_ms=0, model="llama3.1"),
+        generation=1,
+    )
+    summary = optimizer.cost_summary()
+    assert summary is not None
+    assert summary.total_cost == 0.003
+    assert summary.total_cost >= settings.cost_budget_limit
+
+
 @pytest.mark.parametrize(
     "env_var",
-    ["AUTOCONTEXT_COST_BUDGET_LIMIT", "AUTOCONTEXT_COST_THROTTLE_ABOVE_TOTAL", "AUTOCONTEXT_CONSULTATION_COST_BUDGET"],
+    ["AUTOCONTEXT_COST_BUDGET_LIMIT", "AUTOCONTEXT_COST_THROTTLE_ABOVE_TOTAL"],
 )
-def test_every_dollar_denominated_setting_is_covered(monkeypatch: pytest.MonkeyPatch, env_var: str) -> None:
-    """All three, not just the one that prompted the issue.
-
-    Covering one and missing two would leave the same silent gap behind a
-    warning that looks like coverage.
-    """
+def test_each_generation_dollar_setting_is_covered(
+    monkeypatch: pytest.MonkeyPatch,
+    env_var: str,
+) -> None:
     results = _advisories(
         monkeypatch,
-        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        AUTOCONTEXT_AGENT_PROVIDER="mlx",
         AUTOCONTEXT_ROLE_ROUTING="auto",
         **{env_var: "5"},
     )
@@ -111,35 +138,90 @@ def test_every_dollar_denominated_setting_is_covered(monkeypatch: pytest.MonkeyP
     assert env_var in results[0].detail
 
 
-def test_the_message_points_at_a_bound_that_works(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Naming the problem without an alternative leaves the operator stuck."""
+def test_disabled_generation_cost_tracking_is_warned(monkeypatch: pytest.MonkeyPatch) -> None:
     results = _advisories(
         monkeypatch,
-        AUTOCONTEXT_AGENT_PROVIDER="ollama",
-        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_AGENT_PROVIDER="anthropic",
+        AUTOCONTEXT_COST_TRACKING_ENABLED="false",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+    )
+    assert len(results) == 1
+    assert "cost tracking is disabled" in results[0].detail
+
+
+def test_tree_exploration_generation_budget_is_warned(monkeypatch: pytest.MonkeyPatch) -> None:
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="anthropic",
+        AUTOCONTEXT_EXPLORATION_MODE="tree",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+    )
+    assert len(results) == 1
+    assert "tree exploration bypasses" in results[0].detail
+
+
+def test_paid_consultation_budget_is_evaluated_independently(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A priced generation route must not suppress an inert consultation gate."""
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="anthropic",
+        AUTOCONTEXT_CONSULTATION_ENABLED="true",
+        AUTOCONTEXT_CONSULTATION_PROVIDER="anthropic",
+        AUTOCONTEXT_CONSULTATION_API_KEY="configured",
+        AUTOCONTEXT_CONSULTATION_COST_BUDGET="5",
+    )
+    assert len(results) == 1
+    assert results[0].name == "consultation_budget_gate_inert"
+    assert "CompletionResult.cost_usd" in results[0].detail
+
+
+def test_disabled_consultation_budget_explains_why_it_is_inert(monkeypatch: pytest.MonkeyPatch) -> None:
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_CONSULTATION_ENABLED="false",
+        AUTOCONTEXT_CONSULTATION_COST_BUDGET="5",
+    )
+    assert len(results) == 1
+    assert "consultation is disabled" in results[0].detail
+
+
+def test_generation_and_consultation_advisories_can_both_be_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="mlx",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+        AUTOCONTEXT_CONSULTATION_ENABLED="true",
+        AUTOCONTEXT_CONSULTATION_COST_BUDGET="5",
+    )
+    assert {result.name for result in results} == {
+        "generation_budget_gate_inert",
+        "consultation_budget_gate_inert",
+    }
+
+
+def test_time_budget_hint_does_not_promise_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="mlx",
         AUTOCONTEXT_COST_BUDGET_LIMIT="5",
     )
     assert "AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS" in results[0].detail
+    assert "does not cancel an in-flight provider call" in results[0].detail
 
 
-def test_the_message_changes_when_a_time_budget_is_already_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Telling someone to set what they already set reads as a broken check."""
+def test_time_budget_hint_is_honest_when_already_set(monkeypatch: pytest.MonkeyPatch) -> None:
     results = _advisories(
         monkeypatch,
-        AUTOCONTEXT_AGENT_PROVIDER="ollama",
-        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_AGENT_PROVIDER="mlx",
         AUTOCONTEXT_COST_BUDGET_LIMIT="5",
         AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS="600",
     )
     assert "already set (600s)" in results[0].detail
+    assert "after calls return" in results[0].detail
+    assert "does not cancel" in results[0].detail
 
 
 def test_the_dollar_gates_themselves_are_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The fix is visibility, not a change in what the gates measure.
-
-    If a later edit makes a dollar budget bound something other than dollars,
-    this is the test that should stop it.
-    """
     monkeypatch.setenv("AUTOCONTEXT_COST_BUDGET_LIMIT", "5")
     settings = load_settings()
     assert settings.cost_budget_limit == 5.0

--- a/autocontext/tests/test_budget_gate_visibility.py
+++ b/autocontext/tests/test_budget_gate_visibility.py
@@ -1,0 +1,145 @@
+"""AC-934: a dollar budget that can never fire says so.
+
+Two gates are denominated in USD -- `consultation_cost_budget`, and
+`cost_budget_limit` / `cost_throttle_above_total` in the generation pipeline.
+Spend accumulates from `CompletionResult.cost_usd`, which is None for local
+providers, so on an all-local run the total stays at zero and neither gate ever
+fires.
+
+**Not fixed by making a dollar budget bound something else.** The setting says
+dollars, a local run spends no dollars, and not firing is correct. Quietly
+repurposing it as a wall-clock or token bound would hand the operator a limit
+they never asked for in a unit the name does not say -- the silent substitution
+this codebase keeps removing.
+
+What was missing is that nobody was told. These pin that the advisory fires
+exactly when the gate is genuinely unreachable, and stays quiet otherwise: a
+warning on a working cloud run is one operators learn to ignore, which would put
+us back where we started.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.config.settings import load_settings
+from autocontext.preflight import PreflightChecker
+
+
+def _advisories(monkeypatch: pytest.MonkeyPatch, **env: str) -> list:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    settings = load_settings()
+    checker = PreflightChecker("grid_ctf", knowledge_root=Path("/tmp"), settings=settings)
+    return checker.check_budget_gates_can_fire()
+
+
+def test_local_run_with_a_dollar_budget_is_warned(monkeypatch: pytest.MonkeyPatch) -> None:
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+    )
+    assert len(results) == 1
+    assert results[0].name == "budget_gate_inert"
+    assert "AUTOCONTEXT_COST_BUDGET_LIMIT" in results[0].detail
+
+
+def test_the_warning_is_advisory_not_blocking(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A working local run must not be refused over an inert gate.
+
+    The configuration is not wrong -- it is merely unreachable -- and blocking
+    would be worse than the gap being reported.
+    """
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+    )
+    assert results[0].blocking is False
+    assert PreflightChecker.blocking_failures(results) == []
+
+
+def test_no_warning_without_a_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert (
+        _advisories(
+            monkeypatch,
+            AUTOCONTEXT_AGENT_PROVIDER="ollama",
+            AUTOCONTEXT_ROLE_ROUTING="auto",
+        )
+        == []
+    )
+
+
+def test_no_warning_on_a_priced_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate is reachable here, so there is nothing to report.
+
+    This is the case that keeps the warning worth reading.
+    """
+    assert (
+        _advisories(
+            monkeypatch,
+            AUTOCONTEXT_AGENT_PROVIDER="anthropic",
+            AUTOCONTEXT_ROLE_ROUTING="auto",
+            AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    ["AUTOCONTEXT_COST_BUDGET_LIMIT", "AUTOCONTEXT_COST_THROTTLE_ABOVE_TOTAL", "AUTOCONTEXT_CONSULTATION_COST_BUDGET"],
+)
+def test_every_dollar_denominated_setting_is_covered(monkeypatch: pytest.MonkeyPatch, env_var: str) -> None:
+    """All three, not just the one that prompted the issue.
+
+    Covering one and missing two would leave the same silent gap behind a
+    warning that looks like coverage.
+    """
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        **{env_var: "5"},
+    )
+    assert len(results) == 1
+    assert env_var in results[0].detail
+
+
+def test_the_message_points_at_a_bound_that_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Naming the problem without an alternative leaves the operator stuck."""
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+    )
+    assert "AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS" in results[0].detail
+
+
+def test_the_message_changes_when_a_time_budget_is_already_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Telling someone to set what they already set reads as a broken check."""
+    results = _advisories(
+        monkeypatch,
+        AUTOCONTEXT_AGENT_PROVIDER="ollama",
+        AUTOCONTEXT_ROLE_ROUTING="auto",
+        AUTOCONTEXT_COST_BUDGET_LIMIT="5",
+        AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS="600",
+    )
+    assert "already set (600s)" in results[0].detail
+
+
+def test_the_dollar_gates_themselves_are_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fix is visibility, not a change in what the gates measure.
+
+    If a later edit makes a dollar budget bound something other than dollars,
+    this is the test that should stop it.
+    """
+    monkeypatch.setenv("AUTOCONTEXT_COST_BUDGET_LIMIT", "5")
+    settings = load_settings()
+    assert settings.cost_budget_limit == 5.0


### PR DESCRIPTION
Closes AC-934.

## Decision

Keep dollar-denominated gates measuring dollars. Do not silently reinterpret them as token or wall-clock limits. When the live accumulator for a configured gate cannot receive non-zero spend, preflight reports a non-blocking advisory.

## Why the gates are evaluated separately

The generation and consultation gates do not share an accumulator:

- `cost_budget_limit` and `cost_throttle_above_total` price `RoleUsage` through `CostCalculator`. Ollama, vLLM, and remote providers can therefore advance these gates through model-based token pricing even when an endpoint is locally hosted. MLX currently supplies no token usage, so an all-MLX route remains at zero.
- `consultation_cost_budget` sums provider-reported `CompletionResult.cost_usd` from the consultation log. The providers constructible by the consultation path currently leave that field unset, so this gate is evaluated and reported independently even when generation uses a priced provider.

Generation preflight also reports dollar gates as inert when cost tracking is disabled or tree exploration bypasses generation cost accounting.

## Routing consistency

Local-artifact discovery is now shared by orchestration and preflight. The advisory therefore evaluates the same scenario-specific MLX route that execution will use instead of checking an empty routing context.

## Time-budget wording

The advisory mentions `AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS` without promising hard cancellation: it can stop later stages after elapsed wall clock, but it does not cancel an in-flight provider call. When a time budget is already configured, the message says so and retains that limitation.

## Behavior

- Advisory only; it never blocks a working run.
- Generation and consultation can emit separate advisories in the same preflight.
- The dollar gates themselves are unchanged.
- No TypeScript change: these gates are Python-only.

## Verification

| Check | Result |
| --- | --- |
| `ruff check src tests` | pass |
| `mypy src` | pass |
| focused routing/preflight/generation/consultation suite | 147 pass |
| full Python suite | 9,300 pass (three host-information/socket tests rerun outside the filesystem/network sandbox) |
| budget visibility suite | 18 pass |

`uv.lock` is unchanged.
