### PR TITLE
docs: refresh repository surfaces for 0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Everything is filesystem-first: inspect it, diff it, replay it, export it, or fe
 | `show`        | `autoctx show <run-id> --best --json`                   | Inspect a selected generation                           |
 | `simulate`    | `autoctx simulate -d "..."`                             | Model/replay/compare system behavior                    |
 | `investigate` | `autoctx investigate -d "..."`                          | Evidence-driven diagnosis                               |
-| `scenario`    | `autoctx scenario create --description "..."`           | Create a reusable scenario from a description           |
+| `scenario`    | `autoctx scenario create --help`                          | Create from a description, template, or harness spec    |
 | `mission`     | `autoctx mission create --name "..." --goal "..."`      | Verifier-driven multi-step goals                        |
 | `train`       | `uv run autoctx train --scenario <name> --data <jsonl>` | Distill stable behavior into a cheaper runtime (Python) |
 | `serve mcp`   | `autoctx serve mcp`                                     | Give an agent the autocontext tool surface              |
@@ -111,6 +111,29 @@ Python owns the full control-plane package; TypeScript owns several operator-fac
 - **Contracts ship with the package:** CLI contract v2 schemas and shared fixtures are included in wheels and source distributions so downstream tools can validate the same status, show, queue, and export shapes as the CLI.
 - **Ratcheted package boundaries:** domain, analytics, configuration, and storage implementations now follow enforced dependency directions while legacy module paths remain available as compatibility shims.
 <!-- autocontext-whats-new:end -->
+
+### npm runtime highlights included in 0.16.1
+
+The aligned `autoctx@0.16.1` package also carries the TypeScript-first runtime
+work introduced in 0.16.0 and hardened in 0.16.1:
+
+- **Host-owned live composition:** typed runtime capabilities, scoped cleanup
+  and effect policies, reactive component graphs, and durable transactional
+  activation/rollback for trusted hosts.
+- **A production-oriented operator TUI:** the pi-tui client supports local and
+  remote attachment, durable replay, run control and inspection, and bounded,
+  redacted terminal state on Node.js 22.19+.
+- **Image-aware interactive sessions:** compatible TypeScript providers can
+  advertise `image_attachments_v1`; attachment validation is bounded and
+  fail-closed before provider inference.
+- **Protocol and terminal hardening:** exact capability negotiation, protected
+  priority controls, bounded WebSocket resources, credential redaction, and
+  terminal-control sanitization are enforced across the interactive path.
+
+Python parity for the pi-tui client and image attachments remains deferred.
+See the [TypeScript guide](ts/README.md), [runtime composition
+contracts](docs/internal/runtime-component-graph.md), and the full
+[changelog](CHANGELOG.md) for details.
 
 ## Scenario Families
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -110,7 +110,7 @@ prompt-derived data and should be redacted before persistence or export.
 | `uv run autoctx list` / `status <run_id>` / `show <run_id>`                            | Inspect runs                                                                                           |
 | `uv run autoctx replay <run_id> --generation 1`                                        | Replay a generation before accepting knowledge                                                         |
 | `uv run autoctx queue add --task-prompt "..." --rubric "..."`                          | Queue evaluation/improvement work                                                                      |
-| `uv run autoctx scenario create --description "..."`                                   | Create a reusable scenario from a plain-language description                                            |
+| `uv run autoctx scenario create --family workflow --name support --description "..."`   | Create a reusable scenario through a family-specific pipeline                                            |
 | `uv run autoctx serve --host 127.0.0.1 --port 8000`                                    | Start the local HTTP API                                                                               |
 | `uv run autoctx worker --poll-interval 5 --concurrency 2`                              | Process queued tasks beside the API server                                                             |
 | `uv run autoctx serve mcp`                                                             | Expose the MCP tool surface                                                                            |

--- a/autocontext/demo_data/README.md
+++ b/autocontext/demo_data/README.md
@@ -5,8 +5,8 @@ This directory can hold pre-generated runs for demos where live execution time i
 Use:
 
 ```bash
-uv run autoctx run --scenario grid_ctf --gens 3 --run-id demo_seed_grid
-uv run autoctx run --scenario othello --gens 2 --run-id demo_seed_othello
+uv run autoctx run grid_ctf --iterations 3 --run-id demo_seed_grid
+uv run autoctx run othello --iterations 2 --run-id demo_seed_othello
 ```
 
 Then copy selected run folders from `runs/` into this directory if needed for offline presentations.

--- a/autocontext/docs/extensions.md
+++ b/autocontext/docs/extensions.md
@@ -6,7 +6,7 @@ Load extensions with `AUTOCONTEXT_EXTENSIONS`:
 
 ```bash
 AUTOCONTEXT_EXTENSIONS=my_project.autoctx_hooks,./local_hooks.py \
-uv run autoctx run --scenario grid_ctf --gens 3
+uv run autoctx run grid_ctf --iterations 3
 ```
 
 For the TypeScript package, point `AUTOCONTEXT_EXTENSIONS` at JavaScript/ESM
@@ -14,7 +14,7 @@ modules or `module:callable` targets:
 
 ```bash
 AUTOCONTEXT_EXTENSIONS=./local-hooks.mjs \
-bunx autoctx run --scenario grid_ctf --gens 3
+bunx autoctx run grid_ctf --iterations 3
 ```
 
 Set `AUTOCONTEXT_EXTENSION_FAIL_FAST=true` when hook failures should stop the run. By default, hook handler exceptions are recorded on the event and the run continues.

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -76,7 +76,7 @@ run the loop with that model as the agent, set the MLX agent provider and leave 
 path unset, the harness resolves the active MLX checkpoint for the scenario automatically:
 
 ```bash
-AUTOCONTEXT_AGENT_PROVIDER=mlx uv run autoctx run --scenario grid_ctf --gens 1
+AUTOCONTEXT_AGENT_PROVIDER=mlx uv run autoctx run grid_ctf --iterations 1
 ```
 
 So a run can use the local model a prior run produced (the "repeated runs get better"

--- a/autocontext/src/autocontext/hermes/references.py
+++ b/autocontext/src/autocontext/hermes/references.py
@@ -169,7 +169,7 @@ debuggability.
 ## Setting up the MCP server
 
 ```bash
-autoctx mcp-serve
+autoctx serve mcp
 ```
 
 The server speaks MCP on stdio. Add it to your Hermes config under
@@ -180,7 +180,7 @@ The server speaks MCP on stdio. Add it to your Hermes config under
   "mcp_servers": {
     "autocontext": {
       "command": "autoctx",
-      "args": ["mcp-serve"]
+      "args": ["serve", "mcp"]
     }
   }
 }

--- a/autocontext/src/autocontext/hermes/skill.py
+++ b/autocontext/src/autocontext/hermes/skill.py
@@ -90,7 +90,7 @@ Use `--json` whenever Hermes needs to parse the result.
 
 ```bash
 RUN_ID="hermes_$(date +%s)"
-uv run autoctx run --scenario grid_ctf --gens 3 --run-id "$RUN_ID" --json
+uv run autoctx run grid_ctf --iterations 3 --run-id "$RUN_ID" --json
 uv run autoctx status "$RUN_ID" --json
 uv run autoctx replay "$RUN_ID" --generation 1
 ```
@@ -98,7 +98,7 @@ uv run autoctx replay "$RUN_ID" --generation 1
 For a plain-language task:
 
 ```bash
-uv run autoctx solve --description "Improve the support-triage response policy." --gens 3 --json
+uv run autoctx solve "Improve the support-triage response policy." --iterations 3 --json
 ```
 
 For one-shot judgment or improvement:
@@ -117,7 +117,7 @@ export AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
 export AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1
 export AUTOCONTEXT_AGENT_API_KEY=no-key
 export AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b
-uv run autoctx solve --description "..." --gens 3 --json
+uv run autoctx solve "..." --iterations 3 --json
 ```
 
 Keep provider configuration outside the skill when possible. The user or profile should own secrets, base URLs, and model names.
@@ -176,7 +176,7 @@ MCP is optional. If the user has already configured Autocontext MCP, prefer it f
 Check the local integration guide before inventing tool names:
 
 ```bash
-uv run autoctx mcp-serve --help
+uv run autoctx serve mcp --help
 ```
 
 Use MCP only when it adds value beyond the CLI: stable schemas, lower parsing burden, managed tool discovery, or a host policy that disallows shell access.

--- a/autocontext/src/autocontext/scenarios/templates/content-generation/README.md
+++ b/autocontext/src/autocontext/scenarios/templates/content-generation/README.md
@@ -16,7 +16,7 @@ This template sets up an agent task where the goal is to produce high-quality wr
 
 ```bash
 # Scaffold a new scenario from this template
-autoctx new-scenario --template content-generation --name my-blog-task
+autoctx scenario create --template content-generation --name my-blog-task
 
 # The scaffolded task is written under knowledge/_custom_scenarios/my-blog-task
 # and becomes available to Autocontext's agent-task tooling after load/restart.

--- a/autocontext/src/autocontext/scenarios/templates/prompt-optimization/README.md
+++ b/autocontext/src/autocontext/scenarios/templates/prompt-optimization/README.md
@@ -16,7 +16,7 @@ This template sets up an agent task where the goal is to produce an optimized sy
 
 ```bash
 # Scaffold a new scenario from this template
-autoctx new-scenario --template prompt-optimization --name my-prompt-task
+autoctx scenario create --template prompt-optimization --name my-prompt-task
 
 # The scaffolded task is written under knowledge/_custom_scenarios/my-prompt-task
 # and becomes available to Autocontext's agent-task tooling after load/restart.

--- a/autocontext/src/autocontext/scenarios/templates/rag-accuracy/README.md
+++ b/autocontext/src/autocontext/scenarios/templates/rag-accuracy/README.md
@@ -16,7 +16,7 @@ This template sets up an agent task where the goal is to produce an optimized RA
 
 ```bash
 # Scaffold a new scenario from this template
-autoctx new-scenario --template rag-accuracy --name my-rag-task
+autoctx scenario create --template rag-accuracy --name my-rag-task
 
 # The scaffolded task is written under knowledge/_custom_scenarios/my-rag-task
 # and becomes available to Autocontext's agent-task tooling after load/restart.

--- a/autocontext/src/autocontext/skills/generic.py
+++ b/autocontext/src/autocontext/skills/generic.py
@@ -82,17 +82,17 @@ result programmatically; the human-readable form is not a stable interface.
 ## Running a Scenario
 
 ```bash
-autoctx run --scenario grid_ctf --gens 3 --json
+autoctx run grid_ctf --iterations 3 --json
 ```
 
-`--gens` is the number of generations. Each one produces a candidate, scores it,
+`--iterations` is the number of generations. Each one produces a candidate, scores it,
 and folds what it learned into the knowledge for that scenario.
 
 Give the run an id you choose when you need to refer back to it:
 
 ```bash
 RUN_ID="my_run_$(date +%s)"
-autoctx run --scenario grid_ctf --gens 3 --run-id "$RUN_ID" --json
+autoctx run grid_ctf --iterations 3 --run-id "$RUN_ID" --json
 autoctx status "$RUN_ID" --json
 ```
 
@@ -101,7 +101,7 @@ autoctx status "$RUN_ID" --json
 When there is no scenario, describe the task:
 
 ```bash
-autoctx solve --description "Improve the support-triage response policy." --gens 3 --json
+autoctx solve "Improve the support-triage response policy." --iterations 3 --json
 ```
 
 ## Scoring or Improving a Single Output
@@ -136,7 +136,8 @@ autoctx watch "$RUN_ID"
 ## Creating a New Scenario
 
 ```bash
-autoctx new-scenario
+autoctx scenario create --list
+autoctx scenario create --template content-generation --name support-content
 ```
 
 Scaffolds from the template library. Use this when the task recurs and deserves
@@ -152,7 +153,7 @@ export AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
 export AUTOCONTEXT_AGENT_BASE_URL=http://localhost:11434/v1
 export AUTOCONTEXT_AGENT_API_KEY=no-key
 export AUTOCONTEXT_LOCAL_MODEL=llama3.1
-autoctx run --scenario grid_ctf --gens 3 --json
+autoctx run grid_ctf --iterations 3 --json
 ```
 
 Keep secrets and base URLs in the environment or the user's profile, never in a

--- a/autocontext/tests/test_hermes_references.py
+++ b/autocontext/tests/test_hermes_references.py
@@ -67,7 +67,7 @@ def test_cli_workflows_reference_includes_concrete_commands() -> None:
 
 def test_mcp_workflows_reference_maps_cli_to_tool_names() -> None:
     body = render_reference("mcp-workflows")
-    assert "autoctx mcp-serve" in body
+    assert "autoctx serve mcp" in body
     assert "autocontext_judge" in body
     assert "autocontext_improve" in body
     # Explicit guidance on CLI-vs-MCP preference.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ metadata is available.
 - [Background session domain and parity contract](background-session-domain.md)
 - [Background execution trust boundaries and credential model](background-execution-trust-boundaries.md)
 
-## Execution Surfaces (0.3.0)
+## Execution Surfaces
 
 - **`simulate`** — modeled-world exploration with sweeps, replay, compare, export
 - **`investigate`** — evidence-driven diagnosis in synthetic harness or iterative LLM modes
@@ -94,7 +94,7 @@ metadata is available.
 - **`train`** — distill curated datasets into scenario-local models
 - **`hermes`** — read-only Hermes v0.12 skill/Curator inspection plus Hermes skill export
 
-## Trace Pipeline (0.3.0)
+## Trace Pipeline
 
 - Public trace schema v1.0.0 for cross-harness interchange
 - Privacy-aware export with sensitive-data redaction (21 patterns)

--- a/docs/internal/scenario-parity-matrix.md
+++ b/docs/internal/scenario-parity-matrix.md
@@ -1,172 +1,114 @@
 # Scenario Parity Matrix — Python & TypeScript
 
-> Produced for [AC-431](https://linear.app/greyhaven/issue/AC-431). Captures the current state of scenario surfaces, creation flows, and runtime support across both packages.
+> Current through PyPI `autocontext==0.16.1` and npm `autoctx@0.16.1`. This
+> replaces the original AC-431 planning snapshot, which predated TypeScript
+> materialization, family-aware solve routing, code generation, spec auto-heal,
+> and operator-loop execution.
 
 ## Product Goal
 
-> A user can describe a scenario, task, mission, or related objective in plain language, and the agent can build, develop, use, think through, and adapt the runtime structures it needs in real time to improve its ultimate output.
+A user can describe a scenario, task, mission, or related objective in plain
+language, and the agent can build, persist, execute, evaluate, and adapt the
+runtime structures needed to improve the result. Built-in scenarios are
+deterministic fixtures for development and CI, not the product abstraction.
 
-Built-in scenarios are **not** the product. They are deterministic test fixtures for CI and development. The actual success criterion is the plain-language creation → runtime adaptation → iterative improvement loop. This matrix measures how close each package is to delivering that end-to-end.
+## Built-in Deterministic Fixtures
 
-## 1. Built-in Deterministic Fixtures
+| Fixture | Python | TypeScript | Contract |
+| --- | :---: | :---: | --- |
+| `grid_ctf` | ✅ | ✅ | Game fixture |
+| `othello` | ✅ | ✅ | Game fixture |
+| `resource_trader` | — | ✅ | TypeScript game fixture |
+| `word_count` | — | ✅ | TypeScript deterministic agent-task fixture |
 
-> **These exist for testing only.** They are hardcoded harness surfaces for CI smoke tests and deterministic regression coverage. They are not the product abstraction and should not be confused with the plain-language creation flow that represents the real user-facing value.
+TypeScript keeps game fixtures in `SCENARIO_REGISTRY` and deterministic agent
+tasks in `AGENT_TASK_REGISTRY`. Python uses one scenario registry for its
+built-ins and persisted custom scenarios.
 
-These are hardcoded scenarios registered in `SCENARIO_REGISTRY` at import time. They exist primarily as **deterministic test fixtures** and CI smoke-test surfaces, not as the primary product abstraction.
+## Shared Family Vocabulary
 
-| Fixture | Python (`autocontext/`) | TypeScript (`ts/`) | Type | Notes |
-|---------|:-----------------------:|:------------------:|------|-------|
-| `grid_ctf` | ✅ Registered | ✅ Registered | Game | Full `ScenarioInterface`; used in CI smoke tests |
-| `othello` | ✅ Registered | ✅ Registered | Game | Full `ScenarioInterface` |
-| `resource_trader` | ❌ | ✅ Registered | Game | TS-only built-in game scenario |
-| `word_count` | ❌ | ✅ Registered (in `AGENT_TASK_REGISTRY`) | Agent task | TS-only deterministic agent task (algorithmic eval, no LLM judge needed) |
+Both packages define the same 11 families and scenario markers.
 
-**Key point:** Built-in fixtures are test harnesses. The real product goal is plain-language scenario creation → runtime execution → improvement.
+| Family | Evaluation model | Primary output |
+| --- | --- | --- |
+| `game` | Tournament | JSON strategy |
+| `agent_task` | Judge or deterministic evaluator | Free text, code, or schema-shaped JSON |
+| `simulation` | Trace evaluation | Action trace |
+| `artifact_editing` | Artifact validation | Artifact diff |
+| `investigation` | Evidence evaluation | Action trace |
+| `workflow` | Workflow evaluation | Action trace |
+| `negotiation` | Negotiation evaluation | Action trace |
+| `schema_evolution` | Schema adaptation | Action trace |
+| `tool_fragility` | Drift adaptation | Action trace |
+| `operator_loop` | Judgment evaluation | Action trace |
+| `coordination` | Coordination evaluation | Action trace |
 
-**Note:** TypeScript now has a separate `AGENT_TASK_REGISTRY` for built-in agent tasks with deterministic evaluation, in addition to `SCENARIO_REGISTRY` for game scenarios.
+Python expresses these as typed interfaces and family pipelines. TypeScript
+uses TypeScript contracts, Zod schemas, family designers, type guards, and a
+sandboxed generated-scenario runtime.
 
-## 2. Scenario Family Registry
+## Public Creation Paths
 
-Both packages define the same 11 scenario families. Family metadata is registered at import time.
+The canonical command is `autoctx scenario create`; `autoctx new-scenario`
+remains a compatibility alias.
 
-| Family | Python | TypeScript | Evaluation Mode | Output Modes |
-|--------|:------:|:----------:|-----------------|-------------|
-| `game` | ✅ `ScenarioInterface` | ✅ `ScenarioInterface` | `tournament` | `json_strategy` |
-| `agent_task` | ✅ `AgentTaskInterface` | ✅ (type guards only) | `llm_judge` | `free_text`, `code`, `json_schema` |
-| `simulation` | ✅ `SimulationInterface` | ✅ (spec + creator) | `trace_evaluation` | `action_trace` |
-| `artifact_editing` | ✅ `ArtifactEditingInterface` | ✅ (spec + creator) | `artifact_validation` | `artifact_diff` |
-| `investigation` | ✅ `InvestigationInterface` | ✅ (spec + creator) | `evidence_evaluation` | `action_trace` |
-| `workflow` | ✅ `WorkflowInterface` | ✅ (spec + creator) | `workflow_evaluation` | `action_trace` |
-| `negotiation` | ✅ `NegotiationInterface` | ✅ (spec + creator) | `negotiation_evaluation` | `action_trace` |
-| `schema_evolution` | ✅ `SchemaEvolutionInterface` | ✅ (spec + creator) | `schema_adaptation` | `action_trace` |
-| `tool_fragility` | ✅ `ToolFragilityInterface` | ✅ (spec + creator) | `drift_adaptation` | `action_trace` |
-| `operator_loop` | ✅ `OperatorLoopInterface` | ✅ (spec + creator) | `judgment_evaluation` | `action_trace` |
-| `coordination` | ✅ `CoordinationInterface` | ✅ (spec + creator) | `coordination_evaluation` | `action_trace` |
+| Path | Python 0.16.1 | TypeScript 0.16.1 |
+| --- | --- | --- |
+| Template | `scenario create --template <t> --name <n>` | Same; persists the selected template |
+| Natural language | `scenario create --family <family> --name <n> --description "..."` for the nine registered custom family pipelines | `scenario create --description "..."`; classifies, designs, heals, validates, and materializes |
+| Existing spec | Custom scenarios are loaded from `knowledge/_custom_scenarios/`; use the family or template path to scaffold | `scenario create --from-spec <file>` or `--from-stdin`; validates and materializes |
+| Solve on demand | `autoctx solve "..."`; classifies and creates through the selected family path | `autoctx solve "..."`; classifies, heals, materializes, and selects the family execution route |
+| MCP | `autocontext_solve_scenario` uses the Python solve manager | The MCP/server solve surface uses the TypeScript solve manager |
 
-**Python** defines full ABCs per family with typed interface classes. **TypeScript** defines type markers, Zod schemas, and runtime type guards for all 11 families (`isGameScenario`, `isAgentTask`, `isSimulation`, `isNegotiation`, etc. in `family-interfaces.ts`) but uses structural typing rather than runtime class hierarchies.
+The Python family-specific `scenario create` registry currently covers
+`simulation`, `artifact_editing`, `investigation`, `workflow`, `negotiation`,
+`schema_evolution`, `tool_fragility`, `operator_loop`, and `coordination`.
+Agent-task scaffolding is available through the three templates, while
+plain-language `autoctx solve` can select `agent_task` directly.
 
-## 3. Creation Pipeline Components
+## Materialization And Execution
 
-The creation pipeline takes a plain-language description through: **classify → design → spec → codegen → validate → register**.
+| Family group | Python 0.16.1 | TypeScript 0.16.1 | Remaining difference |
+| --- | --- | --- | --- |
+| Built-in `game` | `GenerationRunner` tournament and Elo loop | `GenerationRunner` tournament and Elo loop | TypeScript has two additional fixtures |
+| Generated `game` from `solve` | Generates, validates, registers, and runs the custom game | Persists the spec but rejects names absent from the built-in game registry | Custom generated-game execution is not symmetric |
+| `agent_task` | Persists executable Python and runs the task-like improvement loop | Persists a runnable spec and runs `ImprovementLoop` | Implementation and persistence formats differ |
+| `artifact_editing` | Generates executable Python and adapts it to the task-like improvement loop | Generates and validates JavaScript, then performs bounded artifact execution | TypeScript does not run the same iterative loop |
+| `simulation`, `investigation`, `workflow`, `negotiation`, `schema_evolution`, `tool_fragility`, `coordination` | Family codegen plus `GenerationRunner` | Family codegen, execution validation, sandboxed action execution, and result packaging | TypeScript executes one bounded generated-scenario pass rather than Python's generation loop |
+| `operator_loop` | Family codegen plus operator-loop execution | Family codegen, execution validation, clarification/escalation behavior, and bounded execution | Runtime implementations differ, but neither side is scaffolding-only |
 
-### Python (`autocontext/`)
+All ten non-game TypeScript families now have durable materialization. The
+nine codegen families emit `scenario.js`; `agent_task` persists a runnable
+spec. Generated source is execution-validated before it is accepted. This
+means the earlier AC-433 and AC-434 statements that TypeScript was spec-only or
+game-only are no longer current.
 
-| Component | `agent_task` | `simulation` | `artifact_editing` | `investigation` | `workflow` | `negotiation` | `schema_evolution` | `tool_fragility` | `operator_loop` | `coordination` |
-|-----------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Designer | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Spec schema | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Codegen | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ disabled | ✅ |
-| Creator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ disabled | ✅ |
-| Validator | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Pipeline (`FamilyPipeline`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Family classifier | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+## Current Intentional Differences
 
-**Note:** Only `agent_task` has a dedicated validator module (`agent_task_validator.py`). All other families validate via their `FamilyPipeline.validate_spec()` and `validate_source()` methods. `operator_loop` is the explicit exception on the runtime side: the family metadata, spec, and pipeline exist, but code generation and creator scaffolding are intentionally disabled.
+- Python and TypeScript share command paths and family names, but some
+  `scenario create` flags are runtime-specific. Use `autoctx scenario create
+  --help` in the selected runtime or inspect the [CLI contract](../cli-contract.md).
+- Python owns the full generation-based control plane. TypeScript owns the TUI
+  and several operator-facing/runtime adapter surfaces, and uses a bounded
+  sandboxed executor for generated non-task families.
+- TypeScript has spec auto-heal and execution validation for generated family
+  source. Python performs validation inside its family creator and pipeline
+  implementations.
+- Template assets exist in both packages, but their on-disk formats differ
+  (YAML/example bundles in Python and packaged JSON definitions in TypeScript).
+- `resource_trader` and `word_count` remain TypeScript-only deterministic
+  fixtures; they do not limit custom family creation in Python.
 
-### TypeScript (`ts/`)
+## Implementation References
 
-| Component | `agent_task` | `simulation` | `artifact_editing` | `investigation` | `workflow` | `negotiation` | `schema_evolution` | `tool_fragility` | `operator_loop` | `coordination` |
-|-----------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Designer | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Spec schema (Zod) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Codegen | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Creator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Validator | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Pipeline (`FamilyPipeline`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Family classifier | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-
-**Key gap:** TypeScript has **no codegen modules** for any family. Python generates executable Python source code per family; TS creators produce spec scaffolds but not runnable source.
-
-## 4. Plain-Language Creation Flows
-
-How a user goes from a text description to a runnable scenario.
-
-### Python
-
-| Path | Command | What it does | Families supported |
-|------|---------|-------------|-------------------|
-| **Template scaffolding** | `autoctx new-scenario --template <t> --name <n>` | Scaffolds from built-in templates (`content-generation`, `prompt-optimization`, `rag-accuracy`) | `agent_task` only |
-| **Solve on demand** | `autoctx solve --description "..."` | NL → legacy `ScenarioCreator` → generic scenario spec → codegen → validate → register → run GenerationRunner → export package | Legacy generic `ScenarioInterface` path; not family-aware |
-| **MCP tool** | `autocontext_solve_scenario` | Same solve-manager pipeline exposed via MCP server | Same legacy generic solve path |
-| **Custom loader** | Automatic on startup | Scans `knowledge/_custom_scenarios/` and registers persisted scenarios | All families with persisted artifacts |
-
-**Python's public solve path is still legacy:** `autoctx solve` and `autocontext_solve_scenario` currently use the older generic `ScenarioCreator`, not the richer family-specific creators. The family-specific Python creators do exist internally for most families, but that is not yet the path exposed by the public solve/MCP surface.
-
-### TypeScript
-
-| Path | Command | What it does | Families supported |
-|------|---------|-------------|-------------------|
-| **Template scaffolding** | `autoctx new-scenario --template <t> --name <n>` | Scaffolds from built-in templates (`content-generation`, `prompt-optimization`, `rag-accuracy`) into `knowledge/_custom_scenarios/` | `agent_task` only |
-| **NL creation** | `autoctx new-scenario --description "..."` | NL → lightweight `createScenarioFromDescription()` → produces `name`, `family`, `taskPrompt`, `rubric` | All families (spec only) |
-| **From spec** | `autoctx new-scenario --from-spec <file>` | Validates and echoes spec | All families |
-| **Solve on demand** | Via `SolveManager` (CLI `solve` not yet a subcommand, but accessible via MCP/server) | NL → `createScenarioFromDescription()` → check `SCENARIO_REGISTRY` → run `GenerationRunner` if found | **Only `game` family** |
-| **Custom loader** | `loadCustomScenarios()` | Scans `knowledge/_custom_scenarios/` and registers agent-task specs | `agent_task` (other types stored but not runnable) |
-
-**TypeScript solve collapses to game-only execution:** The `SolveManager.runJob()` looks up the created scenario name in `SCENARIO_REGISTRY` (which only contains `grid_ctf`). If the name isn't found, it persists a scaffold and throws an error. Even when a non-game family is correctly classified and designed, the execution path fails because `GenerationRunner` requires a `ScenarioInterface` (game contract). This is the gap documented in **AC-434**.
-
-**TypeScript `new-scenario` doesn't materialize artifacts:** The `--description` path produces a spec but does not persist a runnable artifact under `knowledge/_custom_scenarios/`. This is the gap documented in **AC-433**.
-
-## 5. Runtime Execution Support
-
-**This is the table that matters.** Can a user describe something in plain language and have the agent build, run, and iteratively improve it?
-
-| Family | Python Runtime | TypeScript Runtime | Gap |
-|--------|:--------------:|:------------------:|-----|
-| `game` | ✅ `GenerationRunner` (tournament + Elo) | ✅ `GenerationRunner` (tournament + Elo) | Parity |
-| `agent_task` | ✅ `ImprovementLoop` + `LLMJudge` + `TaskRunner` | ✅ `ImprovementLoop` + `judge()` + `TaskRunner` | Parity |
-| `simulation` | ✅ Via custom codegen → `ScenarioInterface` subclass | ❌ No codegen; creator produces spec only | **AC-434** |
-| `artifact_editing` | ✅ Via custom codegen | ❌ No codegen | **AC-434** |
-| `investigation` | ✅ Via custom codegen | ❌ No codegen | **AC-434** |
-| `workflow` | ✅ Via custom codegen | ❌ No codegen | **AC-434** |
-| `negotiation` | ✅ Via custom codegen | ❌ No codegen | **AC-434** |
-| `schema_evolution` | ✅ Via custom codegen | ❌ No codegen | **AC-434** |
-| `tool_fragility` | ✅ Via custom codegen | ❌ No codegen | **AC-434** |
-| `operator_loop` | ❌ Scaffolding intentionally disabled | ❌ No codegen | **AC-432**, **AC-434** |
-| `coordination` | ✅ Via custom codegen | ❌ No codegen | **AC-434** |
-
-**Summary:** Python has internal family-specific creation/runtime support for most custom families, but the public `solve`/MCP path still uses a legacy generic scenario creator and `operator_loop` remains intentionally unsupported. TypeScript correctly classifies and designs specs, but for 9 of 11 families the result **cannot actually execute** because there is no codegen step to turn the spec into runnable code. In both packages, the user-facing plain-language story is therefore narrower than the internal family metadata suggests.
-
-## 6. Explicit Limitations & Mismatches
-
-### TypeScript is missing:
-
-1. **Codegen pipeline** — No `*_codegen.ts` modules exist. Python generates executable `.py` source per family; TS has no equivalent.
-2. **Runtime execution for 9 families** — `simulation`, `artifact_editing`, `investigation`, `workflow`, `negotiation`, `schema_evolution`, `tool_fragility`, `operator_loop`, `coordination` are design-only.
-3. **`new-scenario` artifact materialization** — Does not persist durable scenario artifacts (AC-433).
-4. **`solve` family awareness** — Collapses to game-only execution (AC-434).
-5. **Spec auto-heal** — Python has `spec_auto_heal.py`; TS does not.
-6. **Agent task revision** — Python has `agent_task_revision.py`; TS does not.
-7. **Scenario templates** — Python has a `templates/` library (content-generation, prompt-optimization, rag-accuracy); TS has none.
-
-### Python is missing:
-
-1. **`resource_trader` fixture** — TS-only built-in game scenario; not ported to Python.
-2. **`word_count` fixture** — TS-only deterministic agent task; not ported to Python.
-3. **`AGENT_TASK_REGISTRY`** — TS has a separate registry for built-in agent tasks with algorithmic evaluation; Python does not distinguish these from custom agent tasks.
-4. **Family-aware public solve/MCP path** — `autoctx solve` and `autocontext_solve_scenario` still use the legacy generic `ScenarioCreator`, not the richer family-specific creation pipeline.
-5. **Executable `operator_loop` scaffolding** — Family metadata exists, but runtime scaffolding is intentionally disabled.
-
-### Both packages share:
-
-- Same 11 family names and type markers
-- Same family classification logic
-- Same custom scenario persistence layout (`knowledge/_custom_scenarios/<name>/`)
-- Same migration SQL (cross-compatible)
-- Solve-on-demand MCP entrypoints, but with different runtime depth and naming conventions
-
-## 7. Follow-up Issues
-
-| Issue | Summary | Status |
-|-------|---------|--------|
-| **AC-432** | Decide operator_loop support scope | Backlog |
-| **AC-433** | TS `new-scenario` must materialize runnable artifacts, not just specs | Backlog |
-| **AC-434** | TS `solve` must honor family-aware created scenarios instead of collapsing to game-only | Backlog |
-| *New* | Align Python `solve`/MCP with the family-specific creator pipeline, or explicitly document the legacy generic scope | To create |
-| *New* | Add codegen modules to TypeScript for non-game families (prerequisite for AC-434) | To create |
-| *New* | Port scenario templates to TypeScript (`content-generation`, `prompt-optimization`, `rag-accuracy`) | To create |
-| *New* | Add spec auto-heal to TypeScript | To create |
-| *New* | Port `resource_trader` and `word_count` built-in scenarios to Python | To create |
+- Python solve routing: `autocontext/src/autocontext/knowledge/solver.py`
+- Python family creator registry:
+  `autocontext/src/autocontext/scenarios/custom/creator_registry.py`
+- TypeScript solve routing: `ts/src/knowledge/solve-scenario-routing.ts`
+- TypeScript materialization: `ts/src/scenarios/materialize.ts`
+- TypeScript codegen registry: `ts/src/scenarios/codegen/registry.ts`
+- Cross-runtime CLI shapes: `docs/cli-contract.json`
 
 ---
 
-*Last updated: 2026-03-26*
+*Last verified against the 0.16.1 release sources: 2026-08-15.*

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,8 @@ These are copy-paste starting points for people evaluating the repo, integrating
 - Want to wire Claude Code or another MCP client? Use the MCP config snippet.
 - Want a typed Python integration? Use the Python SDK example.
 - Want a Node/TypeScript integration? Use the TypeScript library example.
+- Want to operate local or remote runs in a terminal? Use the TypeScript TUI example.
+- Want to compose trusted live runtime components? Use the runtime composition example.
 - Want to package generic Fetch/ESM agent app artifacts? Use the generated Fetch packaging example.
 - Want to prototype a reusable TypeScript agent handler? Use the experimental agent-runtime example.
 - Want always-on queued work? Use the persistent host worker recipe.
@@ -50,14 +52,24 @@ stdout. `--format strategy` remains a compatibility alias for `--format json`.
 
 ## Create A Scenario Or Start MCP
 
-Use the canonical nested commands in scripts and agent instructions:
+Use the canonical nested commands in scripts and agent instructions. Python
+selects a family pipeline explicitly; TypeScript can classify a plain-language
+description and materialize the resulting scenario:
 
 ```bash
-uv run autoctx scenario create --description "evaluate concise support replies"
+uv run autoctx scenario create \
+  --family workflow \
+  --name billing_support_workflow \
+  --description "evaluate and route concise billing-support replies"
+
+bunx autoctx scenario create --description "evaluate concise support replies"
+
 uv run autoctx serve mcp
 ```
 
-Both command paths are shared by the Python and npm CLIs.
+The `scenario create` and `serve mcp` paths are shared by the Python and npm
+CLIs; their scenario-creation flag sets are documented in the
+[cross-runtime CLI contract](../docs/cli-contract.md).
 
 ## Claude Code MCP Config
 
@@ -188,6 +200,70 @@ Example provider setup:
 export AUTOCONTEXT_PROVIDER=anthropic
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
+
+## TypeScript TUI
+
+The npm CLI includes the Node.js 22.19+ pi-tui operator client. Start a local
+interactive server and client together:
+
+```bash
+autoctx tui
+```
+
+Or attach the client to an existing TypeScript server:
+
+```bash
+autoctx tui --connect https://host.example
+```
+
+Non-loopback endpoints must use HTTPS/WSS. Python exposes its existing CLI and
+API surfaces but does not yet ship this TUI. See the [operator TUI
+guide](../ts/README.md#operator-tui) for commands, key bindings, replay, and
+security behavior.
+
+## Trusted-Host Runtime Composition
+
+The package root exposes a typed, host-owned component graph. A consumer waits
+until its declared provider is present, and reconciling to an empty graph
+drains both components:
+
+```ts
+import {
+  RuntimeComponentGraph,
+  defineRuntimeCapability,
+  provideRuntimeCapability,
+  type RuntimeComponentManifest,
+} from "autoctx";
+
+const endpoint = defineRuntimeCapability<string>("service.endpoint");
+
+const provider: RuntimeComponentManifest = {
+  id: "provider",
+  instanceId: "provider@1",
+  provides: [provideRuntimeCapability(endpoint, "https://api.example")],
+  activate: () => undefined,
+};
+
+const consumer: RuntimeComponentManifest = {
+  id: "consumer",
+  instanceId: "consumer@1",
+  requires: [endpoint],
+  activate: ({ get }) => {
+    console.log(get(endpoint));
+  },
+};
+
+const graph = new RuntimeComponentGraph();
+await graph.reconcile([consumer]);
+await graph.reconcile([consumer, provider]);
+await graph.reconcile([]);
+```
+
+Keep graph construction and artifact-to-manifest resolution in trusted host
+code. Before granting generated components live capabilities, read the
+[component graph](../docs/internal/runtime-component-graph.md), [effect
+policy](../docs/internal/runtime-effect-policy.md), and [transactional
+activation](../docs/internal/runtime-transactional-activation.md) contracts.
 
 ## Generated Fetch Packaging
 

--- a/pi/skills/autocontext/SKILL.md
+++ b/pi/skills/autocontext/SKILL.md
@@ -104,6 +104,6 @@ For standalone usage outside Pi, install the `autoctx` CLI:
 ```bash
 npm install -g autoctx
 autoctx init
-autoctx solve --description "your problem" --gens 5
+autoctx solve "your problem" --iterations 5
 autoctx simulate --description "your simulation" --runs 3
 ```

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -13,8 +13,8 @@ uv sync --group dev
 export AUTOCONTEXT_AGENT_PROVIDER="${AUTOCONTEXT_AGENT_PROVIDER:-deterministic}"
 
 echo "Running demo generations..."
-uv run autoctx run --scenario grid_ctf --gens 3 --run-id demo_grid
-uv run autoctx run --scenario othello --gens 2 --run-id demo_othello
+uv run autoctx run grid_ctf --iterations 3 --run-id demo_grid
+uv run autoctx run othello --iterations 2 --run-id demo_othello
 
 echo "Starting dashboard at http://127.0.0.1:8000"
 uv run autoctx serve --host 127.0.0.1 --port 8000

--- a/scripts/escalation-sweep/README.md
+++ b/scripts/escalation-sweep/README.md
@@ -6,7 +6,7 @@ Release-validation helper: run every "Scenarios"-state Linear issue through
 ## Prerequisites
 
 - `jq` and Python 3.11+ on PATH.
-- `autoctx` CLI installed (either a published release `pip install autocontext==0.4.6`
+- `autoctx` CLI installed (either a published release `pip install autocontext==0.16.1`
   or run the checked-out source via `cd autocontext && uv run autoctx ...`).
 - An agent provider. By default the harness uses `AUTOCONTEXT_AGENT_PROVIDER=claude-cli`,
   which invokes the locally-authenticated `claude` binary (Anthropic subscription) — no
@@ -19,16 +19,16 @@ Release-validation helper: run every "Scenarios"-state Linear issue through
 
 ```bash
 # 1. Fetch the current manifest of scenarios in the "Scenarios" workflow state.
-python scripts/escalation-sweep/fetch_manifest.py .sweep/0.4.4/manifest.json
+python scripts/escalation-sweep/fetch_manifest.py .sweep/0.16.1/manifest.json
 
 # 2. Run the sweep. One solve per scenario, 2 generations each by default.
 bash scripts/escalation-sweep/run_sweep.sh \
-    .sweep/0.4.4/manifest.json \
-    .sweep/0.4.4/results \
-    --gens 2 --timeout 600
+    .sweep/0.16.1/manifest.json \
+    .sweep/0.16.1/results \
+    --iterations 2 --timeout 600
 
 # 3. Classify + tally.
-python scripts/escalation-sweep/summarize.py .sweep/0.4.4/results
+python scripts/escalation-sweep/summarize.py .sweep/0.16.1/results
 ```
 
 Expect ~5-10 min per scenario. Runs serially by design.

--- a/scripts/escalation-sweep/run_sweep.sh
+++ b/scripts/escalation-sweep/run_sweep.sh
@@ -2,7 +2,7 @@
 # Run `autoctx solve` against each entry in a sweep manifest and capture results.
 #
 # Usage:
-#   scripts/escalation-sweep/run_sweep.sh <manifest.json> <output_dir> [--gens N] [--timeout SEC]
+#   scripts/escalation-sweep/run_sweep.sh <manifest.json> <output_dir> [--iterations N] [--timeout SEC]
 #
 # Writes one <identifier>.out.json per entry (structured solve output or error
 # payload) and one <identifier>.meta.json with {identifier, exit_code,
@@ -25,7 +25,7 @@ set -euo pipefail
 export AUTOCONTEXT_AGENT_PROVIDER
 
 if [[ $# -lt 2 ]]; then
-  echo "usage: $0 <manifest.json> <output_dir> [--gens N] [--timeout SEC]" >&2
+  echo "usage: $0 <manifest.json> <output_dir> [--iterations N] [--timeout SEC]" >&2
   exit 2
 fi
 
@@ -33,12 +33,13 @@ MANIFEST=$1
 OUTPUT_DIR=$2
 shift 2
 
-GENS=2
+ITERATIONS=2
 TIMEOUT=600
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --gens) GENS=$2; shift 2 ;;
+    --iterations) ITERATIONS=$2; shift 2 ;;
+    --gens) ITERATIONS=$2; shift 2 ;;
     --timeout) TIMEOUT=$2; shift 2 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -56,7 +57,7 @@ mkdir -p "$WORKSPACES_DIR"
 
 COUNT=$(jq 'length' "$MANIFEST")
 echo "sweeping $COUNT scenarios from $MANIFEST → $OUTPUT_DIR" >&2
-echo "  provider=$AUTOCONTEXT_AGENT_PROVIDER gens=$GENS timeout=${TIMEOUT}s" >&2
+echo "  provider=$AUTOCONTEXT_AGENT_PROVIDER iterations=$ITERATIONS timeout=${TIMEOUT}s" >&2
 echo "  isolated_workspaces=$WORKSPACES_DIR" >&2
 
 INDEX=()
@@ -88,7 +89,7 @@ for i in $(seq 0 $((COUNT - 1))); do
   AUTOCONTEXT_AUDIT_LOG_PATH="$WORKSPACE_DIR/runs/audit.ndjson" \
   autoctx solve \
     --description "$(cat "$DESC_FILE")" \
-    --gens "$GENS" \
+    --iterations "$ITERATIONS" \
     --timeout "$TIMEOUT" \
     --json \
     > "$OUT_JSON" 2>&1

--- a/skills/autocontext-creator/SKILL.md
+++ b/skills/autocontext-creator/SKILL.md
@@ -33,17 +33,17 @@ result programmatically; the human-readable form is not a stable interface.
 ## Running a Scenario
 
 ```bash
-autoctx run --scenario grid_ctf --gens 3 --json
+autoctx run grid_ctf --iterations 3 --json
 ```
 
-`--gens` is the number of generations. Each one produces a candidate, scores it,
+`--iterations` is the number of generations. Each one produces a candidate, scores it,
 and folds what it learned into the knowledge for that scenario.
 
 Give the run an id you choose when you need to refer back to it:
 
 ```bash
 RUN_ID="my_run_$(date +%s)"
-autoctx run --scenario grid_ctf --gens 3 --run-id "$RUN_ID" --json
+autoctx run grid_ctf --iterations 3 --run-id "$RUN_ID" --json
 autoctx status "$RUN_ID" --json
 ```
 
@@ -52,7 +52,7 @@ autoctx status "$RUN_ID" --json
 When there is no scenario, describe the task:
 
 ```bash
-autoctx solve --description "Improve the support-triage response policy." --gens 3 --json
+autoctx solve "Improve the support-triage response policy." --iterations 3 --json
 ```
 
 ## Scoring or Improving a Single Output
@@ -87,7 +87,8 @@ autoctx watch "$RUN_ID"
 ## Creating a New Scenario
 
 ```bash
-autoctx new-scenario
+autoctx scenario create --list
+autoctx scenario create --template content-generation --name support-content
 ```
 
 Scaffolds from the template library. Use this when the task recurs and deserves
@@ -103,7 +104,7 @@ export AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
 export AUTOCONTEXT_AGENT_BASE_URL=http://localhost:11434/v1
 export AUTOCONTEXT_AGENT_API_KEY=no-key
 export AUTOCONTEXT_LOCAL_MODEL=llama3.1
-autoctx run --scenario grid_ctf --gens 3 --json
+autoctx run grid_ctf --iterations 3 --json
 ```
 
 Keep secrets and base URLs in the environment or the user's profile, never in a

--- a/skills/autocontext/SKILL.md
+++ b/skills/autocontext/SKILL.md
@@ -76,7 +76,7 @@ Use `--json` whenever Hermes needs to parse the result.
 
 ```bash
 RUN_ID="hermes_$(date +%s)"
-uv run autoctx run --scenario grid_ctf --gens 3 --run-id "$RUN_ID" --json
+uv run autoctx run grid_ctf --iterations 3 --run-id "$RUN_ID" --json
 uv run autoctx status "$RUN_ID" --json
 uv run autoctx replay "$RUN_ID" --generation 1
 ```
@@ -84,7 +84,7 @@ uv run autoctx replay "$RUN_ID" --generation 1
 For a plain-language task:
 
 ```bash
-uv run autoctx solve --description "Improve the support-triage response policy." --gens 3 --json
+uv run autoctx solve "Improve the support-triage response policy." --iterations 3 --json
 ```
 
 For one-shot judgment or improvement:
@@ -103,7 +103,7 @@ export AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
 export AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1
 export AUTOCONTEXT_AGENT_API_KEY=no-key
 export AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b
-uv run autoctx solve --description "..." --gens 3 --json
+uv run autoctx solve "..." --iterations 3 --json
 ```
 
 Keep provider configuration outside the skill when possible. The user or profile should own secrets, base URLs, and model names.
@@ -162,7 +162,7 @@ MCP is optional. If the user has already configured Autocontext MCP, prefer it f
 Check the local integration guide before inventing tool names:
 
 ```bash
-uv run autoctx mcp-serve --help
+uv run autoctx serve mcp --help
 ```
 
 Use MCP only when it adds value beyond the CLI: stable schemas, lower parsing burden, managed tool discovery, or a host policy that disallows shell access.

--- a/skills/autocontext/references/mcp-workflows.md
+++ b/skills/autocontext/references/mcp-workflows.md
@@ -8,7 +8,7 @@ debuggability.
 ## Setting up the MCP server
 
 ```bash
-autoctx mcp-serve
+autoctx serve mcp
 ```
 
 The server speaks MCP on stdio. Add it to your Hermes config under
@@ -19,7 +19,7 @@ The server speaks MCP on stdio. Add it to your Hermes config under
   "mcp_servers": {
     "autocontext": {
       "command": "autoctx",
-      "args": ["mcp-serve"]
+      "args": ["serve", "mcp"]
     }
   }
 }

--- a/ts/README.md
+++ b/ts/README.md
@@ -98,7 +98,7 @@ const orchestrator = new AgentOrchestrator(provider, {
 | Command                                                | Purpose                                                      |
 | ------------------------------------------------------ | ------------------------------------------------------------ |
 | `autoctx solve "..." --iterations 3`                   | Generate and run a scenario from a plain-language goal       |
-| `autoctx run --scenario <name> --iterations 3`         | Run a saved scenario                                         |
+| `autoctx run <name> --iterations 3`                    | Run a saved scenario                                         |
 | `autoctx status <run-id> --json`                       | Read one run snapshot                                        |
 | `autoctx watch <run-id> --ndjson`                      | Stream run snapshots                                         |
 | `autoctx show <run-id> --best --json`                  | Inspect the best generation                                  |

--- a/ts/tests/package-parity.test.ts
+++ b/ts/tests/package-parity.test.ts
@@ -117,7 +117,7 @@ describe("README positioning", () => {
 
   it("describes the full command surface", () => {
     const readme = readFileSync(join(import.meta.dirname, "..", "README.md"), "utf-8");
-    expect(readme).toContain("run --scenario");
+    expect(readme).toContain("run <name>");
     expect(readme).toContain("serve mcp");
     expect(readme).toContain("export");
     expect(readme).toContain("import-package");


### PR DESCRIPTION
## Summary

- expand the root README's 0.16.1 coverage with the aligned npm runtime, TUI, image-attachment, and hardening highlights
- add copy-paste TypeScript TUI and trusted-host runtime composition examples
- update secondary guides, templates, demos, sweep helpers, and shipped agent skills to use the canonical 0.16.1 CLI paths and flags
- replace the stale scenario parity planning snapshot with the current Python/TypeScript creation, materialization, and execution behavior
- document the runtime-specific `scenario create` flag shapes instead of implying one invocation works identically in both runtimes

## Why

The primary release surfaces were versioned for 0.16.1, but repository documentation still had incomplete npm release coverage and several secondary examples taught compatibility aliases. The scenario parity matrix also described completed TypeScript materialization, codegen, solve routing, spec healing, and operator-loop work as missing or backlogged. This made the repository disagree with the shipped CLIs and current implementation.

## User impact

Readers now get valid copy-paste commands for the selected runtime, current examples for the TypeScript operator/runtime surfaces, and an accurate view of the remaining Python/TypeScript differences. Compatibility aliases remain documented where they are intentionally supported.

## Validation

- `python3 scripts/sync_release_surfaces.py --check`
- `bash -n scripts/demo.sh scripts/escalation-sweep/run_sweep.sh`
- `.venv/bin/pytest tests/test_generic_skills.py tests/test_hermes_references.py tests/test_hermes_skill_validation.py tests/test_hermes_skill_distribution.py` — 49 passed
- `git diff --check`
- executed the new runtime component graph example against the 0.16.1 TypeScript source