### PR TITLE
chore(release): prepare autoctx 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-14
+
+This is a TypeScript-first release. The Python package remains at `0.15.1`;
+Python parity for the pi-tui client and image-attachment delivery is deferred.
+
 ### Changed
 
 - The npm package now requires Node.js 22.19.0 or newer, matching the exact
@@ -786,7 +791,8 @@ A new cross-runtime parity audit (`test_cli_contract_parity.py` + `cli-contract-
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.14.0...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/ts-v0.16.0...HEAD
+[0.16.0]: https://github.com/greyhaven-ai/autocontext/compare/ts-v0.15.1...ts-v0.16.0
 [0.14.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.13.0...py-v0.14.0
 [0.13.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.12.0...py-v0.13.0
 [0.12.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.11.0...py-v0.12.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ autocontext is a harness for agent improvement. Give it a goal, it runs the task
 | ------------------- | ------------------------------------- |
 | Python CLI          | `uv tool install autocontext==0.15.1` |
 | Python library/dev  | `uv pip install autocontext==0.15.1`  |
-| TypeScript/Node CLI | `bun add -g autoctx@0.15.1`           |
+| TypeScript/Node CLI | `bun add -g autoctx@0.16.0`           |
 | Pi extension        | `pi install npm:pi-autocontext@0.10.0` |
 
 The PyPI package is `autocontext`; the CLI is `autoctx`. The npm package is `autoctx` (not the unrelated `autocontext` npm package). Provider variables live in [`.env.example`](.env.example).

--- a/autocontext/tests/test_release_surface_manifest.py
+++ b/autocontext/tests/test_release_surface_manifest.py
@@ -31,20 +31,42 @@ def test_release_manifest_syncs_public_surfaces() -> None:
 def test_release_manifest_renders_whats_new_asset() -> None:
     sync = _load_sync_module()
     manifest = sync.ReleaseManifest(
-        core_version="1.2.3",
+        python_version="1.2.3",
+        npm_version="4.5.6",
+        whats_new_version="7.8.9",
         pi_version="0.8.0",
         pi_autoctx_dependency="^0.8.0",
         whats_new=("**One** thing.", "**Two** thing."),
     )
 
     assert sync.render_whats_new_asset(manifest) == "**One** thing.\n**Two** thing.\n"
-    assert sync.render_whats_new_heading(manifest) == "What's New in 1.2.3"
+    assert sync.render_whats_new_heading(manifest) == "What's New in 7.8.9"
+
+
+def test_core_package_versions_can_advance_independently() -> None:
+    sync = _load_sync_module()
+    manifest = sync.ReleaseManifest(
+        python_version="1.2.3",
+        npm_version="4.5.6",
+        whats_new_version="7.8.9",
+        pi_version="0.8.0",
+        pi_autoctx_dependency="^4.0.0",
+        whats_new=("**One** thing.",),
+    )
+
+    root = sync.sync_root_readme((REPO_ROOT / "README.md").read_text(encoding="utf-8"), manifest)
+
+    assert "autocontext==1.2.3" in root
+    assert "autoctx@4.5.6" in root
+    assert "What's New in 7.8.9" in root
 
 
 def test_pi_version_syncs_install_snippets() -> None:
     sync = _load_sync_module()
     manifest = sync.ReleaseManifest(
-        core_version="0.14.0",
+        python_version="0.14.0",
+        npm_version="0.14.0",
+        whats_new_version="0.14.0",
         pi_version="0.9.0",
         pi_autoctx_dependency="^0.9.0",
         whats_new=("**One** thing.",),
@@ -63,7 +85,9 @@ def test_pi_version_syncs_install_snippets() -> None:
 def test_release_manifest_checks_package_version_files() -> None:
     sync = _load_sync_module()
     manifest = sync.ReleaseManifest(
-        core_version="9.9.9",
+        python_version="9.9.9",
+        npm_version="8.8.8",
+        whats_new_version="9.9.9",
         pi_version="0.8.0",
         pi_autoctx_dependency="^0.9.0",
         whats_new=("**One** thing.",),
@@ -81,7 +105,14 @@ def test_release_manifest_checks_package_version_files() -> None:
         (Path(__file__).resolve().parents[1] / "src" / "autocontext" / "__init__.py").read_text(encoding="utf-8"),
     )
     assert shipped is not None
-    assert f"autocontext/src/autocontext/__init__.py version {shipped.group(1)} != manifest 9.9.9" in issues
+    assert (
+        "autocontext/src/autocontext/__init__.py version "
+        f"{shipped.group(1)} != manifest python_version 9.9.9"
+    ) in issues
+    npm_package = json.loads((REPO_ROOT / "ts" / "package.json").read_text(encoding="utf-8"))
+    assert (
+        f"ts/package.json version {npm_package['version']} != manifest npm_version 8.8.8"
+    ) in issues
     # Read from the file for the same reason as the version above: hardcoding
     # the shipped pi values turned every pi bump into a test edit, which is
     # exactly what happened bumping the autoctx pin to ^0.15.0.

--- a/docs/release-manifest.json
+++ b/docs/release-manifest.json
@@ -1,5 +1,7 @@
 {
-  "core_version": "0.15.1",
+  "python_version": "0.15.1",
+  "npm_version": "0.16.0",
+  "whats_new_version": "0.15.1",
   "pi_version": "0.10.0",
   "pi_autoctx_dependency": "^0.15.0",
   "whats_new": [

--- a/scripts/sync_release_surfaces.py
+++ b/scripts/sync_release_surfaces.py
@@ -20,7 +20,9 @@ _VERSION_RE = r"\d+\.\d+\.\d+"
 
 @dataclass(frozen=True, slots=True)
 class ReleaseManifest:
-    core_version: str
+    python_version: str
+    npm_version: str
+    whats_new_version: str
     pi_version: str
     pi_autoctx_dependency: str
     whats_new: tuple[str, ...]
@@ -29,7 +31,9 @@ class ReleaseManifest:
 def load_release_manifest(path: Path = MANIFEST_PATH) -> ReleaseManifest:
     data = json.loads(path.read_text(encoding="utf-8"))
     return ReleaseManifest(
-        core_version=str(data["core_version"]),
+        python_version=str(data["python_version"]),
+        npm_version=str(data["npm_version"]),
+        whats_new_version=str(data["whats_new_version"]),
         pi_version=str(data["pi_version"]),
         pi_autoctx_dependency=str(data["pi_autoctx_dependency"]),
         whats_new=tuple(str(item) for item in data["whats_new"]),
@@ -41,7 +45,7 @@ def render_whats_new_asset(manifest: ReleaseManifest) -> str:
 
 
 def render_whats_new_heading(manifest: ReleaseManifest) -> str:
-    return f"What's New in {manifest.core_version}"
+    return f"What's New in {manifest.whats_new_version}"
 
 
 def render_readme_whats_new_block(manifest: ReleaseManifest) -> str:
@@ -68,9 +72,9 @@ def _replace_block(text: str, start: str, end: str, replacement: str) -> str:
 
 def _replace_versions(text: str, manifest: ReleaseManifest) -> str:
     text = re.sub(
-        rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text
+        rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.python_version}", text
     )
-    text = re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.core_version}", text)
+    text = re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.npm_version}", text)
     return re.sub(
         rf"pi-autocontext@{_VERSION_RE}", f"pi-autocontext@{manifest.pi_version}", text
     )
@@ -106,12 +110,12 @@ def sync_root_readme(text: str, manifest: ReleaseManifest) -> str:
 
 def sync_python_readme(text: str, manifest: ReleaseManifest) -> str:
     return re.sub(
-        rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text
+        rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.python_version}", text
     )
 
 
 def sync_ts_readme(text: str, manifest: ReleaseManifest) -> str:
-    return re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.core_version}", text)
+    return re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.npm_version}", text)
 
 
 def render_pi_package_note(manifest: ReleaseManifest) -> str:
@@ -192,21 +196,37 @@ def check_release_surfaces(manifest: ReleaseManifest) -> list[str]:
         REPO_ROOT / "autocontext" / "src" / "autocontext" / "__init__.py"
     )
     package_version = str(_read_json(REPO_ROOT / "ts" / "package.json")["version"])
+    package_lock = _read_json(REPO_ROOT / "ts" / "package-lock.json")
+    package_lock_version = str(package_lock["version"])
+    package_lock_root = cast(dict[str, Any], cast(dict[str, Any], package_lock["packages"])[""])
+    package_lock_root_version = str(package_lock_root["version"])
     pi_package = _read_json(REPO_ROOT / "pi" / "package.json")
     pi_version = str(pi_package["version"])
     pi_dependencies = cast(dict[str, Any], pi_package["dependencies"])
     pi_autoctx_dependency = str(pi_dependencies["autoctx"])
-    if pyproject_version != manifest.core_version:
+    if pyproject_version != manifest.python_version:
         issues.append(
-            f"autocontext/pyproject.toml version {pyproject_version} != manifest {manifest.core_version}"
+            "autocontext/pyproject.toml version "
+            f"{pyproject_version} != manifest python_version {manifest.python_version}"
         )
-    if python_init_version != manifest.core_version:
+    if python_init_version != manifest.python_version:
         issues.append(
-            f"autocontext/src/autocontext/__init__.py version {python_init_version} != manifest {manifest.core_version}"
+            "autocontext/src/autocontext/__init__.py version "
+            f"{python_init_version} != manifest python_version {manifest.python_version}"
         )
-    if package_version != manifest.core_version:
+    if package_version != manifest.npm_version:
         issues.append(
-            f"ts/package.json version {package_version} != manifest {manifest.core_version}"
+            f"ts/package.json version {package_version} != manifest npm_version {manifest.npm_version}"
+        )
+    if package_lock_version != manifest.npm_version:
+        issues.append(
+            "ts/package-lock.json version "
+            f"{package_lock_version} != manifest npm_version {manifest.npm_version}"
+        )
+    if package_lock_root_version != manifest.npm_version:
+        issues.append(
+            "ts/package-lock.json root package version "
+            f"{package_lock_root_version} != manifest npm_version {manifest.npm_version}"
         )
     if pi_version != manifest.pi_version:
         issues.append(f"pi/package.json version {pi_version} != manifest {manifest.pi_version}")

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-tui": "0.84.2",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- release autoctx 0.16.0 as a TypeScript-first release
- split release-surface versions so Python remains independently pinned at 0.15.1
- sync npm package metadata, lockfile, README, changelog, and release-manifest validation

## Verification
- npm run lint
- npm run build
- npm test: 863 files and 6,426 tests passed
- npm pack --dry-run --json: autoctx@0.16.0 with 4,126 entries
- release-surface tests: 5 passed
- Ruff and MyPy on the release sync script

## Publication
After merge, tag the exact main commit as ts-v0.16.0. The trusted publish-ts workflow will publish with GitHub OIDC provenance.