### PR TITLE
[codex] Split trusted accelerator evaluator from generated candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Hostile accelerator candidates can now execute behind an accelerator-neutral,
+  typed, bounded, non-pickle authority protocol. A protected Docker runner gives
+  the trusted evaluator and candidate/incumbent separate process, mount,
+  environment, socket, and report identities; evaluator-randomized timed
+  challenges, independently observed memory, replay-verifiable receipts, host
+  attestation binding, verified teardown, and orphan reconciliation keep
+  candidate clocks/reports, private plans, and confirmation state outside the
+  generated-code boundary. H100/MIG is the first conformance profile, and its
+  production campaign guard remains until the opt-in live adversarial gate
+  passes (AC-1003).
 - Generated GPU kernels can now run through a pinned-image Docker worker that
   shares the ResearchWorkspace lockdown primitive: read-only harness/input
   mounts, ephemeral byte/inode-bounded workspace, deny-network/scrubbed
@@ -58,8 +68,9 @@ All notable changes to this project will be documented in this file.
   into protocol identity, requires correctness plus per-case no-regression
   gates, and uses a persisted Bonferroni proposal budget. Profile-namespaced
   H100 evidence schema and export validation are prepared for disjoint
-  primary/confirmation plans; production execution remains fail-closed pending
-  the trusted evaluator boundary in AC-1003 (AC-994).
+  primary/confirmation plans; the subsequent AC-1003 authority boundary is now
+  implemented, while production execution remains fail-closed pending its real
+  H100/MIG validation (AC-994).
 - An optional Python `CampaignScheduler` dispatches branch/trial jobs across
   local workers and remote adapters using capability/resource matching,
   expiring leases, heartbeats, bounded retry and concurrency, idempotent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ All notable changes to this project will be documented in this file.
   typed, bounded, non-pickle authority protocol. A protected Docker runner gives
   the trusted evaluator and candidate/incumbent separate process, mount,
   environment, socket, and report identities; evaluator-randomized timed
-  challenges, independently observed memory, replay-verifiable receipts, host
-  attestation binding, verified teardown, and orphan reconciliation keep
+  challenges, compact HMAC-authenticated replay receipts, host build/boundary
+  and accelerator-attestation binding, an authenticated outer envelope for
+  every portable profile-evidence field, plus verified normal teardown keep
   candidate clocks/reports, private plans, and confirmation state outside the
   generated-code boundary. H100/MIG is the first conformance profile, and its
-  production campaign guard remains until the opt-in live adversarial gate
-  passes (AC-1003).
+  production campaign and protected runner remain fail-closed until independently
+  attested role grants, out-of-interpreter mutation observation, comparable
+  reference timing, crash-safe container creation, and the opt-in live
+  adversarial gate are all available (AC-1003).
 - Generated GPU kernels can now run through a pinned-image Docker worker that
   shares the ResearchWorkspace lockdown primitive: read-only harness/input
   mounts, ephemeral byte/inode-bounded workspace, deny-network/scrubbed
@@ -68,9 +71,11 @@ All notable changes to this project will be documented in this file.
   into protocol identity, requires correctness plus per-case no-regression
   gates, and uses a persisted Bonferroni proposal budget. Profile-namespaced
   H100 evidence schema and export validation are prepared for disjoint
-  primary/confirmation plans; the subsequent AC-1003 authority boundary is now
-  implemented, while production execution remains fail-closed pending its real
-  H100/MIG validation (AC-994).
+  primary/confirmation plans. The authenticated AC-1003 authority prototype and
+  release guard are implemented, but AC-1003 remains incomplete: production
+  stays fail-closed pending role-separated telemetry, trusted mutation
+  observation, comparable reference timing, crash-safe container creation, and
+  subsequent H100/MIG validation (AC-994).
 - An optional Python `CampaignScheduler` dispatches branch/trial jobs across
   local workers and remote adapters using capability/resource matching,
   expiring leases, heartbeats, bounded retry and concurrency, idempotent

--- a/autocontext/docs/kernel-evolution.md
+++ b/autocontext/docs/kernel-evolution.md
@@ -26,6 +26,13 @@ correctness, timing, telemetry, and the authoritative report. The legacy local
 subprocess runner is lifecycle containment only and now requires the
 conspicuous `trusted_unsafe=True` opt-in.
 
+For authoritative evaluation of hostile generated code, use
+`DockerProtectedKernelBenchmarkRunner`. Its core protocol is accelerator
+neutral: attestations name a backend, vendor, architecture, device/partition,
+runtime, driver, and capacity without encoding CUDA, NVIDIA, MIG, or H100 into
+the schema. The H100/MIG example is the first conformance profile, not a limit
+on future ROCm, other accelerator, or VM-backed implementations.
+
 ## Production host-containment worker
 
 This composition establishes the host and GPU-partition boundary only. The
@@ -92,6 +99,54 @@ Linux capabilities are dropped, `no-new-privileges` is enabled, the environment
 is rebuilt from an empty set, and network mode is `none`. Every outcome removes
 and verifies the labeled container. Before a new run, expired labeled workers
 left by a crashed coordinator are reconciled.
+
+## Protected evaluator authority boundary
+
+`DockerProtectedKernelBenchmarkRunner` creates three separately named
+containers: a trusted evaluator, an isolated candidate authority, and an
+isolated incumbent authority. The evaluator mounts private plans, references,
+its immutable code, two Unix-socket directories, and report storage, but no
+generated source. Each artifact container mounts only its own read-only source,
+the public authority worker/support files, and one read-only socket directory.
+It receives no private-plan path, report path, evaluator build identity, other
+role channel, ambient credential, network, or durable writable mount.
+
+The socket contract uses strict bounded JSON headers and canonical safetensors
+payloads; pickle and candidate-authored timing/resource/report fields are not
+accepted. The evaluator creates fresh randomized timed inputs, independently
+checks each returned tensor against its trusted reference, measures wall time
+around the authority exchange, and observes accelerator-partition memory from
+the trusted side. This prevents cached correctness outputs, forged clocks, or a
+candidate-local `torch` patch from becoming authoritative evidence.
+
+Every report can carry an
+`autocontext.accelerator-authority-receipt/v1` receipt binding:
+
+- candidate and incumbent artifact identities;
+- private-plan commitment and input/output commitments;
+- evaluator-owned ordered timing/resource measurements;
+- evaluator build and public boundary-manifest digests;
+- the generic accelerator attestation and the report content itself.
+
+`KernelBenchmarkEvaluatorConfig(require_authority_receipt=True)` rejects a
+missing receipt. The protected Docker runner additionally replays the receipt
+and requires its device, partition kind/capacity, attestor, and underlying host
+grant digest to match host attestation. Protocol corruption, evaluator crash,
+candidate crash, OOM, timeout, and teardown failure remain separate outcomes.
+All containers are killed and removal-verified after every run; expiry labels
+support fail-closed orphan reconciliation after coordinator loss.
+
+Protected adaptive campaigns should also set
+`adaptive_feedback_policy="aggregate-gates"`. Promotion and persisted audit
+evidence still use the exact trusted statistics, but later candidate prompts
+receive only documented passed/failed/not-evaluated gates and a disposition—no
+candidate-modulatable latency digits or exact derived metrics. Confirmation
+feedback remains quarantined as before.
+
+The H100 example's protected factory is available for the opt-in hardware gate,
+but its normal recursive campaign still fails before mailbox creation. That
+guard must remain until the exact digest-pinned Docker/MIG path passes a real
+H100 adversarial validation and its receipt is reviewed.
 
 ## Run the vertical slice
 

--- a/autocontext/docs/kernel-evolution.md
+++ b/autocontext/docs/kernel-evolution.md
@@ -111,7 +111,8 @@ the public authority worker/support files, and one read-only socket directory.
 It receives no private-plan path, report path, evaluator build identity, other
 role channel, ambient credential, network, or durable writable mount.
 
-The socket contract uses strict bounded JSON headers and canonical safetensors
+The socket contract uses strict bounded JSON headers (including duplicate-key
+rejection) and canonical safetensors
 payloads; pickle and candidate-authored timing/resource/report fields are not
 accepted. The evaluator creates fresh randomized timed inputs, independently
 checks each returned tensor against its trusted reference, measures wall time
@@ -124,17 +125,37 @@ Every report can carry an
 
 - candidate and incumbent artifact identities;
 - private-plan commitment and input/output commitments;
-- evaluator-owned ordered timing/resource measurements;
+- a constant-size evaluator-owned transcript summary: ordered transcript and
+  request/response set roots, unique exchange counts, outcome counts, and
+  role-specific resource peaks;
 - evaluator build and public boundary-manifest digests;
 - the generic accelerator attestation and the report content itself.
 
-`KernelBenchmarkEvaluatorConfig(require_authority_receipt=True)` rejects a
-missing receipt. The protected Docker runner additionally replays the receipt
-and requires its device, partition kind/capacity, attestor, and underlying host
-grant digest to match host attestation. Protocol corruption, evaluator crash,
+Receipts are authenticated with HMAC-SHA256 under an operator-pinned key id and
+owner-only 0400/0600 secret file. The secret is mounted only into the evaluator
+and is never serialized in a manifest, report, observation, or profile export.
+`KernelBenchmarkEvaluatorConfig(require_authority_receipt=True)` requires that
+external trust configuration and rejects missing, self-issued, tampered, or
+wrong-build receipts. Replay also reconciles transcript outcomes and resource
+peaks with the authenticated report. The protected Docker runner requires the
+authenticated evaluator/boundary digests, device, partition kind/capacity,
+attestor, and underlying host grant digest to match host-computed values.
+Protocol corruption, evaluator crash,
 candidate crash, OOM, timeout, and teardown failure remain separate outcomes.
-All containers are killed and removal-verified after every run; expiry labels
-support fail-closed orphan reconciliation after coordinator loss.
+
+Portable campaign profile evidence is separately wrapped in
+`autocontext.kernel-profile-evidence-envelope/v1`. Its canonical content digest
+and HMAC authenticate the complete profile payload—champion and report wrapper
+identities, decision policy, holdout summaries, resource claims, and campaign
+counts—so a valid evaluator receipt cannot be transplanted into a doctored
+profile artifact. Consumers must verify the outer envelope with the pinned key
+before using any profile field.
+
+Normal teardown kills and removal-verifies every created container. Crash-safe
+ownership during synchronous container creation is not implemented, so the
+protected runner remains unavailable; expiry labels alone do not close that
+pre-watchdog coordinator-loss window. Manifests expose this as the unavailable
+`crash_safe_container_creation` requirement.
 
 Protected adaptive campaigns should also set
 `adaptive_feedback_policy="aggregate-gates"`. Promotion and persisted audit
@@ -143,10 +164,14 @@ receive only documented passed/failed/not-evaluated gates and a disposition—no
 candidate-modulatable latency digits or exact derived metrics. Confirmation
 feedback remains quarantined as before.
 
-The H100 example's protected factory is available for the opt-in hardware gate,
-but its normal recursive campaign still fails before mailbox creation. That
-guard must remain until the exact digest-pinned Docker/MIG path passes a real
-H100 adversarial validation and its receipt is reviewed.
+The H100 example's protected factory is constructible and manifest-inspectable,
+but neither it nor the normal recursive campaign can execute authoritative
+work. The runner returns `resource_policy_unsupported` before Docker while
+independently attested role grants, trusted out-of-process mutation observation,
+comparable candidate/incumbent/reference timing boundaries, and crash-safe
+container creation are unavailable. The release guard must remain until all
+four requirements are implemented and
+the exact digest-pinned path passes real H100 adversarial validation.
 
 ## Run the vertical slice
 

--- a/autocontext/src/autocontext/kernel_evolution/__init__.py
+++ b/autocontext/src/autocontext/kernel_evolution/__init__.py
@@ -1,5 +1,32 @@
 """Correctness-first recursive optimization for externally benchmarked kernels."""
 
+from autocontext.kernel_evolution.authority_protocol import (
+    AUTHORITY_PROTOCOL_VERSION,
+    AUTHORITY_RECEIPT_VERSION,
+    AcceleratorAttestation,
+    AuthorityExecutionOutcome,
+    AuthorityMeasurement,
+    AuthorityRequest,
+    AuthorityResponse,
+    KernelEvaluatorAuthorityReceipt,
+    authority_message_digest,
+    authority_report_content_digest,
+    build_authority_receipt,
+    canonical_authority_digest,
+    verify_authority_receipt,
+)
+from autocontext.kernel_evolution.authority_runner import (
+    PROTECTED_EVALUATOR_BOUNDARY,
+    DockerProtectedKernelBenchmarkRunner,
+)
+from autocontext.kernel_evolution.authority_wire import (
+    MAX_AUTHORITY_HEADER_BYTES,
+    MAX_AUTHORITY_PAYLOAD_BYTES,
+    AuthorityWireError,
+    encode_authority_frame,
+    receive_authority_frame,
+    send_authority_frame,
+)
 from autocontext.kernel_evolution.benchmark import (
     ExternalKernelBenchmarkRunner,
     KernelBenchmarkEvaluator,
@@ -64,15 +91,25 @@ from autocontext.kernel_evolution.runner import (
 )
 
 __all__ = [
+    "AUTHORITY_PROTOCOL_VERSION",
+    "AUTHORITY_RECEIPT_VERSION",
     "ARTIFACT_IDENTITY_VERSION",
     "PROTOCOL_COMPATIBILITY_VERSION",
+    "PROTECTED_EVALUATOR_BOUNDARY",
     "SCHEMA_VERSION",
     "ExternalKernelBenchmarkRunner",
+    "AcceleratorAttestation",
+    "AuthorityExecutionOutcome",
+    "AuthorityMeasurement",
+    "AuthorityRequest",
+    "AuthorityResponse",
+    "AuthorityWireError",
     "DockerGPUDeviceAttestation",
     "DockerGPUDeviceAttestor",
     "DockerGPUDeviceGrant",
     "DockerKernelBenchmarkRunner",
     "DockerKernelWorkerLimits",
+    "DockerProtectedKernelBenchmarkRunner",
     "NvidiaSMIGPUDeviceAttestor",
     "KernelAttemptRecord",
     "KernelBaselineError",
@@ -95,6 +132,7 @@ __all__ = [
     "KernelHardwareIdentity",
     "KernelCasePerformanceReport",
     "KernelIntegrityError",
+    "KernelEvaluatorAuthorityReceipt",
     "KernelLineageStore",
     "KernelPerformanceReport",
     "KernelPromotionGateResult",
@@ -112,8 +150,18 @@ __all__ = [
     "PrecisionProfileName",
     "RELAXED_PRECISION_SEMANTICS",
     "STRICT_FP32_SEMANTICS",
+    "MAX_AUTHORITY_HEADER_BYTES",
+    "MAX_AUTHORITY_PAYLOAD_BYTES",
     "artifact_digest",
     "artifact_digest_from_source_digest",
     "canonical_digest",
+    "authority_message_digest",
+    "authority_report_content_digest",
+    "build_authority_receipt",
+    "canonical_authority_digest",
     "content_digest",
+    "encode_authority_frame",
+    "receive_authority_frame",
+    "send_authority_frame",
+    "verify_authority_receipt",
 ]

--- a/autocontext/src/autocontext/kernel_evolution/__init__.py
+++ b/autocontext/src/autocontext/kernel_evolution/__init__.py
@@ -1,19 +1,31 @@
 """Correctness-first recursive optimization for externally benchmarked kernels."""
 
 from autocontext.kernel_evolution.authority_protocol import (
+    AUTHORITY_AUTHENTICATION_ALGORITHM,
     AUTHORITY_PROTOCOL_VERSION,
     AUTHORITY_RECEIPT_VERSION,
+    MAX_AUTHORITY_HMAC_SECRET_BYTES,
+    MIN_AUTHORITY_HMAC_SECRET_BYTES,
     AcceleratorAttestation,
     AuthorityExecutionOutcome,
     AuthorityMeasurement,
+    AuthorityOutcomeCounts,
+    AuthorityReceiptAuthentication,
     AuthorityRequest,
     AuthorityResponse,
+    AuthorityTranscriptSummary,
     KernelEvaluatorAuthorityReceipt,
     authority_message_digest,
     authority_report_content_digest,
     build_authority_receipt,
     canonical_authority_digest,
+    read_authority_hmac_secret,
     verify_authority_receipt,
+    verify_authority_receipt_integrity,
+)
+from autocontext.kernel_evolution.authority_readiness import (
+    protected_evaluator_boundary_error,
+    protected_evaluator_boundary_requirements,
 )
 from autocontext.kernel_evolution.authority_runner import (
     PROTECTED_EVALUATOR_BOUNDARY,
@@ -68,6 +80,13 @@ from autocontext.kernel_evolution.models import (
     canonical_digest,
     content_digest,
 )
+from autocontext.kernel_evolution.profile_evidence import (
+    PROFILE_EVIDENCE_ENVELOPE_VERSION,
+    ProfileEvidenceAuthentication,
+    ProfileEvidenceEnvelope,
+    build_profile_evidence_envelope,
+    verify_profile_evidence_envelope,
+)
 from autocontext.kernel_evolution.protocols import (
     RELAXED_PRECISION_SEMANTICS,
     STRICT_FP32_SEMANTICS,
@@ -91,18 +110,25 @@ from autocontext.kernel_evolution.runner import (
 )
 
 __all__ = [
+    "AUTHORITY_AUTHENTICATION_ALGORITHM",
     "AUTHORITY_PROTOCOL_VERSION",
     "AUTHORITY_RECEIPT_VERSION",
+    "MAX_AUTHORITY_HMAC_SECRET_BYTES",
+    "MIN_AUTHORITY_HMAC_SECRET_BYTES",
     "ARTIFACT_IDENTITY_VERSION",
     "PROTOCOL_COMPATIBILITY_VERSION",
     "PROTECTED_EVALUATOR_BOUNDARY",
+    "PROFILE_EVIDENCE_ENVELOPE_VERSION",
     "SCHEMA_VERSION",
     "ExternalKernelBenchmarkRunner",
     "AcceleratorAttestation",
     "AuthorityExecutionOutcome",
     "AuthorityMeasurement",
+    "AuthorityOutcomeCounts",
+    "AuthorityReceiptAuthentication",
     "AuthorityRequest",
     "AuthorityResponse",
+    "AuthorityTranscriptSummary",
     "AuthorityWireError",
     "DockerGPUDeviceAttestation",
     "DockerGPUDeviceAttestor",
@@ -148,6 +174,8 @@ __all__ = [
     "KernelSequentialTestingPolicy",
     "KernelStatisticsPolicy",
     "PrecisionProfileName",
+    "ProfileEvidenceAuthentication",
+    "ProfileEvidenceEnvelope",
     "RELAXED_PRECISION_SEMANTICS",
     "STRICT_FP32_SEMANTICS",
     "MAX_AUTHORITY_HEADER_BYTES",
@@ -158,10 +186,16 @@ __all__ = [
     "authority_message_digest",
     "authority_report_content_digest",
     "build_authority_receipt",
+    "build_profile_evidence_envelope",
     "canonical_authority_digest",
     "content_digest",
     "encode_authority_frame",
     "receive_authority_frame",
+    "read_authority_hmac_secret",
     "send_authority_frame",
     "verify_authority_receipt",
+    "verify_authority_receipt_integrity",
+    "verify_profile_evidence_envelope",
+    "protected_evaluator_boundary_error",
+    "protected_evaluator_boundary_requirements",
 ]

--- a/autocontext/src/autocontext/kernel_evolution/authority_protocol.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_protocol.py
@@ -1,16 +1,20 @@
 """Typed contracts for a trusted evaluator and isolated accelerator candidates.
 
-The models in this module are intentionally accelerator-neutral.  CUDA, MIG,
+The models in this module are intentionally accelerator-neutral. CUDA, MIG,
 and H100 are deployment profiles; they are not protocol identity fields.
 Candidate processes may return tensor bytes and a bounded outcome code, but
-only the trusted evaluator may create measurements or an authority receipt.
+only the trusted evaluator may create measurements or an authenticated receipt.
 """
 
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
+import os
 import re
+import stat
+from pathlib import Path
 from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -21,6 +25,9 @@ AUTHORITY_PROTOCOL_VERSION: Literal["autocontext.accelerator-authority/v1"] = (
 AUTHORITY_RECEIPT_VERSION: Literal["autocontext.accelerator-authority-receipt/v1"] = (
     "autocontext.accelerator-authority-receipt/v1"
 )
+AUTHORITY_AUTHENTICATION_ALGORITHM: Literal["hmac-sha256"] = "hmac-sha256"
+MIN_AUTHORITY_HMAC_SECRET_BYTES = 32
+MAX_AUTHORITY_HMAC_SECRET_BYTES = 4_096
 AuthorityRole = Literal["candidate", "incumbent"]
 AuthorityOperation = Literal["initialize", "execute", "shutdown"]
 AuthorityResponseOutcome = Literal["complete", "candidate_error", "oom", "protocol_error"]
@@ -34,7 +41,18 @@ AuthorityExecutionOutcome = Literal[
     "candidate_crashed",
     "teardown_failed",
 ]
+_AUTHORITY_EXECUTION_OUTCOMES: tuple[AuthorityExecutionOutcome, ...] = (
+    "complete",
+    "candidate_error",
+    "timeout",
+    "oom",
+    "protocol_corruption",
+    "evaluator_crashed",
+    "candidate_crashed",
+    "teardown_failed",
+)
 Digest = Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")]
+AuthenticationTag = Annotated[str, Field(pattern=r"^hmac-sha256:[0-9a-f]{64}$")]
 _SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$")
 
 
@@ -50,8 +68,79 @@ def canonical_authority_digest(payload: dict[str, Any] | bytes | str) -> str:
     return f"sha256:{hashlib.sha256(raw).hexdigest()}"
 
 
+def _canonical_authority_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _validate_key_id(value: str) -> None:
+    if _SAFE_IDENTIFIER.fullmatch(value) is None:
+        raise ValueError("authority authentication key_id must be a safe non-empty identifier")
+
+
+def _validated_hmac_secret(secret: bytes) -> bytes:
+    if not isinstance(secret, bytes):
+        raise TypeError("authority HMAC secret must be bytes")
+    if not MIN_AUTHORITY_HMAC_SECRET_BYTES <= len(secret) <= MAX_AUTHORITY_HMAC_SECRET_BYTES:
+        raise ValueError(
+            "authority HMAC secret must contain between "
+            f"{MIN_AUTHORITY_HMAC_SECRET_BYTES} and {MAX_AUTHORITY_HMAC_SECRET_BYTES} bytes"
+        )
+    return secret
+
+
+def read_authority_hmac_secret(path: Path) -> bytes:
+    """Read a bounded, stable, non-symlink host trust secret exactly once."""
+
+    supplied = Path(path)
+    if ".." in supplied.parts:
+        raise ValueError("authority HMAC secret path must not contain '..'")
+    absolute = supplied if supplied.is_absolute() else Path.cwd() / supplied
+    current = Path(absolute.anchor)
+    current_stat = current.lstat()
+    try:
+        for component in absolute.parts[1:]:
+            current /= component
+            current_stat = current.lstat()
+            if stat.S_ISLNK(current_stat.st_mode):
+                raise ValueError("authority HMAC secret path cannot contain symlinks")
+    except FileNotFoundError as exc:
+        raise ValueError("authority HMAC secret file does not exist") from exc
+    if not stat.S_ISREG(current_stat.st_mode):
+        raise ValueError("authority HMAC secret must be a regular file")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(absolute, flags)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError("authority HMAC secret must be a regular file")
+        expected_owner = getattr(os, "geteuid", lambda: before.st_uid)()
+        if before.st_uid != expected_owner:
+            raise ValueError("authority HMAC secret must be owned by the current host user")
+        if stat.S_IMODE(before.st_mode) not in {0o400, 0o600}:
+            raise ValueError("authority HMAC secret permissions must be exactly 0400 or 0600")
+        payload = bytearray()
+        while len(payload) <= MAX_AUTHORITY_HMAC_SECRET_BYTES:
+            chunk = os.read(descriptor, MAX_AUTHORITY_HMAC_SECRET_BYTES + 1 - len(payload))
+            if not chunk:
+                break
+            payload.extend(chunk)
+        after = os.fstat(descriptor)
+        current_stat = absolute.lstat()
+        identities = {
+            (item.st_dev, item.st_ino, item.st_mode, item.st_uid, item.st_size, item.st_mtime_ns)
+            for item in (before, after, current_stat)
+        }
+        if len(identities) != 1:
+            raise ValueError("authority HMAC secret changed while it was read")
+        return _validated_hmac_secret(bytes(payload))
+    finally:
+        os.close(descriptor)
+
+
 class _AuthorityModel(BaseModel):
-    model_config = ConfigDict(extra="forbid", allow_inf_nan=False, frozen=True)
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False, frozen=True, strict=True)
 
 
 class AcceleratorAttestation(_AuthorityModel):
@@ -168,8 +257,66 @@ class AuthorityMeasurement(_AuthorityModel):
     outcome: AuthorityExecutionOutcome
 
 
+class AuthorityOutcomeCounts(_AuthorityModel):
+    """Bounded outcome histogram authenticated by the trusted evaluator."""
+
+    complete: int = Field(ge=0)
+    candidate_error: int = Field(ge=0)
+    timeout: int = Field(ge=0)
+    oom: int = Field(ge=0)
+    protocol_corruption: int = Field(ge=0)
+    evaluator_crashed: int = Field(ge=0)
+    candidate_crashed: int = Field(ge=0)
+    teardown_failed: int = Field(ge=0)
+
+    @property
+    def total(self) -> int:
+        return sum(self.model_dump().values())
+
+
+class AuthorityTranscriptSummary(_AuthorityModel):
+    """Constant-size commitment to an evaluator-owned exchange transcript."""
+
+    measurement_count: int = Field(ge=2)
+    candidate_measurement_count: int = Field(ge=1)
+    incumbent_measurement_count: int = Field(ge=1)
+    unique_request_count: int = Field(ge=2)
+    unique_response_count: int = Field(ge=2)
+    request_set_digest: Digest
+    response_set_digest: Digest
+    total_elapsed_ns: int = Field(ge=2)
+    candidate_observed_peak_memory_bytes: int = Field(ge=0)
+    incumbent_observed_peak_memory_bytes: int = Field(ge=0)
+    outcomes: AuthorityOutcomeCounts
+
+    @model_validator(mode="after")
+    def validate_totals_and_uniqueness(self) -> Self:
+        if self.candidate_measurement_count + self.incumbent_measurement_count != self.measurement_count:
+            raise ValueError("authority transcript role counts do not match its measurement count")
+        if self.unique_request_count != self.measurement_count:
+            raise ValueError("authority transcript contains duplicate request digests")
+        if self.unique_response_count != self.measurement_count:
+            raise ValueError("authority transcript contains duplicate response digests")
+        if self.outcomes.total != self.measurement_count:
+            raise ValueError("authority transcript outcome counts do not match its measurement count")
+        return self
+
+
+class AuthorityReceiptAuthentication(_AuthorityModel):
+    """Operator-pinned authentication metadata; the shared secret is never serialized."""
+
+    algorithm: Literal["hmac-sha256"] = AUTHORITY_AUTHENTICATION_ALGORITHM
+    key_id: str
+    tag: AuthenticationTag
+
+    @model_validator(mode="after")
+    def validate_key_id(self) -> Self:
+        _validate_key_id(self.key_id)
+        return self
+
+
 class KernelEvaluatorAuthorityReceipt(_AuthorityModel):
-    """Replay-verifiable evidence that candidates did not own evaluation."""
+    """Authenticated, replay-verifiable evidence that candidates did not own evaluation."""
 
     schema_version: Literal["autocontext.accelerator-authority-receipt/v1"] = AUTHORITY_RECEIPT_VERSION
     protocol_version: Literal["autocontext.accelerator-authority/v1"] = AUTHORITY_PROTOCOL_VERSION
@@ -179,29 +326,10 @@ class KernelEvaluatorAuthorityReceipt(_AuthorityModel):
     accelerator_attestation: AcceleratorAttestation
     candidate_artifact_digest: Digest
     incumbent_artifact_digest: Digest
-    measurements: tuple[AuthorityMeasurement, ...]
+    transcript: AuthorityTranscriptSummary
     transcript_digest: Digest
     report_content_digest: Digest
-
-    @model_validator(mode="after")
-    def validate_measurement_chain(self) -> Self:
-        if not self.measurements:
-            raise ValueError("authority receipts require at least one evaluator-owned measurement")
-        sequences = [measurement.sequence for measurement in self.measurements]
-        if sequences != list(range(len(sequences))):
-            raise ValueError("authority receipt measurements must have a contiguous ordered sequence")
-        roles = {measurement.role for measurement in self.measurements}
-        if roles != {"candidate", "incumbent"}:
-            raise ValueError("authority receipts must measure candidate and incumbent independently")
-        expected = canonical_authority_digest(
-            {
-                "protocol_version": self.protocol_version,
-                "measurements": [measurement.model_dump(mode="json") for measurement in self.measurements],
-            }
-        )
-        if self.transcript_digest != expected:
-            raise ValueError("authority receipt transcript digest does not match its measurements")
-        return self
+    authentication: AuthorityReceiptAuthentication
 
     @property
     def receipt_digest(self) -> str:
@@ -222,40 +350,125 @@ def authority_report_content_digest(report: dict[str, Any]) -> str:
     return canonical_authority_digest(payload)
 
 
-def build_authority_receipt(
-    *,
-    evaluator_build_digest: str,
-    boundary_manifest_digest: str,
-    plan_commitment: str,
-    accelerator_attestation: AcceleratorAttestation,
-    candidate_artifact_digest: str,
-    incumbent_artifact_digest: str,
-    measurements: tuple[AuthorityMeasurement, ...],
-    report: dict[str, Any],
-) -> KernelEvaluatorAuthorityReceipt:
-    """Create the canonical host-owned receipt for a completed evaluation."""
+def _receipt_authentication_payload(receipt: KernelEvaluatorAuthorityReceipt) -> dict[str, Any]:
+    payload = receipt.model_dump(mode="json")
+    authentication = dict(payload["authentication"])
+    authentication.pop("tag")
+    payload["authentication"] = authentication
+    return payload
 
+
+def _authentication_tag(payload: dict[str, Any], secret: bytes) -> str:
+    tag = hmac.new(_validated_hmac_secret(secret), _canonical_authority_bytes(payload), hashlib.sha256).hexdigest()
+    return f"hmac-sha256:{tag}"
+
+
+def _summarize_measurements(
+    measurements: tuple[AuthorityMeasurement, ...],
+) -> tuple[AuthorityTranscriptSummary, str]:
+    if not measurements:
+        raise ValueError("authority receipts require at least one evaluator-owned measurement")
+    sequences = [measurement.sequence for measurement in measurements]
+    if sequences != list(range(len(sequences))):
+        raise ValueError("authority receipt measurements must have a contiguous ordered sequence")
+    roles = {measurement.role for measurement in measurements}
+    if roles != {"candidate", "incumbent"}:
+        raise ValueError("authority receipts must measure candidate and incumbent independently")
+
+    request_digests = [measurement.request_digest for measurement in measurements]
+    response_digests = [measurement.response_digest for measurement in measurements]
+    unique_request_count = len(set(request_digests))
+    unique_response_count = len(set(response_digests))
+    if unique_request_count != len(measurements):
+        raise ValueError("authority receipt measurements contain a replayed request digest")
+    if unique_response_count != len(measurements):
+        raise ValueError("authority receipt measurements contain a replayed response digest")
+
+    outcome_counts = {
+        outcome: sum(measurement.outcome == outcome for measurement in measurements)
+        for outcome in _AUTHORITY_EXECUTION_OUTCOMES
+    }
+    summary = AuthorityTranscriptSummary(
+        measurement_count=len(measurements),
+        candidate_measurement_count=sum(measurement.role == "candidate" for measurement in measurements),
+        incumbent_measurement_count=sum(measurement.role == "incumbent" for measurement in measurements),
+        unique_request_count=unique_request_count,
+        unique_response_count=unique_response_count,
+        request_set_digest=canonical_authority_digest(
+            {"kind": "authority-request-set/v1", "digests": sorted(request_digests)}
+        ),
+        response_set_digest=canonical_authority_digest(
+            {"kind": "authority-response-set/v1", "digests": sorted(response_digests)}
+        ),
+        total_elapsed_ns=sum(measurement.elapsed_ns for measurement in measurements),
+        candidate_observed_peak_memory_bytes=max(
+            measurement.observed_peak_memory_bytes
+            for measurement in measurements
+            if measurement.role == "candidate"
+        ),
+        incumbent_observed_peak_memory_bytes=max(
+            measurement.observed_peak_memory_bytes
+            for measurement in measurements
+            if measurement.role == "incumbent"
+        ),
+        outcomes=AuthorityOutcomeCounts(**outcome_counts),
+    )
     transcript_digest = canonical_authority_digest(
         {
             "protocol_version": AUTHORITY_PROTOCOL_VERSION,
             "measurements": [measurement.model_dump(mode="json") for measurement in measurements],
         }
     )
-    return KernelEvaluatorAuthorityReceipt(
-        evaluator_build_digest=evaluator_build_digest,
-        boundary_manifest_digest=boundary_manifest_digest,
-        plan_commitment=plan_commitment,
-        accelerator_attestation=accelerator_attestation,
-        candidate_artifact_digest=candidate_artifact_digest,
-        incumbent_artifact_digest=incumbent_artifact_digest,
-        measurements=measurements,
-        transcript_digest=transcript_digest,
-        report_content_digest=authority_report_content_digest(report),
-    )
+    return summary, transcript_digest
 
 
-def verify_authority_receipt(receipt: KernelEvaluatorAuthorityReceipt, report: dict[str, Any]) -> None:
-    """Fail closed when a persisted receipt cannot replay against its report."""
+def _require_report_resource(report: dict[str, Any], name: str) -> int:
+    resources = report.get("resources")
+    if not isinstance(resources, dict):
+        raise ValueError("authority receipt report is missing trusted resource telemetry")
+    value = resources.get(name)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"authority receipt report has invalid {name}")
+    return value
+
+
+def _verify_report_outcomes(receipt: KernelEvaluatorAuthorityReceipt, report: dict[str, Any]) -> None:
+    outcomes = receipt.transcript.outcomes
+    status = report.get("evaluation_status")
+    failure = report.get("failure_kind")
+    if status == "complete":
+        if failure is not None or outcomes.complete != receipt.transcript.measurement_count:
+            raise ValueError("authority transcript outcomes contradict a complete report")
+        return
+    if status not in {"candidate_error", "infrastructure_error"} or not isinstance(failure, str):
+        raise ValueError("authority receipt report has an invalid evaluation outcome")
+    required_outcomes: dict[str, tuple[int, ...]] = {
+        "oom": (outcomes.oom,),
+        "protocol_corruption": (outcomes.protocol_corruption,),
+        "candidate_crash": (outcomes.candidate_crashed,),
+        "evaluator_crash": (outcomes.evaluator_crashed,),
+        "timeout": (outcomes.timeout,),
+        "teardown_failure": (outcomes.teardown_failed,),
+        "syntax": (outcomes.candidate_error, outcomes.candidate_crashed),
+        "compile": (outcomes.candidate_error, outcomes.candidate_crashed),
+        "crash": (outcomes.candidate_error, outcomes.candidate_crashed),
+        "contract": (outcomes.protocol_corruption,),
+    }
+    required = required_outcomes.get(failure)
+    if required is not None and not any(value > 0 for value in required):
+        raise ValueError("authority transcript outcomes do not explain the report failure")
+    if (
+        failure in {"correctness", "reference_failure", "unstable_environment"}
+        and outcomes.complete != receipt.transcript.measurement_count
+    ):
+        raise ValueError("authority transcript outcomes contradict an evaluator-owned report failure")
+
+
+def verify_authority_receipt_integrity(
+    receipt: KernelEvaluatorAuthorityReceipt,
+    report: dict[str, Any],
+) -> None:
+    """Replay authenticated receipt claims against report content without granting trust."""
 
     if receipt.report_content_digest != authority_report_content_digest(report):
         raise ValueError("authority receipt is bound to different report content")
@@ -266,23 +479,117 @@ def verify_authority_receipt(receipt: KernelEvaluatorAuthorityReceipt, report: d
     protocol = report.get("protocol")
     if not isinstance(protocol, dict) or protocol.get("seed_commitment") != receipt.plan_commitment:
         raise ValueError("authority receipt plan commitment does not match the report")
+    resources = report.get("resources")
+    if not isinstance(resources, dict):
+        raise ValueError("authority receipt report is missing trusted resource telemetry")
+    if (
+        _require_report_resource(report, "candidate_observed_peak_bytes")
+        != receipt.transcript.candidate_observed_peak_memory_bytes
+        or _require_report_resource(report, "incumbent_observed_peak_bytes")
+        != receipt.transcript.incumbent_observed_peak_memory_bytes
+    ):
+        raise ValueError("authority transcript peaks do not match report resource telemetry")
+    if resources.get("telemetry_authority") != "trusted-evaluator-observed/v1":
+        raise ValueError("authority receipt report does not identify trusted resource telemetry")
+    if resources.get("accelerator_attestation_digest") != receipt.accelerator_attestation.digest:
+        raise ValueError("authority receipt report is bound to a different accelerator attestation")
+    if resources.get("device_total_memory_bytes") != receipt.accelerator_attestation.enforced_memory_bytes:
+        raise ValueError("authority receipt report accelerator capacity does not match its attestation")
+    _verify_report_outcomes(receipt, report)
+
+
+def build_authority_receipt(
+    *,
+    evaluator_build_digest: str,
+    boundary_manifest_digest: str,
+    plan_commitment: str,
+    accelerator_attestation: AcceleratorAttestation,
+    candidate_artifact_digest: str,
+    incumbent_artifact_digest: str,
+    measurements: tuple[AuthorityMeasurement, ...],
+    report: dict[str, Any],
+    signing_key_id: str,
+    signing_secret: bytes,
+) -> KernelEvaluatorAuthorityReceipt:
+    """Create a compact authenticated receipt from evaluator-owned measurements."""
+
+    _validate_key_id(signing_key_id)
+    _validated_hmac_secret(signing_secret)
+    transcript, transcript_digest = _summarize_measurements(measurements)
+    unsigned = KernelEvaluatorAuthorityReceipt(
+        evaluator_build_digest=evaluator_build_digest,
+        boundary_manifest_digest=boundary_manifest_digest,
+        plan_commitment=plan_commitment,
+        accelerator_attestation=accelerator_attestation,
+        candidate_artifact_digest=candidate_artifact_digest,
+        incumbent_artifact_digest=incumbent_artifact_digest,
+        transcript=transcript,
+        transcript_digest=transcript_digest,
+        report_content_digest=authority_report_content_digest(report),
+        authentication=AuthorityReceiptAuthentication(
+            key_id=signing_key_id,
+            tag="hmac-sha256:" + "0" * 64,
+        ),
+    )
+    tag = _authentication_tag(_receipt_authentication_payload(unsigned), signing_secret)
+    receipt = unsigned.model_copy(update={"authentication": unsigned.authentication.model_copy(update={"tag": tag})})
+    verify_authority_receipt_integrity(receipt, report)
+    return receipt
+
+
+def verify_authority_receipt(
+    receipt: KernelEvaluatorAuthorityReceipt,
+    report: dict[str, Any],
+    *,
+    trusted_key_id: str,
+    trusted_secret: bytes,
+    expected_evaluator_build_digest: str | None = None,
+    expected_boundary_manifest_digest: str | None = None,
+) -> None:
+    """Authenticate and replay a persisted receipt against pinned host trust."""
+
+    _validate_key_id(trusted_key_id)
+    if receipt.authentication.key_id != trusted_key_id:
+        raise ValueError("authority receipt authentication key is not trusted")
+    expected_tag = _authentication_tag(_receipt_authentication_payload(receipt), trusted_secret)
+    if not hmac.compare_digest(receipt.authentication.tag, expected_tag):
+        raise ValueError("authority receipt authentication tag is invalid")
+    if (
+        expected_evaluator_build_digest is not None
+        and receipt.evaluator_build_digest != expected_evaluator_build_digest
+    ):
+        raise ValueError("authority receipt evaluator build does not match the host-computed digest")
+    if (
+        expected_boundary_manifest_digest is not None
+        and receipt.boundary_manifest_digest != expected_boundary_manifest_digest
+    ):
+        raise ValueError("authority receipt boundary does not match the host-computed digest")
+    verify_authority_receipt_integrity(receipt, report)
 
 
 __all__ = [
+    "AUTHORITY_AUTHENTICATION_ALGORITHM",
     "AUTHORITY_PROTOCOL_VERSION",
     "AUTHORITY_RECEIPT_VERSION",
+    "MAX_AUTHORITY_HMAC_SECRET_BYTES",
+    "MIN_AUTHORITY_HMAC_SECRET_BYTES",
     "AcceleratorAttestation",
     "AuthorityExecutionOutcome",
     "AuthorityMeasurement",
     "AuthorityOperation",
+    "AuthorityOutcomeCounts",
+    "AuthorityReceiptAuthentication",
     "AuthorityRequest",
     "AuthorityResponse",
     "AuthorityResponseOutcome",
     "AuthorityRole",
+    "AuthorityTranscriptSummary",
     "KernelEvaluatorAuthorityReceipt",
     "authority_message_digest",
     "authority_report_content_digest",
     "build_authority_receipt",
     "canonical_authority_digest",
+    "read_authority_hmac_secret",
     "verify_authority_receipt",
+    "verify_authority_receipt_integrity",
 ]

--- a/autocontext/src/autocontext/kernel_evolution/authority_protocol.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_protocol.py
@@ -1,0 +1,288 @@
+"""Typed contracts for a trusted evaluator and isolated accelerator candidates.
+
+The models in this module are intentionally accelerator-neutral.  CUDA, MIG,
+and H100 are deployment profiles; they are not protocol identity fields.
+Candidate processes may return tensor bytes and a bounded outcome code, but
+only the trusted evaluator may create measurements or an authority receipt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+AUTHORITY_PROTOCOL_VERSION: Literal["autocontext.accelerator-authority/v1"] = (
+    "autocontext.accelerator-authority/v1"
+)
+AUTHORITY_RECEIPT_VERSION: Literal["autocontext.accelerator-authority-receipt/v1"] = (
+    "autocontext.accelerator-authority-receipt/v1"
+)
+AuthorityRole = Literal["candidate", "incumbent"]
+AuthorityOperation = Literal["initialize", "execute", "shutdown"]
+AuthorityResponseOutcome = Literal["complete", "candidate_error", "oom", "protocol_error"]
+AuthorityExecutionOutcome = Literal[
+    "complete",
+    "candidate_error",
+    "timeout",
+    "oom",
+    "protocol_corruption",
+    "evaluator_crashed",
+    "candidate_crashed",
+    "teardown_failed",
+]
+Digest = Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")]
+_SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$")
+
+
+def canonical_authority_digest(payload: dict[str, Any] | bytes | str) -> str:
+    """Return a branded SHA-256 digest for a canonical authority payload."""
+
+    if isinstance(payload, dict):
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    elif isinstance(payload, str):
+        raw = payload.encode("utf-8")
+    else:
+        raw = payload
+    return f"sha256:{hashlib.sha256(raw).hexdigest()}"
+
+
+class _AuthorityModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False, frozen=True)
+
+
+class AcceleratorAttestation(_AuthorityModel):
+    """Host-verified identity for one accelerator partition or device grant."""
+
+    backend: str
+    vendor: str
+    architecture: str
+    device_id: str
+    isolation_kind: str
+    enforced_memory_bytes: int = Field(ge=1)
+    runtime: str
+    driver: str
+    attestor_id: str
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_identifiers(self) -> Self:
+        for name in (
+            "backend",
+            "vendor",
+            "architecture",
+            "device_id",
+            "isolation_kind",
+            "runtime",
+            "driver",
+            "attestor_id",
+        ):
+            value = getattr(self, name)
+            if _SAFE_IDENTIFIER.fullmatch(value) is None:
+                raise ValueError(f"{name} must be a safe non-empty identifier")
+        for key, value in self.metadata.items():
+            if _SAFE_IDENTIFIER.fullmatch(key) is None or not value or any(char in value for char in "\r\n\0"):
+                raise ValueError("accelerator metadata must contain safe single-line string pairs")
+        return self
+
+    @property
+    def digest(self) -> str:
+        return canonical_authority_digest(self.model_dump(mode="json"))
+
+
+class AuthorityRequest(_AuthorityModel):
+    """One evaluator-owned request sent to an isolated candidate authority."""
+
+    protocol_version: Literal["autocontext.accelerator-authority/v1"] = AUTHORITY_PROTOCOL_VERSION
+    request_id: Digest
+    session_nonce: Digest
+    sequence: int = Field(ge=0)
+    role: AuthorityRole
+    operation: AuthorityOperation
+    artifact_digest: Digest
+    input_manifest_digest: Digest
+    payload_digest: Digest
+    payload_bytes: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_operation_payload(self) -> Self:
+        empty_digest = canonical_authority_digest(b"")
+        if self.operation == "shutdown" and (
+            self.payload_bytes != 0 or self.payload_digest != empty_digest or self.input_manifest_digest != empty_digest
+        ):
+            raise ValueError("shutdown requests cannot carry candidate-controlled payloads")
+        return self
+
+
+class AuthorityResponse(_AuthorityModel):
+    """Untrusted candidate response; timing and resource claims are excluded."""
+
+    protocol_version: Literal["autocontext.accelerator-authority/v1"] = AUTHORITY_PROTOCOL_VERSION
+    request_id: Digest
+    session_nonce: Digest
+    sequence: int = Field(ge=0)
+    role: AuthorityRole
+    artifact_digest: Digest
+    outcome: AuthorityResponseOutcome
+    output_manifest_digest: Digest
+    payload_digest: Digest
+    payload_bytes: int = Field(ge=0)
+    diagnostic_code: Literal[
+        "none",
+        "compile",
+        "execution",
+        "oom",
+        "malformed_request",
+        "malformed_output",
+    ] = "none"
+
+    @model_validator(mode="after")
+    def validate_outcome_payload(self) -> Self:
+        if self.outcome == "complete" and self.diagnostic_code != "none":
+            raise ValueError("complete responses cannot include a diagnostic code")
+        if self.outcome != "complete" and self.diagnostic_code == "none":
+            raise ValueError("failed responses require a bounded diagnostic code")
+        if self.outcome != "complete" and (
+            self.payload_bytes != 0
+            or self.payload_digest != canonical_authority_digest(b"")
+            or self.output_manifest_digest != canonical_authority_digest({})
+        ):
+            raise ValueError("failed responses cannot carry candidate-controlled output payloads")
+        return self
+
+
+class AuthorityMeasurement(_AuthorityModel):
+    """Evaluator-owned measurement for one request/response exchange."""
+
+    sequence: int = Field(ge=0)
+    role: AuthorityRole
+    request_digest: Digest
+    response_digest: Digest
+    input_commitment: Digest
+    output_commitment: Digest
+    elapsed_ns: int = Field(ge=1)
+    observed_peak_memory_bytes: int = Field(ge=0)
+    outcome: AuthorityExecutionOutcome
+
+
+class KernelEvaluatorAuthorityReceipt(_AuthorityModel):
+    """Replay-verifiable evidence that candidates did not own evaluation."""
+
+    schema_version: Literal["autocontext.accelerator-authority-receipt/v1"] = AUTHORITY_RECEIPT_VERSION
+    protocol_version: Literal["autocontext.accelerator-authority/v1"] = AUTHORITY_PROTOCOL_VERSION
+    evaluator_build_digest: Digest
+    boundary_manifest_digest: Digest
+    plan_commitment: Digest
+    accelerator_attestation: AcceleratorAttestation
+    candidate_artifact_digest: Digest
+    incumbent_artifact_digest: Digest
+    measurements: tuple[AuthorityMeasurement, ...]
+    transcript_digest: Digest
+    report_content_digest: Digest
+
+    @model_validator(mode="after")
+    def validate_measurement_chain(self) -> Self:
+        if not self.measurements:
+            raise ValueError("authority receipts require at least one evaluator-owned measurement")
+        sequences = [measurement.sequence for measurement in self.measurements]
+        if sequences != list(range(len(sequences))):
+            raise ValueError("authority receipt measurements must have a contiguous ordered sequence")
+        roles = {measurement.role for measurement in self.measurements}
+        if roles != {"candidate", "incumbent"}:
+            raise ValueError("authority receipts must measure candidate and incumbent independently")
+        expected = canonical_authority_digest(
+            {
+                "protocol_version": self.protocol_version,
+                "measurements": [measurement.model_dump(mode="json") for measurement in self.measurements],
+            }
+        )
+        if self.transcript_digest != expected:
+            raise ValueError("authority receipt transcript digest does not match its measurements")
+        return self
+
+    @property
+    def receipt_digest(self) -> str:
+        return canonical_authority_digest(self.model_dump(mode="json"))
+
+
+def authority_message_digest(message: AuthorityRequest | AuthorityResponse) -> str:
+    """Digest one typed message without trusting candidate serialization."""
+
+    return canonical_authority_digest(message.model_dump(mode="json"))
+
+
+def authority_report_content_digest(report: dict[str, Any]) -> str:
+    """Digest a report while excluding the receipt that binds that digest."""
+
+    payload = dict(report)
+    payload.pop("evaluator_authority_receipt", None)
+    return canonical_authority_digest(payload)
+
+
+def build_authority_receipt(
+    *,
+    evaluator_build_digest: str,
+    boundary_manifest_digest: str,
+    plan_commitment: str,
+    accelerator_attestation: AcceleratorAttestation,
+    candidate_artifact_digest: str,
+    incumbent_artifact_digest: str,
+    measurements: tuple[AuthorityMeasurement, ...],
+    report: dict[str, Any],
+) -> KernelEvaluatorAuthorityReceipt:
+    """Create the canonical host-owned receipt for a completed evaluation."""
+
+    transcript_digest = canonical_authority_digest(
+        {
+            "protocol_version": AUTHORITY_PROTOCOL_VERSION,
+            "measurements": [measurement.model_dump(mode="json") for measurement in measurements],
+        }
+    )
+    return KernelEvaluatorAuthorityReceipt(
+        evaluator_build_digest=evaluator_build_digest,
+        boundary_manifest_digest=boundary_manifest_digest,
+        plan_commitment=plan_commitment,
+        accelerator_attestation=accelerator_attestation,
+        candidate_artifact_digest=candidate_artifact_digest,
+        incumbent_artifact_digest=incumbent_artifact_digest,
+        measurements=measurements,
+        transcript_digest=transcript_digest,
+        report_content_digest=authority_report_content_digest(report),
+    )
+
+
+def verify_authority_receipt(receipt: KernelEvaluatorAuthorityReceipt, report: dict[str, Any]) -> None:
+    """Fail closed when a persisted receipt cannot replay against its report."""
+
+    if receipt.report_content_digest != authority_report_content_digest(report):
+        raise ValueError("authority receipt is bound to different report content")
+    if report.get("candidate_artifact_digest") != receipt.candidate_artifact_digest:
+        raise ValueError("authority receipt candidate identity does not match the report")
+    if report.get("incumbent_artifact_digest") != receipt.incumbent_artifact_digest:
+        raise ValueError("authority receipt incumbent identity does not match the report")
+    protocol = report.get("protocol")
+    if not isinstance(protocol, dict) or protocol.get("seed_commitment") != receipt.plan_commitment:
+        raise ValueError("authority receipt plan commitment does not match the report")
+
+
+__all__ = [
+    "AUTHORITY_PROTOCOL_VERSION",
+    "AUTHORITY_RECEIPT_VERSION",
+    "AcceleratorAttestation",
+    "AuthorityExecutionOutcome",
+    "AuthorityMeasurement",
+    "AuthorityOperation",
+    "AuthorityRequest",
+    "AuthorityResponse",
+    "AuthorityResponseOutcome",
+    "AuthorityRole",
+    "KernelEvaluatorAuthorityReceipt",
+    "authority_message_digest",
+    "authority_report_content_digest",
+    "build_authority_receipt",
+    "canonical_authority_digest",
+    "verify_authority_receipt",
+]

--- a/autocontext/src/autocontext/kernel_evolution/authority_readiness.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_readiness.py
@@ -1,0 +1,54 @@
+"""Authoritative readiness policy for protected accelerator evaluation."""
+
+from __future__ import annotations
+
+from autocontext.kernel_evolution.docker_watchdog import crash_safe_container_creation_policy
+
+_ROLE_ISOLATION_AVAILABLE = False
+_MUTATION_OBSERVATION_AVAILABLE = False
+_COMPARABLE_TIMING_AVAILABLE = False
+
+
+def protected_evaluator_boundary_requirements() -> dict[str, dict[str, bool | str]]:
+    """Return every boundary that must be ready before protected Docker dispatch."""
+
+    return {
+        "accelerator_role_isolation": {
+            "required": "independently-attested-evaluator-candidate-incumbent-grants/v1",
+            "available": _ROLE_ISOLATION_AVAILABLE,
+            "reason": (
+                "protected accelerator evidence requires independently attested evaluator, candidate, and incumbent "
+                "grants; the v1 shared-grant topology is unsupported"
+            ),
+        },
+        "trusted_out_of_process_mutation_observation": {
+            "required": "trusted-out-of-process-input-mutation-observation/v1",
+            "available": _MUTATION_OBSERVATION_AVAILABLE,
+            "reason": (
+                "protected accelerator evidence requires trusted out-of-process input-mutation observation; "
+                "the v1 same-interpreter authority is unsupported"
+            ),
+        },
+        "comparable_timing_boundaries": {
+            "required": "comparable-candidate-incumbent-reference-timing/v1",
+            "available": _COMPARABLE_TIMING_AVAILABLE,
+            "reason": (
+                "protected accelerator evidence requires comparable candidate/incumbent/reference timing boundaries; "
+                "the v1 RPC/local timing topology is unsupported"
+            ),
+        },
+        "crash_safe_container_creation": dict(crash_safe_container_creation_policy()),
+    }
+
+
+def protected_evaluator_boundary_error() -> str | None:
+    """Return the first unavailable boundary reason, or ``None`` when dispatch is safe."""
+
+    for requirement in protected_evaluator_boundary_requirements().values():
+        if requirement.get("available") is not True:
+            reason = requirement.get("reason")
+            return str(reason) if reason else "protected accelerator evidence boundary is unavailable"
+    return None
+
+
+__all__ = ["protected_evaluator_boundary_error", "protected_evaluator_boundary_requirements"]

--- a/autocontext/src/autocontext/kernel_evolution/authority_runner.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_runner.py
@@ -1,0 +1,777 @@
+"""Docker composition for a trusted evaluator and isolated candidates.
+
+The evaluator and each generated artifact run in distinct Docker PID, mount,
+environment, and process namespaces.  The evaluator creates Unix sockets;
+candidate containers receive read-only access to exactly one socket directory,
+their own source, and explicitly public support paths.  Candidate containers
+never mount private plans, references, report storage, or evaluator code.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from autocontext.execution.docker_isolation import (
+    DockerIsolationLimits,
+    build_docker_isolation_command,
+    sanitized_docker_environment,
+)
+from autocontext.execution.scenario_remote_package import require_pinned_runtime_image
+from autocontext.kernel_evolution import _process_control
+from autocontext.kernel_evolution.authority_protocol import (
+    KernelEvaluatorAuthorityReceipt,
+    canonical_authority_digest,
+    verify_authority_receipt,
+)
+from autocontext.kernel_evolution.benchmark import (
+    KernelBenchmarkExecution,
+    _fingerprint_paths,
+    _reject_json_constant,
+)
+from autocontext.kernel_evolution.docker_watchdog import (
+    CLEANUP_TIMEOUT_SECONDS,
+    DOCKER_KERNEL_OWNER_LABEL,
+    docker_container_missing,
+    launch_deadline_watchdog,
+    terminate_process_group,
+)
+from autocontext.kernel_evolution.docker_worker import (
+    DockerKernelWorkerLimits,
+    _validate_json_entries,
+    _validate_json_nesting,
+)
+from autocontext.kernel_evolution.gpu_attestation import (
+    DockerGPUDeviceAttestation,
+    DockerGPUDeviceAttestor,
+    DockerGPUDeviceGrant,
+    attest_partition_grant,
+)
+from autocontext.kernel_evolution.models import ARTIFACT_IDENTITY_VERSION, KernelCandidate, content_digest
+
+PROTECTED_EVALUATOR_BOUNDARY = "trusted-evaluator/isolated-accelerator-candidate-v1"
+_OWNER_LABEL = "ai.autocontext.kernel-authority-owner"
+_EXPIRY_LABEL = "ai.autocontext.expires-at"
+_ROLE_LABEL = "ai.autocontext.kernel-authority-role"
+_SOCKET_NAME = "authority.sock"
+_SOCKET_STARTUP_GRACE_SECONDS = 20.0
+
+
+class DockerProtectedKernelBenchmarkRunner:
+    """Run a trusted evaluator beside two isolated candidate authorities."""
+
+    def __init__(
+        self,
+        evaluator_command: Sequence[str],
+        *,
+        image: str,
+        container_python: str,
+        evaluator_immutable_paths: Sequence[Path],
+        evaluator_build_paths: Sequence[Path] | None = None,
+        candidate_runtime_path: Path,
+        candidate_support_paths: Sequence[Path] = (),
+        gpu_grant: DockerGPUDeviceGrant,
+        gpu_attestor: DockerGPUDeviceAttestor,
+        limits: DockerKernelWorkerLimits | None = None,
+        docker_binary: str = "docker",
+        source_suffix: str = ".py",
+        temporary_root: Path | None = None,
+    ) -> None:
+        if not evaluator_command or not evaluator_immutable_paths:
+            raise ValueError("protected evaluation requires a command and evaluator-only immutable paths")
+        if re.fullmatch(r"\.[A-Za-z0-9]{1,12}", source_suffix) is None:
+            raise ValueError("source_suffix must be a short safe extension")
+        rendered = "\0".join(evaluator_command)
+        required = ("{candidate_socket}", "{incumbent_socket}", "{report}")
+        missing = [placeholder for placeholder in required if placeholder not in rendered]
+        if missing:
+            raise ValueError(f"protected evaluator command is missing placeholders: {', '.join(missing)}")
+        require_pinned_runtime_image(image)
+        resolved_binary = shutil.which(docker_binary)
+        if resolved_binary is None:
+            raise RuntimeError(f"Docker executable is unavailable: {docker_binary}")
+        if not container_python.startswith("/") or ".." in Path(container_python).parts:
+            raise ValueError("container_python must be an absolute normalized container path")
+        self._evaluator_command = tuple(evaluator_command)
+        self.image = image
+        self.container_python = container_python
+        self.docker_binary = resolved_binary
+        self._evaluator_paths = tuple(Path(path).resolve(strict=True) for path in evaluator_immutable_paths)
+        self._evaluator_build_paths = tuple(
+            Path(path).resolve(strict=True) for path in (evaluator_build_paths or evaluator_immutable_paths)
+        )
+        if not self._evaluator_build_paths or any(path not in self._evaluator_paths for path in self._evaluator_build_paths):
+            raise ValueError("evaluator build paths must be a non-empty subset of immutable evaluator paths")
+        self._candidate_runtime = candidate_runtime_path.resolve(strict=True)
+        self._candidate_support = tuple(Path(path).resolve(strict=True) for path in candidate_support_paths)
+        if self._candidate_runtime in self._evaluator_paths:
+            raise ValueError("candidate runtime cannot be an evaluator-private immutable path")
+        for support_path in self._candidate_support:
+            for evaluator_path in self._evaluator_paths:
+                if evaluator_path == support_path or evaluator_path.is_relative_to(support_path):
+                    raise ValueError("candidate support paths cannot expose evaluator-private immutable material")
+        self._evaluator_integrity_digest = _fingerprint_paths(self._evaluator_paths)
+        self._evaluator_digest = _fingerprint_paths(self._evaluator_build_paths)
+        self._candidate_boundary_digest = _fingerprint_paths((self._candidate_runtime, *self._candidate_support))
+        self.gpu_grant = gpu_grant
+        if not gpu_attestor.attestor_id.strip():
+            raise ValueError("accelerator attestor must expose a non-empty identity")
+        self.gpu_attestor = gpu_attestor
+        self.limits = limits or DockerKernelWorkerLimits()
+        self._source_suffix = source_suffix
+        self._temporary_root = temporary_root
+        self._report_limits = _process_control.ReportLimits(
+            max_bytes=self.limits.max_report_bytes,
+            max_entries=self.limits.max_report_entries,
+            max_depth=self.limits.max_report_depth,
+        )
+
+    def manifest(self) -> dict[str, Any]:
+        """Return public deployment identity without private-plan paths."""
+
+        return {
+            "kind": "docker-protected-accelerator-evaluator",
+            "evidence_boundary": PROTECTED_EVALUATOR_BOUNDARY,
+            "artifact_identity_version": ARTIFACT_IDENTITY_VERSION,
+            "image": self.image,
+            "container_python": self.container_python,
+            "evaluator_command": list(self._evaluator_command),
+            "evaluator_immutable_count": len(self._evaluator_paths),
+            "evaluator_build_count": len(self._evaluator_build_paths),
+            "evaluator_build_digest": self._evaluator_digest,
+            "candidate_runtime_digest": self._candidate_boundary_digest,
+            "candidate_support_count": len(self._candidate_support),
+            "requested_accelerator_grant": asdict(self.gpu_grant),
+            "accelerator_attestor": self.gpu_attestor.manifest(),
+            "limits": asdict(self.limits),
+            "candidate_mount_policy": "source+runtime+public-support+one-readonly-socket",
+            "evaluator_mount_policy": "private-harness+channels+report;no-generated-source",
+            "network": "deny",
+            "ambient_credentials": "scrubbed",
+        }
+
+    def run(
+        self,
+        candidate: KernelCandidate,
+        incumbent: KernelCandidate,
+        *,
+        timeout_seconds: float,
+    ) -> KernelBenchmarkExecution:
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive and finite")
+        if candidate.source_suffix != self._source_suffix or incumbent.source_suffix != self._source_suffix:
+            return KernelBenchmarkExecution(returncode=None, error="candidate/incumbent suffix does not match runner")
+        attestation, attestation_error = self._attest_accelerator()
+        if attestation_error is not None:
+            return KernelBenchmarkExecution(
+                returncode=None,
+                error=attestation_error,
+                outcome="resource_policy_unsupported",
+            )
+        assert attestation is not None
+        if not self._immutable_boundary_unchanged():
+            return KernelBenchmarkExecution(
+                returncode=None,
+                error="trusted evaluator or candidate runtime changed before launch",
+                harness_unchanged=False,
+            )
+        try:
+            self.reconcile()
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            return KernelBenchmarkExecution(
+                returncode=None,
+                error=f"authority orphan reconciliation failed: {type(exc).__name__}: {exc}",
+                outcome="teardown_failed",
+            )
+        if not self._image_available():
+            return KernelBenchmarkExecution(returncode=None, error="pinned protected-evaluator image is unavailable")
+        return self._run_session(candidate, incumbent, attestation, timeout_seconds=timeout_seconds)
+
+    def _run_session(
+        self,
+        candidate: KernelCandidate,
+        incumbent: KernelCandidate,
+        attestation: DockerGPUDeviceAttestation,
+        *,
+        timeout_seconds: float,
+    ) -> KernelBenchmarkExecution:
+        with tempfile.TemporaryDirectory(prefix="autoctx-kernel-authority-", dir=self._temporary_root) as temp_name:
+            root = Path(temp_name)
+            candidate_source = self._stage_source(root / "candidate", candidate)
+            incumbent_source = self._stage_source(root / "incumbent", incumbent)
+            candidate_channel = root / "candidate-channel"
+            incumbent_channel = root / "incumbent-channel"
+            report_root = root / "report"
+            for directory in (candidate_channel, incumbent_channel, report_root):
+                directory.mkdir(mode=0o700)
+            report_identity = _process_control.filesystem_object_identity(report_root.lstat())
+            report_path = report_root / "report.json"
+            session_id = uuid.uuid4().hex
+            names = {
+                "evaluator": f"autoctx-evaluator-{session_id[:18]}",
+                "candidate": f"autoctx-candidate-{session_id[:18]}",
+                "incumbent": f"autoctx-incumbent-{session_id[:18]}",
+            }
+            expires_at = time.time() + timeout_seconds + CLEANUP_TIMEOUT_SECONDS
+            evaluator_command = self._evaluator_docker_command(
+                names["evaluator"],
+                candidate_channel,
+                incumbent_channel,
+                report_root,
+                candidate,
+                incumbent,
+                attestation,
+                expires_at,
+            )
+            candidate_command = self._candidate_docker_command(
+                names["candidate"],
+                candidate_source,
+                candidate_channel,
+                candidate,
+                "candidate",
+                attestation,
+                expires_at,
+            )
+            incumbent_command = self._candidate_docker_command(
+                names["incumbent"],
+                incumbent_source,
+                incumbent_channel,
+                incumbent,
+                "incumbent",
+                attestation,
+                expires_at,
+            )
+            execution = self._execute_authorities(
+                evaluator_command,
+                candidate_command,
+                incumbent_command,
+                names=names,
+                socket_paths=(candidate_channel / _SOCKET_NAME, incumbent_channel / _SOCKET_NAME),
+                report_path=report_path,
+                report_identity=report_identity,
+                timeout_seconds=timeout_seconds,
+                accelerator_attestation=attestation,
+                watchdog_root=root,
+                expires_at=expires_at,
+            )
+            return KernelBenchmarkExecution(
+                **{
+                    **asdict(execution),
+                    "harness_unchanged": self._immutable_boundary_unchanged(),
+                    "candidate_unchanged": self._source_unchanged(candidate_source, candidate),
+                    "incumbent_unchanged": self._source_unchanged(incumbent_source, incumbent),
+                }
+            )
+
+    def _execute_authorities(
+        self,
+        evaluator_command: list[str],
+        candidate_command: list[str],
+        incumbent_command: list[str],
+        *,
+        names: dict[str, str],
+        socket_paths: tuple[Path, Path],
+        report_path: Path,
+        report_identity: _process_control.FilesystemObjectIdentity,
+        timeout_seconds: float,
+        accelerator_attestation: DockerGPUDeviceAttestation,
+        watchdog_root: Path,
+        expires_at: float,
+    ) -> KernelBenchmarkExecution:
+        deadline = time.monotonic() + timeout_seconds
+        evaluator: subprocess.Popen[bytes] | None = None
+        candidates: list[subprocess.Popen[bytes]] = []
+        watchdogs: list[subprocess.Popen[bytes]] = []
+        stdout = _process_control.BoundedOutput()
+        stderr = _process_control.BoundedOutput()
+        drains: list[threading.Thread] = []
+        timed_out = False
+        returncode: int | None = None
+        outcome = "complete"
+        error: str | None = None
+        payload: dict[str, Any] | None = None
+        cleanup_errors: list[str] = []
+        try:
+            evaluator = subprocess.Popen(  # noqa: S603
+                evaluator_command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=sanitized_docker_environment(),
+            )
+            watchdogs.append(
+                launch_deadline_watchdog(
+                    self.docker_binary,
+                    names["evaluator"],
+                    expires_at,
+                    watchdog_root / "evaluator-watchdog-ready",
+                )
+            )
+            assert evaluator.stdout is not None and evaluator.stderr is not None
+            drains = [
+                threading.Thread(
+                    target=_process_control.drain_bounded,
+                    args=(evaluator.stdout, stdout, self.limits.max_output_bytes),
+                    daemon=True,
+                ),
+                threading.Thread(
+                    target=_process_control.drain_bounded,
+                    args=(evaluator.stderr, stderr, self.limits.max_output_bytes),
+                    daemon=True,
+                ),
+            ]
+            for thread in drains:
+                thread.start()
+            self._wait_for_evaluator_sockets(evaluator, socket_paths, deadline)
+            for command in (candidate_command, incumbent_command):
+                candidate_process = subprocess.Popen(  # noqa: S603
+                    command,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=sanitized_docker_environment(),
+                )
+                candidates.append(candidate_process)
+                role = "candidate" if len(candidates) == 1 else "incumbent"
+                watchdogs.append(
+                    launch_deadline_watchdog(
+                        self.docker_binary,
+                        names[role],
+                        expires_at,
+                        watchdog_root / f"{role}-watchdog-ready",
+                    )
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise subprocess.TimeoutExpired(evaluator_command, timeout_seconds)
+            returncode = evaluator.wait(timeout=remaining)
+            payload = self._read_report(report_path, report_identity)
+            if returncode != 0:
+                outcome = self._reported_failure_outcome(payload, default="evaluator_crashed")
+                error = f"trusted evaluator exited with status {returncode}"
+            elif payload is None:
+                outcome = "protocol_corruption"
+                error = "trusted evaluator exited without a valid bounded report"
+            else:
+                receipt_error = self._validate_receipt(payload, accelerator_attestation)
+                if receipt_error is not None:
+                    outcome = "protocol_corruption"
+                    error = receipt_error
+                else:
+                    outcome = self._reported_failure_outcome(payload, default="complete")
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            outcome = "timeout"
+            error = "protected evaluator authority session timed out"
+        except (OSError, RuntimeError, ValueError) as exc:
+            outcome = "evaluator_crashed"
+            error = f"protected evaluator authority session failed: {type(exc).__name__}: {exc}"
+        finally:
+            if evaluator is not None and evaluator.poll() is None:
+                evaluator.kill()
+            for process in candidates:
+                if process.poll() is None:
+                    process.kill()
+            for name in names.values():
+                try:
+                    self._remove_container(name)
+                    self._verify_removed(name)
+                except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+                    cleanup_errors.append(f"{name}: {type(exc).__name__}: {exc}")
+            for index, watchdog in enumerate(watchdogs):
+                try:
+                    terminate_process_group(watchdog, description=f"authority watchdog {index}")
+                except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+                    cleanup_errors.append(f"watchdog {index}: {type(exc).__name__}: {exc}")
+            for thread in drains:
+                thread.join(timeout=CLEANUP_TIMEOUT_SECONDS)
+        if cleanup_errors:
+            outcome = "teardown_failed"
+            error = "; ".join(cleanup_errors)
+        elif stdout.exceeded or stderr.exceeded or stdout.read_failed or stderr.read_failed:
+            outcome = "resource_exceeded"
+            error = "protected evaluator diagnostic output exceeded its bounded channel"
+        return KernelBenchmarkExecution(
+            returncode=returncode,
+            timed_out=timed_out,
+            report_payload=payload,
+            stdout=stdout.text,
+            stderr=stderr.text,
+            stdout_truncated=stdout.exceeded or stdout.read_failed,
+            stderr_truncated=stderr.exceeded or stderr.read_failed,
+            error=error,
+            outcome=outcome,  # type: ignore[arg-type]
+        )
+
+    def _evaluator_docker_command(
+        self,
+        container_name: str,
+        candidate_channel: Path,
+        incumbent_channel: Path,
+        report_root: Path,
+        candidate: KernelCandidate,
+        incumbent: KernelCandidate,
+        attestation: DockerGPUDeviceAttestation,
+        expires_at: float,
+    ) -> list[str]:
+        replacements = self._identity_replacements(candidate, incumbent)
+        replacements.update(
+            {
+                "{candidate_socket}": f"/channels/candidate/{_SOCKET_NAME}",
+                "{incumbent_socket}": f"/channels/incumbent/{_SOCKET_NAME}",
+                "{report}": "/output/report.json",
+            }
+        )
+        for index in range(len(self._evaluator_paths)):
+            replacements[f"{{immutable_{index}}}"] = f"/evaluator/{index}"
+        argv = [self._replace(raw, replacements) for raw in self._evaluator_command]
+        return self._isolation_command(
+            container_name=container_name,
+            role="evaluator",
+            attestation=attestation,
+            expires_at=expires_at,
+            readonly_mounts={path: f"/evaluator/{index}" for index, path in enumerate(self._evaluator_paths)},
+            writable_mounts={
+                candidate_channel: "/channels/candidate",
+                incumbent_channel: "/channels/incumbent",
+                report_root: "/output",
+            },
+            argv=argv,
+            extra_environment={
+                "AUTOCONTEXT_EVALUATOR_BUILD_DIGEST": self._evaluator_digest,
+                "AUTOCONTEXT_BOUNDARY_MANIFEST_DIGEST": canonical_authority_digest(self.manifest()),
+            },
+        )
+
+    def _candidate_docker_command(
+        self,
+        container_name: str,
+        source_path: Path,
+        channel_path: Path,
+        artifact: KernelCandidate,
+        role: str,
+        attestation: DockerGPUDeviceAttestation,
+        expires_at: float,
+    ) -> list[str]:
+        argv = [
+            self.container_python,
+            "-I",
+            "-B",
+            "/authority/worker.py",
+            "--connect",
+            f"/channel/{_SOCKET_NAME}",
+            "--source",
+            f"/artifact/source{self._source_suffix}",
+            "--entrypoint",
+            artifact.entrypoint,
+            "--artifact-digest",
+            artifact.artifact_digest,
+            "--role",
+            role,
+        ]
+        for index in range(len(self._candidate_support)):
+            argv.extend(("--support-path", f"/support/{index}"))
+        readonly_mounts = {
+            self._candidate_runtime: "/authority/worker.py",
+            source_path: f"/artifact/source{self._source_suffix}",
+            channel_path: "/channel",
+        }
+        readonly_mounts.update({path: f"/support/{index}" for index, path in enumerate(self._candidate_support)})
+        return self._isolation_command(
+            container_name=container_name,
+            role=role,
+            attestation=attestation,
+            expires_at=expires_at,
+            readonly_mounts=readonly_mounts,
+            writable_mounts={},
+            argv=argv,
+        )
+
+    def _isolation_command(
+        self,
+        *,
+        container_name: str,
+        role: str,
+        attestation: DockerGPUDeviceAttestation,
+        expires_at: float,
+        readonly_mounts: dict[Path, str],
+        writable_mounts: dict[Path, str],
+        argv: list[str],
+        extra_environment: dict[str, str] | None = None,
+    ) -> list[str]:
+        environment = {
+            "AUTOCONTEXT_ACCELERATOR_DEVICE_ID": attestation.device_id,
+            "AUTOCONTEXT_ACCELERATOR_ISOLATION_KIND": attestation.isolation_kind,
+            "AUTOCONTEXT_ACCELERATOR_ENFORCED_MEMORY_BYTES": str(attestation.enforced_memory_bytes),
+            "AUTOCONTEXT_ACCELERATOR_ATTESTOR_ID": attestation.attestor_id,
+            "AUTOCONTEXT_ACCELERATOR_ATTESTATION_DIGEST": attestation.digest,
+            # Compatibility aliases for the existing CUDA profile reader.
+            "AUTOCONTEXT_GPU_DEVICE_ID": attestation.device_id,
+            "AUTOCONTEXT_GPU_ISOLATION_KIND": attestation.isolation_kind,
+            "AUTOCONTEXT_GPU_ENFORCED_MEMORY_BYTES": str(attestation.enforced_memory_bytes),
+            "AUTOCONTEXT_GPU_ATTESTOR_ID": attestation.attestor_id,
+            "AUTOCONTEXT_GPU_ATTESTATION_DIGEST": attestation.digest,
+        }
+        environment.update(extra_environment or {})
+        return build_docker_isolation_command(
+            docker_binary=self.docker_binary,
+            image=self.image,
+            container_name=container_name,
+            labels={
+                _OWNER_LABEL: container_name,
+                DOCKER_KERNEL_OWNER_LABEL: container_name,
+                _EXPIRY_LABEL: f"{expires_at:.6f}",
+                _ROLE_LABEL: role,
+            },
+            limits=DockerIsolationLimits(
+                memory_mb=self.limits.memory_mb,
+                cpu_count=self.limits.cpu_count,
+                cpu_time_seconds=self.limits.cpu_time_seconds,
+                pids_limit=self.limits.pids_limit,
+            ),
+            readonly_mounts=readonly_mounts,
+            writable_mounts=writable_mounts,
+            tmpfs_mounts={
+                "/tmp": "rw,noexec,nosuid,nodev,size=64m,nr_inodes=1024",
+                "/workspace": (
+                    f"rw,nosuid,nodev,exec,size={self.limits.max_workspace_bytes},nr_inodes={self.limits.max_workspace_inodes}"
+                ),
+            },
+            argv=argv,
+            gpu_device=attestation.device_id,
+            auto_remove=False,
+            working_dir="/workspace",
+            environment=environment,
+        )
+
+    def reconcile(self, *, now: float | None = None) -> int:
+        """Remove expired evaluator/candidate containers after coordinator loss."""
+
+        listed = subprocess.run(  # noqa: S603
+            [self.docker_binary, "ps", "-aq", "--filter", f"label={_OWNER_LABEL}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=CLEANUP_TIMEOUT_SECONDS,
+            env=sanitized_docker_environment(),
+        )
+        container_ids = tuple(value for value in listed.stdout.splitlines() if value.strip())
+        current = time.time() if now is None else now
+        expired: list[str] = []
+        for container_id in container_ids:
+            inspected = subprocess.run(  # noqa: S603
+                [
+                    self.docker_binary,
+                    "inspect",
+                    "--format",
+                    f'{{{{.Id}}}}\t{{{{ index .Config.Labels "{_EXPIRY_LABEL}" }}}}',
+                    container_id,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=CLEANUP_TIMEOUT_SECONDS,
+                env=sanitized_docker_environment(),
+            )
+            if inspected.returncode != 0:
+                if docker_container_missing(inspected):
+                    continue
+                raise RuntimeError("authority container inspection failed")
+            container, separator, raw_expiry = inspected.stdout.strip().partition("\t")
+            try:
+                expiry = float(raw_expiry)
+            except ValueError as exc:
+                raise RuntimeError("owned authority container has invalid expiry metadata") from exc
+            if not separator or not math.isfinite(expiry) or expiry <= 0:
+                raise RuntimeError("owned authority container has invalid expiry metadata")
+            if expiry <= current:
+                expired.append(container)
+        for container_id in expired:
+            self._remove_container(container_id)
+            self._verify_removed(container_id)
+        return len(expired)
+
+    def _attest_accelerator(self) -> tuple[DockerGPUDeviceAttestation | None, str | None]:
+        try:
+            return (
+                attest_partition_grant(
+                    self.gpu_grant,
+                    self.gpu_attestor,
+                    max_gpu_memory_bytes=self.limits.max_gpu_memory_bytes,
+                ),
+                None,
+            )
+        except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as exc:
+            return None, f"trusted accelerator attestation failed: {type(exc).__name__}: {exc}"
+
+    def _immutable_boundary_unchanged(self) -> bool:
+        try:
+            return (
+                _fingerprint_paths(self._evaluator_paths) == self._evaluator_integrity_digest
+                and _fingerprint_paths((self._candidate_runtime, *self._candidate_support))
+                == self._candidate_boundary_digest
+            )
+        except (OSError, ValueError):
+            return False
+
+    def _wait_for_evaluator_sockets(
+        self,
+        evaluator: subprocess.Popen[bytes],
+        paths: tuple[Path, Path],
+        deadline: float,
+    ) -> None:
+        startup_deadline = min(deadline, time.monotonic() + _SOCKET_STARTUP_GRACE_SECONDS)
+        while time.monotonic() < startup_deadline:
+            if evaluator.poll() is not None:
+                raise RuntimeError("trusted evaluator exited before creating authority sockets")
+            if all(self._is_socket(path) for path in paths):
+                return
+            time.sleep(0.01)
+        raise RuntimeError("trusted evaluator did not create bounded authority sockets before startup deadline")
+
+    def _read_report(
+        self,
+        report_path: Path,
+        report_identity: _process_control.FilesystemObjectIdentity,
+    ) -> dict[str, Any] | None:
+        try:
+            payload = _process_control.read_bounded_regular_file(
+                report_path,
+                self._report_limits.max_bytes,
+                expected_parent=report_identity,
+                description="protected evaluator report",
+            )
+            text = _validate_json_nesting(payload, self._report_limits)
+            decoded = json.loads(text, parse_constant=_reject_json_constant)
+            _validate_json_entries(decoded, self._report_limits)
+            return decoded if isinstance(decoded, dict) else None
+        except (FileNotFoundError, json.JSONDecodeError, OSError, RecursionError, ValueError):
+            return None
+
+    @staticmethod
+    def _validate_receipt(
+        payload: dict[str, Any],
+        attestation: DockerGPUDeviceAttestation,
+    ) -> str | None:
+        try:
+            receipt = KernelEvaluatorAuthorityReceipt.model_validate(payload.get("evaluator_authority_receipt"))
+            verify_authority_receipt(receipt, payload)
+        except (TypeError, ValueError):
+            return "trusted evaluator report omitted or forged its authority receipt"
+        accelerator = receipt.accelerator_attestation
+        if (
+            accelerator.device_id != attestation.device_id
+            or accelerator.isolation_kind != attestation.isolation_kind
+            or accelerator.enforced_memory_bytes != attestation.enforced_memory_bytes
+            or accelerator.attestor_id != attestation.attestor_id
+            or accelerator.metadata.get("grant_attestation_digest") != attestation.digest
+        ):
+            return "trusted evaluator receipt does not match the host-attested accelerator grant"
+        return None
+
+    @staticmethod
+    def _reported_failure_outcome(payload: dict[str, Any] | None, *, default: str) -> str:
+        failure = payload.get("failure_kind") if payload is not None else None
+        if not isinstance(failure, str):
+            return default
+        return {
+            "oom": "oom",
+            "protocol_corruption": "protocol_corruption",
+            "evaluator_crash": "evaluator_crashed",
+            "candidate_crash": "candidate_crashed",
+            "teardown_failure": "teardown_failed",
+            "timeout": "timeout",
+        }.get(failure, default)
+
+    @staticmethod
+    def _identity_replacements(candidate: KernelCandidate, incumbent: KernelCandidate) -> dict[str, str]:
+        return {
+            "{artifact_identity_version}": candidate.artifact_identity_version,
+            "{candidate_artifact_digest}": candidate.artifact_digest,
+            "{incumbent_artifact_digest}": incumbent.artifact_digest,
+            "{candidate_source_digest}": candidate.source_digest,
+            "{incumbent_source_digest}": incumbent.source_digest,
+            "{candidate_source_suffix}": candidate.source_suffix,
+            "{incumbent_source_suffix}": incumbent.source_suffix,
+            "{candidate_entrypoint}": candidate.entrypoint,
+            "{incumbent_entrypoint}": incumbent.entrypoint,
+        }
+
+    @staticmethod
+    def _replace(raw: str, replacements: dict[str, str]) -> str:
+        value = raw
+        for placeholder, replacement in replacements.items():
+            value = value.replace(placeholder, replacement)
+        return value
+
+    @staticmethod
+    def _stage_source(root: Path, artifact: KernelCandidate) -> Path:
+        root.mkdir(mode=0o700)
+        path = root / f"source{artifact.source_suffix}"
+        path.write_bytes(artifact.source_bytes)
+        path.chmod(0o444)
+        return path
+
+    @staticmethod
+    def _source_unchanged(path: Path, artifact: KernelCandidate) -> bool:
+        try:
+            return content_digest(path.read_bytes()) == artifact.source_digest
+        except OSError:
+            return False
+
+    @staticmethod
+    def _is_socket(path: Path) -> bool:
+        try:
+            return stat.S_ISSOCK(path.lstat().st_mode)
+        except OSError:
+            return False
+
+    def _image_available(self) -> bool:
+        completed = subprocess.run(  # noqa: S603
+            [self.docker_binary, "image", "inspect", self.image],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=CLEANUP_TIMEOUT_SECONDS,
+            env=sanitized_docker_environment(),
+        )
+        return completed.returncode == 0
+
+    def _remove_container(self, container_name: str) -> None:
+        completed = subprocess.run(  # noqa: S603
+            [self.docker_binary, "rm", "-f", container_name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=CLEANUP_TIMEOUT_SECONDS,
+            env=sanitized_docker_environment(),
+        )
+        if completed.returncode != 0 and not docker_container_missing(completed):
+            raise RuntimeError((completed.stderr or completed.stdout).strip()[-240:])
+
+    def _verify_removed(self, container_name: str) -> None:
+        completed = subprocess.run(  # noqa: S603
+            [self.docker_binary, "ps", "-aq", "--filter", f"label={_OWNER_LABEL}={container_name}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=CLEANUP_TIMEOUT_SECONDS,
+            env=sanitized_docker_environment(),
+        )
+        if completed.stdout.strip():
+            raise RuntimeError("authority container or descendant remained after teardown")
+
+
+__all__ = ["PROTECTED_EVALUATOR_BOUNDARY", "DockerProtectedKernelBenchmarkRunner"]

--- a/autocontext/src/autocontext/kernel_evolution/authority_runner.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_runner.py
@@ -13,7 +13,6 @@ import json
 import math
 import re
 import shutil
-import stat
 import subprocess
 import tempfile
 import threading
@@ -34,7 +33,12 @@ from autocontext.kernel_evolution import _process_control
 from autocontext.kernel_evolution.authority_protocol import (
     KernelEvaluatorAuthorityReceipt,
     canonical_authority_digest,
+    read_authority_hmac_secret,
     verify_authority_receipt,
+)
+from autocontext.kernel_evolution.authority_readiness import (
+    protected_evaluator_boundary_error,
+    protected_evaluator_boundary_requirements,
 )
 from autocontext.kernel_evolution.benchmark import (
     KernelBenchmarkExecution,
@@ -44,9 +48,17 @@ from autocontext.kernel_evolution.benchmark import (
 from autocontext.kernel_evolution.docker_watchdog import (
     CLEANUP_TIMEOUT_SECONDS,
     DOCKER_KERNEL_OWNER_LABEL,
+    create_docker_container,
     docker_container_missing,
+    docker_image_available,
+    is_unix_socket,
+    launch_bounded_output_drains,
     launch_deadline_watchdog,
+    remove_docker_container,
+    start_attached_docker_container,
+    terminate_attached_docker_processes,
     terminate_process_group,
+    verify_docker_container_removed,
 )
 from autocontext.kernel_evolution.docker_worker import (
     DockerKernelWorkerLimits,
@@ -67,6 +79,8 @@ _EXPIRY_LABEL = "ai.autocontext.expires-at"
 _ROLE_LABEL = "ai.autocontext.kernel-authority-role"
 _SOCKET_NAME = "authority.sock"
 _SOCKET_STARTUP_GRACE_SECONDS = 20.0
+_AUTHORITY_HMAC_SECRET_CONTAINER_PATH = "/run/secrets/autocontext-authority-hmac"
+_SAFE_AUTHORITY_HMAC_KEY_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$")
 
 
 class DockerProtectedKernelBenchmarkRunner:
@@ -84,6 +98,8 @@ class DockerProtectedKernelBenchmarkRunner:
         candidate_support_paths: Sequence[Path] = (),
         gpu_grant: DockerGPUDeviceGrant,
         gpu_attestor: DockerGPUDeviceAttestor,
+        authority_hmac_key_id: str,
+        authority_hmac_secret_path: Path,
         limits: DockerKernelWorkerLimits | None = None,
         docker_binary: str = "docker",
         source_suffix: str = ".py",
@@ -104,6 +120,8 @@ class DockerProtectedKernelBenchmarkRunner:
             raise RuntimeError(f"Docker executable is unavailable: {docker_binary}")
         if not container_python.startswith("/") or ".." in Path(container_python).parts:
             raise ValueError("container_python must be an absolute normalized container path")
+        if _SAFE_AUTHORITY_HMAC_KEY_ID.fullmatch(authority_hmac_key_id) is None:
+            raise ValueError("authority_hmac_key_id must be a safe non-empty identifier")
         self._evaluator_command = tuple(evaluator_command)
         self.image = image
         self.container_python = container_python
@@ -115,11 +133,20 @@ class DockerProtectedKernelBenchmarkRunner:
         if not self._evaluator_build_paths or any(path not in self._evaluator_paths for path in self._evaluator_build_paths):
             raise ValueError("evaluator build paths must be a non-empty subset of immutable evaluator paths")
         self._candidate_runtime = candidate_runtime_path.resolve(strict=True)
+        if not self._candidate_runtime.is_file():
+            raise ValueError("candidate_runtime_path must be a regular file")
         self._candidate_support = tuple(Path(path).resolve(strict=True) for path in candidate_support_paths)
-        if self._candidate_runtime in self._evaluator_paths:
+        secret_path = Path(authority_hmac_secret_path)
+        self._authority_hmac_secret_path = secret_path if secret_path.is_absolute() else Path.cwd() / secret_path
+        self._authority_hmac_secret = read_authority_hmac_secret(self._authority_hmac_secret_path)
+        self._authority_hmac_secret_path = self._authority_hmac_secret_path.resolve(strict=True)
+        self._authority_hmac_key_id = authority_hmac_key_id
+        if any(self._authority_hmac_secret_path.is_relative_to(path) for path in self._evaluator_paths):
+            raise ValueError("authority HMAC secret must use its dedicated evaluator-only mount")
+        if self._candidate_runtime in (*self._evaluator_paths, self._authority_hmac_secret_path):
             raise ValueError("candidate runtime cannot be an evaluator-private immutable path")
         for support_path in self._candidate_support:
-            for evaluator_path in self._evaluator_paths:
+            for evaluator_path in (*self._evaluator_paths, self._authority_hmac_secret_path):
                 if evaluator_path == support_path or evaluator_path.is_relative_to(support_path):
                     raise ValueError("candidate support paths cannot expose evaluator-private immutable material")
         self._evaluator_integrity_digest = _fingerprint_paths(self._evaluator_paths)
@@ -141,6 +168,7 @@ class DockerProtectedKernelBenchmarkRunner:
     def manifest(self) -> dict[str, Any]:
         """Return public deployment identity without private-plan paths."""
 
+        requirements = protected_evaluator_boundary_requirements()
         return {
             "kind": "docker-protected-accelerator-evaluator",
             "evidence_boundary": PROTECTED_EVALUATOR_BOUNDARY,
@@ -158,6 +186,14 @@ class DockerProtectedKernelBenchmarkRunner:
             "limits": asdict(self.limits),
             "candidate_mount_policy": "source+runtime+public-support+one-readonly-socket",
             "evaluator_mount_policy": "private-harness+channels+report;no-generated-source",
+            "authority_authentication": {"algorithm": "hmac-sha256", "key_id": self._authority_hmac_key_id},
+            "protected_boundary_requirements": requirements,
+            "crash_safe_container_creation": requirements["crash_safe_container_creation"],
+            "accelerator_role_isolation": requirements["accelerator_role_isolation"],
+            "trusted_out_of_process_mutation_observation": requirements[
+                "trusted_out_of_process_mutation_observation"
+            ],
+            "comparable_timing_boundaries": requirements["comparable_timing_boundaries"],
             "network": "deny",
             "ambient_credentials": "scrubbed",
         }
@@ -173,6 +209,13 @@ class DockerProtectedKernelBenchmarkRunner:
             raise ValueError("timeout_seconds must be positive and finite")
         if candidate.source_suffix != self._source_suffix or incumbent.source_suffix != self._source_suffix:
             return KernelBenchmarkExecution(returncode=None, error="candidate/incumbent suffix does not match runner")
+        policy_error = protected_evaluator_boundary_error()
+        if policy_error is not None:
+            return KernelBenchmarkExecution(
+                returncode=None,
+                error=policy_error,
+                outcome="resource_policy_unsupported",
+            )
         attestation, attestation_error = self._attest_accelerator()
         if attestation_error is not None:
             return KernelBenchmarkExecution(
@@ -195,7 +238,7 @@ class DockerProtectedKernelBenchmarkRunner:
                 error=f"authority orphan reconciliation failed: {type(exc).__name__}: {exc}",
                 outcome="teardown_failed",
             )
-        if not self._image_available():
+        if not docker_image_available(self.docker_binary, self.image):
             return KernelBenchmarkExecution(returncode=None, error="pinned protected-evaluator image is unavailable")
         return self._run_session(candidate, incumbent, attestation, timeout_seconds=timeout_seconds)
 
@@ -293,66 +336,62 @@ class DockerProtectedKernelBenchmarkRunner:
         deadline = time.monotonic() + timeout_seconds
         evaluator: subprocess.Popen[bytes] | None = None
         candidates: list[subprocess.Popen[bytes]] = []
-        watchdogs: list[subprocess.Popen[bytes]] = []
+        watchdogs: dict[str, subprocess.Popen[bytes]] = {}
         stdout = _process_control.BoundedOutput()
         stderr = _process_control.BoundedOutput()
         drains: list[threading.Thread] = []
+        quota_exceeded = threading.Event()
+        quota_termination_started = threading.Event()
+        lifecycle_lock = threading.Lock()
         timed_out = False
         returncode: int | None = None
         outcome = "complete"
         error: str | None = None
         payload: dict[str, Any] | None = None
         cleanup_errors: list[str] = []
-        try:
-            evaluator = subprocess.Popen(  # noqa: S603
-                evaluator_command,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=sanitized_docker_environment(),
-            )
-            watchdogs.append(
-                launch_deadline_watchdog(
+
+        def terminate_for_output_quota() -> None:
+            with lifecycle_lock:
+                if quota_termination_started.is_set():
+                    return
+                quota_termination_started.set()
+                for name in names.values():
+                    try:
+                        self._remove_container(name)
+                    except (OSError, RuntimeError, subprocess.SubprocessError):
+                        pass
+
+        def launch(role: str, command: list[str], *, capture_output: bool) -> subprocess.Popen[bytes]:
+            with lifecycle_lock:
+                if quota_exceeded.is_set():
+                    raise subprocess.TimeoutExpired(command, timeout_seconds)
+                create_docker_container(command, timeout_seconds=deadline - time.monotonic())
+                watchdogs[role] = launch_deadline_watchdog(
                     self.docker_binary,
-                    names["evaluator"],
+                    names[role],
                     expires_at,
-                    watchdog_root / "evaluator-watchdog-ready",
+                    watchdog_root / f"{role}-watchdog-ready",
                 )
+                return start_attached_docker_container(
+                    self.docker_binary,
+                    names[role],
+                    capture_output=capture_output,
+                )
+
+        try:
+            evaluator = launch("evaluator", evaluator_command, capture_output=True)
+            drains = launch_bounded_output_drains(
+                evaluator,
+                max_output_bytes=self.limits.max_output_bytes,
+                stdout=stdout,
+                stderr=stderr,
+                quota_exceeded=quota_exceeded,
+                terminate=terminate_for_output_quota,
             )
-            assert evaluator.stdout is not None and evaluator.stderr is not None
-            drains = [
-                threading.Thread(
-                    target=_process_control.drain_bounded,
-                    args=(evaluator.stdout, stdout, self.limits.max_output_bytes),
-                    daemon=True,
-                ),
-                threading.Thread(
-                    target=_process_control.drain_bounded,
-                    args=(evaluator.stderr, stderr, self.limits.max_output_bytes),
-                    daemon=True,
-                ),
-            ]
-            for thread in drains:
-                thread.start()
             self._wait_for_evaluator_sockets(evaluator, socket_paths, deadline)
             for command in (candidate_command, incumbent_command):
-                candidate_process = subprocess.Popen(  # noqa: S603
-                    command,
-                    stdin=subprocess.DEVNULL,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    env=sanitized_docker_environment(),
-                )
-                candidates.append(candidate_process)
-                role = "candidate" if len(candidates) == 1 else "incumbent"
-                watchdogs.append(
-                    launch_deadline_watchdog(
-                        self.docker_binary,
-                        names[role],
-                        expires_at,
-                        watchdog_root / f"{role}-watchdog-ready",
-                    )
-                )
+                role = "candidate" if not candidates else "incumbent"
+                candidates.append(launch(role, command, capture_output=False))
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise subprocess.TimeoutExpired(evaluator_command, timeout_seconds)
@@ -372,31 +411,35 @@ class DockerProtectedKernelBenchmarkRunner:
                 else:
                     outcome = self._reported_failure_outcome(payload, default="complete")
         except subprocess.TimeoutExpired:
-            timed_out = True
-            outcome = "timeout"
-            error = "protected evaluator authority session timed out"
+            timed_out = not quota_exceeded.is_set()
+            outcome = "timeout" if timed_out else "resource_exceeded"
+            error = (
+                "protected evaluator authority session timed out"
+                if timed_out
+                else "protected evaluator diagnostic output exceeded its bounded channel"
+            )
         except (OSError, RuntimeError, ValueError) as exc:
             outcome = "evaluator_crashed"
             error = f"protected evaluator authority session failed: {type(exc).__name__}: {exc}"
         finally:
-            if evaluator is not None and evaluator.poll() is None:
-                evaluator.kill()
-            for process in candidates:
-                if process.poll() is None:
-                    process.kill()
-            for name in names.values():
+            roles = ("candidate", "incumbent")[: len(candidates)]
+            attached = [("evaluator", evaluator), *zip(roles, candidates, strict=True)]
+            cleanup_errors.extend(terminate_attached_docker_processes(attached))
+            for thread in drains:
+                thread.join(timeout=CLEANUP_TIMEOUT_SECONDS)
+            for role, name in names.items():
                 try:
                     self._remove_container(name)
                     self._verify_removed(name)
                 except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
                     cleanup_errors.append(f"{name}: {type(exc).__name__}: {exc}")
-            for index, watchdog in enumerate(watchdogs):
-                try:
-                    terminate_process_group(watchdog, description=f"authority watchdog {index}")
-                except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
-                    cleanup_errors.append(f"watchdog {index}: {type(exc).__name__}: {exc}")
-            for thread in drains:
-                thread.join(timeout=CLEANUP_TIMEOUT_SECONDS)
+                else:
+                    watchdog = watchdogs.get(role)
+                    if watchdog is not None:
+                        try:
+                            terminate_process_group(watchdog, description=f"{role} authority watchdog")
+                        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+                            cleanup_errors.append(f"{role} watchdog: {type(exc).__name__}: {exc}")
         if cleanup_errors:
             outcome = "teardown_failed"
             error = "; ".join(cleanup_errors)
@@ -442,7 +485,10 @@ class DockerProtectedKernelBenchmarkRunner:
             role="evaluator",
             attestation=attestation,
             expires_at=expires_at,
-            readonly_mounts={path: f"/evaluator/{index}" for index, path in enumerate(self._evaluator_paths)},
+            readonly_mounts={
+                **{path: f"/evaluator/{index}" for index, path in enumerate(self._evaluator_paths)},
+                self._authority_hmac_secret_path: _AUTHORITY_HMAC_SECRET_CONTAINER_PATH,
+            },
             writable_mounts={
                 candidate_channel: "/channels/candidate",
                 incumbent_channel: "/channels/incumbent",
@@ -452,6 +498,8 @@ class DockerProtectedKernelBenchmarkRunner:
             extra_environment={
                 "AUTOCONTEXT_EVALUATOR_BUILD_DIGEST": self._evaluator_digest,
                 "AUTOCONTEXT_BOUNDARY_MANIFEST_DIGEST": canonical_authority_digest(self.manifest()),
+                "AUTOCONTEXT_AUTHORITY_HMAC_KEY_ID": self._authority_hmac_key_id,
+                "AUTOCONTEXT_AUTHORITY_HMAC_SECRET_FILE": _AUTHORITY_HMAC_SECRET_CONTAINER_PATH,
             },
         )
 
@@ -636,7 +684,7 @@ class DockerProtectedKernelBenchmarkRunner:
         while time.monotonic() < startup_deadline:
             if evaluator.poll() is not None:
                 raise RuntimeError("trusted evaluator exited before creating authority sockets")
-            if all(self._is_socket(path) for path in paths):
+            if all(is_unix_socket(path) for path in paths):
                 return
             time.sleep(0.01)
         raise RuntimeError("trusted evaluator did not create bounded authority sockets before startup deadline")
@@ -660,14 +708,21 @@ class DockerProtectedKernelBenchmarkRunner:
         except (FileNotFoundError, json.JSONDecodeError, OSError, RecursionError, ValueError):
             return None
 
-    @staticmethod
     def _validate_receipt(
+        self,
         payload: dict[str, Any],
         attestation: DockerGPUDeviceAttestation,
     ) -> str | None:
         try:
             receipt = KernelEvaluatorAuthorityReceipt.model_validate(payload.get("evaluator_authority_receipt"))
-            verify_authority_receipt(receipt, payload)
+            verify_authority_receipt(
+                receipt,
+                payload,
+                trusted_key_id=self._authority_hmac_key_id,
+                trusted_secret=self._authority_hmac_secret,
+                expected_evaluator_build_digest=self._evaluator_digest,
+                expected_boundary_manifest_digest=canonical_authority_digest(self.manifest()),
+            )
         except (TypeError, ValueError):
             return "trusted evaluator report omitted or forged its authority receipt"
         accelerator = receipt.accelerator_attestation
@@ -731,47 +786,11 @@ class DockerProtectedKernelBenchmarkRunner:
         except OSError:
             return False
 
-    @staticmethod
-    def _is_socket(path: Path) -> bool:
-        try:
-            return stat.S_ISSOCK(path.lstat().st_mode)
-        except OSError:
-            return False
-
-    def _image_available(self) -> bool:
-        completed = subprocess.run(  # noqa: S603
-            [self.docker_binary, "image", "inspect", self.image],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=CLEANUP_TIMEOUT_SECONDS,
-            env=sanitized_docker_environment(),
-        )
-        return completed.returncode == 0
-
     def _remove_container(self, container_name: str) -> None:
-        completed = subprocess.run(  # noqa: S603
-            [self.docker_binary, "rm", "-f", container_name],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=CLEANUP_TIMEOUT_SECONDS,
-            env=sanitized_docker_environment(),
-        )
-        if completed.returncode != 0 and not docker_container_missing(completed):
-            raise RuntimeError((completed.stderr or completed.stdout).strip()[-240:])
+        remove_docker_container(self.docker_binary, container_name)
 
     def _verify_removed(self, container_name: str) -> None:
-        completed = subprocess.run(  # noqa: S603
-            [self.docker_binary, "ps", "-aq", "--filter", f"label={_OWNER_LABEL}={container_name}"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=CLEANUP_TIMEOUT_SECONDS,
-            env=sanitized_docker_environment(),
-        )
-        if completed.stdout.strip():
-            raise RuntimeError("authority container or descendant remained after teardown")
+        verify_docker_container_removed(self.docker_binary, container_name)
 
 
 __all__ = ["PROTECTED_EVALUATOR_BOUNDARY", "DockerProtectedKernelBenchmarkRunner"]

--- a/autocontext/src/autocontext/kernel_evolution/authority_tensor.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_tensor.py
@@ -1,0 +1,53 @@
+"""Canonical safetensors payloads for accelerator authority messages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.kernel_evolution.authority_protocol import canonical_authority_digest
+from autocontext.kernel_evolution.authority_wire import AuthorityWireError
+
+
+def _tensor_manifest(tensors: dict[str, Any]) -> dict[str, Any]:
+    return {
+        name: {
+            "dtype": str(tensor.dtype),
+            "shape": list(tensor.shape),
+            "stride": list(tensor.stride()),
+            "bytes": tensor.numel() * tensor.element_size(),
+        }
+        for name, tensor in sorted(tensors.items())
+    }
+
+
+def serialize_tensor_list(values: list[Any], *, prefix: str) -> tuple[bytes, str]:
+    """Serialize positional tensors without pickle or executable metadata."""
+
+    from safetensors.torch import save
+    from torch import Tensor
+
+    if any(not isinstance(value, Tensor) for value in values):
+        raise TypeError("authority v1 accepts only positional tensor values")
+    tensors = {
+        f"{prefix}_{index:04d}": value.detach().cpu().contiguous()
+        for index, value in enumerate(values)
+    }
+    payload = save(tensors) if tensors else b""
+    return payload, canonical_authority_digest(_tensor_manifest(tensors))
+
+
+def deserialize_tensor_list(payload: bytes, *, prefix: str) -> tuple[list[Any], str]:
+    """Decode a bounded safetensors payload with canonical positional names."""
+
+    from safetensors.torch import load
+
+    if not payload:
+        return [], canonical_authority_digest({})
+    tensors = load(payload)
+    expected = [f"{prefix}_{index:04d}" for index in range(len(tensors))]
+    if sorted(tensors) != expected:
+        raise AuthorityWireError("authority tensor payload contains non-canonical names")
+    return [tensors[name] for name in expected], canonical_authority_digest(_tensor_manifest(tensors))
+
+
+__all__ = ["deserialize_tensor_list", "serialize_tensor_list"]

--- a/autocontext/src/autocontext/kernel_evolution/authority_tensor.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_tensor.py
@@ -2,52 +2,325 @@
 
 from __future__ import annotations
 
+import json
+import re
+import struct
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from autocontext.kernel_evolution.authority_protocol import canonical_authority_digest
-from autocontext.kernel_evolution.authority_wire import AuthorityWireError
+from autocontext.kernel_evolution.authority_wire import MAX_AUTHORITY_PAYLOAD_BYTES, AuthorityWireError
+
+_TENSOR_MAGIC = b"ACTENS2\0"
+_PREFIX = struct.Struct("!8sI")
+_MAX_METADATA_BYTES = 1024 * 1024
+_MAX_TENSOR_COUNT = 4096
+_MAX_EXACT_LAYOUT_ELEMENTS = 65_536
+_SAFE_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_MANIFEST_FIELDS = {"bytes", "dtype", "shape", "storage_offset", "stride"}
 
 
-def _tensor_manifest(tensors: dict[str, Any]) -> dict[str, Any]:
+def _tensor_manifest(tensors: Mapping[str, Any]) -> dict[str, Any]:
     return {
         name: {
             "dtype": str(tensor.dtype),
             "shape": list(tensor.shape),
             "stride": list(tensor.stride()),
+            "storage_offset": tensor.storage_offset(),
             "bytes": tensor.numel() * tensor.element_size(),
         }
         for name, tensor in sorted(tensors.items())
     }
 
 
-def serialize_tensor_list(values: list[Any], *, prefix: str) -> tuple[bytes, str]:
-    """Serialize positional tensors without pickle or executable metadata."""
+def _checked_layout(
+    shape: Sequence[int],
+    stride: Sequence[int],
+    storage_offset: int,
+    element_size: int,
+) -> int:
+    """Return the required backing-storage length for a supported layout."""
 
-    from safetensors.torch import save
-    from torch import Tensor
+    if len(shape) != len(stride):
+        raise AuthorityWireError("authority tensor shape and stride ranks differ")
+    if storage_offset < 0 or element_size < 1:
+        raise AuthorityWireError("authority tensor has an invalid storage layout")
+    if any(dimension < 0 for dimension in shape) or any(step < 0 for step in stride):
+        raise AuthorityWireError("authority tensor uses an unsupported negative shape or stride")
 
+    logical_elements = 1
+    for dimension in shape:
+        logical_elements *= dimension
+    if logical_elements == 0:
+        storage_elements = storage_offset
+    else:
+        required_span = 1
+        needs_exact_check = False
+        for step, dimension in sorted(
+            (step, dimension) for step, dimension in zip(stride, shape, strict=True) if dimension > 1
+        ):
+            if step < required_span:
+                needs_exact_check = True
+            required_span += (dimension - 1) * step
+        storage_elements = storage_offset + required_span
+        if needs_exact_check:
+            if logical_elements > _MAX_EXACT_LAYOUT_ELEMENTS:
+                raise AuthorityWireError("authority tensor uses an unsupported irregular storage layout")
+            _reject_exact_layout_overlap(shape, stride)
+
+    if storage_elements * element_size > MAX_AUTHORITY_PAYLOAD_BYTES:
+        raise AuthorityWireError("authority tensor backing storage exceeds the wire payload limit")
+    return storage_elements
+
+
+def _reject_exact_layout_overlap(shape: Sequence[int], stride: Sequence[int]) -> None:
+    """Reject collisions by enumerating a fixed-bounded irregular layout."""
+
+    offsets = {0}
+    for dimension, step in zip(shape, stride, strict=True):
+        if dimension <= 1:
+            continue
+        expanded: set[int] = set()
+        for index in range(dimension):
+            delta = index * step
+            for offset in offsets:
+                expanded_offset = offset + delta
+                if expanded_offset in expanded:
+                    raise AuthorityWireError("authority tensor uses unsupported overlapping storage")
+                expanded.add(expanded_offset)
+        offsets = expanded
+
+
+def _storage_identity(tensor: Any) -> tuple[str, int] | None:
+    try:
+        storage = tensor.untyped_storage()
+    except (RuntimeError, TypeError) as exc:
+        raise AuthorityWireError("authority tensor does not expose supported backing storage") from exc
+    if storage.nbytes() == 0:
+        return None
+    return str(tensor.device), int(storage.data_ptr())
+
+
+def _validate_source_tensors(values: Sequence[Any]) -> None:
+    from torch import Tensor, strided
+
+    if len(values) > _MAX_TENSOR_COUNT:
+        raise AuthorityWireError("authority tensor payload contains too many tensors")
     if any(not isinstance(value, Tensor) for value in values):
         raise TypeError("authority v1 accepts only positional tensor values")
-    tensors = {
-        f"{prefix}_{index:04d}": value.detach().cpu().contiguous()
-        for index, value in enumerate(values)
-    }
-    payload = save(tensors) if tensors else b""
-    return payload, canonical_authority_digest(_tensor_manifest(tensors))
+
+    storage_identities: set[tuple[str, int]] = set()
+    for value in values:
+        if value.layout != strided or value.is_quantized or value.device.type == "meta":
+            raise AuthorityWireError("authority tensor uses an unsupported layout or device")
+        shape = tuple(int(dimension) for dimension in value.shape)
+        stride = tuple(int(step) for step in value.stride())
+        _checked_layout(shape, stride, int(value.storage_offset()), int(value.element_size()))
+        identity = _storage_identity(value)
+        if identity is not None and identity in storage_identities:
+            raise AuthorityWireError("authority tensor list contains unsupported storage aliases")
+        if identity is not None:
+            storage_identities.add(identity)
+
+
+def _canonical_tensor_names(prefix: str, count: int) -> list[str]:
+    if _SAFE_NAME.fullmatch(prefix) is None:
+        raise ValueError("authority tensor prefix is not a safe canonical name")
+    return [f"{prefix}_{index:04d}" for index in range(count)]
+
+
+def _encode_metadata(magic: bytes, metadata: dict[str, Any], body: bytes) -> bytes:
+    encoded = json.dumps(metadata, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(encoded) > _MAX_METADATA_BYTES:
+        raise AuthorityWireError("authority tensor metadata exceeded its fixed byte limit")
+    payload = _PREFIX.pack(magic, len(encoded)) + encoded + body
+    if len(payload) > MAX_AUTHORITY_PAYLOAD_BYTES:
+        raise AuthorityWireError("authority tensor payload exceeded the wire payload limit")
+    return payload
+
+
+def _decode_metadata(payload: bytes, magic: bytes) -> tuple[dict[str, Any], bytes]:
+    if len(payload) < _PREFIX.size:
+        raise AuthorityWireError("authority tensor payload ended before its metadata prefix")
+    decoded_magic, metadata_size = _PREFIX.unpack(payload[: _PREFIX.size])
+    if decoded_magic != magic:
+        raise AuthorityWireError("authority tensor payload used an unknown format")
+    if metadata_size < 2 or metadata_size > _MAX_METADATA_BYTES:
+        raise AuthorityWireError("authority tensor payload declared invalid metadata")
+    body_offset = _PREFIX.size + metadata_size
+    if body_offset > len(payload):
+        raise AuthorityWireError("authority tensor payload ended before its declared metadata")
+    try:
+        metadata = json.loads(
+            payload[_PREFIX.size : body_offset].decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError, ValueError) as exc:
+        raise AuthorityWireError("authority tensor payload contained invalid metadata") from exc
+    if not isinstance(metadata, dict):
+        raise AuthorityWireError("authority tensor metadata must be an object")
+    return metadata, payload[body_offset:]
+
+
+def serialize_tensor_list(values: list[Any], *, prefix: str) -> tuple[bytes, str]:
+    """Serialize positional tensors while retaining their exact strided ABI."""
+
+    if len(values) > _MAX_TENSOR_COUNT:
+        raise AuthorityWireError("authority tensor payload contains too many tensors")
+    names = _canonical_tensor_names(prefix, len(values))
+    if not names:
+        return b"", canonical_authority_digest({})
+    import torch
+    from safetensors.torch import save
+
+    _validate_source_tensors(values)
+    storages: dict[str, Any] = {}
+    views: dict[str, Any] = {}
+    planned_bytes = 0
+    for name, value in zip(names, values, strict=True):
+        shape = tuple(int(dimension) for dimension in value.shape)
+        stride = tuple(int(step) for step in value.stride())
+        storage_offset = int(value.storage_offset())
+        storage_elements = _checked_layout(shape, stride, storage_offset, int(value.element_size()))
+        planned_bytes += storage_elements * int(value.element_size())
+        if planned_bytes > MAX_AUTHORITY_PAYLOAD_BYTES:
+            raise AuthorityWireError("authority tensor backing storage exceeds the wire payload limit")
+        try:
+            storage = torch.zeros(storage_elements, dtype=value.dtype, device="cpu")
+            view = torch.as_strided(storage, shape, stride, storage_offset)
+            view.copy_(value.detach().resolve_conj().resolve_neg().cpu())
+        except (RuntimeError, TypeError) as exc:
+            raise AuthorityWireError("authority tensor could not preserve its declared storage layout") from exc
+        storages[name] = storage
+        views[name] = view
+
+    manifest = _tensor_manifest(views)
+    try:
+        safetensors_payload = save(storages)
+    except Exception as exc:
+        raise AuthorityWireError("authority tensor dtype is not supported by safetensors") from exc
+    payload = _encode_metadata(_TENSOR_MAGIC, manifest, safetensors_payload)
+    return payload, canonical_authority_digest(manifest)
+
+
+def _validate_manifest(metadata: dict[str, Any], prefix: str) -> list[str]:
+    if len(metadata) > _MAX_TENSOR_COUNT:
+        raise AuthorityWireError("authority tensor payload contains too many tensors")
+    names = _canonical_tensor_names(prefix, len(metadata))
+    if sorted(metadata) != names:
+        raise AuthorityWireError("authority tensor payload contains non-canonical names")
+    for name in names:
+        entry = metadata[name]
+        if not isinstance(entry, dict) or set(entry) != _MANIFEST_FIELDS:
+            raise AuthorityWireError("authority tensor manifest has an invalid entry")
+        shape = entry["shape"]
+        stride = entry["stride"]
+        if (
+            not isinstance(entry["dtype"], str)
+            or not isinstance(shape, list)
+            or not isinstance(stride, list)
+            or any(type(value) is not int for value in shape)
+            or any(type(value) is not int for value in stride)
+            or type(entry["storage_offset"]) is not int
+            or type(entry["bytes"]) is not int
+            or entry["bytes"] < 0
+        ):
+            raise AuthorityWireError("authority tensor manifest contains invalid ABI metadata")
+    return names
 
 
 def deserialize_tensor_list(payload: bytes, *, prefix: str) -> tuple[list[Any], str]:
-    """Decode a bounded safetensors payload with canonical positional names."""
-
-    from safetensors.torch import load
+    """Decode a bounded safetensors payload and reconstruct its exact ABI."""
 
     if not payload:
         return [], canonical_authority_digest({})
-    tensors = load(payload)
-    expected = [f"{prefix}_{index:04d}" for index in range(len(tensors))]
-    if sorted(tensors) != expected:
-        raise AuthorityWireError("authority tensor payload contains non-canonical names")
-    return [tensors[name] for name in expected], canonical_authority_digest(_tensor_manifest(tensors))
+    import torch
+    from safetensors.torch import load
+
+    manifest, safetensors_payload = _decode_metadata(payload, _TENSOR_MAGIC)
+    names = _validate_manifest(manifest, prefix)
+    if not names:
+        raise AuthorityWireError("empty authority tensor lists must use the canonical empty payload")
+    try:
+        storages = load(safetensors_payload)
+    except Exception as exc:
+        raise AuthorityWireError("authority tensor payload contained invalid safetensors storage") from exc
+    if sorted(storages) != names:
+        raise AuthorityWireError("authority tensor storage contains non-canonical names")
+
+    tensors: dict[str, Any] = {}
+    for name in names:
+        entry = manifest[name]
+        storage = storages[name]
+        shape = tuple(entry["shape"])
+        stride = tuple(entry["stride"])
+        storage_offset = entry["storage_offset"]
+        if storage.ndim != 1 or not storage.is_contiguous() or storage.storage_offset() != 0:
+            raise AuthorityWireError("authority tensor backing storage is not canonical")
+        if str(storage.dtype) != entry["dtype"]:
+            raise AuthorityWireError("authority tensor dtype does not match its manifest")
+        expected_elements = _checked_layout(shape, stride, storage_offset, int(storage.element_size()))
+        logical_elements = 1
+        for dimension in shape:
+            logical_elements *= dimension
+        if storage.numel() != expected_elements or entry["bytes"] != logical_elements * storage.element_size():
+            raise AuthorityWireError("authority tensor storage size does not match its manifest")
+        try:
+            tensors[name] = torch.as_strided(storage, shape, stride, storage_offset)
+        except RuntimeError as exc:
+            raise AuthorityWireError("authority tensor manifest declared an invalid storage view") from exc
+
+    decoded_manifest = _tensor_manifest(tensors)
+    if decoded_manifest != manifest:
+        raise AuthorityWireError("authority tensor ABI does not match its canonical manifest")
+    return [tensors[name] for name in names], canonical_authority_digest(decoded_manifest)
 
 
-__all__ = ["deserialize_tensor_list", "serialize_tensor_list"]
+def copy_tensor_to_device_preserving_abi(value: Any, *, device: str) -> Any:
+    """Copy canonical tensor storage to a device without compacting its view."""
+
+    import torch
+
+    _validate_source_tensors([value])
+    shape = tuple(int(dimension) for dimension in value.shape)
+    stride = tuple(int(step) for step in value.stride())
+    storage_offset = int(value.storage_offset())
+    storage_elements = _checked_layout(shape, stride, storage_offset, int(value.element_size()))
+    try:
+        if value.numel() == 0:
+            target_storage = torch.zeros(storage_elements, dtype=value.dtype, device=device)
+        else:
+            source_storage = torch.as_strided(value, (storage_elements,), (1,), 0)
+            target_storage = source_storage.to(device=device, non_blocking=False, copy=True)
+        copied = torch.as_strided(target_storage, shape, stride, storage_offset)
+    except (RuntimeError, TypeError) as exc:
+        raise AuthorityWireError("device transfer could not preserve the authority tensor ABI") from exc
+    if (
+        copied.dtype != value.dtype
+        or copied.shape != value.shape
+        or copied.stride() != value.stride()
+        or copied.storage_offset() != value.storage_offset()
+    ):
+        raise AuthorityWireError("device transfer changed the authority tensor ABI")
+    return copied
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant {value}")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate authority tensor metadata key")
+        result[key] = value
+    return result
+
+
+__all__ = [
+    "copy_tensor_to_device_preserving_abi",
+    "deserialize_tensor_list",
+    "serialize_tensor_list",
+]

--- a/autocontext/src/autocontext/kernel_evolution/authority_wire.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_wire.py
@@ -6,7 +6,7 @@ import json
 import socket
 import struct
 from collections.abc import Callable
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from pydantic import ValidationError
 
@@ -66,7 +66,7 @@ def receive_authority_frame(
     *,
     max_payload_bytes: int = MAX_AUTHORITY_PAYLOAD_BYTES,
 ) -> tuple[_MessageT, bytes]:
-    """Read and validate one frame without invoking pickle or object hooks."""
+    """Read and validate one frame without invoking pickle or object construction."""
 
     if max_payload_bytes < 0:
         raise ValueError("max_payload_bytes must be non-negative")
@@ -81,7 +81,11 @@ def receive_authority_frame(
     raw_header = _read_exact(connection.recv, header_size)
     payload = _read_exact(connection.recv, payload_size)
     try:
-        decoded = json.loads(raw_header.decode("utf-8"), parse_constant=_reject_json_constant)
+        decoded = json.loads(
+            raw_header.decode("utf-8"),
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
         message = model.model_validate(decoded)
     except (UnicodeDecodeError, json.JSONDecodeError, ValidationError, RecursionError, ValueError) as exc:
         raise AuthorityWireError("authority frame contained an invalid typed JSON header") from exc
@@ -104,6 +108,15 @@ def send_authority_frame(
 
 def _reject_json_constant(value: str) -> None:
     raise ValueError(f"invalid JSON constant {value}")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    decoded: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in decoded:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        decoded[key] = value
+    return decoded
 
 
 __all__ = [

--- a/autocontext/src/autocontext/kernel_evolution/authority_wire.py
+++ b/autocontext/src/autocontext/kernel_evolution/authority_wire.py
@@ -1,0 +1,117 @@
+"""Bounded, non-pickle framing for isolated accelerator authorities."""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+from collections.abc import Callable
+from typing import TypeVar
+
+from pydantic import ValidationError
+
+from autocontext.kernel_evolution.authority_protocol import (
+    AuthorityRequest,
+    AuthorityResponse,
+    canonical_authority_digest,
+)
+
+WIRE_MAGIC = b"ACAB1\0"
+MAX_AUTHORITY_HEADER_BYTES = 32 * 1024
+MAX_AUTHORITY_PAYLOAD_BYTES = 512 * 1024 * 1024
+_PREFIX = struct.Struct("!6sIQ")
+_MessageT = TypeVar("_MessageT", AuthorityRequest, AuthorityResponse)
+
+
+class AuthorityWireError(ValueError):
+    """Raised when an authority frame is malformed, oversized, or truncated."""
+
+
+def _read_exact(receiver: Callable[[int], bytes], size: int) -> bytes:
+    payload = bytearray()
+    while len(payload) < size:
+        chunk = receiver(size - len(payload))
+        if not chunk:
+            raise AuthorityWireError("authority frame ended before its declared length")
+        payload.extend(chunk)
+    return bytes(payload)
+
+
+def encode_authority_frame(
+    message: AuthorityRequest | AuthorityResponse,
+    payload: bytes,
+    *,
+    max_payload_bytes: int = MAX_AUTHORITY_PAYLOAD_BYTES,
+) -> bytes:
+    """Encode one typed header plus opaque tensor bytes with fixed framing."""
+
+    if max_payload_bytes < 0 or len(payload) > max_payload_bytes:
+        raise AuthorityWireError("authority payload exceeded its configured byte limit")
+    if message.payload_bytes != len(payload) or message.payload_digest != canonical_authority_digest(payload):
+        raise AuthorityWireError("authority payload does not match its typed size and digest")
+    header = json.dumps(
+        message.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    if len(header) > MAX_AUTHORITY_HEADER_BYTES:
+        raise AuthorityWireError("authority header exceeded its fixed byte limit")
+    return _PREFIX.pack(WIRE_MAGIC, len(header), len(payload)) + header + payload
+
+
+def receive_authority_frame(
+    connection: socket.socket,
+    model: type[_MessageT],
+    *,
+    max_payload_bytes: int = MAX_AUTHORITY_PAYLOAD_BYTES,
+) -> tuple[_MessageT, bytes]:
+    """Read and validate one frame without invoking pickle or object hooks."""
+
+    if max_payload_bytes < 0:
+        raise ValueError("max_payload_bytes must be non-negative")
+    prefix = _read_exact(connection.recv, _PREFIX.size)
+    magic, header_size, payload_size = _PREFIX.unpack(prefix)
+    if magic != WIRE_MAGIC:
+        raise AuthorityWireError("authority frame used an unknown wire protocol")
+    if header_size < 2 or header_size > MAX_AUTHORITY_HEADER_BYTES:
+        raise AuthorityWireError("authority frame declared an invalid header size")
+    if payload_size > max_payload_bytes:
+        raise AuthorityWireError("authority frame declared an oversized payload")
+    raw_header = _read_exact(connection.recv, header_size)
+    payload = _read_exact(connection.recv, payload_size)
+    try:
+        decoded = json.loads(raw_header.decode("utf-8"), parse_constant=_reject_json_constant)
+        message = model.model_validate(decoded)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError, RecursionError, ValueError) as exc:
+        raise AuthorityWireError("authority frame contained an invalid typed JSON header") from exc
+    if message.payload_bytes != len(payload) or message.payload_digest != canonical_authority_digest(payload):
+        raise AuthorityWireError("authority frame payload failed size or digest validation")
+    return message, payload
+
+
+def send_authority_frame(
+    connection: socket.socket,
+    message: AuthorityRequest | AuthorityResponse,
+    payload: bytes,
+    *,
+    max_payload_bytes: int = MAX_AUTHORITY_PAYLOAD_BYTES,
+) -> None:
+    """Send exactly one bounded authority frame."""
+
+    connection.sendall(encode_authority_frame(message, payload, max_payload_bytes=max_payload_bytes))
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant {value}")
+
+
+__all__ = [
+    "MAX_AUTHORITY_HEADER_BYTES",
+    "MAX_AUTHORITY_PAYLOAD_BYTES",
+    "WIRE_MAGIC",
+    "AuthorityWireError",
+    "encode_authority_frame",
+    "receive_authority_frame",
+    "send_authority_frame",
+]

--- a/autocontext/src/autocontext/kernel_evolution/benchmark.py
+++ b/autocontext/src/autocontext/kernel_evolution/benchmark.py
@@ -13,13 +13,14 @@ import sys
 import tempfile
 import threading
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, NoReturn, Protocol
 
 from pydantic import ValidationError
 
 from autocontext.kernel_evolution import _process_control
+from autocontext.kernel_evolution.benchmark_authority import BenchmarkAuthorityVerifier
 from autocontext.kernel_evolution.evaluator_config import KernelBenchmarkEvaluatorConfig
 from autocontext.kernel_evolution.models import (
     ARTIFACT_IDENTITY_VERSION,
@@ -28,26 +29,14 @@ from autocontext.kernel_evolution.models import (
     KernelCandidate,
     content_digest,
 )
-from autocontext.kernel_evolution.promotion_statistics import (
-    bootstrap_lcb,
-    geometric_mean_ratio,
-    percentile,
-)
+from autocontext.kernel_evolution.promotion_statistics import bootstrap_lcb, geometric_mean_ratio, percentile
 from autocontext.kernel_evolution.resource_policy import evaluate_kernel_resource_policy
 
 _WINDOWS_LAUNCH_GATE = b"\x01"
 KernelBenchmarkExecutionOutcome = Literal[
-    "complete",
-    "timeout",
-    "oom",
-    "resource_exceeded",
-    "resource_policy_unsupported",
-    "missing_resource_telemetry",
-    "resource_identity_mismatch",
-    "protocol_corruption",
-    "evaluator_crashed",
-    "candidate_crashed",
-    "teardown_failed",
+    "complete", "timeout", "oom", "resource_exceeded", "resource_policy_unsupported",
+    "missing_resource_telemetry", "resource_identity_mismatch", "protocol_corruption",
+    "evaluator_crashed", "candidate_crashed", "teardown_failed",
 ]
 
 
@@ -594,9 +583,10 @@ class KernelBenchmarkEvaluator:
     def __init__(self, runner: KernelBenchmarkRunner, config: KernelBenchmarkEvaluatorConfig) -> None:
         self._runner = runner
         self.config = config
+        self._authority = BenchmarkAuthorityVerifier(config)
 
     def manifest(self) -> dict[str, Any]:
-        return {"evaluator": asdict(self.config), "runner": self._runner.manifest()}
+        return {"evaluator": self.config.manifest(), "runner": self._runner.manifest()}
 
     def evaluate(
         self,
@@ -641,10 +631,12 @@ class KernelBenchmarkEvaluator:
             return reject("harness_modified", "The immutable benchmark harness changed during evaluation.")
         if not execution.candidate_unchanged or not execution.incumbent_unchanged:
             return reject("artifact_modified", "A candidate or incumbent artifact changed during evaluation.")
+        if execution.outcome == "teardown_failed":
+            return reject("teardown_failed", execution.error or "Benchmark authority teardown could not be verified.")
+        if execution.outcome != "complete":
+            return reject(execution.outcome, execution.error or f"Benchmark failed with {execution.outcome}.")
         if execution.timed_out:
             return reject("timeout", f"Benchmark timed out after {self.config.timeout_seconds:g}s.")
-        if execution.outcome != "complete" and execution.report_payload is None:
-            return reject(execution.outcome, execution.error or f"Benchmark failed with {execution.outcome}.")
         if execution.error is not None and execution.outcome == "complete":
             return reject("contract_error", execution.error)
         if execution.returncode != 0 and execution.outcome == "complete":
@@ -679,14 +671,9 @@ class KernelBenchmarkEvaluator:
                 "Report source digest, suffix, entrypoint, or ABI-bound artifact identity does not match the evaluated pair.",
                 report,
             )
-        if self.config.require_authority_receipt and report.evaluator_authority_receipt is None:
-            return reject(
-                "missing_authority_receipt",
-                "Production evaluation requires a trusted-evaluator authority receipt.",
-                report,
-            )
-        if execution.outcome != "complete":
-            return reject(execution.outcome, execution.error or f"Benchmark failed with {execution.outcome}.", report)
+        authority_rejection = self._authority.verify_receipt(report)
+        if authority_rejection is not None:
+            return reject(authority_rejection[0], authority_rejection[1], report)
         if expected_scope_id is not None and report.hardware_scope_id != expected_scope_id:
             return reject("scope_mismatch", "Hardware, toolchain, or workload fingerprint changed during the run.", report)
         if expected_baseline_id is not None and report.baseline_id != expected_baseline_id:
@@ -711,6 +698,9 @@ class KernelBenchmarkEvaluator:
             return reject("correctness_failed", f"Candidate correctness failed: {failures}", report)
         if report.evaluation_status != "complete" or report.performance is None:
             return reject("contract_error", "A successful candidate report did not contain performance measurements.", report)
+        timing_rejection = self._authority.verify_timing_comparability(report)
+        if timing_rejection is not None:
+            return reject(timing_rejection[0], timing_rejection[1], report)
         resource_policy = evaluate_kernel_resource_policy(
             report,
             require_telemetry=self.config.require_resource_telemetry,

--- a/autocontext/src/autocontext/kernel_evolution/benchmark.py
+++ b/autocontext/src/autocontext/kernel_evolution/benchmark.py
@@ -44,6 +44,9 @@ KernelBenchmarkExecutionOutcome = Literal[
     "resource_policy_unsupported",
     "missing_resource_telemetry",
     "resource_identity_mismatch",
+    "protocol_corruption",
+    "evaluator_crashed",
+    "candidate_crashed",
     "teardown_failed",
 ]
 
@@ -674,6 +677,12 @@ class KernelBenchmarkEvaluator:
             return reject(
                 "identity_mismatch",
                 "Report source digest, suffix, entrypoint, or ABI-bound artifact identity does not match the evaluated pair.",
+                report,
+            )
+        if self.config.require_authority_receipt and report.evaluator_authority_receipt is None:
+            return reject(
+                "missing_authority_receipt",
+                "Production evaluation requires a trusted-evaluator authority receipt.",
                 report,
             )
         if execution.outcome != "complete":

--- a/autocontext/src/autocontext/kernel_evolution/benchmark_authority.py
+++ b/autocontext/src/autocontext/kernel_evolution/benchmark_authority.py
@@ -1,0 +1,78 @@
+"""Authenticated authority and timing-boundary policy for benchmark reports."""
+
+from __future__ import annotations
+
+from autocontext.kernel_evolution.authority_protocol import (
+    read_authority_hmac_secret,
+    verify_authority_receipt,
+)
+from autocontext.kernel_evolution.evaluator_config import KernelBenchmarkEvaluatorConfig
+from autocontext.kernel_evolution.models import KernelBenchmarkReport
+
+AuthorityRejection = tuple[str, str]
+
+
+class BenchmarkAuthorityVerifier:
+    """Keep host trust material private while returning bounded rejection details."""
+
+    def __init__(self, config: KernelBenchmarkEvaluatorConfig) -> None:
+        self._config = config
+        self._secret = (
+            read_authority_hmac_secret(config.authority_hmac_secret_path)
+            if config.authority_hmac_secret_path is not None
+            else None
+        )
+
+    def verify_receipt(self, report: KernelBenchmarkReport) -> AuthorityRejection | None:
+        """Authenticate required receipts against the operator-pinned identity."""
+
+        if not self._config.require_authority_receipt:
+            return None
+        receipt = report.evaluator_authority_receipt
+        if receipt is None:
+            return (
+                "missing_authority_receipt",
+                "Production evaluation requires a trusted-evaluator authority receipt.",
+            )
+        assert self._config.authority_hmac_key_id is not None
+        assert self._config.expected_evaluator_build_digest is not None
+        assert self._config.expected_boundary_manifest_digest is not None
+        assert self._secret is not None
+        try:
+            verify_authority_receipt(
+                receipt,
+                report.model_dump(mode="json"),
+                trusted_key_id=self._config.authority_hmac_key_id,
+                trusted_secret=self._secret,
+                expected_evaluator_build_digest=self._config.expected_evaluator_build_digest,
+                expected_boundary_manifest_digest=self._config.expected_boundary_manifest_digest,
+            )
+        except (TypeError, ValueError) as exc:
+            return (
+                "invalid_authority_receipt",
+                f"Trusted-evaluator authority receipt verification failed: {exc}",
+            )
+        return None
+
+    def verify_timing_comparability(self, report: KernelBenchmarkReport) -> AuthorityRejection | None:
+        """Reject metrics that mix incomparable candidate/reference timing boundaries."""
+
+        evidence = report.metadata.get("timing_comparability")
+        if self._config.require_authority_receipt and not isinstance(evidence, dict):
+            return (
+                "timing_boundary_mismatch",
+                "Protected evaluation omitted its trusted timing-boundary comparability evidence.",
+            )
+        if isinstance(evidence, dict) and (
+            evidence.get("candidate_incumbent_comparable") is not True
+            or evidence.get("reference_comparable") is not True
+            or evidence.get("promotion_comparison") != ["candidate_ms", "incumbent_ms"]
+        ):
+            return (
+                "timing_boundary_mismatch",
+                "Candidate, incumbent, and reference timings were not measured under comparable trusted boundaries.",
+            )
+        return None
+
+
+__all__ = ["BenchmarkAuthorityVerifier"]

--- a/autocontext/src/autocontext/kernel_evolution/docker_watchdog.py
+++ b/autocontext/src/autocontext/kernel_evolution/docker_watchdog.py
@@ -66,6 +66,7 @@ def launch_deadline_watchdog(
             container_name,
             f"{expires_at:.9f}",
             str(ready_path),
+            str(os.getpid()),
         ],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
@@ -90,8 +91,9 @@ def run_deadline_watchdog(
     container_name: str,
     expires_at: float,
     ready_path: Path,
+    coordinator_pid: int | None = None,
 ) -> int:
-    """Remove the owned container at its wall deadline, even if the coordinator dies."""
+    """Remove the owned container at its deadline or when its coordinator dies."""
 
     if (
         not docker_binary
@@ -100,6 +102,7 @@ def run_deadline_watchdog(
         or re.fullmatch(r"[A-Za-z0-9_.-]+", container_name) is None
         or not math.isfinite(expires_at)
         or expires_at <= 0
+        or (coordinator_pid is not None and coordinator_pid < 2)
     ):
         return 2
     try:
@@ -107,7 +110,7 @@ def run_deadline_watchdog(
     except OSError:
         return 2
     deadline = time.monotonic() + max(0.0, expires_at - time.time())
-    while time.monotonic() < deadline:
+    while time.monotonic() < deadline and (coordinator_pid is None or os.getppid() == coordinator_pid):
         time.sleep(min(_POLL_SECONDS, max(0.0, deadline - time.monotonic())))
 
     env = sanitized_docker_environment()
@@ -143,13 +146,14 @@ def run_deadline_watchdog(
 
 
 def _entrypoint(argv: Sequence[str]) -> int:
-    if len(argv) != 6 or argv[1] != "--docker-deadline-watchdog":
+    if len(argv) != 7 or argv[1] != "--docker-deadline-watchdog":
         return 2
     try:
         expires_at = float(argv[4])
+        coordinator_pid = int(argv[6])
     except ValueError:
         return 2
-    return run_deadline_watchdog(argv[2], argv[3], expires_at, Path(argv[5]))
+    return run_deadline_watchdog(argv[2], argv[3], expires_at, Path(argv[5]), coordinator_pid)
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised as a detached host helper

--- a/autocontext/src/autocontext/kernel_evolution/docker_watchdog.py
+++ b/autocontext/src/autocontext/kernel_evolution/docker_watchdog.py
@@ -6,23 +6,159 @@ import math
 import os
 import re
 import signal
+import stat
 import subprocess
 import sys
+import threading
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import Any
 
 from autocontext.execution.docker_isolation import sanitized_docker_environment
+from autocontext.kernel_evolution import _process_control
 
 DOCKER_KERNEL_OWNER_LABEL = "ai.autocontext.kernel-worker"
 CLEANUP_TIMEOUT_SECONDS = 10.0
 _POLL_SECONDS = 0.2
 
 
+def crash_safe_container_creation_policy() -> dict[str, bool | str]:
+    """Describe the unavailable creator-supervisor ownership boundary."""
+
+    return {
+        "required": "supervised-create-before-coordinator-ownership/v1",
+        "available": False,
+        "reason": (
+            "protected accelerator evidence requires crash-safe container creation; "
+            "the v1 coordinator-owned docker create path is unsupported"
+        ),
+    }
+
+
 def docker_container_missing(completed: subprocess.CompletedProcess[Any]) -> bool:
     detail = f"{completed.stderr or ''}\n{completed.stdout or ''}".casefold()
     return "no such container" in detail or "no such object" in detail
+
+
+def is_unix_socket(path: Path) -> bool:
+    """Return whether a path currently names a Unix-domain socket."""
+
+    try:
+        return stat.S_ISSOCK(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
+def create_docker_container(command: Sequence[str], *, timeout_seconds: float) -> None:
+    """Create, but do not start, one fully configured Docker container."""
+
+    if len(command) < 2 or command[1] != "run":
+        raise RuntimeError("Docker authority command must begin with 'docker run'")
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise subprocess.TimeoutExpired(command, max(0.0, timeout_seconds))
+    completed = subprocess.run(  # noqa: S603
+        [command[0], "create", *command[2:]],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        env=sanitized_docker_environment(),
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()[-240:]
+        raise RuntimeError(f"Docker authority container creation failed: {detail or 'unknown error'}")
+
+
+def start_attached_docker_container(
+    docker_binary: str,
+    container_name: str,
+    *,
+    capture_output: bool,
+) -> subprocess.Popen[bytes]:
+    """Start and attach to a container that already has a live watchdog."""
+
+    output = subprocess.PIPE if capture_output else subprocess.DEVNULL
+    return subprocess.Popen(  # noqa: S603
+        [docker_binary, "start", "--attach", container_name],
+        stdin=subprocess.DEVNULL,
+        stdout=output,
+        stderr=output,
+        start_new_session=True,
+        env=sanitized_docker_environment(),
+    )
+
+
+def launch_bounded_output_drains(
+    process: subprocess.Popen[bytes],
+    *,
+    max_output_bytes: int,
+    stdout: _process_control.BoundedOutput,
+    stderr: _process_control.BoundedOutput,
+    quota_exceeded: threading.Event,
+    terminate: Callable[[], None],
+) -> list[threading.Thread]:
+    """Drain both attached pipes with the shared quota and termination signal."""
+
+    assert process.stdout is not None and process.stderr is not None
+    drains = [
+        threading.Thread(
+            target=_process_control.drain_bounded,
+            args=(stream, max_output_bytes, result, quota_exceeded, terminate),
+            daemon=True,
+        )
+        for stream, result in ((process.stdout, stdout), (process.stderr, stderr))
+    ]
+    for thread in drains:
+        thread.start()
+    return drains
+
+
+def remove_docker_container(docker_binary: str, container_identity: str) -> None:
+    """Force-remove one exact Docker container identity."""
+
+    completed = subprocess.run(  # noqa: S603
+        [docker_binary, "rm", "-f", container_identity],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=CLEANUP_TIMEOUT_SECONDS,
+        env=sanitized_docker_environment(),
+    )
+    if completed.returncode != 0 and not docker_container_missing(completed):
+        raise RuntimeError((completed.stderr or completed.stdout).strip()[-240:])
+
+
+def verify_docker_container_removed(docker_binary: str, container_identity: str) -> None:
+    """Fail unless Docker confirms that the exact identity is absent."""
+
+    completed = subprocess.run(  # noqa: S603
+        [docker_binary, "inspect", container_identity],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=CLEANUP_TIMEOUT_SECONDS,
+        env=sanitized_docker_environment(),
+    )
+    if completed.returncode == 0:
+        raise RuntimeError("authority container remained after teardown")
+    if not docker_container_missing(completed):
+        detail = (completed.stderr or completed.stdout).strip()[-240:]
+        raise RuntimeError(f"authority container removal verification failed: {detail or 'unknown error'}")
+
+
+def docker_image_available(docker_binary: str, image: str) -> bool:
+    """Return whether the exact pinned image is present without pulling it."""
+
+    completed = subprocess.run(  # noqa: S603
+        [docker_binary, "image", "inspect", image],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=CLEANUP_TIMEOUT_SECONDS,
+        env=sanitized_docker_environment(),
+    )
+    return completed.returncode == 0
 
 
 def terminate_process_group(proc: subprocess.Popen[bytes], *, description: str) -> None:
@@ -47,6 +183,22 @@ def terminate_process_group(proc: subprocess.Popen[bytes], *, description: str) 
             raise RuntimeError(f"{description} process group remained alive after SIGKILL") from exc
     if proc.poll() is None:
         raise RuntimeError(f"{description} process remained alive after termination")
+
+
+def terminate_attached_docker_processes(
+    processes: Iterable[tuple[str, subprocess.Popen[bytes] | None]],
+) -> list[str]:
+    """Boundedly terminate and reap attached Docker CLI process groups."""
+
+    errors: list[str] = []
+    for role, process in processes:
+        if process is None:
+            continue
+        try:
+            terminate_process_group(process, description=f"{role} authority Docker attach")
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            errors.append(f"{role} Docker attach: {type(exc).__name__}: {exc}")
+    return errors
 
 
 def launch_deadline_watchdog(

--- a/autocontext/src/autocontext/kernel_evolution/docker_worker.py
+++ b/autocontext/src/autocontext/kernel_evolution/docker_worker.py
@@ -48,6 +48,7 @@ from autocontext.kernel_evolution.gpu_attestation import (
     DockerGPUDeviceAttestor,
     DockerGPUDeviceGrant,
     NvidiaSMIGPUDeviceAttestor,
+    attest_partition_grant,
 )
 from autocontext.kernel_evolution.models import ARTIFACT_IDENTITY_VERSION, KernelCandidate, content_digest
 
@@ -324,29 +325,14 @@ class DockerKernelBenchmarkRunner:
             )
 
     def _attest_gpu(self) -> tuple[DockerGPUDeviceAttestation | None, str | None]:
-        if self.gpu_grant.isolation_kind == "visibility-only":
-            return None, "GPU memory enforcement is unavailable; use a verified MIG or hardware partition grant"
         try:
-            attestation = self.gpu_attestor.attest(self.gpu_grant)
+            attestation = attest_partition_grant(
+                self.gpu_grant,
+                self.gpu_attestor,
+                max_gpu_memory_bytes=self.limits.max_gpu_memory_bytes,
+            )
         except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as exc:
             return None, f"trusted GPU grant attestation failed: {type(exc).__name__}: {exc}"
-        if attestation.attestor_id != self.gpu_attestor.attestor_id:
-            return None, "trusted GPU grant attestation returned an unexpected attestor identity"
-        if (
-            attestation.device_id != self.gpu_grant.device_id
-            or attestation.isolation_kind != self.gpu_grant.isolation_kind
-        ):
-            return None, "trusted GPU grant attestation does not match the requested partition identity"
-        expected_capacity = self.gpu_grant.enforced_memory_bytes
-        if expected_capacity is None or attestation.enforced_memory_bytes != expected_capacity:
-            return None, "trusted GPU grant capacity does not match the configured hard partition capacity"
-        if attestation.enforced_memory_bytes > self.limits.max_gpu_memory_bytes:
-            return (
-                None,
-                "GPU partition capacity "
-                f"{attestation.enforced_memory_bytes} exceeds configured hard limit "
-                f"{self.limits.max_gpu_memory_bytes} bytes",
-            )
         return attestation, None
 
     def reconcile(self, *, now: float | None = None) -> int:

--- a/autocontext/src/autocontext/kernel_evolution/evaluator_config.py
+++ b/autocontext/src/autocontext/kernel_evolution/evaluator_config.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
-from typing import Literal
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
 
+from autocontext.kernel_evolution.authority_protocol import read_authority_hmac_secret
 from autocontext.kernel_evolution.promotion_statistics import minimum_bootstrap_samples
 from autocontext.kernel_evolution.protocols import KernelStatisticsPolicy
+
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_KEY_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,6 +25,10 @@ class KernelBenchmarkEvaluatorConfig:
     max_feedback_chars: int = 4_000
     require_resource_telemetry: bool = False
     require_authority_receipt: bool = False
+    authority_hmac_key_id: str | None = None
+    authority_hmac_secret_path: Path | None = field(default=None, repr=False)
+    expected_evaluator_build_digest: str | None = None
+    expected_boundary_manifest_digest: str | None = None
     adaptive_feedback_policy: Literal["detailed", "aggregate-gates"] = "detailed"
     max_gpu_memory_bytes: int | None = None
 
@@ -38,6 +48,27 @@ class KernelBenchmarkEvaluatorConfig:
             raise ValueError("adaptive_feedback_policy must be detailed or aggregate-gates")
         if self.max_gpu_memory_bytes is not None and self.max_gpu_memory_bytes < 1:
             raise ValueError("max_gpu_memory_bytes must be positive")
+        authority_values = (
+            self.authority_hmac_key_id,
+            self.authority_hmac_secret_path,
+            self.expected_evaluator_build_digest,
+            self.expected_boundary_manifest_digest,
+        )
+        if self.require_authority_receipt and any(value is None for value in authority_values):
+            raise ValueError(
+                "required authority receipts need a pinned HMAC key, secret file, evaluator build, and boundary digest"
+            )
+        if any(value is not None for value in authority_values) and any(value is None for value in authority_values):
+            raise ValueError("authority trust configuration must be supplied as one complete set")
+        if self.authority_hmac_key_id is not None:
+            if _KEY_ID.fullmatch(self.authority_hmac_key_id) is None:
+                raise ValueError("authority_hmac_key_id must be a safe non-empty identifier")
+            assert self.authority_hmac_secret_path is not None
+            read_authority_hmac_secret(self.authority_hmac_secret_path)
+            for name in ("expected_evaluator_build_digest", "expected_boundary_manifest_digest"):
+                value = getattr(self, name)
+                if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+                    raise ValueError(f"{name} must be a branded SHA-256 digest")
 
     def validate_confidence_resolution(self, alpha: float) -> None:
         """Fail closed when the configured resampling cannot resolve ``alpha``."""
@@ -47,6 +78,26 @@ class KernelBenchmarkEvaluatorConfig:
                 f"bootstrap_samples ({self.bootstrap_samples}) cannot resolve alpha={alpha:.12g}; "
                 f"at least {required} samples are required"
             )
+
+    def manifest(self) -> dict[str, Any]:
+        """Return evaluator policy without serializing the verifier secret path."""
+
+        payload = asdict(self)
+        payload.pop("authority_hmac_secret_path")
+        payload["authority_trust"] = (
+            {
+                "algorithm": "hmac-sha256",
+                "key_id": self.authority_hmac_key_id,
+                "expected_evaluator_build_digest": self.expected_evaluator_build_digest,
+                "expected_boundary_manifest_digest": self.expected_boundary_manifest_digest,
+            }
+            if self.authority_hmac_key_id is not None
+            else None
+        )
+        payload.pop("authority_hmac_key_id")
+        payload.pop("expected_evaluator_build_digest")
+        payload.pop("expected_boundary_manifest_digest")
+        return payload
 
     @property
     def statistics_policy(self) -> KernelStatisticsPolicy:

--- a/autocontext/src/autocontext/kernel_evolution/evaluator_config.py
+++ b/autocontext/src/autocontext/kernel_evolution/evaluator_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import Literal
 
 from autocontext.kernel_evolution.promotion_statistics import minimum_bootstrap_samples
 from autocontext.kernel_evolution.protocols import KernelStatisticsPolicy
@@ -17,6 +18,8 @@ class KernelBenchmarkEvaluatorConfig:
     bootstrap_samples: int = 2_000
     max_feedback_chars: int = 4_000
     require_resource_telemetry: bool = False
+    require_authority_receipt: bool = False
+    adaptive_feedback_policy: Literal["detailed", "aggregate-gates"] = "detailed"
     max_gpu_memory_bytes: int | None = None
 
     def __post_init__(self) -> None:
@@ -31,6 +34,8 @@ class KernelBenchmarkEvaluatorConfig:
             raise ValueError(f"bootstrap_samples must be at least {minimum_nominal_samples}")
         if self.max_feedback_chars < 128:
             raise ValueError("max_feedback_chars must be at least 128")
+        if self.adaptive_feedback_policy not in {"detailed", "aggregate-gates"}:
+            raise ValueError("adaptive_feedback_policy must be detailed or aggregate-gates")
         if self.max_gpu_memory_bytes is not None and self.max_gpu_memory_bytes < 1:
             raise ValueError("max_gpu_memory_bytes must be positive")
 

--- a/autocontext/src/autocontext/kernel_evolution/gpu_attestation.py
+++ b/autocontext/src/autocontext/kernel_evolution/gpu_attestation.py
@@ -90,6 +90,33 @@ class DockerGPUDeviceAttestor(Protocol):
     def attest(self, grant: DockerGPUDeviceGrant) -> DockerGPUDeviceAttestation: ...
 
 
+def attest_partition_grant(
+    grant: DockerGPUDeviceGrant,
+    attestor: DockerGPUDeviceAttestor,
+    *,
+    max_gpu_memory_bytes: int,
+) -> DockerGPUDeviceAttestation:
+    """Resolve and verify one hard accelerator partition grant."""
+
+    if max_gpu_memory_bytes < 1:
+        raise ValueError("max_gpu_memory_bytes must be positive")
+    if grant.isolation_kind == "visibility-only":
+        raise RuntimeError("GPU memory enforcement is unavailable; use a verified MIG or hardware partition grant")
+    attestation = attestor.attest(grant)
+    if attestation.attestor_id != attestor.attestor_id:
+        raise RuntimeError("trusted GPU grant attestation returned an unexpected attestor identity")
+    if attestation.device_id != grant.device_id or attestation.isolation_kind != grant.isolation_kind:
+        raise RuntimeError("trusted GPU grant attestation does not match the requested partition identity")
+    if grant.enforced_memory_bytes is None or attestation.enforced_memory_bytes != grant.enforced_memory_bytes:
+        raise RuntimeError("trusted GPU grant capacity does not match the configured hard partition capacity")
+    if attestation.enforced_memory_bytes > max_gpu_memory_bytes:
+        raise RuntimeError(
+            "GPU partition capacity "
+            f"{attestation.enforced_memory_bytes} exceeds configured hard limit {max_gpu_memory_bytes} bytes"
+        )
+    return attestation
+
+
 class _NvmlMemory(ctypes.Structure):
     _fields_ = [
         ("total", ctypes.c_ulonglong),
@@ -272,6 +299,7 @@ __all__ = [
     "DockerGPUDeviceGrant",
     "GPUIsolationKind",
     "NvidiaSMIGPUDeviceAttestor",
+    "attest_partition_grant",
 ]
 
 

--- a/autocontext/src/autocontext/kernel_evolution/models.py
+++ b/autocontext/src/autocontext/kernel_evolution/models.py
@@ -10,6 +10,10 @@ from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, model_validator
 
+from autocontext.kernel_evolution.authority_protocol import (
+    KernelEvaluatorAuthorityReceipt,
+    verify_authority_receipt,
+)
 from autocontext.kernel_evolution.protocols import (
     KernelDecisionPolicy,
     KernelProtocolSemantics,
@@ -255,7 +259,7 @@ class KernelCompileReport(StrictModel):
 
 
 class KernelResourceReport(StrictModel):
-    """Identity-bound CUDA allocator and device-capacity telemetry."""
+    """Identity-bound allocator or evaluator-observed accelerator telemetry."""
 
     candidate_artifact_digest: Digest | None = None
     incumbent_artifact_digest: Digest | None = None
@@ -266,6 +270,10 @@ class KernelResourceReport(StrictModel):
     # Retained for v2 readers; new workers set these to peak reservation.
     candidate_peak_memory_bytes: int | None = Field(default=None, ge=0)
     incumbent_peak_memory_bytes: int | None = Field(default=None, ge=0)
+    candidate_observed_peak_bytes: int | None = Field(default=None, ge=0)
+    incumbent_observed_peak_bytes: int | None = Field(default=None, ge=0)
+    telemetry_authority: Literal["trusted-evaluator-observed/v1"] | None = None
+    accelerator_attestation_digest: Digest | None = None
     device_total_memory_bytes: int | None = Field(default=None, gt=0)
 
     @model_validator(mode="after")
@@ -281,9 +289,19 @@ class KernelResourceReport(StrictModel):
                 self.candidate_peak_reserved_bytes,
                 self.incumbent_peak_allocated_bytes,
                 self.incumbent_peak_reserved_bytes,
+                self.candidate_observed_peak_bytes,
+                self.incumbent_observed_peak_bytes,
             ):
                 if value is not None and value > self.device_total_memory_bytes:
-                    raise ValueError("CUDA peak telemetry cannot exceed total device bytes")
+                    raise ValueError("accelerator peak telemetry cannot exceed total device bytes")
+        observed = (self.candidate_observed_peak_bytes, self.incumbent_observed_peak_bytes)
+        if any(value is not None for value in observed):
+            if any(value is None for value in observed):
+                raise ValueError("trusted evaluator peaks must cover candidate and incumbent")
+            if self.telemetry_authority != "trusted-evaluator-observed/v1":
+                raise ValueError("evaluator-observed peaks require the trusted telemetry authority")
+            if self.accelerator_attestation_digest is None:
+                raise ValueError("evaluator-observed peaks require an accelerator attestation digest")
         return self
 
     @property
@@ -292,6 +310,7 @@ class KernelResourceReport(StrictModel):
             self.candidate_peak_allocated_bytes,
             self.candidate_peak_reserved_bytes,
             self.candidate_peak_memory_bytes,
+            self.candidate_observed_peak_bytes,
         )
         present = [value for value in values if value is not None]
         return max(present) if present else None
@@ -307,6 +326,10 @@ KernelFailureKind = Literal[
     "crash",
     "unstable_environment",
     "contract",
+    "protocol_corruption",
+    "evaluator_crash",
+    "candidate_crash",
+    "teardown_failure",
     "reference_failure",
 ]
 
@@ -335,6 +358,7 @@ class KernelBenchmarkReport(StrictModel):
     correctness: KernelCorrectnessReport | None
     performance: KernelPerformanceReport | None
     resources: KernelResourceReport = Field(default_factory=KernelResourceReport)
+    evaluator_authority_receipt: KernelEvaluatorAuthorityReceipt | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
@@ -358,6 +382,15 @@ class KernelBenchmarkReport(StrictModel):
             raise ValueError("incumbent artifact digest does not match its source digest and ABI")
         if self.hardware_scope_id != self.hardware.scope_id:
             raise ValueError("hardware_scope_id does not match the canonical hardware identity")
+        if self.evaluator_authority_receipt is not None:
+            verify_authority_receipt(self.evaluator_authority_receipt, self.model_dump(mode="json"))
+            attestation = self.evaluator_authority_receipt.accelerator_attestation
+            if attestation.backend != self.hardware.backend or attestation.architecture != self.hardware.architecture:
+                raise ValueError("authority receipt accelerator identity does not match report hardware")
+            if self.resources.accelerator_attestation_digest != attestation.digest:
+                raise ValueError("resource telemetry is not bound to the receipt accelerator attestation")
+            if self.resources.device_total_memory_bytes != attestation.enforced_memory_bytes:
+                raise ValueError("resource telemetry capacity does not match receipt accelerator attestation")
         resources = self.resources
         if (
             resources.candidate_artifact_digest is not None

--- a/autocontext/src/autocontext/kernel_evolution/models.py
+++ b/autocontext/src/autocontext/kernel_evolution/models.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, model_validator
 
 from autocontext.kernel_evolution.authority_protocol import (
     KernelEvaluatorAuthorityReceipt,
-    verify_authority_receipt,
+    verify_authority_receipt_integrity,
 )
 from autocontext.kernel_evolution.protocols import (
     KernelDecisionPolicy,
@@ -383,7 +383,7 @@ class KernelBenchmarkReport(StrictModel):
         if self.hardware_scope_id != self.hardware.scope_id:
             raise ValueError("hardware_scope_id does not match the canonical hardware identity")
         if self.evaluator_authority_receipt is not None:
-            verify_authority_receipt(self.evaluator_authority_receipt, self.model_dump(mode="json"))
+            verify_authority_receipt_integrity(self.evaluator_authority_receipt, self.model_dump(mode="json"))
             attestation = self.evaluator_authority_receipt.accelerator_attestation
             if attestation.backend != self.hardware.backend or attestation.architecture != self.hardware.architecture:
                 raise ValueError("authority receipt accelerator identity does not match report hardware")

--- a/autocontext/src/autocontext/kernel_evolution/profile_evidence.py
+++ b/autocontext/src/autocontext/kernel_evolution/profile_evidence.py
@@ -1,0 +1,223 @@
+"""Authenticated envelope for portable kernel profile evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import re
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from autocontext.kernel_evolution.authority_protocol import (
+    MAX_AUTHORITY_HMAC_SECRET_BYTES,
+    MIN_AUTHORITY_HMAC_SECRET_BYTES,
+    canonical_authority_digest,
+)
+
+PROFILE_EVIDENCE_ENVELOPE_VERSION: Literal["autocontext.kernel-profile-evidence-envelope/v1"] = (
+    "autocontext.kernel-profile-evidence-envelope/v1"
+)
+MAX_PROFILE_EVIDENCE_BYTES = 64 * 1024 * 1024
+MAX_PROFILE_EVIDENCE_ENVELOPE_BYTES = MAX_PROFILE_EVIDENCE_BYTES + 64 * 1024
+MAX_PROFILE_EVIDENCE_DEPTH = 64
+MAX_PROFILE_EVIDENCE_ENTRIES = 1_000_000
+Digest = Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")]
+AuthenticationTag = Annotated[str, Field(pattern=r"^hmac-sha256:[0-9a-f]{64}$")]
+_SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$")
+
+
+class _ProfileEvidenceModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False, frozen=True, strict=True)
+
+
+class ProfileEvidenceAuthentication(_ProfileEvidenceModel):
+    """Operator-pinned authentication metadata for one complete profile payload."""
+
+    algorithm: Literal["hmac-sha256"] = "hmac-sha256"
+    key_id: str
+    tag: AuthenticationTag
+
+    @model_validator(mode="after")
+    def validate_key_id(self) -> Self:
+        if _SAFE_IDENTIFIER.fullmatch(self.key_id) is None:
+            raise ValueError("profile evidence authentication key_id must be a safe non-empty identifier")
+        return self
+
+
+class ProfileEvidenceEnvelope(_ProfileEvidenceModel):
+    """Strict outer envelope whose tag authenticates every portable evidence field."""
+
+    schema_version: Literal["autocontext.kernel-profile-evidence-envelope/v1"] = (
+        PROFILE_EVIDENCE_ENVELOPE_VERSION
+    )
+    profile: dict[str, Any]
+    content_digest: Digest
+    authentication: ProfileEvidenceAuthentication
+
+    @model_validator(mode="after")
+    def validate_profile_json(self) -> Self:
+        _validate_profile_json(self.profile)
+        return self
+
+
+def _validate_profile_json(profile: dict[str, Any]) -> None:
+    if not profile:
+        raise ValueError("profile evidence payload must not be empty")
+    schema_version = profile.get("schema_version")
+    if (
+        not isinstance(schema_version, str)
+        or not schema_version
+        or any(char in schema_version for char in "\r\n\0")
+    ):
+        raise ValueError("profile evidence payload must contain a safe schema_version")
+    entries = 0
+
+    def validate(value: Any, *, depth: int) -> None:
+        nonlocal entries
+        if depth > MAX_PROFILE_EVIDENCE_DEPTH:
+            raise ValueError("profile evidence payload exceeded its nesting limit")
+        entries += 1
+        if entries > MAX_PROFILE_EVIDENCE_ENTRIES:
+            raise ValueError("profile evidence payload exceeded its entry limit")
+        if value is None or type(value) in {bool, int, str}:
+            return
+        if type(value) is float:
+            if not math.isfinite(value):
+                raise ValueError("profile evidence payload must contain only finite numbers")
+            return
+        if type(value) is list:
+            for item in value:
+                validate(item, depth=depth + 1)
+            return
+        if type(value) is dict:
+            for key, item in value.items():
+                if type(key) is not str:
+                    raise ValueError("profile evidence JSON object keys must be strings")
+                validate(item, depth=depth + 1)
+            return
+        raise ValueError("profile evidence payload must contain only canonical JSON values")
+
+    validate(profile, depth=0)
+    if len(_canonical_bytes(profile)) > MAX_PROFILE_EVIDENCE_BYTES:
+        raise ValueError("profile evidence payload exceeded its byte limit")
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _decode_envelope_json(raw: bytes | str) -> dict[str, Any]:
+    encoded = raw.encode("utf-8") if isinstance(raw, str) else raw
+    if len(encoded) > MAX_PROFILE_EVIDENCE_ENVELOPE_BYTES:
+        raise ValueError("profile evidence envelope exceeded its byte limit")
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"invalid JSON constant {value}")
+
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        decoded: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in decoded:
+                raise ValueError(f"duplicate JSON object key {key!r}")
+            decoded[key] = value
+        return decoded
+
+    decoded = json.loads(
+        encoded.decode("utf-8"),
+        parse_constant=reject_constant,
+        object_pairs_hook=reject_duplicates,
+    )
+    if not isinstance(decoded, dict):
+        raise ValueError("profile evidence envelope root must be a JSON object")
+    return decoded
+
+
+def _validated_secret(secret: bytes) -> bytes:
+    if not isinstance(secret, bytes):
+        raise TypeError("profile evidence HMAC secret must be bytes")
+    if not MIN_AUTHORITY_HMAC_SECRET_BYTES <= len(secret) <= MAX_AUTHORITY_HMAC_SECRET_BYTES:
+        raise ValueError(
+            "profile evidence HMAC secret must contain between "
+            f"{MIN_AUTHORITY_HMAC_SECRET_BYTES} and {MAX_AUTHORITY_HMAC_SECRET_BYTES} bytes"
+        )
+    return secret
+
+
+def _authentication_payload(envelope: ProfileEvidenceEnvelope) -> dict[str, Any]:
+    payload = envelope.model_dump(mode="json")
+    authentication = dict(payload["authentication"])
+    authentication.pop("tag")
+    payload["authentication"] = authentication
+    return payload
+
+
+def _authentication_tag(envelope: ProfileEvidenceEnvelope, secret: bytes) -> str:
+    raw = _canonical_bytes(_authentication_payload(envelope))
+    tag = hmac.new(_validated_secret(secret), raw, hashlib.sha256).hexdigest()
+    return f"hmac-sha256:{tag}"
+
+
+def build_profile_evidence_envelope(
+    profile: dict[str, Any],
+    *,
+    signing_key_id: str,
+    signing_secret: bytes,
+) -> ProfileEvidenceEnvelope:
+    """Authenticate one canonical, bounded profile payload in a strict envelope."""
+
+    unsigned = ProfileEvidenceEnvelope(
+        profile=profile,
+        content_digest=canonical_authority_digest(profile),
+        authentication=ProfileEvidenceAuthentication(
+            key_id=signing_key_id,
+            tag="hmac-sha256:" + "0" * 64,
+        ),
+    )
+    tag = _authentication_tag(unsigned, signing_secret)
+    envelope = unsigned.model_copy(
+        update={"authentication": unsigned.authentication.model_copy(update={"tag": tag})}
+    )
+    verify_profile_evidence_envelope(
+        envelope,
+        trusted_key_id=signing_key_id,
+        trusted_secret=signing_secret,
+    )
+    return envelope
+
+
+def verify_profile_evidence_envelope(
+    envelope: ProfileEvidenceEnvelope | dict[str, Any] | bytes | str,
+    *,
+    trusted_key_id: str,
+    trusted_secret: bytes,
+) -> ProfileEvidenceEnvelope:
+    """Verify exact content, operator identity, and authentication for an envelope."""
+
+    candidate = _decode_envelope_json(envelope) if isinstance(envelope, (bytes, str)) else envelope
+    validated = ProfileEvidenceEnvelope.model_validate(candidate)
+    if _SAFE_IDENTIFIER.fullmatch(trusted_key_id) is None:
+        raise ValueError("trusted profile evidence key_id must be a safe non-empty identifier")
+    if validated.authentication.key_id != trusted_key_id:
+        raise ValueError("profile evidence authentication key is not trusted")
+    if not hmac.compare_digest(validated.content_digest, canonical_authority_digest(validated.profile)):
+        raise ValueError("profile evidence content digest does not match its payload")
+    expected_tag = _authentication_tag(validated, trusted_secret)
+    if not hmac.compare_digest(validated.authentication.tag, expected_tag):
+        raise ValueError("profile evidence authentication tag is invalid")
+    return validated
+
+
+__all__ = [
+    "MAX_PROFILE_EVIDENCE_BYTES",
+    "MAX_PROFILE_EVIDENCE_DEPTH",
+    "MAX_PROFILE_EVIDENCE_ENVELOPE_BYTES",
+    "MAX_PROFILE_EVIDENCE_ENTRIES",
+    "PROFILE_EVIDENCE_ENVELOPE_VERSION",
+    "ProfileEvidenceAuthentication",
+    "ProfileEvidenceEnvelope",
+    "build_profile_evidence_envelope",
+    "verify_profile_evidence_envelope",
+]

--- a/autocontext/src/autocontext/kernel_evolution/resource_policy.py
+++ b/autocontext/src/autocontext/kernel_evolution/resource_policy.py
@@ -19,47 +19,65 @@ def evaluate_kernel_resource_policy(
     require_telemetry: bool,
     max_gpu_memory_bytes: int | None,
 ) -> KernelResourcePolicyResult:
-    """Validate complete, identity-bound, independently measured CUDA peaks."""
+    """Validate complete, identity-bound, independently measured accelerator peaks."""
 
     resources = report.resources
-    required = {
+    identity_required = {
         "candidate_artifact_digest": resources.candidate_artifact_digest,
         "incumbent_artifact_digest": resources.incumbent_artifact_digest,
-        "candidate_peak_allocated_bytes": resources.candidate_peak_allocated_bytes,
-        "candidate_peak_reserved_bytes": resources.candidate_peak_reserved_bytes,
-        "incumbent_peak_allocated_bytes": resources.incumbent_peak_allocated_bytes,
-        "incumbent_peak_reserved_bytes": resources.incumbent_peak_reserved_bytes,
         "device_total_memory_bytes": resources.device_total_memory_bytes,
     }
     if require_telemetry or max_gpu_memory_bytes is not None:
-        missing = sorted(name for name, value in required.items() if value is None)
+        missing = sorted(name for name, value in identity_required.items() if value is None)
+        observed_complete = (
+            resources.telemetry_authority == "trusted-evaluator-observed/v1"
+            and resources.accelerator_attestation_digest is not None
+            and resources.candidate_observed_peak_bytes is not None
+            and resources.incumbent_observed_peak_bytes is not None
+        )
+        allocator_complete = all(
+            value is not None
+            for value in (
+                resources.candidate_peak_allocated_bytes,
+                resources.candidate_peak_reserved_bytes,
+                resources.incumbent_peak_allocated_bytes,
+                resources.incumbent_peak_reserved_bytes,
+            )
+        )
+        if not observed_complete and not allocator_complete:
+            missing.append("complete allocator or trusted-evaluator peak telemetry")
         if missing:
             return KernelResourcePolicyResult(
                 "missing_resource_telemetry",
-                f"Required CUDA resource telemetry is missing: {', '.join(missing)}.",
+                f"Required accelerator resource telemetry is missing: {', '.join(missing)}.",
             )
     if resources.candidate_artifact_digest not in {None, report.candidate_artifact_digest}:
-        return KernelResourcePolicyResult("resource_identity_mismatch", "Candidate CUDA telemetry identity does not match.")
+        return KernelResourcePolicyResult(
+            "resource_identity_mismatch", "Candidate accelerator telemetry identity does not match."
+        )
     if resources.incumbent_artifact_digest not in {None, report.incumbent_artifact_digest}:
-        return KernelResourcePolicyResult("resource_identity_mismatch", "Incumbent CUDA telemetry identity does not match.")
+        return KernelResourcePolicyResult(
+            "resource_identity_mismatch", "Incumbent accelerator telemetry identity does not match."
+        )
     if max_gpu_memory_bytes is not None:
         candidate_peak = resources.candidate_enforced_peak_bytes
         incumbent_values = (
             resources.incumbent_peak_allocated_bytes,
             resources.incumbent_peak_reserved_bytes,
             resources.incumbent_peak_memory_bytes,
+            resources.incumbent_observed_peak_bytes,
         )
         incumbent_present = [value for value in incumbent_values if value is not None]
         incumbent_peak = max(incumbent_present) if incumbent_present else None
         if candidate_peak is not None and candidate_peak > max_gpu_memory_bytes:
             return KernelResourcePolicyResult(
                 "resource_exceeded",
-                f"Candidate CUDA peak {candidate_peak} exceeds enforced limit {max_gpu_memory_bytes} bytes.",
+                f"Candidate accelerator peak {candidate_peak} exceeds enforced limit {max_gpu_memory_bytes} bytes.",
             )
         if incumbent_peak is not None and incumbent_peak > max_gpu_memory_bytes:
             return KernelResourcePolicyResult(
                 "resource_exceeded",
-                f"Incumbent CUDA peak {incumbent_peak} exceeds enforced limit {max_gpu_memory_bytes} bytes.",
+                f"Incumbent accelerator peak {incumbent_peak} exceeds enforced limit {max_gpu_memory_bytes} bytes.",
             )
     return KernelResourcePolicyResult()
 

--- a/autocontext/src/autocontext/kernel_evolution/runner.py
+++ b/autocontext/src/autocontext/kernel_evolution/runner.py
@@ -163,16 +163,32 @@ class KernelPromotionPolicy:
             )
         statuses["valid_evaluation"] = "passed"
         resources = observation.report.resources if observation.report is not None else None
-        telemetry_present = resources is not None and all(
-            value is not None
-            for value in (
-                resources.candidate_artifact_digest,
-                resources.incumbent_artifact_digest,
-                resources.candidate_peak_allocated_bytes,
-                resources.candidate_peak_reserved_bytes,
-                resources.incumbent_peak_allocated_bytes,
-                resources.incumbent_peak_reserved_bytes,
-                resources.device_total_memory_bytes,
+        telemetry_present = (
+            resources is not None
+            and all(
+                value is not None
+                for value in (
+                    resources.candidate_artifact_digest,
+                    resources.incumbent_artifact_digest,
+                    resources.device_total_memory_bytes,
+                )
+            )
+            and (
+                all(
+                    value is not None
+                    for value in (
+                        resources.candidate_peak_allocated_bytes,
+                        resources.candidate_peak_reserved_bytes,
+                        resources.incumbent_peak_allocated_bytes,
+                        resources.incumbent_peak_reserved_bytes,
+                    )
+                )
+                or (
+                    resources.telemetry_authority == "trusted-evaluator-observed/v1"
+                    and resources.accelerator_attestation_digest is not None
+                    and resources.candidate_observed_peak_bytes is not None
+                    and resources.incumbent_observed_peak_bytes is not None
+                )
             )
         )
         if telemetry_present:
@@ -546,19 +562,33 @@ class KernelEvolutionRunner:
                 observation,
                 provisional_decision,
             )
-            metrics: dict[str, float] = {}
-            if observation.relative_improvement is not None:
-                metrics["relative_improvement"] = float(observation.relative_improvement)
-            if observation.speedup_lcb is not None:
-                metrics["speedup_lcb"] = float(observation.speedup_lcb)
-            performance_dimension = min(1.0, float(observation.speedup_vs_incumbent or 0.0))
+            aggregate_feedback = self._evaluator.config.adaptive_feedback_policy == "aggregate-gates"
+            if aggregate_feedback:
+                gate_status = {gate.name: gate.status for gate in provisional_decision.gates}
+                disclosed_feedback = (
+                    "Aggregate benchmark gates: "
+                    + ", ".join(f"{gate.name}={gate.status}" for gate in provisional_decision.gates)
+                    + f". Disposition={provisional_decision.reason}."
+                )
+                metrics: dict[str, float] = {}
+                performance_dimension = float(gate_status.get("relative_improvement") == "passed")
+                adaptive_score = float(provisional_decision.promote)
+            else:
+                disclosed_feedback = provisional_decision.feedback
+                metrics = {}
+                if observation.relative_improvement is not None:
+                    metrics["relative_improvement"] = float(observation.relative_improvement)
+                if observation.speedup_lcb is not None:
+                    metrics["speedup_lcb"] = float(observation.speedup_lcb)
+                performance_dimension = min(1.0, float(observation.speedup_vs_incumbent or 0.0))
+                adaptive_score = self._score(observation)
             return AgentTaskGenerationEvaluation(
                 output=source,
-                score=self._score(observation),
+                score=adaptive_score,
                 # Confirmation evidence is persisted for audit, but its
                 # detailed feedback and metrics must not become training data
                 # for later adaptive proposals.
-                reasoning=provisional_decision.feedback,
+                reasoning=disclosed_feedback,
                 dimension_scores={
                     "correctness": 1.0 if observation.eligible else 0.0,
                     "performance": performance_dimension,
@@ -566,7 +596,7 @@ class KernelEvolutionRunner:
                 },
                 met_threshold=decision.promote,
                 lesson_signal=LessonSignal(
-                    hint=provisional_decision.feedback,
+                    hint=disclosed_feedback,
                     plateau=provisional_decision.reason in {"insufficient_improvement", "confidence_interval"},
                     metrics=metrics,
                 ),

--- a/autocontext/tests/test_docker_kernel_worker.py
+++ b/autocontext/tests/test_docker_kernel_worker.py
@@ -1231,6 +1231,43 @@ def test_detached_watchdog_removes_only_its_owned_container(
     assert (tmp_path / "ready").read_text(encoding="ascii") == "ready\n"
 
 
+def test_detached_watchdog_removes_container_when_coordinator_parent_disappears(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    removed: list[list[str]] = []
+    parent_ids = iter((1234, 1))
+    listed = False
+
+    def fake_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal listed
+        del kwargs
+        if argv[1:3] == ["ps", "-aq"]:
+            if not listed:
+                listed = True
+                return subprocess.CompletedProcess(argv, 0, stdout="owned-id\n", stderr="")
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        if argv[1:3] == ["rm", "-f"]:
+            removed.append(argv)
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(docker_watchdog_module, "_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(docker_watchdog_module.os, "getppid", lambda: next(parent_ids))
+    monkeypatch.setattr(docker_watchdog_module.subprocess, "run", fake_run)
+
+    result = docker_watchdog_module.run_deadline_watchdog(
+        "/usr/bin/docker",
+        "autoctx-kernel-deadbeef",
+        time.time() + 60,
+        tmp_path / "ready",
+        coordinator_pid=1234,
+    )
+
+    assert result == 0
+    assert removed == [["/usr/bin/docker", "rm", "-f", "owned-id"]]
+
+
 def test_worker_oom_is_distinct_and_verifies_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/autocontext/tests/test_docker_kernel_worker.py
+++ b/autocontext/tests/test_docker_kernel_worker.py
@@ -347,24 +347,41 @@ def test_attested_capacity_must_exactly_match_configured_grant(
 @pytest.mark.parametrize(
     ("outcome", "expected"),
     [
+        ("timeout", "timeout"),
         ("oom", "oom"),
         ("resource_exceeded", "resource_exceeded"),
         ("resource_policy_unsupported", "resource_policy_unsupported"),
+        ("missing_resource_telemetry", "missing_resource_telemetry"),
         ("resource_identity_mismatch", "resource_identity_mismatch"),
+        ("protocol_corruption", "protocol_corruption"),
+        ("evaluator_crashed", "evaluator_crashed"),
+        ("candidate_crashed", "candidate_crashed"),
         ("teardown_failed", "teardown_failed"),
     ],
 )
 def test_evaluator_preserves_distinct_worker_outcomes(outcome: Any, expected: str) -> None:
     candidate = KernelCandidate(source="candidate")
     incumbent = KernelCandidate(source="incumbent")
+    forged_payload = _report(candidate, incumbent)
+    forged_payload["problem_id"] = "candidate-controlled-forged-problem"
     evaluator = KernelBenchmarkEvaluator(
-        _ExecutionRunner(KernelBenchmarkExecution(returncode=None, outcome=outcome, error=expected)),
+        _ExecutionRunner(
+            KernelBenchmarkExecution(
+                returncode=None,
+                timed_out=True,
+                outcome=outcome,
+                error=expected,
+                report_payload=forged_payload,
+            )
+        ),
         KernelBenchmarkEvaluatorConfig(problem_id="p1"),
     )
 
     observation = evaluator.evaluate(candidate, incumbent)
 
     assert observation.rejection_reason == expected
+    assert observation.feedback == expected
+    assert observation.report is None
 
 
 def test_required_telemetry_rejects_and_gate_feedback_is_three_state() -> None:

--- a/autocontext/tests/test_kernel_authority_protocol.py
+++ b/autocontext/tests/test_kernel_authority_protocol.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import struct
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
@@ -18,6 +20,7 @@ from autocontext.kernel_evolution import (
     build_authority_receipt,
     canonical_authority_digest,
     encode_authority_frame,
+    read_authority_hmac_secret,
     receive_authority_frame,
     verify_authority_receipt,
 )
@@ -38,6 +41,10 @@ class _MemoryConnection:
 
 def _digest(value: bytes | str) -> str:
     return canonical_authority_digest(value)
+
+
+_HMAC_KEY_ID = "test-authority-key-v1"
+_HMAC_SECRET = b"test-only-authority-secret-material-32-bytes"
 
 
 def _attestation() -> AcceleratorAttestation:
@@ -81,6 +88,31 @@ def _response(request: AuthorityRequest, payload: bytes = b"output-bytes") -> Au
         payload_digest=_digest(payload),
         payload_bytes=len(payload),
     )
+
+
+def _report(
+    candidate_digest: str,
+    incumbent_digest: str,
+    *,
+    candidate_peak: int,
+    incumbent_peak: int,
+) -> dict[str, object]:
+    attestation = _attestation()
+    return {
+        "evaluation_status": "complete",
+        "failure_kind": None,
+        "candidate_artifact_digest": candidate_digest,
+        "incumbent_artifact_digest": incumbent_digest,
+        "protocol": {"seed_commitment": _digest("private-plan")},
+        "performance": {"blocks": [{"candidate_ms": 0.01, "incumbent_ms": 0.011}]},
+        "resources": {
+            "candidate_observed_peak_bytes": candidate_peak,
+            "incumbent_observed_peak_bytes": incumbent_peak,
+            "telemetry_authority": "trusted-evaluator-observed/v1",
+            "accelerator_attestation_digest": attestation.digest,
+            "device_total_memory_bytes": attestation.enforced_memory_bytes,
+        },
+    }
 
 
 def test_authority_protocol_is_accelerator_neutral_and_strict() -> None:
@@ -136,6 +168,12 @@ def test_authority_wire_rejects_forged_truncated_and_oversized_frames() -> None:
 
     with pytest.raises(AuthorityWireError, match="byte limit"):
         encode_authority_frame(request, payload, max_payload_bytes=2)
+
+    raw_header = json.dumps(request.model_dump(mode="json"), separators=(",", ":"))
+    duplicate_header = raw_header.replace('"sequence":0', '"sequence":999,"sequence":0').encode()
+    duplicate_frame = struct.pack("!6sIQ", WIRE_MAGIC, len(duplicate_header), len(payload)) + duplicate_header + payload
+    with pytest.raises(AuthorityWireError, match="invalid typed JSON header"):
+        receive_authority_frame(_MemoryConnection(duplicate_frame), AuthorityRequest)
 
 
 def test_candidate_response_cannot_claim_timing_or_resources() -> None:
@@ -196,12 +234,12 @@ def test_authority_receipt_replays_report_and_detects_tampering() -> None:
             outcome="complete",
         ),
     )
-    report = {
-        "candidate_artifact_digest": candidate_request.artifact_digest,
-        "incumbent_artifact_digest": incumbent_request.artifact_digest,
-        "protocol": {"seed_commitment": _digest("private-plan")},
-        "performance": {"blocks": [{"candidate_ms": 0.01, "incumbent_ms": 0.011}]},
-    }
+    report = _report(
+        candidate_request.artifact_digest,
+        incumbent_request.artifact_digest,
+        candidate_peak=1_024,
+        incumbent_peak=2_048,
+    )
     receipt = build_authority_receipt(
         evaluator_build_digest=_digest("evaluator-build"),
         boundary_manifest_digest=_digest("boundary-manifest"),
@@ -211,16 +249,92 @@ def test_authority_receipt_replays_report_and_detects_tampering() -> None:
         incumbent_artifact_digest=incumbent_request.artifact_digest,
         measurements=measurements,
         report=report,
+        signing_key_id=_HMAC_KEY_ID,
+        signing_secret=_HMAC_SECRET,
     )
     report["evaluator_authority_receipt"] = receipt.model_dump(mode="json")
 
-    verify_authority_receipt(receipt, report)
+    verify_authority_receipt(
+        receipt,
+        report,
+        trusted_key_id=_HMAC_KEY_ID,
+        trusted_secret=_HMAC_SECRET,
+        expected_evaluator_build_digest=_digest("evaluator-build"),
+        expected_boundary_manifest_digest=_digest("boundary-manifest"),
+    )
     assert receipt.receipt_digest.startswith("sha256:")
+    assert receipt.transcript.measurement_count == 2
+    assert receipt.transcript.unique_request_count == 2
+    assert receipt.transcript.unique_response_count == 2
 
     tampered = json.loads(json.dumps(report))
     tampered["performance"]["blocks"][0]["candidate_ms"] = 0.000001
     with pytest.raises(ValueError, match="different report content"):
-        verify_authority_receipt(receipt, tampered)
+        verify_authority_receipt(
+            receipt,
+            tampered,
+            trusted_key_id=_HMAC_KEY_ID,
+            trusted_secret=_HMAC_SECRET,
+        )
+
+    forged_build = receipt.model_copy(update={"evaluator_build_digest": _digest("forged-build")})
+    with pytest.raises(ValueError, match="authentication tag"):
+        verify_authority_receipt(
+            forged_build,
+            report,
+            trusted_key_id=_HMAC_KEY_ID,
+            trusted_secret=_HMAC_SECRET,
+        )
+
+    with pytest.raises(ValueError, match="authentication key"):
+        verify_authority_receipt(
+            receipt,
+            report,
+            trusted_key_id="different-host-key",
+            trusted_secret=_HMAC_SECRET,
+        )
+
+    with pytest.raises(ValueError, match="host-computed digest"):
+        verify_authority_receipt(
+            receipt,
+            report,
+            trusted_key_id=_HMAC_KEY_ID,
+            trusted_secret=_HMAC_SECRET,
+            expected_evaluator_build_digest=_digest("different-host-build"),
+        )
+
+    contradictory = list(measurements)
+    contradictory[0] = contradictory[0].model_copy(update={"outcome": "candidate_error"})
+    with pytest.raises(ValueError, match="outcomes contradict a complete report"):
+        build_authority_receipt(
+            evaluator_build_digest=_digest("evaluator-build"),
+            boundary_manifest_digest=_digest("boundary-manifest"),
+            plan_commitment=_digest("private-plan"),
+            accelerator_attestation=_attestation(),
+            candidate_artifact_digest=candidate_request.artifact_digest,
+            incumbent_artifact_digest=incumbent_request.artifact_digest,
+            measurements=tuple(contradictory),
+            report={key: value for key, value in report.items() if key != "evaluator_authority_receipt"},
+            signing_key_id=_HMAC_KEY_ID,
+            signing_secret=_HMAC_SECRET,
+        )
+
+    wrong_resources = {key: value for key, value in report.items() if key != "evaluator_authority_receipt"}
+    wrong_resources = json.loads(json.dumps(wrong_resources))
+    wrong_resources["resources"]["candidate_observed_peak_bytes"] = 999
+    with pytest.raises(ValueError, match="transcript peaks"):
+        build_authority_receipt(
+            evaluator_build_digest=_digest("evaluator-build"),
+            boundary_manifest_digest=_digest("boundary-manifest"),
+            plan_commitment=_digest("private-plan"),
+            accelerator_attestation=_attestation(),
+            candidate_artifact_digest=candidate_request.artifact_digest,
+            incumbent_artifact_digest=incumbent_request.artifact_digest,
+            measurements=measurements,
+            report=wrong_resources,
+            signing_key_id=_HMAC_KEY_ID,
+            signing_secret=_HMAC_SECRET,
+        )
 
 
 def test_authority_receipt_requires_independent_contiguous_roles() -> None:
@@ -237,7 +351,7 @@ def test_authority_receipt_requires_independent_contiguous_roles() -> None:
         observed_peak_memory_bytes=1,
         outcome="complete",
     )
-    with pytest.raises(ValidationError, match="candidate and incumbent"):
+    with pytest.raises(ValueError, match="candidate and incumbent"):
         build_authority_receipt(
             evaluator_build_digest=_digest("evaluator-build"),
             boundary_manifest_digest=_digest("boundary-manifest"),
@@ -246,9 +360,127 @@ def test_authority_receipt_requires_independent_contiguous_roles() -> None:
             candidate_artifact_digest=_digest("candidate"),
             incumbent_artifact_digest=_digest("incumbent"),
             measurements=(measurement,),
-            report={
-                "candidate_artifact_digest": _digest("candidate"),
-                "incumbent_artifact_digest": _digest("incumbent"),
-                "protocol": {"seed_commitment": _digest("private-plan")},
-            },
+            report=_report(_digest("candidate"), _digest("incumbent"), candidate_peak=1, incumbent_peak=1),
+            signing_key_id=_HMAC_KEY_ID,
+            signing_secret=_HMAC_SECRET,
         )
+
+
+def test_authority_receipt_rejects_replayed_messages_and_stays_constant_size() -> None:
+    measurements = tuple(
+        AuthorityMeasurement(
+            sequence=index,
+            role="candidate" if index % 2 == 0 else "incumbent",
+            request_digest=_digest(f"request-{index}"),
+            response_digest=_digest(f"response-{index}"),
+            input_commitment=_digest(f"input-{index}"),
+            output_commitment=_digest(f"output-{index}"),
+            elapsed_ns=index + 1,
+            observed_peak_memory_bytes=1_000 + index,
+            outcome="complete",
+        )
+        for index in range(2_000)
+    )
+    report = _report(
+        _digest("candidate"),
+        _digest("incumbent"),
+        candidate_peak=2_998,
+        incumbent_peak=2_999,
+    )
+    receipt = build_authority_receipt(
+        evaluator_build_digest=_digest("evaluator-build"),
+        boundary_manifest_digest=_digest("boundary-manifest"),
+        plan_commitment=_digest("private-plan"),
+        accelerator_attestation=_attestation(),
+        candidate_artifact_digest=_digest("candidate"),
+        incumbent_artifact_digest=_digest("incumbent"),
+        measurements=measurements,
+        report=report,
+        signing_key_id=_HMAC_KEY_ID,
+        signing_secret=_HMAC_SECRET,
+    )
+
+    assert receipt.transcript.measurement_count == 2_000
+    assert "measurements" not in receipt.model_dump(mode="json")
+    assert len(receipt.model_dump_json()) < 4_096
+
+    replayed = list(measurements)
+    replayed[-1] = replayed[-1].model_copy(update={"response_digest": replayed[0].response_digest})
+    with pytest.raises(ValueError, match="replayed response digest"):
+        build_authority_receipt(
+            evaluator_build_digest=_digest("evaluator-build"),
+            boundary_manifest_digest=_digest("boundary-manifest"),
+            plan_commitment=_digest("private-plan"),
+            accelerator_attestation=_attestation(),
+            candidate_artifact_digest=_digest("candidate"),
+            incumbent_artifact_digest=_digest("incumbent"),
+            measurements=tuple(replayed),
+            report=report,
+            signing_key_id=_HMAC_KEY_ID,
+            signing_secret=_HMAC_SECRET,
+        )
+
+
+def test_authority_models_reject_coercible_protocol_values() -> None:
+    request = _request()
+    with pytest.raises(ValidationError, match="int_type"):
+        AuthorityRequest.model_validate({**request.model_dump(mode="json"), "sequence": "0"})
+    with pytest.raises(ValidationError, match="int_type"):
+        AuthorityRequest.model_validate({**request.model_dump(mode="json"), "payload_bytes": False})
+
+
+@pytest.mark.skipif(os.name == "nt", reason="authority secret ownership and mode are POSIX host controls")
+def test_authority_hmac_secret_reader_rejects_unsafe_or_unstable_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = tmp_path / "authority.secret"
+    secret.write_bytes(_HMAC_SECRET)
+    secret.chmod(0o600)
+    assert read_authority_hmac_secret(secret) == _HMAC_SECRET
+
+    with pytest.raises(ValueError, match="regular file"):
+        read_authority_hmac_secret(Path("/"))
+
+    secret.chmod(0o644)
+    with pytest.raises(ValueError, match="exactly 0400 or 0600"):
+        read_authority_hmac_secret(secret)
+    secret.chmod(0o600)
+
+    oversized = tmp_path / "oversized.secret"
+    oversized.write_bytes(b"x" * 4_097)
+    oversized.chmod(0o600)
+    with pytest.raises(ValueError, match="between 32 and 4096"):
+        read_authority_hmac_secret(oversized)
+
+    secret_dir = tmp_path / "secret-dir"
+    secret_dir.mkdir()
+    nested = secret_dir / "nested.secret"
+    nested.write_bytes(_HMAC_SECRET)
+    nested.chmod(0o600)
+    symlink = tmp_path / "secret-link"
+    symlink.symlink_to(secret_dir, target_is_directory=True)
+    with pytest.raises(ValueError, match="cannot contain symlinks"):
+        read_authority_hmac_secret(symlink / nested.name)
+
+    real_fstat = os.fstat
+    calls = 0
+
+    def unstable_fstat(descriptor: int) -> os.stat_result | SimpleNamespace:
+        nonlocal calls
+        calls += 1
+        result = real_fstat(descriptor)
+        if calls != 2:
+            return result
+        return SimpleNamespace(
+            st_dev=result.st_dev,
+            st_ino=result.st_ino,
+            st_mode=result.st_mode,
+            st_uid=result.st_uid,
+            st_size=result.st_size,
+            st_mtime_ns=result.st_mtime_ns + 1,
+        )
+
+    monkeypatch.setattr(os, "fstat", unstable_fstat)
+    with pytest.raises(ValueError, match="changed while it was read"):
+        read_authority_hmac_secret(secret)

--- a/autocontext/tests/test_kernel_authority_protocol.py
+++ b/autocontext/tests/test_kernel_authority_protocol.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.kernel_evolution import (
+    MAX_AUTHORITY_PAYLOAD_BYTES,
+    AcceleratorAttestation,
+    AuthorityMeasurement,
+    AuthorityRequest,
+    AuthorityResponse,
+    AuthorityWireError,
+    authority_message_digest,
+    build_authority_receipt,
+    canonical_authority_digest,
+    encode_authority_frame,
+    receive_authority_frame,
+    verify_authority_receipt,
+)
+from autocontext.kernel_evolution.authority_wire import WIRE_MAGIC
+
+
+class _MemoryConnection:
+    def __init__(self, payload: bytes, *, chunk_size: int = 7) -> None:
+        self._payload = bytearray(payload)
+        self._chunk_size = chunk_size
+
+    def recv(self, size: int) -> bytes:
+        amount = min(size, self._chunk_size, len(self._payload))
+        result = bytes(self._payload[:amount])
+        del self._payload[:amount]
+        return result
+
+
+def _digest(value: bytes | str) -> str:
+    return canonical_authority_digest(value)
+
+
+def _attestation() -> AcceleratorAttestation:
+    return AcceleratorAttestation(
+        backend="cuda",
+        vendor="nvidia",
+        architecture="sm90",
+        device_id="MIG-GPU-deadbeef/1/0",
+        isolation_kind="hardware-partition",
+        enforced_memory_bytes=8 * 1024**3,
+        runtime="cuda-12.8",
+        driver="570.1",
+        attestor_id="nvml-partition-v1",
+        metadata={"region": "us-central"},
+    )
+
+
+def _request(payload: bytes = b"tensor-bytes") -> AuthorityRequest:
+    return AuthorityRequest(
+        request_id=_digest("request-1"),
+        session_nonce=_digest("session"),
+        sequence=0,
+        role="candidate",
+        operation="execute",
+        artifact_digest=_digest("candidate"),
+        input_manifest_digest=_digest("manifest"),
+        payload_digest=_digest(payload),
+        payload_bytes=len(payload),
+    )
+
+
+def _response(request: AuthorityRequest, payload: bytes = b"output-bytes") -> AuthorityResponse:
+    return AuthorityResponse(
+        request_id=request.request_id,
+        session_nonce=request.session_nonce,
+        sequence=request.sequence,
+        role=request.role,
+        artifact_digest=request.artifact_digest,
+        outcome="complete",
+        output_manifest_digest=_digest("output-manifest"),
+        payload_digest=_digest(payload),
+        payload_bytes=len(payload),
+    )
+
+
+def test_authority_protocol_is_accelerator_neutral_and_strict() -> None:
+    attestation = _attestation()
+    assert attestation.backend == "cuda"
+    assert attestation.vendor == "nvidia"
+    assert attestation.digest.startswith("sha256:")
+
+    rocm = attestation.model_copy(
+        update={
+            "backend": "rocm",
+            "vendor": "amd",
+            "architecture": "gfx942",
+            "device_id": "partition-7",
+            "runtime": "rocm-7.0",
+            "driver": "amdgpu-7.0",
+        }
+    )
+    assert rocm.backend == "rocm"
+    assert rocm.digest != attestation.digest
+
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        AcceleratorAttestation.model_validate({**attestation.model_dump(), "h100_only": True})
+
+
+def test_authority_wire_round_trip_is_bounded_and_non_pickle() -> None:
+    payload = b"opaque-safetensors-payload"
+    request = _request(payload)
+    frame = encode_authority_frame(request, payload)
+    decoded, decoded_payload = receive_authority_frame(_MemoryConnection(frame), AuthorityRequest)
+
+    assert decoded == request
+    assert decoded_payload == payload
+    source = Path(__file__).resolve().parents[1] / "src" / "autocontext" / "kernel_evolution" / "authority_wire.py"
+    wire_source = source.read_text(encoding="utf-8")
+    assert "import pickle" not in wire_source
+    assert "pickle.loads" not in wire_source
+
+
+def test_authority_wire_rejects_forged_truncated_and_oversized_frames() -> None:
+    payload = b"payload"
+    request = _request(payload)
+    frame = encode_authority_frame(request, payload)
+
+    with pytest.raises(AuthorityWireError, match="digest"):
+        receive_authority_frame(_MemoryConnection(frame[:-1] + b"X"), AuthorityRequest)
+    with pytest.raises(AuthorityWireError, match="ended"):
+        receive_authority_frame(_MemoryConnection(frame[:-1]), AuthorityRequest)
+
+    oversized = struct.pack("!6sIQ", WIRE_MAGIC, 2, MAX_AUTHORITY_PAYLOAD_BYTES + 1) + b"{}"
+    with pytest.raises(AuthorityWireError, match="oversized"):
+        receive_authority_frame(_MemoryConnection(oversized), AuthorityRequest)
+
+    with pytest.raises(AuthorityWireError, match="byte limit"):
+        encode_authority_frame(request, payload, max_payload_bytes=2)
+
+
+def test_candidate_response_cannot_claim_timing_or_resources() -> None:
+    request = _request()
+    response = _response(request)
+    forged = {
+        **response.model_dump(mode="json"),
+        "elapsed_ns": 1,
+        "peak_memory_bytes": 1,
+    }
+
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        AuthorityResponse.model_validate(forged)
+
+    with pytest.raises(ValidationError, match="failed responses cannot carry"):
+        AuthorityResponse.model_validate(
+            {
+                **response.model_dump(mode="json"),
+                "outcome": "candidate_error",
+                "diagnostic_code": "execution",
+            }
+        )
+
+
+def test_authority_receipt_replays_report_and_detects_tampering() -> None:
+    candidate_request = _request(b"candidate-input")
+    candidate_response = _response(candidate_request, b"candidate-output")
+    incumbent_request = candidate_request.model_copy(
+        update={
+            "request_id": _digest("request-2"),
+            "sequence": 1,
+            "role": "incumbent",
+            "artifact_digest": _digest("incumbent"),
+        }
+    )
+    incumbent_response = _response(incumbent_request, b"incumbent-output")
+    measurements = (
+        AuthorityMeasurement(
+            sequence=0,
+            role="candidate",
+            request_digest=authority_message_digest(candidate_request),
+            response_digest=authority_message_digest(candidate_response),
+            input_commitment=candidate_request.payload_digest,
+            output_commitment=candidate_response.payload_digest,
+            elapsed_ns=10_000,
+            observed_peak_memory_bytes=1_024,
+            outcome="complete",
+        ),
+        AuthorityMeasurement(
+            sequence=1,
+            role="incumbent",
+            request_digest=authority_message_digest(incumbent_request),
+            response_digest=authority_message_digest(incumbent_response),
+            input_commitment=incumbent_request.payload_digest,
+            output_commitment=incumbent_response.payload_digest,
+            elapsed_ns=11_000,
+            observed_peak_memory_bytes=2_048,
+            outcome="complete",
+        ),
+    )
+    report = {
+        "candidate_artifact_digest": candidate_request.artifact_digest,
+        "incumbent_artifact_digest": incumbent_request.artifact_digest,
+        "protocol": {"seed_commitment": _digest("private-plan")},
+        "performance": {"blocks": [{"candidate_ms": 0.01, "incumbent_ms": 0.011}]},
+    }
+    receipt = build_authority_receipt(
+        evaluator_build_digest=_digest("evaluator-build"),
+        boundary_manifest_digest=_digest("boundary-manifest"),
+        plan_commitment=_digest("private-plan"),
+        accelerator_attestation=_attestation(),
+        candidate_artifact_digest=candidate_request.artifact_digest,
+        incumbent_artifact_digest=incumbent_request.artifact_digest,
+        measurements=measurements,
+        report=report,
+    )
+    report["evaluator_authority_receipt"] = receipt.model_dump(mode="json")
+
+    verify_authority_receipt(receipt, report)
+    assert receipt.receipt_digest.startswith("sha256:")
+
+    tampered = json.loads(json.dumps(report))
+    tampered["performance"]["blocks"][0]["candidate_ms"] = 0.000001
+    with pytest.raises(ValueError, match="different report content"):
+        verify_authority_receipt(receipt, tampered)
+
+
+def test_authority_receipt_requires_independent_contiguous_roles() -> None:
+    request = _request()
+    response = _response(request)
+    measurement = AuthorityMeasurement(
+        sequence=0,
+        role="candidate",
+        request_digest=authority_message_digest(request),
+        response_digest=authority_message_digest(response),
+        input_commitment=request.payload_digest,
+        output_commitment=response.payload_digest,
+        elapsed_ns=1,
+        observed_peak_memory_bytes=1,
+        outcome="complete",
+    )
+    with pytest.raises(ValidationError, match="candidate and incumbent"):
+        build_authority_receipt(
+            evaluator_build_digest=_digest("evaluator-build"),
+            boundary_manifest_digest=_digest("boundary-manifest"),
+            plan_commitment=_digest("private-plan"),
+            accelerator_attestation=_attestation(),
+            candidate_artifact_digest=_digest("candidate"),
+            incumbent_artifact_digest=_digest("incumbent"),
+            measurements=(measurement,),
+            report={
+                "candidate_artifact_digest": _digest("candidate"),
+                "incumbent_artifact_digest": _digest("incumbent"),
+                "protocol": {"seed_commitment": _digest("private-plan")},
+            },
+        )

--- a/autocontext/tests/test_kernel_authority_tensor.py
+++ b/autocontext/tests/test_kernel_authority_tensor.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import struct
+
+import pytest
+
+from autocontext.kernel_evolution import AuthorityWireError, canonical_authority_digest
+from autocontext.kernel_evolution.authority_tensor import (
+    copy_tensor_to_device_preserving_abi,
+    deserialize_tensor_list,
+    serialize_tensor_list,
+)
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+
+def test_authority_tensor_round_trip_preserves_transposed_offset_abi() -> None:
+    base = torch.arange(42, dtype=torch.float32).reshape(6, 7)
+    value = base[1:6, 1:6].t()
+    assert value.storage_offset() == 8
+    assert not value.is_contiguous()
+
+    payload, manifest_digest = serialize_tensor_list([value], prefix="input")
+    decoded, decoded_manifest_digest = deserialize_tensor_list(payload, prefix="input")
+
+    assert len(decoded) == 1
+    restored = decoded[0]
+    assert restored.dtype == value.dtype
+    assert restored.shape == value.shape
+    assert restored.stride() == value.stride()
+    assert restored.storage_offset() == value.storage_offset()
+    assert torch.equal(restored, value)
+    assert decoded_manifest_digest == manifest_digest
+    assert serialize_tensor_list(decoded, prefix="input") == (payload, manifest_digest)
+
+
+def test_authority_tensor_round_trip_preserves_non_dense_stride() -> None:
+    value = torch.arange(20, dtype=torch.int64)[2:18:3]
+
+    payload, _manifest_digest = serialize_tensor_list([value], prefix="output")
+    [restored], _decoded_manifest_digest = deserialize_tensor_list(payload, prefix="output")
+
+    assert restored.shape == value.shape
+    assert restored.stride() == value.stride()
+    assert restored.storage_offset() == value.storage_offset()
+    assert torch.equal(restored, value)
+
+
+def test_authority_tensor_round_trip_accepts_irregular_non_overlapping_stride() -> None:
+    value = torch.as_strided(torch.arange(18), (2, 2, 2), (4, 6, 7))
+    assert len({i * 4 + j * 6 + k * 7 for i in range(2) for j in range(2) for k in range(2)}) == value.numel()
+
+    payload, _manifest_digest = serialize_tensor_list([value], prefix="input")
+    [restored], _decoded_manifest_digest = deserialize_tensor_list(payload, prefix="input")
+
+    assert restored.shape == value.shape
+    assert restored.stride() == value.stride()
+    assert restored.storage_offset() == value.storage_offset()
+    assert torch.equal(restored, value)
+
+
+def test_authority_tensor_device_copy_preserves_transposed_offset_abi_on_cpu() -> None:
+    value = torch.arange(30, dtype=torch.float32).reshape(5, 6)[1:, 1:5].t()
+
+    copied = copy_tensor_to_device_preserving_abi(value, device="cpu")
+
+    assert copied.data_ptr() != value.data_ptr()
+    assert copied.shape == value.shape
+    assert copied.stride() == value.stride()
+    assert copied.storage_offset() == value.storage_offset()
+    assert torch.equal(copied, value)
+
+
+def test_authority_tensor_empty_offset_round_trip_and_device_copy_are_consistent() -> None:
+    value = torch.as_strided(torch.empty(0), (0,), (1,), 100)
+
+    payload, _manifest_digest = serialize_tensor_list([value], prefix="input")
+    [restored], _decoded_manifest_digest = deserialize_tensor_list(payload, prefix="input")
+    copied = copy_tensor_to_device_preserving_abi(value, device="cpu")
+
+    for result in (restored, copied):
+        assert result.shape == value.shape
+        assert result.stride() == value.stride()
+        assert result.storage_offset() == value.storage_offset() == 100
+        assert torch.equal(result, value)
+
+
+def test_authority_tensor_empty_list_keeps_canonical_empty_commitment() -> None:
+    payload, manifest_digest = serialize_tensor_list([], prefix="input")
+
+    assert payload == b""
+    assert manifest_digest == canonical_authority_digest({})
+    assert deserialize_tensor_list(payload, prefix="input") == ([], manifest_digest)
+
+
+def test_authority_tensor_rejects_noncanonical_framed_empty_list() -> None:
+    payload = struct.pack("!8sI", b"ACTENS2\0", 2) + b"{}"
+
+    with pytest.raises(AuthorityWireError, match="canonical empty payload"):
+        deserialize_tensor_list(payload, prefix="input")
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        lambda: [torch.arange(8), torch.arange(8)],
+        lambda: [torch.arange(8).as_strided((2, 2), (1, 1))],
+        lambda: [torch.ones(1, 3).expand(4, 3)],
+    ],
+    ids=("independent", "internal-overlap", "expanded-overlap"),
+)
+def test_authority_tensor_overlap_validation_accepts_only_independent_storage(values) -> None:
+    tensors = values()
+    if len(tensors) == 2:
+        serialize_tensor_list(tensors, prefix="input")
+        return
+
+    with pytest.raises(AuthorityWireError, match="overlapping storage"):
+        serialize_tensor_list(tensors, prefix="input")
+
+
+def test_authority_tensor_rejects_cross_value_storage_aliases() -> None:
+    storage = torch.arange(12)
+
+    with pytest.raises(AuthorityWireError, match="storage aliases"):
+        serialize_tensor_list([storage[:6], storage[6:]], prefix="input")
+
+
+def test_authority_tensor_decoder_rejects_forged_overlapping_manifest() -> None:
+    payload, _manifest_digest = serialize_tensor_list([torch.arange(4).reshape(2, 2)], prefix="input")
+    magic, metadata_size = struct.unpack("!8sI", payload[:12])
+    metadata = json.loads(payload[12 : 12 + metadata_size])
+    metadata["input_0000"]["stride"] = [1, 1]
+    forged_metadata = json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode()
+    forged = struct.pack("!8sI", magic, len(forged_metadata)) + forged_metadata + payload[12 + metadata_size :]
+
+    with pytest.raises(AuthorityWireError, match="overlapping storage"):
+        deserialize_tensor_list(forged, prefix="input")
+
+
+def test_authority_tensor_exact_layout_check_rejects_irregular_overlap() -> None:
+    value = torch.as_strided(torch.arange(21), (2, 2, 2), (4, 6, 10))
+
+    with pytest.raises(AuthorityWireError, match="overlapping storage"):
+        serialize_tensor_list([value], prefix="input")
+
+
+def test_authority_tensor_count_limit_precedes_name_allocation() -> None:
+    with pytest.raises(AuthorityWireError, match="too many tensors"):
+        serialize_tensor_list([object()] * 4097, prefix="input")
+
+
+def test_authority_tensor_rejects_noncanonical_prefix() -> None:
+    with pytest.raises(ValueError, match="safe canonical name"):
+        serialize_tensor_list([torch.ones(1)], prefix="../input")

--- a/autocontext/tests/test_kernel_evolution.py
+++ b/autocontext/tests/test_kernel_evolution.py
@@ -232,7 +232,11 @@ class FakeBenchmarkRunner:
         )
 
 
-def _evaluator(fake: FakeBenchmarkRunner) -> KernelBenchmarkEvaluator:
+def _evaluator(
+    fake: FakeBenchmarkRunner,
+    *,
+    adaptive_feedback_policy: str = "detailed",
+) -> KernelBenchmarkEvaluator:
     return KernelBenchmarkEvaluator(
         fake,
         KernelBenchmarkEvaluatorConfig(
@@ -240,6 +244,7 @@ def _evaluator(fake: FakeBenchmarkRunner) -> KernelBenchmarkEvaluator:
             timeout_seconds=12.5,
             min_timing_blocks=5,
             bootstrap_samples=6_000,
+            adaptive_feedback_policy=adaptive_feedback_policy,  # type: ignore[arg-type]
         ),
     )
 
@@ -252,6 +257,7 @@ def _runner(
     confirmation_fn: KernelConfirmationFn | None = None,
     precision_profile: PrecisionProfileName | None = None,
     proposal_cap: int | None = None,
+    adaptive_feedback_policy: str = "detailed",
 ) -> tuple[KernelEvolutionRunner, list[str]]:
     prompts: list[str] = []
 
@@ -270,7 +276,7 @@ def _runner(
             proposal_cap=proposal_cap,
         ),
         generate,
-        _evaluator(fake),
+        _evaluator(fake, adaptive_feedback_policy=adaptive_feedback_policy),
         tmp_path,
         run_id="kernel-test",
         confirmation_fn=confirmation_fn,
@@ -715,6 +721,24 @@ def test_confirmation_details_are_quarantined_from_recursive_prompts(tmp_path: P
     assert result.attempts[1].confirmation_decision is not None
     assert secret in result.attempts[1].confirmation_decision.feedback
     assert secret not in prompts[1]
+
+
+def test_aggregate_gate_feedback_blocks_candidate_timing_covert_channel(tmp_path: Path) -> None:
+    runner, prompts = _runner(
+        tmp_path,
+        FakeBenchmarkRunner(),
+        ["winner", "tiny-gain"],
+        adaptive_feedback_policy="aggregate-gates",
+    )
+
+    result = runner.run(proposals=2)
+
+    assert len(result.attempts) == 3
+    recursive_prompt = prompts[1]
+    assert "Aggregate benchmark gates:" in recursive_prompt
+    assert "paired speedup" not in recursive_prompt
+    assert "relative_improvement" in recursive_prompt
+    assert "1.1111" not in recursive_prompt
 
 
 def test_same_protocol_confirmation_fails_freshness_gate(tmp_path: Path) -> None:

--- a/autocontext/tests/test_kernel_evolution.py
+++ b/autocontext/tests/test_kernel_evolution.py
@@ -11,6 +11,8 @@ from autocontext.kernel_evolution import (
     RELAXED_PRECISION_SEMANTICS,
     SCHEMA_VERSION,
     STRICT_FP32_SEMANTICS,
+    AcceleratorAttestation,
+    AuthorityMeasurement,
     KernelBaselineError,
     KernelBenchmarkEvaluator,
     KernelBenchmarkEvaluatorConfig,
@@ -35,6 +37,8 @@ from autocontext.kernel_evolution import (
     KernelSequentialTestingPolicy,
     KernelTimingBlock,
     PrecisionProfileName,
+    build_authority_receipt,
+    canonical_authority_digest,
     content_digest,
 )
 from autocontext.kernel_evolution.confirmation import _confirmation_veto
@@ -232,6 +236,77 @@ class FakeBenchmarkRunner:
         )
 
 
+class _AuthoritySigningFakeRunner(FakeBenchmarkRunner):
+    def __init__(self, *, signing_secret: bytes, reference_comparable: bool) -> None:
+        super().__init__()
+        self.signing_secret = signing_secret
+        self.reference_comparable = reference_comparable
+        self.evaluator_build_digest = canonical_authority_digest("host-evaluator-build")
+        self.boundary_manifest_digest = canonical_authority_digest("host-boundary")
+
+    def run(
+        self,
+        candidate: KernelCandidate,
+        incumbent: KernelCandidate,
+        *,
+        timeout_seconds: float,
+    ) -> KernelBenchmarkExecution:
+        del timeout_seconds
+        payload = self._report(candidate, incumbent, correct=True).model_dump(mode="json")
+        attestation = AcceleratorAttestation(
+            backend=self.hardware.backend,
+            vendor="test-vendor",
+            architecture=self.hardware.architecture,
+            device_id="test-partition-1",
+            isolation_kind="test-partition",
+            enforced_memory_bytes=1_024,
+            runtime=self.hardware.runtime,
+            driver=self.hardware.driver,
+            attestor_id="test-host-attestor-v1",
+        )
+        payload["resources"] = {
+            "candidate_observed_peak_bytes": 100,
+            "incumbent_observed_peak_bytes": 101,
+            "telemetry_authority": "trusted-evaluator-observed/v1",
+            "accelerator_attestation_digest": attestation.digest,
+            "device_total_memory_bytes": attestation.enforced_memory_bytes,
+        }
+        payload["metadata"]["timing_comparability"] = {
+            "promotion_comparison": ["candidate_ms", "incumbent_ms"],
+            "candidate_incumbent_comparable": True,
+            "reference_comparable": self.reference_comparable,
+        }
+        payload = KernelBenchmarkReport.model_validate(payload).model_dump(mode="json")
+        measurements = tuple(
+            AuthorityMeasurement(
+                sequence=index,
+                role=role,
+                request_digest=canonical_authority_digest(f"request-{role}"),
+                response_digest=canonical_authority_digest(f"response-{role}"),
+                input_commitment=canonical_authority_digest(f"input-{role}"),
+                output_commitment=canonical_authority_digest(f"output-{role}"),
+                elapsed_ns=10 + index,
+                observed_peak_memory_bytes=100 + index,
+                outcome="complete",
+            )
+            for index, role in enumerate(("candidate", "incumbent"))
+        )
+        receipt = build_authority_receipt(
+            evaluator_build_digest=self.evaluator_build_digest,
+            boundary_manifest_digest=self.boundary_manifest_digest,
+            plan_commitment=payload["protocol"]["seed_commitment"],
+            accelerator_attestation=attestation,
+            candidate_artifact_digest=candidate.artifact_digest,
+            incumbent_artifact_digest=incumbent.artifact_digest,
+            measurements=measurements,
+            report=payload,
+            signing_key_id="operator-key-v1",
+            signing_secret=self.signing_secret,
+        )
+        payload["evaluator_authority_receipt"] = receipt.model_dump(mode="json")
+        return KernelBenchmarkExecution(returncode=0, report_payload=payload)
+
+
 def _evaluator(
     fake: FakeBenchmarkRunner,
     *,
@@ -247,6 +322,47 @@ def _evaluator(
             adaptive_feedback_policy=adaptive_feedback_policy,  # type: ignore[arg-type]
         ),
     )
+
+
+def test_authority_eligibility_rejects_self_issued_receipts_and_incomparable_timings(tmp_path: Path) -> None:
+    host_secret = b"operator-owned-authority-secret-material"
+    secret_path = tmp_path / "authority-hmac.secret"
+    secret_path.write_bytes(host_secret)
+    secret_path.chmod(0o600)
+    candidate = KernelCandidate(source="winner")
+    incumbent = KernelCandidate(source="baseline")
+
+    def evaluator(runner: _AuthoritySigningFakeRunner) -> KernelBenchmarkEvaluator:
+        return KernelBenchmarkEvaluator(
+            runner,
+            KernelBenchmarkEvaluatorConfig(
+                problem_id="kernelbench-level1-problem1",
+                timeout_seconds=12.5,
+                min_timing_blocks=5,
+                bootstrap_samples=6_000,
+                require_authority_receipt=True,
+                authority_hmac_key_id="operator-key-v1",
+                authority_hmac_secret_path=secret_path,
+                expected_evaluator_build_digest=runner.evaluator_build_digest,
+                expected_boundary_manifest_digest=runner.boundary_manifest_digest,
+            ),
+        )
+
+    self_issued = evaluator(
+        _AuthoritySigningFakeRunner(
+            signing_secret=b"candidate-controlled-signing-secret-material",
+            reference_comparable=True,
+        )
+    ).evaluate(candidate, incumbent)
+    assert not self_issued.eligible
+    assert self_issued.rejection_reason == "invalid_authority_receipt"
+    assert "authentication tag is invalid" in self_issued.feedback
+
+    incomparable = evaluator(
+        _AuthoritySigningFakeRunner(signing_secret=host_secret, reference_comparable=False)
+    ).evaluate(candidate, incumbent)
+    assert not incomparable.eligible
+    assert incomparable.rejection_reason == "timing_boundary_mismatch"
 
 
 def _runner(

--- a/autocontext/tests/test_kernel_h100_adapter_authority.py
+++ b/autocontext/tests/test_kernel_h100_adapter_authority.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from autocontext.kernel_evolution.authority_tensor import copy_tensor_to_device_preserving_abi
+
+_ADAPTER = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "kernel_evolution"
+    / "kernelbench_h100"
+    / "adapter.py"
+)
+
+
+def _adapter_function(name: str, namespace: dict[str, Any] | None = None) -> Any:
+    tree = ast.parse(_ADAPTER.read_text(encoding="utf-8"))
+    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name)
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+    globals_: dict[str, Any] = {} if namespace is None else namespace
+    exec(compile(module, str(_ADAPTER), "exec"), globals_)
+    return globals_[name]
+
+
+def test_protected_adapter_rejects_response_patching_candidate_before_dispatch() -> None:
+    guard = _adapter_function("_require_protected_mutation_authority")
+    fake_main = ModuleType("__main__")
+    original_response = object()
+    fake_main._response = original_response  # type: ignore[attr-defined]
+    attack = compile(
+        "import sys\n"
+        "sys.modules['__main__']._response = lambda *args, **kwargs: ('forged', b'original-input')\n",
+        "adversarial_mutating_candidate.py",
+        "exec",
+    )
+    real_main = sys.modules.get("__main__")
+    try:
+        sys.modules["__main__"] = fake_main
+        exec(attack, {})
+    finally:
+        if real_main is None:
+            sys.modules.pop("__main__", None)
+        else:
+            sys.modules["__main__"] = real_main
+    assert fake_main._response is not original_response  # type: ignore[attr-defined]
+
+    with pytest.raises(SystemExit, match="trusted out-of-process input-mutation observer"):
+        guard(protected_mode=True)
+
+    source = _ADAPTER.read_text(encoding="utf-8")
+    assert source.index("_require_protected_mutation_authority(protected_mode=protected_mode)") < source.index(
+        "candidate_endpoint.listen()"
+    )
+
+
+def test_mutating_candidate_changes_evaluator_owned_tensor_state() -> None:
+    torch = pytest.importorskip("torch")
+    equal = _adapter_function("_equal", {"torch": torch})
+    candidate_input = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    evaluator_before = candidate_input.clone()
+
+    def mutating_candidate(value):
+        value.add_(1)
+        return value
+
+    mutating_candidate(candidate_input)
+    assert not equal(evaluator_before, candidate_input)
+
+
+def test_tensor_state_comparison_includes_stride_and_storage_offset() -> None:
+    torch = pytest.importorskip("torch")
+    equal = _adapter_function("_equal", {"torch": torch})
+    contiguous = torch.arange(6).reshape(2, 3)
+    transposed_storage = contiguous.t().contiguous().t()
+
+    assert torch.equal(contiguous, transposed_storage)
+    assert contiguous.stride() != transposed_storage.stride()
+    assert not equal(contiguous, transposed_storage)
+
+
+def test_tensor_snapshot_preserves_nonzero_offset_without_false_mutation() -> None:
+    torch = pytest.importorskip("torch")
+    clone = _adapter_function(
+        "_clone",
+        {
+            "copy_tensor_to_device_preserving_abi": copy_tensor_to_device_preserving_abi,
+            "torch": torch,
+        },
+    )
+    equal = _adapter_function("_equal", {"torch": torch})
+    value = torch.arange(12, dtype=torch.float32)[3:9]
+
+    snapshot = clone(value)
+
+    assert snapshot.data_ptr() != value.data_ptr()
+    assert snapshot.stride() == value.stride()
+    assert snapshot.storage_offset() == value.storage_offset() == 3
+    assert equal(snapshot, value)
+
+
+def test_tensor_snapshot_detects_actual_mutation_of_offset_view() -> None:
+    torch = pytest.importorskip("torch")
+    clone = _adapter_function(
+        "_clone",
+        {
+            "copy_tensor_to_device_preserving_abi": copy_tensor_to_device_preserving_abi,
+            "torch": torch,
+        },
+    )
+    equal = _adapter_function("_equal", {"torch": torch})
+    value = torch.arange(12, dtype=torch.float32)[3:9]
+    snapshot = clone(value)
+
+    value.add_(1)
+
+    assert not equal(snapshot, value)
+
+
+def test_protected_timing_compares_only_shared_evaluator_owned_rpc_boundaries() -> None:
+    source = _ADAPTER.read_text(encoding="utf-8")
+
+    assert 'comparable_names = ("candidate_ms", "incumbent_ms") if remote_authority_timing else names' in source
+    assert '"candidate_incumbent_comparable": True' in source
+    assert '"reference_comparable": not remote_authority_timing' in source
+    assert '"promotion_comparison": ["candidate_ms", "incumbent_ms"]' in source
+
+    transport = (_ADAPTER.parent / "authority_transport.py").read_text(encoding="utf-8")
+    assert "started = time.perf_counter_ns()" in transport
+    assert "return self.last_measurement.elapsed_ns / 1_000_000.0" in transport

--- a/autocontext/tests/test_kernel_h100_production_runtime.py
+++ b/autocontext/tests/test_kernel_h100_production_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import importlib
 import json
 import os
@@ -11,22 +12,43 @@ from typing import Any
 import pytest
 
 from autocontext.kernel_evolution import (
+    AcceleratorAttestation,
+    AuthorityMeasurement,
     DockerKernelWorkerLimits,
     KernelCandidate,
     KernelDecisionPolicy,
     KernelSequentialTestingPolicy,
     KernelStatisticsPolicy,
+    ProfileEvidenceEnvelope,
+    build_authority_receipt,
+    canonical_authority_digest,
     canonical_digest,
+    read_authority_hmac_secret,
+    verify_profile_evidence_envelope,
 )
 
 _BUNDLE = Path(__file__).resolve().parents[2] / "examples" / "kernel_evolution" / "kernelbench_h100"
 _PINNED_IMAGE = f"registry.example/autocontext-kernel@sha256:{'a' * 64}"
+_AUTHORITY_KEY_ID = "test-h100-authority-v1"
+_AUTHORITY_SECRET = b"test-only-h100-authority-secret-material"
 
 
 class _SerializableNamespace(SimpleNamespace):
     def model_dump(self, *, mode: str) -> dict[str, Any]:
         assert mode == "json"
-        return dict(vars(self))
+
+        def convert(value: Any) -> Any:
+            if hasattr(value, "model_dump"):
+                return value.model_dump(mode="json")
+            if isinstance(value, list):
+                return [convert(item) for item in value]
+            if isinstance(value, tuple):
+                return [convert(item) for item in value]
+            if isinstance(value, dict):
+                return {key: convert(item) for key, item in value.items()}
+            return value
+
+        return {key: convert(value) for key, value in vars(self).items()}
 
 
 @pytest.fixture
@@ -37,7 +59,19 @@ def runtime_modules(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, Any]:
     return production_runtime, campaign
 
 
-def _runtime(production_runtime: Any, *, gpu_memory_bytes: int = 8 * 1024**3) -> Any:
+def _authority_secret(tmp_path: Path) -> Path:
+    path = tmp_path / "authority-hmac.secret"
+    path.write_bytes(_AUTHORITY_SECRET)
+    path.chmod(0o600)
+    return path
+
+
+def _runtime(
+    production_runtime: Any,
+    authority_secret_path: Path,
+    *,
+    gpu_memory_bytes: int = 8 * 1024**3,
+) -> Any:
     return production_runtime.H100DockerRuntimeConfig(
         image=_PINNED_IMAGE,
         docker_binary="docker-production",
@@ -46,12 +80,14 @@ def _runtime(production_runtime: Any, *, gpu_memory_bytes: int = 8 * 1024**3) ->
         gpu_device="MIG-GPU-deadbeef/1/0",
         gpu_isolation_kind="mig",
         gpu_memory_bytes=gpu_memory_bytes,
+        authority_hmac_key_id=_AUTHORITY_KEY_ID,
+        authority_hmac_secret_path=authority_secret_path,
         limits=DockerKernelWorkerLimits(max_gpu_memory_bytes=8 * 1024**3),
         timeout_seconds=180.0,
     )
 
 
-def test_production_runtime_is_pinned_and_protected_composition_is_runnable_for_validation(
+def test_production_runtime_is_pinned_and_protected_composition_is_inspectable_while_unavailable(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     runtime_modules: tuple[Any, Any],
@@ -62,7 +98,8 @@ def test_production_runtime_is_pinned_and_protected_composition_is_runnable_for_
     (autokernel_root / "kernel.py").write_text("def kernel_fn(a, b): return a @ b\n", encoding="utf-8")
     private_plan = tmp_path / "private-plan.json"
     private_plan.write_text("{}\n", encoding="utf-8")
-    runtime = _runtime(production_runtime)
+    authority_secret = _authority_secret(tmp_path)
+    runtime = _runtime(production_runtime, authority_secret)
     runtime_manifest = runtime.manifest()
     assert runtime_manifest["image"] == _PINNED_IMAGE
     assert runtime_manifest["docker_binary"] == "docker-production"
@@ -70,10 +107,27 @@ def test_production_runtime_is_pinned_and_protected_composition_is_runnable_for_
     assert runtime_manifest["gpu_device"] == "MIG-GPU-deadbeef/1/0"
     assert runtime_manifest["gpu_memory_bytes"] == 8 * 1024**3
     assert runtime_manifest["limits"]["max_gpu_memory_bytes"] == 8 * 1024**3
-    assert runtime_manifest["evidence_boundary"] == {
-        "required": "trusted-evaluator/isolated-accelerator-candidate-v1",
+    assert runtime_manifest["evidence_boundary"]["required"] == (
+        "trusted-evaluator/isolated-accelerator-candidate-v1"
+    )
+    assert runtime_manifest["evidence_boundary"]["available"] is False
+    assert runtime_manifest["evidence_boundary"]["requirements"]["crash_safe_container_creation"] == {
+        "required": "supervised-create-before-coordinator-ownership/v1",
         "available": False,
+        "reason": (
+            "protected accelerator evidence requires crash-safe container creation; "
+            "the v1 coordinator-owned docker create path is unsupported"
+        ),
     }
+    assert any(
+        "crash-safe" in requirement
+        for requirement in runtime_manifest["evidence_boundary"]["unmet_requirements"]
+    )
+    assert runtime_manifest["authority_authentication"] == {
+        "algorithm": "hmac-sha256",
+        "key_id": _AUTHORITY_KEY_ID,
+    }
+    assert str(authority_secret) not in str(runtime_manifest)
 
     captured: dict[str, Any] = {}
 
@@ -87,7 +141,10 @@ def test_production_runtime_is_pinned_and_protected_composition_is_runnable_for_
             captured["runner"] = kwargs
 
         def manifest(self) -> dict[str, Any]:
-            return {"kind": "fake-protected-runner"}
+            return {
+                "kind": "fake-protected-runner",
+                "evaluator_build_digest": canonical_authority_digest("fake-evaluator-build"),
+            }
 
     monkeypatch.setattr(production_runtime, "NvidiaSMIGPUDeviceAttestor", FakeAttestor)
     monkeypatch.setattr(production_runtime, "DockerProtectedKernelBenchmarkRunner", FakeProtectedRunner)
@@ -108,9 +165,13 @@ def test_production_runtime_is_pinned_and_protected_composition_is_runnable_for_
     assert manifest["evaluator"]["require_authority_receipt"] is True
     assert manifest["evaluator"]["require_resource_telemetry"] is True
     assert manifest["evaluator"]["adaptive_feedback_policy"] == "aggregate-gates"
+    assert manifest["evaluator"]["authority_trust"]["key_id"] == _AUTHORITY_KEY_ID
+    assert str(authority_secret) not in str(manifest)
     assert captured["attestor_binary"] == "nvidia-smi-production"
     assert captured["runner"]["evaluator_immutable_paths"] == (_BUNDLE.resolve(), private_plan.resolve())
     assert captured["runner"]["candidate_runtime_path"] == _BUNDLE / "authority_worker.py"
+    assert captured["runner"]["authority_hmac_key_id"] == _AUTHORITY_KEY_ID
+    assert captured["runner"]["authority_hmac_secret_path"] == authority_secret
     command = captured["command"]
     assert "{candidate_socket}" in command and "{incumbent_socket}" in command
     assert "{candidate}" not in command and "{incumbent}" not in command
@@ -120,7 +181,10 @@ def test_production_runtime_is_pinned_and_protected_composition_is_runnable_for_
 def test_production_campaign_has_no_same_interpreter_override(runtime_modules: tuple[Any, Any]) -> None:
     production_runtime, _campaign = runtime_modules
 
-    with pytest.raises(production_runtime.ProductionEvaluatorBoundaryUnavailable, match="real H100/MIG validation"):
+    with pytest.raises(
+        production_runtime.ProductionEvaluatorBoundaryUnavailable,
+        match="comparable candidate/incumbent/reference timing boundaries",
+    ):
         production_runtime.require_protected_evaluator_boundary()
 
     source = (_BUNDLE / "campaign.py").read_text(encoding="utf-8")
@@ -185,6 +249,7 @@ def test_campaign_fails_before_creating_mailbox_or_launching_worker(
     confirmation_plan = tmp_path / "confirmation.json"
     primary_plan.write_text("{}\n", encoding="utf-8")
     confirmation_plan.write_text("{}\n", encoding="utf-8")
+    authority_secret = _authority_secret(tmp_path)
     mailbox = tmp_path / "must-not-exist"
     monkeypatch.setattr(campaign, "private_plan_commitment", lambda path: f"sha256:{'a' * 64}")
     monkeypatch.setattr(campaign, "load_private_plan", lambda *args, **kwargs: {"test": True})
@@ -209,6 +274,10 @@ def test_campaign_fails_before_creating_mailbox_or_launching_worker(
             "mig",
             "--gpu-memory-bytes",
             str(8 * 1024**3),
+            "--authority-hmac-key-id",
+            _AUTHORITY_KEY_ID,
+            "--authority-hmac-secret-file",
+            str(authority_secret),
             "--mailbox",
             str(mailbox),
             "--precision-profile",
@@ -242,6 +311,7 @@ def test_post_run_evidence_failure_publishes_failed_terminal_status(
     confirmation_plan = tmp_path / "confirmation.json"
     primary_plan.write_text("{}\n", encoding="utf-8")
     confirmation_plan.write_text("{}\n", encoding="utf-8")
+    authority_secret = _authority_secret(tmp_path)
     mailbox = tmp_path / "mailbox"
     run_dir = tmp_path / "run"
 
@@ -254,7 +324,13 @@ def test_post_run_evidence_failure_publishes_failed_terminal_status(
             assert proposals == 1
             return SimpleNamespace()
 
-    evaluator = SimpleNamespace(manifest=lambda: {"kind": "fake-protected-evaluator"})
+    evaluator = SimpleNamespace(
+        manifest=lambda: {"kind": "fake-protected-evaluator"},
+        config=SimpleNamespace(
+            expected_evaluator_build_digest=canonical_authority_digest("fake-evaluator-build"),
+            expected_boundary_manifest_digest=canonical_authority_digest("fake-boundary"),
+        ),
+    )
     monkeypatch.setattr(campaign, "private_plan_commitment", lambda path: f"sha256:{'a' * 64}")
     monkeypatch.setattr(campaign, "load_private_plan", lambda *args, **kwargs: {"test": True})
     monkeypatch.setattr(campaign, "_validate_confirmation_schedule", lambda *args, **kwargs: None)
@@ -291,6 +367,10 @@ def test_post_run_evidence_failure_publishes_failed_terminal_status(
             "mig",
             "--gpu-memory-bytes",
             str(8 * 1024**3),
+            "--authority-hmac-key-id",
+            _AUTHORITY_KEY_ID,
+            "--authority-hmac-secret-file",
+            str(authority_secret),
             "--mailbox",
             str(mailbox),
             "--precision-profile",
@@ -313,13 +393,17 @@ def test_post_run_evidence_failure_publishes_failed_terminal_status(
     assert status["error"] == "receipt export failed"
 
 
-def test_runtime_rejects_claimed_gpu_capacity_above_hard_limit(runtime_modules: tuple[Any, Any]) -> None:
+def test_runtime_rejects_claimed_gpu_capacity_above_hard_limit(
+    tmp_path: Path,
+    runtime_modules: tuple[Any, Any],
+) -> None:
     production_runtime, _campaign = runtime_modules
+    authority_secret = _authority_secret(tmp_path)
 
     with pytest.raises(ValueError, match="cannot exceed max_gpu_memory_bytes"):
-        _runtime(production_runtime, gpu_memory_bytes=9 * 1024**3)
+        _runtime(production_runtime, authority_secret, gpu_memory_bytes=9 * 1024**3)
 
-    runtime = _runtime(production_runtime)
+    runtime = _runtime(production_runtime, authority_secret)
     with pytest.raises(ValueError, match="absolute normalized path"):
         production_runtime.H100DockerRuntimeConfig(
             image=runtime.image,
@@ -329,6 +413,8 @@ def test_runtime_rejects_claimed_gpu_capacity_above_hard_limit(runtime_modules: 
             gpu_device=runtime.gpu_device,
             gpu_isolation_kind="mig",
             gpu_memory_bytes=runtime.gpu_memory_bytes,
+            authority_hmac_key_id=runtime.authority_hmac_key_id,
+            authority_hmac_secret_path=runtime.authority_hmac_secret_path,
             limits=runtime.limits,
         )
 
@@ -336,6 +422,8 @@ def test_runtime_rejects_claimed_gpu_capacity_above_hard_limit(runtime_modules: 
 def _profile_result(campaign: Any, runtime: Any) -> SimpleNamespace:
     primary_commitment = f"sha256:{'b' * 64}"
     confirmation_commitment = f"sha256:{'c' * 64}"
+    candidate_artifact_digest = f"sha256:{'3' * 64}"
+    incumbent_artifact_digest = f"sha256:{'9' * 64}"
     attestation_payload = {
         "device_id": runtime.gpu_device,
         "isolation_kind": runtime.gpu_isolation_kind,
@@ -351,28 +439,110 @@ def _profile_result(campaign: Any, runtime: Any) -> SimpleNamespace:
     }
     holdout_correctness = _SerializableNamespace(name="holdout", split="holdout", passed=True)
     holdout_performance = _SerializableNamespace(name="holdout", split="holdout", passed_no_regression=True)
-    primary_report = SimpleNamespace(
+    accelerator = AcceleratorAttestation(
+        backend="cuda",
+        vendor="nvidia",
+        architecture="sm90",
+        device_id=runtime.gpu_device,
+        isolation_kind=runtime.gpu_isolation_kind,
+        enforced_memory_bytes=runtime.gpu_memory_bytes,
+        runtime="cuda-12.8",
+        driver="570.1",
+        attestor_id=attestation_payload["attestor_id"],
+        metadata={"grant_attestation_digest": attestation["device_attestation_digest"]},
+    )
+    resources = {
+        "candidate_observed_peak_bytes": 101,
+        "incumbent_observed_peak_bytes": 102,
+        "telemetry_authority": "trusted-evaluator-observed/v1",
+        "accelerator_attestation_digest": accelerator.digest,
+        "device_total_memory_bytes": runtime.gpu_memory_bytes,
+    }
+    primary_report = _SerializableNamespace(
         schema_version="autocontext.kernelbench-eval/v3",
-        protocol=SimpleNamespace(seed_commitment=primary_commitment),
-        hardware=SimpleNamespace(
+        evaluation_status="complete",
+        failure_kind=None,
+        candidate_artifact_digest=candidate_artifact_digest,
+        incumbent_artifact_digest=incumbent_artifact_digest,
+        protocol=_SerializableNamespace(seed_commitment=primary_commitment),
+        resources=dict(resources),
+        hardware=_SerializableNamespace(
             backend="cuda",
             architecture="sm90",
             device_name="NVIDIA H100 80GB HBM3",
             metadata=dict(attestation),
         ),
-        correctness=SimpleNamespace(slices=[holdout_correctness]),
-        performance=SimpleNamespace(cases=[holdout_performance]),
+        correctness=_SerializableNamespace(slices=[holdout_correctness]),
+        performance=_SerializableNamespace(cases=[holdout_performance]),
     )
-    confirmation_report = SimpleNamespace(
+    confirmation_report = _SerializableNamespace(
         schema_version="autocontext.kernelbench-eval/v3",
-        protocol=SimpleNamespace(seed_commitment=confirmation_commitment),
-        hardware=SimpleNamespace(
+        evaluation_status="complete",
+        failure_kind=None,
+        candidate_artifact_digest=candidate_artifact_digest,
+        incumbent_artifact_digest=incumbent_artifact_digest,
+        protocol=_SerializableNamespace(seed_commitment=confirmation_commitment),
+        resources=dict(resources),
+        hardware=_SerializableNamespace(
             backend="cuda",
             architecture="sm90",
             device_name="NVIDIA H100 80GB HBM3",
             metadata=dict(attestation),
         ),
     )
+    evaluator_build_digest = canonical_authority_digest("profile-evaluator-build")
+    authority_identities = {
+        primary_commitment: {
+            "evaluator_build_digest": evaluator_build_digest,
+            "boundary_manifest_digest": canonical_authority_digest("primary-boundary"),
+        },
+        confirmation_commitment: {
+            "evaluator_build_digest": evaluator_build_digest,
+            "boundary_manifest_digest": canonical_authority_digest("confirmation-boundary"),
+        },
+    }
+
+    def attach_authority_receipt(report: _SerializableNamespace, *, commitment: str, label: str) -> None:
+        measurements = (
+            AuthorityMeasurement(
+                sequence=0,
+                role="candidate",
+                request_digest=canonical_authority_digest(f"{label}-candidate-request"),
+                response_digest=canonical_authority_digest(f"{label}-candidate-response"),
+                input_commitment=canonical_authority_digest(f"{label}-candidate-input"),
+                output_commitment=canonical_authority_digest(f"{label}-candidate-output"),
+                elapsed_ns=10,
+                observed_peak_memory_bytes=101,
+                outcome="complete",
+            ),
+            AuthorityMeasurement(
+                sequence=1,
+                role="incumbent",
+                request_digest=canonical_authority_digest(f"{label}-incumbent-request"),
+                response_digest=canonical_authority_digest(f"{label}-incumbent-response"),
+                input_commitment=canonical_authority_digest(f"{label}-incumbent-input"),
+                output_commitment=canonical_authority_digest(f"{label}-incumbent-output"),
+                elapsed_ns=11,
+                observed_peak_memory_bytes=102,
+                outcome="complete",
+            ),
+        )
+        identity = authority_identities[commitment]
+        report.evaluator_authority_receipt = build_authority_receipt(
+            evaluator_build_digest=identity["evaluator_build_digest"],
+            boundary_manifest_digest=identity["boundary_manifest_digest"],
+            plan_commitment=commitment,
+            accelerator_attestation=accelerator,
+            candidate_artifact_digest=candidate_artifact_digest,
+            incumbent_artifact_digest=incumbent_artifact_digest,
+            measurements=measurements,
+            report=report.model_dump(mode="json"),
+            signing_key_id=runtime.authority_hmac_key_id,
+            signing_secret=read_authority_hmac_secret(runtime.authority_hmac_secret_path),
+        )
+
+    attach_authority_receipt(primary_report, commitment=primary_commitment, label="primary")
+    attach_authority_receipt(confirmation_report, commitment=confirmation_commitment, label="confirmation")
     confirmation = SimpleNamespace(
         report=confirmation_report,
         protocol_id=f"sha256:{'e' * 64}",
@@ -386,7 +556,7 @@ def _profile_result(campaign: Any, runtime: Any) -> SimpleNamespace:
         role="candidate",
         decision="promoted",
         artifact_identity_version="autocontext.kernel-artifact/v2",
-        artifact_digest=f"sha256:{'3' * 64}",
+        artifact_digest=candidate_artifact_digest,
         source_digest=f"sha256:{'4' * 64}",
         source_suffix=".py",
         entrypoint="kernel_fn",
@@ -443,14 +613,16 @@ def _profile_result(campaign: Any, runtime: Any) -> SimpleNamespace:
         attempts=[baseline, champion],
         _primary_commitment=primary_commitment,
         _confirmation_commitment=confirmation_commitment,
+        _authority_identities=authority_identities,
     )
 
 
 def test_profile_evidence_builder_validates_exact_receipts_and_attestation(
+    tmp_path: Path,
     runtime_modules: tuple[Any, Any],
 ) -> None:
     production_runtime, campaign = runtime_modules
-    runtime = _runtime(production_runtime)
+    runtime = _runtime(production_runtime, _authority_secret(tmp_path))
     result = _profile_result(campaign, runtime)
 
     evidence = campaign._build_profile_evidence(
@@ -460,20 +632,69 @@ def test_profile_evidence_builder_validates_exact_receipts_and_attestation(
         primary_commitment=result._primary_commitment,
         confirmation_commitments=(result._confirmation_commitment,),
         runtime=runtime,
+        authority_identities=result._authority_identities,
     )
 
-    assert evidence["schema_version"] == "autocontext.kernel-h100-profile-evidence/v3"
-    assert evidence["champion"]["attempt_id"] == result.champion_attempt_id
-    assert evidence["primary_receipt"]["plan_commitment"] == result._primary_commitment
-    assert evidence["confirmation_receipt"]["plan_commitment"] == result._confirmation_commitment
-    assert evidence["hardware_attestation"]["device_id"] == runtime.gpu_device
-    assert evidence["hardware_attestation"]["attestor_id"] == "nvidia-smi-nvml-mig-v1"
-    assert evidence["decision_policy_id"] == result.decision_policy.policy_id
-    assert evidence["decision_policy"] == result.decision_policy.model_dump(mode="json")
-    assert evidence["proposals_evaluated"] == 1
-    assert evidence["promotions"] == 1
-    assert evidence["all_holdout_correctness_passed"] is True
-    assert evidence["all_holdout_no_regression_passed"] is True
+    assert evidence["schema_version"] == "autocontext.kernel-profile-evidence-envelope/v1"
+    assert evidence["authentication"]["key_id"] == _AUTHORITY_KEY_ID
+    verified = verify_profile_evidence_envelope(
+        ProfileEvidenceEnvelope.model_validate(evidence),
+        trusted_key_id=_AUTHORITY_KEY_ID,
+        trusted_secret=_AUTHORITY_SECRET,
+    )
+    profile = verified.profile
+    assert profile["schema_version"] == "autocontext.kernel-h100-profile-evidence/v3"
+    assert profile["champion"]["attempt_id"] == result.champion_attempt_id
+    assert profile["primary_receipt"]["plan_commitment"] == result._primary_commitment
+    assert profile["confirmation_receipt"]["plan_commitment"] == result._confirmation_commitment
+    assert profile["primary_receipt"]["authority_receipt"]["authentication"]["key_id"] == _AUTHORITY_KEY_ID
+    assert profile["confirmation_receipt"]["authority_receipt_digest"].startswith("sha256:")
+    assert profile["hardware_attestation"]["device_id"] == runtime.gpu_device
+    assert profile["hardware_attestation"]["attestor_id"] == "nvidia-smi-nvml-mig-v1"
+    assert profile["decision_policy_id"] == result.decision_policy.policy_id
+    assert profile["decision_policy"] == result.decision_policy.model_dump(mode="json")
+    assert profile["proposals_evaluated"] == 1
+    assert profile["promotions"] == 1
+    assert profile["all_holdout_correctness_passed"] is True
+    assert profile["all_holdout_no_regression_passed"] is True
+
+    mutations = (
+        lambda payload: payload["profile"]["champion"].__setitem__("source_digest", "sha256:" + "0" * 64),
+        lambda payload: payload["profile"]["decision_policy"].__setitem__("min_relative_improvement", 0.0),
+        lambda payload: payload["profile"].__setitem__("promotions", 999),
+        lambda payload: payload["profile"].__setitem__("all_holdout_correctness_passed", False),
+        lambda payload: payload["profile"]["primary_receipt"].__setitem__(
+            "report_digest", "sha256:" + "1" * 64
+        ),
+        lambda payload: payload["profile"]["primary_receipt"].__setitem__(
+            "authority_receipt_digest", "sha256:" + "2" * 64
+        ),
+    )
+    for mutate in mutations:
+        forged = copy.deepcopy(evidence)
+        mutate(forged)
+        forged["content_digest"] = canonical_authority_digest(forged["profile"])
+        with pytest.raises(ValueError, match="authentication tag"):
+            verify_profile_evidence_envelope(
+                forged,
+                trusted_key_id=_AUTHORITY_KEY_ID,
+                trusted_secret=_AUTHORITY_SECRET,
+            )
+
+    with pytest.raises(ValueError, match="authentication key"):
+        verify_profile_evidence_envelope(
+            evidence,
+            trusted_key_id="different-operator-key",
+            trusted_secret=_AUTHORITY_SECRET,
+        )
+    forged_tag = copy.deepcopy(evidence)
+    forged_tag["authentication"]["tag"] = "hmac-sha256:" + "0" * 64
+    with pytest.raises(ValueError, match="authentication tag"):
+        verify_profile_evidence_envelope(
+            forged_tag,
+            trusted_key_id=_AUTHORITY_KEY_ID,
+            trusted_secret=_AUTHORITY_SECRET,
+        )
 
     champion = result.attempts[1]
     champion.observation.report.hardware.metadata["device_grant"] = "MIG-GPU-forged/1/0"
@@ -485,6 +706,7 @@ def test_profile_evidence_builder_validates_exact_receipts_and_attestation(
             primary_commitment=result._primary_commitment,
             confirmation_commitments=(result._confirmation_commitment,),
             runtime=runtime,
+            authority_identities=result._authority_identities,
         )
 
     result.decision_policy = None
@@ -496,6 +718,7 @@ def test_profile_evidence_builder_validates_exact_receipts_and_attestation(
             primary_commitment=result._primary_commitment,
             confirmation_commitments=(result._confirmation_commitment,),
             runtime=runtime,
+            authority_identities=result._authority_identities,
         )
 
     result = _profile_result(campaign, runtime)
@@ -508,14 +731,48 @@ def test_profile_evidence_builder_validates_exact_receipts_and_attestation(
             primary_commitment=result._primary_commitment,
             confirmation_commitments=(result._confirmation_commitment,),
             runtime=runtime,
+            authority_identities=result._authority_identities,
+        )
+
+    result = _profile_result(campaign, runtime)
+    result.attempts[1].confirmation_observation.report.evaluator_authority_receipt = None
+    with pytest.raises(RuntimeError, match="missing a trusted-evaluator authority receipt"):
+        campaign._build_profile_evidence(
+            result=result,
+            run_id=result.run_id,
+            precision_profile=result.precision_profile,
+            primary_commitment=result._primary_commitment,
+            confirmation_commitments=(result._confirmation_commitment,),
+            runtime=runtime,
+            authority_identities=result._authority_identities,
+        )
+
+    result = _profile_result(campaign, runtime)
+    report = result.attempts[1].observation.report
+    receipt = report.evaluator_authority_receipt
+    report.evaluator_authority_receipt = receipt.model_copy(
+        update={
+            "authentication": receipt.authentication.model_copy(update={"tag": "hmac-sha256:" + "0" * 64})
+        }
+    )
+    with pytest.raises(RuntimeError, match="failed authenticated replay"):
+        campaign._build_profile_evidence(
+            result=result,
+            run_id=result.run_id,
+            precision_profile=result.precision_profile,
+            primary_commitment=result._primary_commitment,
+            confirmation_commitments=(result._confirmation_commitment,),
+            runtime=runtime,
+            authority_identities=result._authority_identities,
         )
 
 
 def test_profile_evidence_rejects_non_h100_or_incomplete_v3_chain(
+    tmp_path: Path,
     runtime_modules: tuple[Any, Any],
 ) -> None:
     production_runtime, campaign = runtime_modules
-    runtime = _runtime(production_runtime)
+    runtime = _runtime(production_runtime, _authority_secret(tmp_path))
     result = _profile_result(campaign, runtime)
     result.attempts[1].observation.report.hardware.architecture = "sm80"
     result.attempts[1].observation.report.hardware.device_name = "NVIDIA A100-SXM4-80GB"
@@ -528,6 +785,7 @@ def test_profile_evidence_rejects_non_h100_or_incomplete_v3_chain(
             primary_commitment=result._primary_commitment,
             confirmation_commitments=(result._confirmation_commitment,),
             runtime=runtime,
+            authority_identities=result._authority_identities,
         )
 
     result = _profile_result(campaign, runtime)
@@ -540,14 +798,16 @@ def test_profile_evidence_rejects_non_h100_or_incomplete_v3_chain(
             primary_commitment=result._primary_commitment,
             confirmation_commitments=(result._confirmation_commitment,),
             runtime=runtime,
+            authority_identities=result._authority_identities,
         )
 
 
 def test_profile_evidence_recomputes_complete_gpu_attestation(
+    tmp_path: Path,
     runtime_modules: tuple[Any, Any],
 ) -> None:
     production_runtime, campaign = runtime_modules
-    runtime = _runtime(production_runtime)
+    runtime = _runtime(production_runtime, _authority_secret(tmp_path))
     result = _profile_result(campaign, runtime)
     champion_report = result.attempts[1].observation.report
     champion_report.hardware.metadata["device_attestor_id"] = "forged-attestor-v1"
@@ -560,6 +820,7 @@ def test_profile_evidence_recomputes_complete_gpu_attestation(
             primary_commitment=result._primary_commitment,
             confirmation_commitments=(result._confirmation_commitment,),
             runtime=runtime,
+            authority_identities=result._authority_identities,
         )
 
 
@@ -567,8 +828,8 @@ def test_profile_evidence_recomputes_complete_gpu_attestation(
     os.environ.get("AUTOCONTEXT_RUN_PROTECTED_GPU_INTEGRATION") != "1",
     reason="requires an explicit protected H100/MIG release host",
 )
-def test_real_h100_protected_authority_adversarial_release_gate(runtime_modules: tuple[Any, Any]) -> None:
-    """Exercise the exact guarded production factory on a real H100/MIG host."""
+def test_reserved_h100_protected_authority_gate_remains_unavailable(runtime_modules: tuple[Any, Any]) -> None:
+    """Reserve the future live gate while proving current execution stops before Docker."""
 
     production_runtime, _campaign = runtime_modules
     profile_contract = importlib.import_module("profile_contract")
@@ -581,6 +842,8 @@ def test_real_h100_protected_authority_adversarial_release_gate(runtime_modules:
             "AUTOCONTEXT_GPU_MEMORY_BYTES",
             "AUTOCONTEXT_AUTOKERNEL_ROOT",
             "AUTOCONTEXT_KERNEL_PRIVATE_PLAN",
+            "AUTOCONTEXT_AUTHORITY_HMAC_KEY_ID",
+            "AUTOCONTEXT_AUTHORITY_HMAC_SECRET_FILE",
         )
     }
     missing = [name for name, value in required.items() if not value]
@@ -597,6 +860,8 @@ def test_real_h100_protected_authority_adversarial_release_gate(runtime_modules:
         gpu_device=str(required["AUTOCONTEXT_GPU_DEVICE_ID"]),
         gpu_isolation_kind="mig",
         gpu_memory_bytes=memory_bytes,
+        authority_hmac_key_id=str(required["AUTOCONTEXT_AUTHORITY_HMAC_KEY_ID"]),
+        authority_hmac_secret_path=Path(str(required["AUTOCONTEXT_AUTHORITY_HMAC_SECRET_FILE"])),
         limits=DockerKernelWorkerLimits(max_gpu_memory_bytes=memory_bytes),
         timeout_seconds=630.0,
     )
@@ -647,12 +912,9 @@ def kernel_fn(a, b):
     second = evaluator.evaluate(hostile, hostile)
 
     for observation in (first, second):
-        assert observation.eligible, observation.feedback
-        assert observation.report is not None
-        receipt = observation.report.evaluator_authority_receipt
-        assert receipt is not None
-        assert {measurement.role for measurement in receipt.measurements} == {"candidate", "incumbent"}
-        assert receipt.accelerator_attestation.device_id == runtime.gpu_device
+        assert not observation.eligible
+        assert observation.rejection_reason == "resource_policy_unsupported"
+        assert "independently attested" in observation.feedback
 
 
 def _plan(seed: int, order: tuple[int, int, int]) -> dict[str, Any]:

--- a/autocontext/tests/test_kernel_h100_production_runtime.py
+++ b/autocontext/tests/test_kernel_h100_production_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,6 +12,7 @@ import pytest
 
 from autocontext.kernel_evolution import (
     DockerKernelWorkerLimits,
+    KernelCandidate,
     KernelDecisionPolicy,
     KernelSequentialTestingPolicy,
     KernelStatisticsPolicy,
@@ -49,8 +51,10 @@ def _runtime(production_runtime: Any, *, gpu_memory_bytes: int = 8 * 1024**3) ->
     )
 
 
-def test_production_runtime_is_pinned_and_runnable_composition_is_unavailable(
-    tmp_path: Path, runtime_modules: tuple[Any, Any]
+def test_production_runtime_is_pinned_and_protected_composition_is_runnable_for_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    runtime_modules: tuple[Any, Any],
 ) -> None:
     production_runtime, _campaign = runtime_modules
     autokernel_root = tmp_path / "autokernel"
@@ -67,29 +71,56 @@ def test_production_runtime_is_pinned_and_runnable_composition_is_unavailable(
     assert runtime_manifest["gpu_memory_bytes"] == 8 * 1024**3
     assert runtime_manifest["limits"]["max_gpu_memory_bytes"] == 8 * 1024**3
     assert runtime_manifest["evidence_boundary"] == {
-        "required": "trusted-evaluator/isolated-gpu-candidate-v1",
+        "required": "trusted-evaluator/isolated-accelerator-candidate-v1",
         "available": False,
     }
 
-    with pytest.raises(production_runtime.ProductionEvaluatorBoundaryUnavailable):
-        production_runtime._compose_docker_evaluator(
-            runtime=runtime,
-            bundle=_BUNDLE,
-            adapter_name="adapter.py",
-            autokernel_root=autokernel_root,
-            private_plan=private_plan,
-            problem_id="kernel-problem",
-            precision_profile="strict-fp32-v1",
-            plan_commitment=f"sha256:{'b' * 64}",
-            proposal_cap=10,
-            familywise_alpha=0.05,
-        )
+    captured: dict[str, Any] = {}
+
+    class FakeAttestor:
+        def __init__(self, binary: str) -> None:
+            captured["attestor_binary"] = binary
+
+    class FakeProtectedRunner:
+        def __init__(self, command: list[str], **kwargs: Any) -> None:
+            captured["command"] = command
+            captured["runner"] = kwargs
+
+        def manifest(self) -> dict[str, Any]:
+            return {"kind": "fake-protected-runner"}
+
+    monkeypatch.setattr(production_runtime, "NvidiaSMIGPUDeviceAttestor", FakeAttestor)
+    monkeypatch.setattr(production_runtime, "DockerProtectedKernelBenchmarkRunner", FakeProtectedRunner)
+    evaluator = production_runtime._compose_docker_evaluator(
+        runtime=runtime,
+        bundle=_BUNDLE,
+        adapter_name="adapter.py",
+        autokernel_root=autokernel_root,
+        private_plan=private_plan,
+        problem_id="kernel-problem",
+        precision_profile="strict-fp32-v1",
+        plan_commitment=f"sha256:{'b' * 64}",
+        proposal_cap=10,
+        familywise_alpha=0.05,
+    )
+
+    manifest = evaluator.manifest()
+    assert manifest["evaluator"]["require_authority_receipt"] is True
+    assert manifest["evaluator"]["require_resource_telemetry"] is True
+    assert manifest["evaluator"]["adaptive_feedback_policy"] == "aggregate-gates"
+    assert captured["attestor_binary"] == "nvidia-smi-production"
+    assert captured["runner"]["evaluator_immutable_paths"] == (_BUNDLE.resolve(), private_plan.resolve())
+    assert captured["runner"]["candidate_runtime_path"] == _BUNDLE / "authority_worker.py"
+    command = captured["command"]
+    assert "{candidate_socket}" in command and "{incumbent_socket}" in command
+    assert "{candidate}" not in command and "{incumbent}" not in command
+    assert str(private_plan) not in command
 
 
 def test_production_campaign_has_no_same_interpreter_override(runtime_modules: tuple[Any, Any]) -> None:
     production_runtime, _campaign = runtime_modules
 
-    with pytest.raises(production_runtime.ProductionEvaluatorBoundaryUnavailable, match="same interpreter"):
+    with pytest.raises(production_runtime.ProductionEvaluatorBoundaryUnavailable, match="real H100/MIG validation"):
         production_runtime.require_protected_evaluator_boundary()
 
     source = (_BUNDLE / "campaign.py").read_text(encoding="utf-8")
@@ -191,7 +222,7 @@ def test_campaign_fails_before_creating_mailbox_or_launching_worker(
         ],
     )
 
-    with pytest.raises(SystemExit, match="production H100 campaigns are disabled"):
+    with pytest.raises(SystemExit, match="production H100 campaigns remain disabled"):
         campaign.main()
 
     assert not mailbox.exists()
@@ -530,6 +561,98 @@ def test_profile_evidence_recomputes_complete_gpu_attestation(
             confirmation_commitments=(result._confirmation_commitment,),
             runtime=runtime,
         )
+
+
+@pytest.mark.skipif(
+    os.environ.get("AUTOCONTEXT_RUN_PROTECTED_GPU_INTEGRATION") != "1",
+    reason="requires an explicit protected H100/MIG release host",
+)
+def test_real_h100_protected_authority_adversarial_release_gate(runtime_modules: tuple[Any, Any]) -> None:
+    """Exercise the exact guarded production factory on a real H100/MIG host."""
+
+    production_runtime, _campaign = runtime_modules
+    profile_contract = importlib.import_module("profile_contract")
+    required = {
+        name: os.environ.get(name)
+        for name in (
+            "AUTOCONTEXT_GPU_DOCKER_IMAGE",
+            "AUTOCONTEXT_GPU_DOCKER_PYTHON",
+            "AUTOCONTEXT_GPU_DEVICE_ID",
+            "AUTOCONTEXT_GPU_MEMORY_BYTES",
+            "AUTOCONTEXT_AUTOKERNEL_ROOT",
+            "AUTOCONTEXT_KERNEL_PRIVATE_PLAN",
+        )
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        pytest.fail(f"protected H100 release gate is missing environment: {', '.join(missing)}")
+    memory_bytes = int(str(required["AUTOCONTEXT_GPU_MEMORY_BYTES"]))
+    autokernel_root = Path(str(required["AUTOCONTEXT_AUTOKERNEL_ROOT"])).resolve(strict=True)
+    private_plan = Path(str(required["AUTOCONTEXT_KERNEL_PRIVATE_PLAN"])).resolve(strict=True)
+    runtime = production_runtime.H100DockerRuntimeConfig(
+        image=str(required["AUTOCONTEXT_GPU_DOCKER_IMAGE"]),
+        docker_binary=os.environ.get("AUTOCONTEXT_DOCKER_BINARY", "docker"),
+        nvidia_smi_binary=os.environ.get("AUTOCONTEXT_NVIDIA_SMI_BINARY", "nvidia-smi"),
+        container_python=str(required["AUTOCONTEXT_GPU_DOCKER_PYTHON"]),
+        gpu_device=str(required["AUTOCONTEXT_GPU_DEVICE_ID"]),
+        gpu_isolation_kind="mig",
+        gpu_memory_bytes=memory_bytes,
+        limits=DockerKernelWorkerLimits(max_gpu_memory_bytes=memory_bytes),
+        timeout_seconds=630.0,
+    )
+    plan_commitment = profile_contract.private_plan_commitment(private_plan)
+    evaluator = production_runtime._compose_docker_evaluator(
+        runtime=runtime,
+        bundle=_BUNDLE,
+        adapter_name="adapter.py",
+        autokernel_root=autokernel_root,
+        private_plan=private_plan,
+        problem_id="kernelbench-v0.1-level1-1-matmul-profiled-h100-v1",
+        precision_profile="strict-fp32-v1",
+        plan_commitment=plan_commitment,
+        proposal_cap=10,
+        familywise_alpha=0.05,
+    )
+    hostile_source = """
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import torch
+
+_marker = pathlib.Path('/workspace/ac1003-persistence-probe')
+_escaped = _marker.exists()
+_marker.write_text('candidate-state')
+for _private_root in ('/evaluator', '/output', '/channels'):
+    if pathlib.Path(_private_root).exists():
+        _escaped = True
+for _secret_name in ('AUTOCONTEXT_EVALUATOR_BUILD_DIGEST', 'AUTOCONTEXT_BOUNDARY_MANIFEST_DIGEST'):
+    if _secret_name in os.environ:
+        _escaped = True
+try:
+    socket.create_connection(('1.1.1.1', 53), timeout=0.05)
+    _escaped = True
+except OSError:
+    pass
+subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(3600)'])
+torch.cuda.Event = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('candidate clock'))
+
+def kernel_fn(a, b):
+    return torch.zeros_like(a @ b) if _escaped else a @ b
+""".strip()
+    hostile = KernelCandidate(source=hostile_source, entrypoint="kernel_fn")
+
+    first = evaluator.evaluate(hostile, hostile)
+    second = evaluator.evaluate(hostile, hostile)
+
+    for observation in (first, second):
+        assert observation.eligible, observation.feedback
+        assert observation.report is not None
+        receipt = observation.report.evaluator_authority_receipt
+        assert receipt is not None
+        assert {measurement.role for measurement in receipt.measurements} == {"candidate", "incumbent"}
+        assert receipt.accelerator_attestation.device_id == runtime.gpu_device
 
 
 def _plan(seed: int, order: tuple[int, int, int]) -> dict[str, Any]:

--- a/autocontext/tests/test_kernel_profile_evidence.py
+++ b/autocontext/tests/test_kernel_profile_evidence.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import copy
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.kernel_evolution import (
+    ProfileEvidenceEnvelope,
+    build_profile_evidence_envelope,
+    canonical_authority_digest,
+    verify_profile_evidence_envelope,
+)
+
+_KEY_ID = "test-profile-evidence-key-v1"
+_SECRET = b"test-only-profile-evidence-secret-material"
+
+
+def _profile() -> dict[str, object]:
+    return {
+        "schema_version": "autocontext.kernel-h100-profile-evidence/v3",
+        "champion": {"artifact_digest": "sha256:" + "a" * 64},
+        "promotions": 1,
+        "all_holdout_correctness_passed": True,
+    }
+
+
+def test_profile_evidence_envelope_authenticates_every_nested_field() -> None:
+    envelope = build_profile_evidence_envelope(
+        _profile(),
+        signing_key_id=_KEY_ID,
+        signing_secret=_SECRET,
+    )
+    assert verify_profile_evidence_envelope(
+        envelope.model_dump(mode="json"),
+        trusted_key_id=_KEY_ID,
+        trusted_secret=_SECRET,
+    ) == envelope
+
+    forged = envelope.model_dump(mode="json")
+    forged["profile"]["champion"]["artifact_digest"] = "sha256:" + "b" * 64
+    forged["content_digest"] = canonical_authority_digest(forged["profile"])
+    with pytest.raises(ValueError, match="authentication tag"):
+        verify_profile_evidence_envelope(
+            forged,
+            trusted_key_id=_KEY_ID,
+            trusted_secret=_SECRET,
+        )
+
+    with pytest.raises(ValueError, match="authentication tag"):
+        verify_profile_evidence_envelope(
+            envelope,
+            trusted_key_id=_KEY_ID,
+            trusted_secret=b"different-profile-evidence-secret-material",
+        )
+
+
+def test_profile_evidence_envelope_rejects_wrong_key_tag_and_shape() -> None:
+    envelope = build_profile_evidence_envelope(
+        _profile(),
+        signing_key_id=_KEY_ID,
+        signing_secret=_SECRET,
+    )
+    with pytest.raises(ValueError, match="authentication key"):
+        verify_profile_evidence_envelope(
+            envelope,
+            trusted_key_id="different-profile-evidence-key",
+            trusted_secret=_SECRET,
+        )
+
+    forged_tag = envelope.model_dump(mode="json")
+    forged_tag["authentication"]["tag"] = "hmac-sha256:" + "0" * 64
+    with pytest.raises(ValueError, match="authentication tag"):
+        verify_profile_evidence_envelope(
+            forged_tag,
+            trusted_key_id=_KEY_ID,
+            trusted_secret=_SECRET,
+        )
+
+    extra = envelope.model_dump(mode="json")
+    extra["unsigned_summary"] = {"promotions": 999}
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        ProfileEvidenceEnvelope.model_validate(extra)
+
+    raw = envelope.model_dump_json()
+    duplicate = raw.replace('"content_digest":', '"content_digest":"sha256:' + "f" * 64 + '","content_digest":')
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        verify_profile_evidence_envelope(
+            duplicate,
+            trusted_key_id=_KEY_ID,
+            trusted_secret=_SECRET,
+        )
+    malformed_number = raw.replace('"promotions":1', '"promotions":NaN')
+    with pytest.raises(ValueError, match="invalid JSON constant"):
+        verify_profile_evidence_envelope(
+            malformed_number,
+            trusted_key_id=_KEY_ID,
+            trusted_secret=_SECRET,
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    (
+        {"schema_version": "valid/v1", "value": math.nan},
+        {"schema_version": "valid/v1", "value": {"not", "json"}},
+        {"schema_version": "bad\nschema", "value": 1},
+    ),
+)
+def test_profile_evidence_envelope_rejects_noncanonical_json(invalid: dict[str, object]) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        build_profile_evidence_envelope(
+            copy.deepcopy(invalid),
+            signing_key_id=_KEY_ID,
+            signing_secret=_SECRET,
+        )

--- a/autocontext/tests/test_protected_kernel_authority_runner.py
+++ b/autocontext/tests/test_protected_kernel_authority_runner.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import io
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autocontext.kernel_evolution import (
+    AcceleratorAttestation,
+    AuthorityMeasurement,
+    DockerGPUDeviceAttestation,
+    DockerGPUDeviceGrant,
+    DockerKernelWorkerLimits,
+    DockerProtectedKernelBenchmarkRunner,
+    KernelCandidate,
+    build_authority_receipt,
+    canonical_authority_digest,
+)
+
+_PINNED_IMAGE = f"registry.example/accelerator-evaluator@sha256:{'a' * 64}"
+
+
+class _Attestor:
+    attestor_id = "test-partition-attestor-v1"
+
+    def manifest(self) -> dict[str, Any]:
+        return {"attestor_id": self.attestor_id}
+
+    def attest(self, grant: DockerGPUDeviceGrant) -> DockerGPUDeviceAttestation:
+        assert grant.enforced_memory_bytes is not None
+        return DockerGPUDeviceAttestation(
+            device_id=grant.device_id,
+            isolation_kind="mig",
+            enforced_memory_bytes=grant.enforced_memory_bytes,
+            attestor_id=self.attestor_id,
+        )
+
+
+@pytest.fixture
+def authority_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]]:
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.shutil.which",
+        lambda value: f"/usr/bin/{value}",
+    )
+    evaluator = tmp_path / "trusted-evaluator.py"
+    private_plan = tmp_path / "private-confirmation-plan.json"
+    reference = tmp_path / "trusted-reference.py"
+    runtime = tmp_path / "candidate-authority-worker.py"
+    support = tmp_path / "public-candidate-support"
+    for path, content in (
+        (evaluator, "# trusted evaluator\n"),
+        (private_plan, "{\"private\": true}\n"),
+        (reference, "# trusted reference\n"),
+        (runtime, "# candidate worker\n"),
+    ):
+        path.write_text(content, encoding="utf-8")
+    support.mkdir()
+    (support / "kernel_api.py").write_text("# public API\n", encoding="utf-8")
+    grant = DockerGPUDeviceGrant(
+        device_id="MIG-GPU-deadbeef/1/0",
+        isolation_kind="mig",
+        enforced_memory_bytes=8 * 1024**3,
+    )
+    runner = DockerProtectedKernelBenchmarkRunner(
+        [
+            "/opt/runtime/bin/python",
+            "{immutable_0}",
+            "--private-plan",
+            "{immutable_1}",
+            "--reference",
+            "{immutable_2}",
+            "--candidate-socket",
+            "{candidate_socket}",
+            "--incumbent-socket",
+            "{incumbent_socket}",
+            "--report",
+            "{report}",
+            "--candidate-artifact-digest",
+            "{candidate_artifact_digest}",
+            "--incumbent-artifact-digest",
+            "{incumbent_artifact_digest}",
+        ],
+        image=_PINNED_IMAGE,
+        container_python="/opt/runtime/bin/python",
+        evaluator_immutable_paths=(evaluator, private_plan, reference),
+        candidate_runtime_path=runtime,
+        candidate_support_paths=(support,),
+        gpu_grant=grant,
+        gpu_attestor=_Attestor(),
+        limits=DockerKernelWorkerLimits(max_gpu_memory_bytes=8 * 1024**3),
+        docker_binary="docker-test",
+    )
+    return runner, {
+        "evaluator": evaluator,
+        "private_plan": private_plan,
+        "reference": reference,
+        "runtime": runtime,
+        "support": support,
+    }
+
+
+def test_candidate_authority_mounts_cannot_reach_private_evaluator_material(
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, paths = authority_runner
+    candidate = KernelCandidate(source="def kernel_fn(a, b): return a @ b", entrypoint="kernel_fn")
+    staged = tmp_path / "candidate.py"
+    staged.write_text(candidate.source, encoding="utf-8")
+    channel = tmp_path / "candidate-channel"
+    channel.mkdir()
+    attestation = _Attestor().attest(runner.gpu_grant)
+
+    command = runner._candidate_docker_command(
+        "candidate-container",
+        staged,
+        channel,
+        candidate,
+        "candidate",
+        attestation,
+        2_000_000_000.0,
+    )
+    rendered = "\0".join(command)
+
+    assert "--network\0none" in rendered
+    assert "--cap-drop\0ALL" in rendered
+    assert "--read-only" in command
+    assert "--security-opt\0no-new-privileges" in rendered
+    assert f"type=bind,src={channel},dst=/channel,readonly" in rendered
+    assert f"type=bind,src={staged},dst=/artifact/source.py,readonly" in rendered
+    assert f"type=bind,src={paths['runtime']},dst=/authority/worker.py,readonly" in rendered
+    assert f"type=bind,src={paths['support']},dst=/support/0,readonly" in rendered
+    assert "/output" not in rendered
+    assert "/evaluator/" not in rendered
+    for private_path in (paths["evaluator"], paths["private_plan"], paths["reference"]):
+        assert str(private_path) not in rendered
+        assert private_path.name not in rendered
+    for credential_name in ("AWS_ACCESS_KEY_ID", "GITHUB_TOKEN", "OPENAI_API_KEY"):
+        assert credential_name not in rendered
+
+
+def test_evaluator_authority_has_private_controls_but_no_generated_source(
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, paths = authority_runner
+    candidate = KernelCandidate(source="def kernel_fn(a, b): return a @ b", entrypoint="kernel_fn")
+    incumbent = KernelCandidate(source="def kernel_fn(a, b): return a.matmul(b)", entrypoint="kernel_fn")
+    candidate_channel = tmp_path / "candidate-channel"
+    incumbent_channel = tmp_path / "incumbent-channel"
+    report = tmp_path / "report"
+    for directory in (candidate_channel, incumbent_channel, report):
+        directory.mkdir()
+    attestation = _Attestor().attest(runner.gpu_grant)
+
+    command = runner._evaluator_docker_command(
+        "evaluator-container",
+        candidate_channel,
+        incumbent_channel,
+        report,
+        candidate,
+        incumbent,
+        attestation,
+        2_000_000_000.0,
+    )
+    rendered = "\0".join(command)
+
+    assert f"type=bind,src={paths['evaluator']},dst=/evaluator/0,readonly" in rendered
+    assert f"type=bind,src={paths['private_plan']},dst=/evaluator/1,readonly" in rendered
+    assert f"type=bind,src={paths['reference']},dst=/evaluator/2,readonly" in rendered
+    assert f"type=bind,src={report},dst=/output" in rendered
+    assert f"type=bind,src={candidate_channel},dst=/channels/candidate" in rendered
+    assert f"type=bind,src={incumbent_channel},dst=/channels/incumbent" in rendered
+    assert candidate.source not in rendered
+    assert incumbent.source not in rendered
+    assert "/artifact/" not in rendered
+
+
+def test_public_manifest_uses_generic_accelerator_boundary_and_redacts_private_paths(
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+) -> None:
+    runner, paths = authority_runner
+    manifest = runner.manifest()
+    rendered = str(manifest)
+
+    assert manifest["evidence_boundary"] == "trusted-evaluator/isolated-accelerator-candidate-v1"
+    assert manifest["kind"] == "docker-protected-accelerator-evaluator"
+    assert manifest["candidate_mount_policy"] == "source+runtime+public-support+one-readonly-socket"
+    assert "H100" not in rendered
+    for private_path in (paths["evaluator"], paths["private_plan"], paths["reference"]):
+        assert str(private_path) not in rendered
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        ("oom", "oom"),
+        ("protocol_corruption", "protocol_corruption"),
+        ("evaluator_crash", "evaluator_crashed"),
+        ("candidate_crash", "candidate_crashed"),
+        ("teardown_failure", "teardown_failed"),
+        ("timeout", "timeout"),
+    ],
+)
+def test_authority_failures_remain_distinct(failure: str, expected: str) -> None:
+    assert (
+        DockerProtectedKernelBenchmarkRunner._reported_failure_outcome(
+            {"failure_kind": failure},
+            default="complete",
+        )
+        == expected
+    )
+
+
+def _receipt_payload(attestation: DockerGPUDeviceAttestation) -> dict[str, Any]:
+    candidate_digest = canonical_authority_digest("candidate")
+    incumbent_digest = canonical_authority_digest("incumbent")
+    plan_digest = canonical_authority_digest("plan")
+    accelerator = AcceleratorAttestation(
+        backend="cuda",
+        vendor="nvidia",
+        architecture="sm90",
+        device_id=attestation.device_id,
+        isolation_kind=attestation.isolation_kind,
+        enforced_memory_bytes=attestation.enforced_memory_bytes,
+        runtime="cuda-12.8",
+        driver="570.1",
+        attestor_id=attestation.attestor_id,
+        metadata={"grant_attestation_digest": attestation.digest},
+    )
+    measurements = tuple(
+        AuthorityMeasurement(
+            sequence=index,
+            role=role,
+            request_digest=canonical_authority_digest(f"request-{role}"),
+            response_digest=canonical_authority_digest(f"response-{role}"),
+            input_commitment=canonical_authority_digest(f"input-{role}"),
+            output_commitment=canonical_authority_digest(f"output-{role}"),
+            elapsed_ns=10 + index,
+            observed_peak_memory_bytes=100 + index,
+            outcome="complete",
+        )
+        for index, role in enumerate(("candidate", "incumbent"))
+    )
+    report: dict[str, Any] = {
+        "candidate_artifact_digest": candidate_digest,
+        "incumbent_artifact_digest": incumbent_digest,
+        "protocol": {"seed_commitment": plan_digest},
+    }
+    receipt = build_authority_receipt(
+        evaluator_build_digest=canonical_authority_digest("build"),
+        boundary_manifest_digest=canonical_authority_digest("boundary"),
+        plan_commitment=plan_digest,
+        accelerator_attestation=accelerator,
+        candidate_artifact_digest=candidate_digest,
+        incumbent_artifact_digest=incumbent_digest,
+        measurements=measurements,
+        report=report,
+    )
+    report["evaluator_authority_receipt"] = receipt.model_dump(mode="json")
+    return report
+
+
+def test_authority_receipt_is_bound_to_the_host_attested_partition() -> None:
+    host_attestation = DockerGPUDeviceAttestation(
+        device_id="MIG-GPU-deadbeef/1/0",
+        isolation_kind="mig",
+        enforced_memory_bytes=8 * 1024**3,
+        attestor_id="test-partition-attestor-v1",
+    )
+    payload = _receipt_payload(host_attestation)
+
+    assert DockerProtectedKernelBenchmarkRunner._validate_receipt(payload, host_attestation) is None
+
+    forged_host_attestation = DockerGPUDeviceAttestation(
+        device_id="MIG-GPU-forged/2/0",
+        isolation_kind="mig",
+        enforced_memory_bytes=8 * 1024**3,
+        attestor_id="test-partition-attestor-v1",
+    )
+    assert "host-attested accelerator grant" in str(
+        DockerProtectedKernelBenchmarkRunner._validate_receipt(payload, forged_host_attestation)
+    )
+
+
+def test_hostile_candidate_has_no_persistent_or_report_writable_mount(
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, _paths = authority_runner
+    candidate = KernelCandidate(
+        source="import torch\ntorch.cuda.Event = lambda *a, **k: None\ndef kernel_fn(a, b): return a @ b",
+        entrypoint="kernel_fn",
+    )
+    source = tmp_path / "hostile.py"
+    source.write_text(candidate.source, encoding="utf-8")
+    channel = tmp_path / "channel"
+    channel.mkdir()
+    command = runner._candidate_docker_command(
+        "hostile-candidate",
+        source,
+        channel,
+        candidate,
+        "candidate",
+        _Attestor().attest(runner.gpu_grant),
+        2_000_000_000.0,
+    )
+    rendered = "\0".join(command)
+
+    # Patching torch is confined to this container/process.  No candidate
+    # mount can persist it, overwrite report authority, or reach another role.
+    assert "--pids-limit" in command
+    assert "dst=/workspace" not in rendered
+    assert "dst=/output" not in rendered
+    assert "dst=/channels/" not in rendered
+    assert "--tmpfs\0/workspace:" in rendered
+    assert f"type=bind,src={channel},dst=/channel,readonly" in rendered
+
+
+def test_timeout_kills_every_authority_and_verifies_container_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, _paths = authority_runner
+    processes: list[Any] = []
+
+    class FakeProcess:
+        def __init__(self, command: list[str], **_kwargs: Any) -> None:
+            self.command = command
+            self.stdout = io.BytesIO()
+            self.stderr = io.BytesIO()
+            self.killed = False
+            processes.append(self)
+
+        def wait(self, timeout: float | None = None) -> int:
+            if self is processes[0]:
+                raise subprocess.TimeoutExpired(self.command, timeout or 0.0)
+            return 0
+
+        def poll(self) -> int | None:
+            return -9 if self.killed else None
+
+        def kill(self) -> None:
+            self.killed = True
+
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.subprocess.Popen",
+        FakeProcess,
+    )
+    monkeypatch.setattr(runner, "_wait_for_evaluator_sockets", lambda *args: None)
+    watched: list[str] = []
+
+    def launch_watchdog(_binary: str, name: str, _expires: float, _ready: Path) -> object:
+        watched.append(name)
+        return object()
+
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.launch_deadline_watchdog",
+        launch_watchdog,
+    )
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.terminate_process_group",
+        lambda *args, **kwargs: None,
+    )
+    removed: list[str] = []
+    verified: list[str] = []
+    monkeypatch.setattr(runner, "_remove_container", removed.append)
+    monkeypatch.setattr(runner, "_verify_removed", verified.append)
+    attestation = _Attestor().attest(runner.gpu_grant)
+
+    execution = runner._execute_authorities(
+        ["docker", "evaluator"],
+        ["docker", "candidate"],
+        ["docker", "incumbent"],
+        names={"evaluator": "eval", "candidate": "cand", "incumbent": "inc"},
+        socket_paths=(tmp_path / "candidate.sock", tmp_path / "incumbent.sock"),
+        report_path=tmp_path / "report.json",
+        report_identity=object(),  # ignored on the timeout path
+        timeout_seconds=0.01,
+        accelerator_attestation=attestation,
+        watchdog_root=tmp_path,
+        expires_at=2_000_000_000.0,
+    )
+
+    assert execution.outcome == "timeout"
+    assert all(process.killed for process in processes)
+    assert removed == ["eval", "cand", "inc"]
+    assert verified == ["eval", "cand", "inc"]
+    assert watched == ["eval", "cand", "inc"]
+
+
+def test_coordinator_loss_reconciliation_removes_expired_authority_containers(
+    monkeypatch: pytest.MonkeyPatch,
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+) -> None:
+    runner, _paths = authority_runner
+    responses = iter(
+        (
+            subprocess.CompletedProcess([], 0, stdout="owned-evaluator\nowned-candidate\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="owned-evaluator\t10\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="owned-candidate\t10\n", stderr=""),
+        )
+    )
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.subprocess.run",
+        lambda *args, **kwargs: next(responses),
+    )
+    removed: list[str] = []
+    verified: list[str] = []
+    monkeypatch.setattr(runner, "_remove_container", removed.append)
+    monkeypatch.setattr(runner, "_verify_removed", verified.append)
+
+    assert runner.reconcile(now=20.0) == 2
+    assert removed == ["owned-evaluator", "owned-candidate"]
+    assert verified == removed

--- a/autocontext/tests/test_protected_kernel_authority_runner.py
+++ b/autocontext/tests/test_protected_kernel_authority_runner.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import io
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
+import autocontext.kernel_evolution.authority_readiness as authority_readiness
 from autocontext.kernel_evolution import (
     AcceleratorAttestation,
     AuthorityMeasurement,
@@ -14,12 +15,18 @@ from autocontext.kernel_evolution import (
     DockerGPUDeviceGrant,
     DockerKernelWorkerLimits,
     DockerProtectedKernelBenchmarkRunner,
+    KernelBenchmarkEvaluator,
+    KernelBenchmarkEvaluatorConfig,
+    KernelBenchmarkExecution,
     KernelCandidate,
     build_authority_receipt,
     canonical_authority_digest,
+    docker_watchdog,
 )
 
 _PINNED_IMAGE = f"registry.example/accelerator-evaluator@sha256:{'a' * 64}"
+_HMAC_KEY_ID = "authority-test-key-v1"
+_HMAC_SECRET = b"test authority hmac secret material"  # 35 bytes
 
 
 class _Attestor:
@@ -52,6 +59,7 @@ def authority_runner(
     reference = tmp_path / "trusted-reference.py"
     runtime = tmp_path / "candidate-authority-worker.py"
     support = tmp_path / "public-candidate-support"
+    hmac_secret = tmp_path / "authority-hmac-secret"
     for path, content in (
         (evaluator, "# trusted evaluator\n"),
         (private_plan, "{\"private\": true}\n"),
@@ -61,6 +69,8 @@ def authority_runner(
         path.write_text(content, encoding="utf-8")
     support.mkdir()
     (support / "kernel_api.py").write_text("# public API\n", encoding="utf-8")
+    hmac_secret.write_bytes(_HMAC_SECRET)
+    hmac_secret.chmod(0o600)
     grant = DockerGPUDeviceGrant(
         device_id="MIG-GPU-deadbeef/1/0",
         isolation_kind="mig",
@@ -92,6 +102,8 @@ def authority_runner(
         candidate_support_paths=(support,),
         gpu_grant=grant,
         gpu_attestor=_Attestor(),
+        authority_hmac_key_id=_HMAC_KEY_ID,
+        authority_hmac_secret_path=hmac_secret,
         limits=DockerKernelWorkerLimits(max_gpu_memory_bytes=8 * 1024**3),
         docker_binary="docker-test",
     )
@@ -101,7 +113,65 @@ def authority_runner(
         "reference": reference,
         "runtime": runtime,
         "support": support,
+        "hmac_secret": hmac_secret,
     }
+
+
+def _rebuild_authority_runner(
+    runner: DockerProtectedKernelBenchmarkRunner,
+    paths: dict[str, Path],
+    *,
+    evaluator_paths: tuple[Path, ...] | None = None,
+    candidate_runtime: Path | None = None,
+    hmac_secret: Path | None = None,
+) -> DockerProtectedKernelBenchmarkRunner:
+    return DockerProtectedKernelBenchmarkRunner(
+        runner._evaluator_command,
+        image=runner.image,
+        container_python=runner.container_python,
+        evaluator_immutable_paths=evaluator_paths
+        or (paths["evaluator"], paths["private_plan"], paths["reference"]),
+        candidate_runtime_path=candidate_runtime or paths["runtime"],
+        candidate_support_paths=(paths["support"],),
+        gpu_grant=runner.gpu_grant,
+        gpu_attestor=_Attestor(),
+        authority_hmac_key_id=_HMAC_KEY_ID,
+        authority_hmac_secret_path=hmac_secret or paths["hmac_secret"],
+        limits=runner.limits,
+        docker_binary="docker-test",
+    )
+
+
+def test_constructor_rejects_candidate_runtime_directory(
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, paths = authority_runner
+    runtime_directory = tmp_path / "runtime-directory"
+    runtime_directory.mkdir()
+
+    with pytest.raises(ValueError, match="candidate_runtime_path must be a regular file"):
+        _rebuild_authority_runner(runner, paths, candidate_runtime=runtime_directory)
+
+
+def test_constructor_rejects_hmac_secret_nested_in_evaluator_tree(
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, paths = authority_runner
+    evaluator_tree = tmp_path / "evaluator-tree"
+    evaluator_tree.mkdir()
+    nested_secret = evaluator_tree / "authority-hmac-secret"
+    nested_secret.write_bytes(_HMAC_SECRET)
+    nested_secret.chmod(0o600)
+
+    with pytest.raises(ValueError, match="dedicated evaluator-only mount"):
+        _rebuild_authority_runner(
+            runner,
+            paths,
+            evaluator_paths=(evaluator_tree, paths["private_plan"], paths["reference"]),
+            hmac_secret=nested_secret,
+        )
 
 
 def test_candidate_authority_mounts_cannot_reach_private_evaluator_material(
@@ -137,7 +207,8 @@ def test_candidate_authority_mounts_cannot_reach_private_evaluator_material(
     assert f"type=bind,src={paths['support']},dst=/support/0,readonly" in rendered
     assert "/output" not in rendered
     assert "/evaluator/" not in rendered
-    for private_path in (paths["evaluator"], paths["private_plan"], paths["reference"]):
+    assert "AUTOCONTEXT_AUTHORITY_HMAC" not in rendered
+    for private_path in (paths["evaluator"], paths["private_plan"], paths["reference"], paths["hmac_secret"]):
         assert str(private_path) not in rendered
         assert private_path.name not in rendered
     for credential_name in ("AWS_ACCESS_KEY_ID", "GITHUB_TOKEN", "OPENAI_API_KEY"):
@@ -176,6 +247,12 @@ def test_evaluator_authority_has_private_controls_but_no_generated_source(
     assert f"type=bind,src={report},dst=/output" in rendered
     assert f"type=bind,src={candidate_channel},dst=/channels/candidate" in rendered
     assert f"type=bind,src={incumbent_channel},dst=/channels/incumbent" in rendered
+    assert (
+        f"type=bind,src={paths['hmac_secret']},dst=/run/secrets/autocontext-authority-hmac,readonly" in rendered
+    )
+    assert f"AUTOCONTEXT_AUTHORITY_HMAC_KEY_ID={_HMAC_KEY_ID}" in rendered
+    assert "AUTOCONTEXT_AUTHORITY_HMAC_SECRET_FILE=/run/secrets/autocontext-authority-hmac" in rendered
+    assert _HMAC_SECRET.decode() not in rendered
     assert candidate.source not in rendered
     assert incumbent.source not in rendered
     assert "/artifact/" not in rendered
@@ -191,9 +268,114 @@ def test_public_manifest_uses_generic_accelerator_boundary_and_redacts_private_p
     assert manifest["evidence_boundary"] == "trusted-evaluator/isolated-accelerator-candidate-v1"
     assert manifest["kind"] == "docker-protected-accelerator-evaluator"
     assert manifest["candidate_mount_policy"] == "source+runtime+public-support+one-readonly-socket"
+    assert manifest["authority_authentication"] == {"algorithm": "hmac-sha256", "key_id": _HMAC_KEY_ID}
+    assert manifest["crash_safe_container_creation"] == {
+        "required": "supervised-create-before-coordinator-ownership/v1",
+        "available": False,
+        "reason": (
+            "protected accelerator evidence requires crash-safe container creation; "
+            "the v1 coordinator-owned docker create path is unsupported"
+        ),
+    }
+    assert manifest["accelerator_role_isolation"] == {
+        "required": "independently-attested-evaluator-candidate-incumbent-grants/v1",
+        "available": False,
+        "reason": (
+            "protected accelerator evidence requires independently attested evaluator, candidate, and incumbent "
+            "grants; the v1 shared-grant topology is unsupported"
+        ),
+    }
+    assert manifest["trusted_out_of_process_mutation_observation"] == {
+        "required": "trusted-out-of-process-input-mutation-observation/v1",
+        "available": False,
+        "reason": (
+            "protected accelerator evidence requires trusted out-of-process input-mutation observation; "
+            "the v1 same-interpreter authority is unsupported"
+        ),
+    }
+    assert manifest["comparable_timing_boundaries"] == {
+        "required": "comparable-candidate-incumbent-reference-timing/v1",
+        "available": False,
+        "reason": (
+            "protected accelerator evidence requires comparable candidate/incumbent/reference timing boundaries; "
+            "the v1 RPC/local timing topology is unsupported"
+        ),
+    }
+    assert manifest["protected_boundary_requirements"] == {
+        name: manifest[name]
+        for name in (
+            "accelerator_role_isolation",
+            "trusted_out_of_process_mutation_observation",
+            "comparable_timing_boundaries",
+            "crash_safe_container_creation",
+        )
+    }
     assert "H100" not in rendered
-    for private_path in (paths["evaluator"], paths["private_plan"], paths["reference"]):
+    for private_path in (paths["evaluator"], paths["private_plan"], paths["reference"], paths["hmac_secret"]):
         assert str(private_path) not in rendered
+
+
+def test_hostile_worker_response_patch_fails_before_any_protected_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+) -> None:
+    runner, _paths = authority_runner
+    candidate = KernelCandidate(
+        source=(
+            "import sys\n"
+            "worker = sys.modules['__main__']\n"
+            "worker._response = lambda *a, **k: {'outcome': 'complete'}\n"
+            "worker.send_authority_frame = lambda *a, **k: None\n"
+            "def kernel_fn(a, b): return a @ b\n"
+        ),
+        entrypoint="kernel_fn",
+    )
+    incumbent = KernelCandidate(source="def kernel_fn(a, b): return a.matmul(b)", entrypoint="kernel_fn")
+
+    def forbidden_dispatch(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("an unavailable protected boundary must fail before attestation or Docker dispatch")
+
+    monkeypatch.setattr(runner, "_attest_accelerator", forbidden_dispatch)
+    monkeypatch.setattr("autocontext.kernel_evolution.authority_runner.create_docker_container", forbidden_dispatch)
+    monkeypatch.setattr("autocontext.kernel_evolution.authority_runner.subprocess.run", forbidden_dispatch)
+    monkeypatch.setattr("autocontext.kernel_evolution.docker_watchdog.subprocess.Popen", forbidden_dispatch)
+
+    execution = runner.run(candidate, incumbent, timeout_seconds=1.0)
+
+    assert execution.outcome == "resource_policy_unsupported"
+    assert execution.timed_out is False
+    assert execution.report_payload is None
+    assert execution.error == (
+        "protected accelerator evidence requires independently attested evaluator, candidate, and incumbent grants; "
+        "the v1 shared-grant topology is unsupported"
+    )
+
+    monkeypatch.setattr(authority_readiness, "_ROLE_ISOLATION_AVAILABLE", True)
+    mutation_execution = runner.run(candidate, incumbent, timeout_seconds=1.0)
+
+    assert mutation_execution.outcome == "resource_policy_unsupported"
+    assert mutation_execution.error == (
+        "protected accelerator evidence requires trusted out-of-process input-mutation observation; "
+        "the v1 same-interpreter authority is unsupported"
+    )
+
+    monkeypatch.setattr(authority_readiness, "_MUTATION_OBSERVATION_AVAILABLE", True)
+    timing_execution = runner.run(candidate, incumbent, timeout_seconds=1.0)
+
+    assert timing_execution.outcome == "resource_policy_unsupported"
+    assert timing_execution.error == (
+        "protected accelerator evidence requires comparable candidate/incumbent/reference timing boundaries; "
+        "the v1 RPC/local timing topology is unsupported"
+    )
+
+    monkeypatch.setattr(authority_readiness, "_COMPARABLE_TIMING_AVAILABLE", True)
+    creation_execution = runner.run(candidate, incumbent, timeout_seconds=1.0)
+
+    assert creation_execution.outcome == "resource_policy_unsupported"
+    assert creation_execution.error == (
+        "protected accelerator evidence requires crash-safe container creation; "
+        "the v1 coordinator-owned docker create path is unsupported"
+    )
 
 
 @pytest.mark.parametrize(
@@ -217,7 +399,12 @@ def test_authority_failures_remain_distinct(failure: str, expected: str) -> None
     )
 
 
-def _receipt_payload(attestation: DockerGPUDeviceAttestation) -> dict[str, Any]:
+def _receipt_payload(
+    runner: DockerProtectedKernelBenchmarkRunner,
+    attestation: DockerGPUDeviceAttestation,
+    *,
+    boundary_digest: str | None = None,
+) -> dict[str, Any]:
     candidate_digest = canonical_authority_digest("candidate")
     incumbent_digest = canonical_authority_digest("incumbent")
     plan_digest = canonical_authority_digest("plan")
@@ -233,6 +420,7 @@ def _receipt_payload(attestation: DockerGPUDeviceAttestation) -> dict[str, Any]:
         attestor_id=attestation.attestor_id,
         metadata={"grant_attestation_digest": attestation.digest},
     )
+    roles: tuple[Literal["candidate", "incumbent"], ...] = ("candidate", "incumbent")
     measurements = tuple(
         AuthorityMeasurement(
             sequence=index,
@@ -245,37 +433,50 @@ def _receipt_payload(attestation: DockerGPUDeviceAttestation) -> dict[str, Any]:
             observed_peak_memory_bytes=100 + index,
             outcome="complete",
         )
-        for index, role in enumerate(("candidate", "incumbent"))
+        for index, role in enumerate(roles)
     )
     report: dict[str, Any] = {
         "candidate_artifact_digest": candidate_digest,
         "incumbent_artifact_digest": incumbent_digest,
         "protocol": {"seed_commitment": plan_digest},
+        "evaluation_status": "complete",
+        "resources": {
+            "candidate_observed_peak_bytes": 100,
+            "incumbent_observed_peak_bytes": 101,
+            "telemetry_authority": "trusted-evaluator-observed/v1",
+            "accelerator_attestation_digest": accelerator.digest,
+            "device_total_memory_bytes": accelerator.enforced_memory_bytes,
+        },
     }
     receipt = build_authority_receipt(
-        evaluator_build_digest=canonical_authority_digest("build"),
-        boundary_manifest_digest=canonical_authority_digest("boundary"),
+        evaluator_build_digest=runner._evaluator_digest,
+        boundary_manifest_digest=boundary_digest or canonical_authority_digest(runner.manifest()),
         plan_commitment=plan_digest,
         accelerator_attestation=accelerator,
         candidate_artifact_digest=candidate_digest,
         incumbent_artifact_digest=incumbent_digest,
         measurements=measurements,
         report=report,
+        signing_key_id=_HMAC_KEY_ID,
+        signing_secret=_HMAC_SECRET,
     )
     report["evaluator_authority_receipt"] = receipt.model_dump(mode="json")
     return report
 
 
-def test_authority_receipt_is_bound_to_the_host_attested_partition() -> None:
+def test_authority_receipt_is_bound_to_host_partition_build_boundary_and_key(
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+) -> None:
+    runner, _paths = authority_runner
     host_attestation = DockerGPUDeviceAttestation(
         device_id="MIG-GPU-deadbeef/1/0",
         isolation_kind="mig",
         enforced_memory_bytes=8 * 1024**3,
         attestor_id="test-partition-attestor-v1",
     )
-    payload = _receipt_payload(host_attestation)
+    payload = _receipt_payload(runner, host_attestation)
 
-    assert DockerProtectedKernelBenchmarkRunner._validate_receipt(payload, host_attestation) is None
+    assert runner._validate_receipt(payload, host_attestation) is None
 
     forged_host_attestation = DockerGPUDeviceAttestation(
         device_id="MIG-GPU-forged/2/0",
@@ -284,8 +485,14 @@ def test_authority_receipt_is_bound_to_the_host_attested_partition() -> None:
         attestor_id="test-partition-attestor-v1",
     )
     assert "host-attested accelerator grant" in str(
-        DockerProtectedKernelBenchmarkRunner._validate_receipt(payload, forged_host_attestation)
+        runner._validate_receipt(payload, forged_host_attestation)
     )
+    wrong_boundary = _receipt_payload(
+        runner,
+        host_attestation,
+        boundary_digest=canonical_authority_digest("wrong-boundary"),
+    )
+    assert "omitted or forged" in str(runner._validate_receipt(wrong_boundary, host_attestation))
 
 
 def test_hostile_candidate_has_no_persistent_or_report_writable_mount(
@@ -322,6 +529,59 @@ def test_hostile_candidate_has_no_persistent_or_report_writable_mount(
     assert f"type=bind,src={channel},dst=/channel,readonly" in rendered
 
 
+def test_docker_authority_create_precedes_session_isolated_attach(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        run_calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout="container-id\n", stderr="")
+
+    popen_calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    class Process:
+        pass
+
+    def popen(command: list[str], **kwargs: Any) -> Any:
+        popen_calls.append((command, kwargs))
+        return Process()
+
+    monkeypatch.setattr(docker_watchdog.subprocess, "run", run)
+    monkeypatch.setattr(docker_watchdog.subprocess, "Popen", popen)
+
+    docker_watchdog.create_docker_container(
+        ["/usr/bin/docker-test", "run", "--name", "authority", "pinned-image"],
+        timeout_seconds=3.0,
+    )
+    process = docker_watchdog.start_attached_docker_container(
+        "/usr/bin/docker-test",
+        "authority",
+        capture_output=True,
+    )
+
+    assert run_calls[0][0] == [
+        "/usr/bin/docker-test",
+        "create",
+        "--name",
+        "authority",
+        "pinned-image",
+    ]
+    assert run_calls[0][1]["timeout"] == 3.0
+    assert popen_calls[0][0] == ["/usr/bin/docker-test", "start", "--attach", "authority"]
+    assert popen_calls[0][1]["start_new_session"] is True
+    assert popen_calls[0][1]["stdout"] is subprocess.PIPE
+    assert popen_calls[0][1]["stderr"] is subprocess.PIPE
+    reaped: list[tuple[Any, str]] = []
+    monkeypatch.setattr(
+        docker_watchdog,
+        "terminate_process_group",
+        lambda value, *, description: reaped.append((value, description)),
+    )
+    assert docker_watchdog.terminate_attached_docker_processes([("evaluator", process)]) == []
+    assert reaped == [(process, "evaluator authority Docker attach")]
+
+
 def test_timeout_kills_every_authority_and_verifies_container_teardown(
     monkeypatch: pytest.MonkeyPatch,
     authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
@@ -329,13 +589,15 @@ def test_timeout_kills_every_authority_and_verifies_container_teardown(
 ) -> None:
     runner, _paths = authority_runner
     processes: list[Any] = []
+    events: list[tuple[str, str]] = []
 
     class FakeProcess:
-        def __init__(self, command: list[str], **_kwargs: Any) -> None:
-            self.command = command
+        def __init__(self, name: str) -> None:
+            self.command = [name]
             self.stdout = io.BytesIO()
             self.stderr = io.BytesIO()
             self.killed = False
+            self.reaped = False
             processes.append(self)
 
         def wait(self, timeout: float | None = None) -> int:
@@ -349,15 +611,23 @@ def test_timeout_kills_every_authority_and_verifies_container_teardown(
         def kill(self) -> None:
             self.killed = True
 
-    monkeypatch.setattr(
-        "autocontext.kernel_evolution.authority_runner.subprocess.Popen",
-        FakeProcess,
-    )
+    def create(command: list[str], *, timeout_seconds: float) -> None:
+        assert timeout_seconds > 0
+        events.append(("create", command[-1]))
+
+    def start(_binary: str, name: str, *, capture_output: bool) -> FakeProcess:
+        assert capture_output is (name == "eval")
+        events.append(("start", name))
+        return FakeProcess(name)
+
+    monkeypatch.setattr("autocontext.kernel_evolution.authority_runner.create_docker_container", create)
+    monkeypatch.setattr("autocontext.kernel_evolution.authority_runner.start_attached_docker_container", start)
     monkeypatch.setattr(runner, "_wait_for_evaluator_sockets", lambda *args: None)
     watched: list[str] = []
 
     def launch_watchdog(_binary: str, name: str, _expires: float, _ready: Path) -> object:
         watched.append(name)
+        events.append(("watchdog", name))
         return object()
 
     monkeypatch.setattr(
@@ -368,20 +638,40 @@ def test_timeout_kills_every_authority_and_verifies_container_teardown(
         "autocontext.kernel_evolution.authority_runner.terminate_process_group",
         lambda *args, **kwargs: None,
     )
+    attached_roles: list[str] = []
+
+    def terminate_attached(attached: Any) -> list[str]:
+        for role, process in attached:
+            if process is not None:
+                attached_roles.append(role)
+                process.kill()
+                process.reaped = True
+        return []
+
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.terminate_attached_docker_processes",
+        terminate_attached,
+    )
     removed: list[str] = []
     verified: list[str] = []
+    drain_calls: list[tuple[int, Any, Any, Any]] = []
+
+    def drain(_stream: Any, limit: int, result: Any, quota: Any, terminate: Any) -> None:
+        drain_calls.append((limit, result, quota, terminate))
+
+    monkeypatch.setattr("autocontext.kernel_evolution._process_control.drain_bounded", drain)
     monkeypatch.setattr(runner, "_remove_container", removed.append)
     monkeypatch.setattr(runner, "_verify_removed", verified.append)
     attestation = _Attestor().attest(runner.gpu_grant)
 
     execution = runner._execute_authorities(
-        ["docker", "evaluator"],
-        ["docker", "candidate"],
-        ["docker", "incumbent"],
+        ["docker", "run", "evaluator-command"],
+        ["docker", "run", "candidate-command"],
+        ["docker", "run", "incumbent-command"],
         names={"evaluator": "eval", "candidate": "cand", "incumbent": "inc"},
         socket_paths=(tmp_path / "candidate.sock", tmp_path / "incumbent.sock"),
         report_path=tmp_path / "report.json",
-        report_identity=object(),  # ignored on the timeout path
+        report_identity=(0, 0, 0),  # ignored on the timeout path
         timeout_seconds=0.01,
         accelerator_attestation=attestation,
         watchdog_root=tmp_path,
@@ -390,9 +680,187 @@ def test_timeout_kills_every_authority_and_verifies_container_teardown(
 
     assert execution.outcome == "timeout"
     assert all(process.killed for process in processes)
+    assert all(process.reaped for process in processes)
+    assert attached_roles == ["evaluator", "candidate", "incumbent"]
     assert removed == ["eval", "cand", "inc"]
     assert verified == ["eval", "cand", "inc"]
     assert watched == ["eval", "cand", "inc"]
+    assert events == [
+        ("create", "evaluator-command"),
+        ("watchdog", "eval"),
+        ("start", "eval"),
+        ("create", "candidate-command"),
+        ("watchdog", "cand"),
+        ("start", "cand"),
+        ("create", "incumbent-command"),
+        ("watchdog", "inc"),
+        ("start", "inc"),
+    ]
+    assert len(drain_calls) == 2
+    assert {call[0] for call in drain_calls} == {runner.limits.max_output_bytes}
+    assert drain_calls[0][2] is drain_calls[1][2]
+    assert all(callable(call[3]) for call in drain_calls)
+
+
+def test_output_quota_terminates_all_names_and_blocks_candidate_start(
+    monkeypatch: pytest.MonkeyPatch,
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, _paths = authority_runner
+    created: list[str] = []
+    removed: list[str] = []
+
+    class EvaluatorProcess:
+        stdout = io.BytesIO()
+        stderr = io.BytesIO()
+
+    evaluator = EvaluatorProcess()
+
+    def create(command: list[str], *, timeout_seconds: float) -> None:
+        assert timeout_seconds > 0
+        created.append(command[-1])
+
+    def start(_binary: str, name: str, *, capture_output: bool) -> Any:
+        assert name == "eval" and capture_output
+        return evaluator
+
+    def exceed_quota(
+        _process: Any,
+        *,
+        max_output_bytes: int,
+        stdout: Any,
+        stderr: Any,
+        quota_exceeded: Any,
+        terminate: Any,
+    ) -> list[Any]:
+        assert max_output_bytes == runner.limits.max_output_bytes
+        assert stderr.exceeded is False
+        stdout.exceeded = True
+        quota_exceeded.set()
+        terminate()
+        return []
+
+    monkeypatch.setattr("autocontext.kernel_evolution.authority_runner.create_docker_container", create)
+    monkeypatch.setattr("autocontext.kernel_evolution.authority_runner.start_attached_docker_container", start)
+    monkeypatch.setattr("autocontext.kernel_evolution.authority_runner.launch_bounded_output_drains", exceed_quota)
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.launch_deadline_watchdog",
+        lambda *args: object(),
+    )
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.terminate_attached_docker_processes",
+        lambda attached: [],
+    )
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.terminate_process_group",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(runner, "_wait_for_evaluator_sockets", lambda *args: None)
+    monkeypatch.setattr(runner, "_remove_container", removed.append)
+    monkeypatch.setattr(runner, "_verify_removed", lambda _name: None)
+
+    execution = runner._execute_authorities(
+        ["docker", "run", "evaluator-command"],
+        ["docker", "run", "candidate-command"],
+        ["docker", "run", "incumbent-command"],
+        names={"evaluator": "eval", "candidate": "cand", "incumbent": "inc"},
+        socket_paths=(tmp_path / "candidate.sock", tmp_path / "incumbent.sock"),
+        report_path=tmp_path / "report.json",
+        report_identity=(0, 0, 0),
+        timeout_seconds=1.0,
+        accelerator_attestation=_Attestor().attest(runner.gpu_grant),
+        watchdog_root=tmp_path,
+        expires_at=2_000_000_000.0,
+    )
+
+    assert execution.outcome == "resource_exceeded"
+    assert execution.timed_out is False
+    assert execution.stdout_truncated is True
+    assert created == ["evaluator-command"]
+    assert removed[:3] == ["eval", "cand", "inc"]
+
+
+def test_failed_container_removal_retains_its_watchdog_and_reports_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+    tmp_path: Path,
+) -> None:
+    runner, _paths = authority_runner
+
+    class FinishedProcess:
+        stdout = io.BytesIO()
+        stderr = io.BytesIO()
+
+        @staticmethod
+        def wait(timeout: float | None = None) -> int:
+            return 0
+
+        @staticmethod
+        def poll() -> int:
+            return 0
+
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.create_docker_container",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.start_attached_docker_container",
+        lambda *args, **kwargs: FinishedProcess(),
+    )
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.launch_bounded_output_drains",
+        lambda *args, **kwargs: [],
+    )
+    watchers: dict[str, object] = {}
+
+    def launch_watchdog(_binary: str, name: str, _expires: float, _ready: Path) -> object:
+        watchers[name] = object()
+        return watchers[name]
+
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.launch_deadline_watchdog",
+        launch_watchdog,
+    )
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.terminate_attached_docker_processes",
+        lambda attached: [],
+    )
+    terminated_watchdogs: list[object] = []
+    monkeypatch.setattr(
+        "autocontext.kernel_evolution.authority_runner.terminate_process_group",
+        lambda process, **kwargs: terminated_watchdogs.append(process),
+    )
+    monkeypatch.setattr(runner, "_wait_for_evaluator_sockets", lambda *args: None)
+    monkeypatch.setattr(runner, "_read_report", lambda *args: None)
+
+    def remove(name: str) -> None:
+        if name == "cand":
+            raise RuntimeError("Docker daemon unavailable")
+
+    verified: list[str] = []
+    monkeypatch.setattr(runner, "_remove_container", remove)
+    monkeypatch.setattr(runner, "_verify_removed", verified.append)
+
+    execution = runner._execute_authorities(
+        ["docker", "run", "evaluator-command"],
+        ["docker", "run", "candidate-command"],
+        ["docker", "run", "incumbent-command"],
+        names={"evaluator": "eval", "candidate": "cand", "incumbent": "inc"},
+        socket_paths=(tmp_path / "candidate.sock", tmp_path / "incumbent.sock"),
+        report_path=tmp_path / "report.json",
+        report_identity=(0, 0, 0),
+        timeout_seconds=1.0,
+        accelerator_attestation=_Attestor().attest(runner.gpu_grant),
+        watchdog_root=tmp_path,
+        expires_at=2_000_000_000.0,
+    )
+
+    assert execution.outcome == "teardown_failed"
+    assert "cand: RuntimeError: Docker daemon unavailable" in str(execution.error)
+    assert verified == ["eval", "inc"]
+    assert terminated_watchdogs == [watchers["eval"], watchers["inc"]]
+    assert watchers["cand"] not in terminated_watchdogs
 
 
 def test_coordinator_loss_reconciliation_removes_expired_authority_containers(
@@ -419,3 +887,64 @@ def test_coordinator_loss_reconciliation_removes_expired_authority_containers(
     assert runner.reconcile(now=20.0) == 2
     assert removed == ["owned-evaluator", "owned-candidate"]
     assert verified == removed
+
+
+def test_removal_verification_inspects_the_exact_reconciled_container_id(
+    monkeypatch: pytest.MonkeyPatch,
+    authority_runner: tuple[DockerProtectedKernelBenchmarkRunner, dict[str, Path]],
+) -> None:
+    runner, _paths = authority_runner
+    calls: list[list[str]] = []
+
+    def missing(command: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="Error: No such object: sha256:owned")
+
+    monkeypatch.setattr(docker_watchdog.subprocess, "run", missing)
+    runner._verify_removed("sha256:owned")
+
+    assert calls == [["/usr/bin/docker-test", "inspect", "sha256:owned"]]
+
+    monkeypatch.setattr(
+        docker_watchdog.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, stdout="{}", stderr=""),
+    )
+    with pytest.raises(RuntimeError, match="remained after teardown"):
+        runner._verify_removed("sha256:owned")
+
+
+def test_teardown_failure_takes_precedence_over_timeout_rejection() -> None:
+    candidate = KernelCandidate(source="def kernel_fn(a, b): return a @ b", entrypoint="kernel_fn")
+    incumbent = KernelCandidate(source="def kernel_fn(a, b): return a.matmul(b)", entrypoint="kernel_fn")
+
+    class TeardownRunner:
+        @staticmethod
+        def run(
+            _candidate: KernelCandidate,
+            _incumbent: KernelCandidate,
+            *,
+            timeout_seconds: float,
+        ) -> KernelBenchmarkExecution:
+            assert timeout_seconds == 3.0
+            return KernelBenchmarkExecution(
+                returncode=None,
+                timed_out=True,
+                outcome="teardown_failed",
+                error="candidate container remained live",
+            )
+
+        @staticmethod
+        def manifest() -> dict[str, Any]:
+            return {"kind": "teardown-test"}
+
+    evaluator = KernelBenchmarkEvaluator(
+        TeardownRunner(),
+        KernelBenchmarkEvaluatorConfig(problem_id="p", timeout_seconds=3.0),
+    )
+
+    observation = evaluator.evaluate(candidate, incumbent)
+
+    assert observation.eligible is False
+    assert observation.rejection_reason == "teardown_failed"
+    assert observation.feedback == "candidate container remained live"

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,9 +43,10 @@ orchestration adapter is synthetic. The companion
 real KernelBench/AutoKernel comparison and now separates strict-FP32 from
 relaxed-precision campaigns, binds private holdout commitments, and applies a
 bounded sequential promotion gate. The historical one-shot smoke accepts only
-trusted source. The production campaign is Docker-composed but intentionally
-fails closed until generated execution is separated from its authoritative
-evaluator.
+trusted source. The accelerator-neutral protected runner now separates
+generated execution from its authoritative evaluator; the production H100
+campaign intentionally remains fail-closed until that exact path passes the
+opt-in real MIG adversarial gate.
 
 ## Python CLI From Source
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,9 +44,11 @@ real KernelBench/AutoKernel comparison and now separates strict-FP32 from
 relaxed-precision campaigns, binds private holdout commitments, and applies a
 bounded sequential promotion gate. The historical one-shot smoke accepts only
 trusted source. The accelerator-neutral protected runner now separates
-generated execution from its authoritative evaluator; the production H100
-campaign intentionally remains fail-closed until that exact path passes the
-opt-in real MIG adversarial gate.
+generated execution from its authoritative evaluator and authenticates compact
+receipts against an operator-pinned host key. The production H100 campaign
+remains fail-closed until role-separated telemetry, trusted mutation
+observation, comparable reference timing, and crash-safe container creation are
+implemented and the exact path passes the opt-in real MIG adversarial gate.
 
 ## Python CLI From Source
 

--- a/examples/kernel_evolution/kernelbench_h100/README.md
+++ b/examples/kernel_evolution/kernelbench_h100/README.md
@@ -123,39 +123,56 @@ The campaign hashes each complete plan before the first proposal. The protected
 evaluator publishes only its canonical SHA-256 commitment. Its private plan,
 reference, evaluator code, report directory, and opposite-role socket are never
 mounted into a candidate container. The production entry point remains disabled
-only because this new boundary has not yet completed the real H100/MIG gate.
+until the authority uses independently attested role grants, observes mutation
+outside generated code's interpreter, measures candidate/incumbent/reference
+under comparable trusted boundaries, creates containers under crash-safe
+supervision, and completes the real H100/MIG gate.
 
 ## Production campaign status
 
-The trusted evaluator/candidate boundary is implemented, but the recursive
-campaign intentionally remains unavailable until the exact path is validated
-on a real H100/MIG partition. Invoking `campaign.py` validates
+The authenticated authority protocol prototype and fail-closed composition
+guard are implemented, but the trusted evaluator/candidate boundary remains
+incomplete. The recursive campaign stays unavailable until its four missing
+boundary requirements are implemented and the exact path is validated on a
+real H100/MIG partition. Invoking `campaign.py` validates
 the private-plan schedule and declarative pinned-image/MIG/limit configuration,
 then raises
 `ProductionEvaluatorBoundaryUnavailable` before creating a mailbox or launching
 a container. It does not attest the host GPU or construct a Docker evaluator.
-There is no campaign override flag. The protected composition helper is
-deliberately runnable by the opt-in release test so that validation exercises
-the exact future production factory without weakening the campaign guard.
+There is no campaign override flag. The protected composition helper remains
+inspectable, but its runner returns `resource_policy_unsupported` before host
+attestation or container launch whenever any of the four authority requirements
+is unavailable. The runner and runtime manifests publish the same authoritative
+requirement map. In particular, crash-safe supervised container creation stays
+explicitly unavailable as `crash_safe_container_creation` rather than relying
+on post-create expiry labels to cover a coordinator crash during `docker create`.
 
-The implemented architecture is an evaluator-owned accelerator RPC over
-bounded JSON headers and canonical safetensors payloads—never pickle. Generated
-code receives only the tensors needed for one invocation. The evaluator uses
-fresh random timed challenges, checks every response against its trusted
-reference, observes end-to-end latency and partition-global memory itself, and
-binds request/output commitments and measurements to both artifact identities,
-the private-plan commitment, evaluator/boundary builds, and host accelerator
-attestation in a replay-verifiable receipt. Candidate timing/report claims are
-not protocol fields. Exact statistics remain in evaluator-owned audit evidence;
-recursive prompts receive only aggregate gate states and the disposition, so a
-candidate cannot use deliberately modulated timing digits as a holdout-return
-channel.
+The implemented prototype is an evaluator-owned accelerator RPC over bounded
+JSON headers and canonical safetensors payloads—never pickle. Tensor payloads
+retain exact shape, stride, and storage offset; unsupported overlapping or
+aliased storage is rejected. Generated code receives only the tensors needed
+for one invocation. The production path remains fail-closed because the current
+same-interpreter authority cannot independently observe input mutation and the
+shared accelerator grant cannot attest role isolation. Worker-issued mutation
+claims are not accepted as evidence, reference timing is not comparable to the
+RPC boundary, and container creation is not yet crash-safe. The evaluator uses fresh random timed
+challenges, checks every response against its trusted reference, observes
+candidate/incumbent end-to-end RPC latency and partition-global memory itself,
+and binds request/output commitments and measurements to both artifact
+identities, the private-plan commitment, evaluator/boundary builds, and host
+accelerator attestation in a replay-verifiable receipt. Candidate timing/report
+claims are not protocol fields. Exact statistics remain in evaluator-owned audit
+evidence; recursive prompts receive only aggregate gate states and the
+disposition, so a candidate cannot use deliberately modulated timing digits as
+a holdout-return channel.
 
 The production composition requires all of the following:
 
 - a digest-pinned `--worker-image` and explicit `--container-python`;
 - `--gpu-device MIG-...`, `--gpu-isolation-kind mig`, and the exact
   `--gpu-memory-bytes` reported by host `nvidia-smi`;
+- an operator-pinned `--authority-hmac-key-id` and owner-only mode-0400/0600
+  `--authority-hmac-secret-file`; the secret path and bytes are never exported;
 - one `--primary-private-plan` and at least one distinct repeatable
   `--confirmation-private-plan` per requested proposal;
 - explicit bounded worker limits, all of which are recorded in the runner
@@ -164,7 +181,9 @@ manifest.
 The authoritative report must identify CUDA, `sm90`, and an NVIDIA H100. Its
 GPU receipt includes the exact device or MIG UUID, isolation kind, enforced
 capacity, and host `attestor_id`; profile export recomputes the branded digest
-over that complete payload and requires the confirmation receipt to match it.
+over that complete payload, reauthenticates the compact primary and confirmation
+authority receipts against the pinned host key and build/boundary digests, and
+exports those authenticated receipts without any private input transcript.
 An A100/`sm80` report, a downgraded v2 link, or a missing/altered attestor field
 cannot be labeled H100 profile evidence.
 
@@ -207,26 +226,33 @@ detached cleanup after coordinator `SIGKILL`. Record the command, image digest,
 MIG UUID/capacity, and test log in the release checklist. This gate validates
 the outer Docker worker; it does not by itself enable `campaign.py`.
 
-The AC-1003 gate exercises the protected factory twice with a hostile candidate
-that probes private mounts/environment and egress, patches `torch.cuda.Event`,
-starts a descendant, and writes a workspace marker. Its outputs remain correct
-only when all probes fail, and the second evaluation proves that no marker
-persists. Supply a valid strict primary plan outside the candidate-visible
-AutoKernel root:
+The reserved AC-1003 test composes the protected factory twice with a hostile
+candidate that would probe private mounts/environment and egress, patch
+`torch.cuda.Event`, start a descendant, and write a workspace marker. Until the
+role-isolated topology exists, both evaluations must fail with
+`resource_policy_unsupported` before that source or any container is launched.
+It is a pre-dispatch invariant, not a live H100 authority validation. The
+normal unit suite covers the unavailable manifest; operators can additionally
+exercise this reserved host setup with a valid strict primary plan outside the
+candidate-visible AutoKernel root:
 
 ```bash
 export AUTOCONTEXT_RUN_PROTECTED_GPU_INTEGRATION=1
 export AUTOCONTEXT_GPU_MEMORY_BYTES=<exact-MIG-capacity-bytes>
 export AUTOCONTEXT_AUTOKERNEL_ROOT=/absolute/path/to/autokernel
 export AUTOCONTEXT_KERNEL_PRIVATE_PLAN=/worker-private/strict-primary.json
+export AUTOCONTEXT_AUTHORITY_HMAC_KEY_ID=release-host-key-v1
+export AUTOCONTEXT_AUTHORITY_HMAC_SECRET_FILE=/worker-private/authority-hmac.secret
 uv run --frozen pytest \
-  tests/test_kernel_h100_production_runtime.py::test_real_h100_protected_authority_adversarial_release_gate \
+  tests/test_kernel_h100_production_runtime.py::test_reserved_h100_protected_authority_gate_remains_unavailable \
   -q
 ```
 
 Do not remove `require_protected_evaluator_boundary()` from `campaign.py` until
-this second gate passes on the digest-pinned release image and its authority
-receipt and teardown log have been reviewed.
+role-separated telemetry, trusted out-of-process mutation observation, and a
+comparable reference timing boundary and crash-safe supervised creation are
+implemented, then the reserved live gate passes on the digest-pinned image and
+its authenticated receipts and teardown log have been reviewed.
 
 ## Named workload and protocol
 
@@ -247,11 +273,13 @@ medians. The adapter uses three warmups and ten evaluator-randomized calls per
 implementation per block. Every timed candidate/incumbent output is checked
 against the trusted reference; the evaluator owns wall-clock measurement around
 the complete authority exchange, so a candidate cannot substitute its clock or
-replay an earlier output. Candidate, incumbent, and PyTorch reference orders
-rotate across blocks. In protected mode the evaluator observes partition-global
-memory changes independently for each authority; the legacy trusted control
-retains allocator peak measurements. Both are bound to exact artifact
-identities. The static workload-family identity
+replay an earlier output. Candidate and incumbent orders rotate across protected
+blocks and share that RPC boundary. The local PyTorch CUDA-event reference is a
+diagnostic with an explicitly non-comparable boundary and is excluded from
+promotion comparisons. Protected evidence therefore remains ineligible until a
+trusted boundary can make all required authority claims. The legacy trusted
+control retains allocator peak measurements. Measurements are bound to exact
+artifact identities. The static workload-family identity
 covers the reference and problem contract; the workload fingerprint also binds
 the selected profile, private-plan commitment, and sequential policy.
 
@@ -355,12 +383,17 @@ observation only as relaxed-precision evidence and records why the exact source
 is rejected by the strict contract. It explicitly marks the strict live H100
 campaign as blocked on AC-1003 and then pending an external H100 run. That
 historical statement remains accurate for the artifact; after the protected
-gate passes and the campaign guard is removed, a completed new campaign writes `profile_evidence.json`
-using schema `autocontext.kernel-h100-profile-evidence/v3`, with the exact
+gate passes and the campaign guard is removed, a completed new campaign writes
+`profile_evidence.json` using the authenticated outer schema
+`autocontext.kernel-profile-evidence-envelope/v1`. Its `profile` payload uses
+schema `autocontext.kernel-h100-profile-evidence/v3`, and the outer content
+digest plus operator-pinned HMAC key and tag authenticate every field, including
+the exact
 champion artifact and attempt identity, content-addressed primary
 and confirmation report receipts, their plan commitments and protocol IDs,
 the complete host-owned decision policy and its canonical policy ID,
-the complete all-v3 result/lineage/report chain, CUDA/SM90/H100 identity, the
+identities replayed from the complete all-v3 result/lineage/report chain before
+export, CUDA/SM90/H100 identity, the
 digest-verified host GPU attestation including its attestor ID, holdout correctness and per-case floors,
 proposal spend, and whether an improvement survived strict FP32.
 

--- a/examples/kernel_evolution/kernelbench_h100/README.md
+++ b/examples/kernel_evolution/kernelbench_h100/README.md
@@ -12,8 +12,10 @@ leaderboard result.
 | --- | --- |
 | `control_smoke.py` | Runs a same-interpreter diagnostic and emits an explicitly non-authoritative control decision. |
 | `campaign.py` | Validates production inputs and fails closed before evaluator, mailbox, or GPU work. |
-| `production_runtime.py` | Models pinned Docker/MIG/limit inputs and enforces the missing trusted-evaluator boundary at construction. |
-| `adapter.py` | Owns compilation, private-plan correctness, per-case and aggregate CUDA-event timing, hardware identity, and the v3 JSON report. |
+| `production_runtime.py` | Composes the protected Docker/MIG evaluator path used for live validation while retaining the production release guard. |
+| `adapter.py` | Trusted evaluator: owns private plans, references, fresh timing challenges, telemetry, and the v3 JSON report without importing generated source in protected mode. |
+| `authority_transport.py` | Evaluator-owned, typed and bounded Unix-socket transport plus independent timing and partition-global memory observation. |
+| `authority_worker.py` | Candidate-side executor; receives only its source, public support code, tensor frames, and one authority socket. |
 | `confirmation_adapter.py` | Runs the independently committed confirmation plan through the same immutable adapter. |
 | `profile_contract.py` | Defines both public precision profiles and validates private plan coverage, commitments, and freshness. |
 | `reference.py` | Pinned KernelBench v0.1 Level 1 problem 1 PyTorch reference. |
@@ -45,14 +47,14 @@ Its JSON uses the separate `autocontext.kernel-h100-control-smoke/v1` schema,
 sets `authoritative: false`, and deliberately omits the forgeable raw report;
 it must never be consumed as canonical promotion or profile evidence.
 
-`campaign.py` no longer has a local-process escape hatch. It validates the
+`campaign.py` has no local-process escape hatch. It validates the
 declarative inputs for a digest-pinned image, explicit MIG UUID and capacity,
 bounded resources, and private-plan schedule. It then fails closed before
 creating a mailbox, resolving Docker, running host attestation, or spending GPU
-time. The current adapter imports generated code into the Python process that
-owns the private plan, correctness oracle, CUDA timers, telemetry, and report.
-Docker protects the host; it cannot make values controlled by that same process
-authoritative.
+time until the protected path passes its real H100/MIG release gate. The path
+itself is now split: the trusted evaluator and candidate/incumbent authorities
+run in distinct containers, and protected adapter mode never receives generated
+source paths.
 
 ## Pin the incumbent
 
@@ -117,33 +119,39 @@ profile is the legacy fixed, contiguous, positive-unit distribution. The
 validator also requires unique seeds, disjoint primary and confirmation inputs,
 and different relative timing orders.
 
-The campaign hashes each complete plan before the first proposal. A sound
-production evaluator must publish only its canonical SHA-256 commitment and
-must never mount or pass the private plan to a candidate-controlled process.
-The current adapter cannot enforce that separation, which is why the production
-entry point is disabled rather than publishing misleading evidence.
+The campaign hashes each complete plan before the first proposal. The protected
+evaluator publishes only its canonical SHA-256 commitment. Its private plan,
+reference, evaluator code, report directory, and opposite-role socket are never
+mounted into a candidate container. The production entry point remains disabled
+only because this new boundary has not yet completed the real H100/MIG gate.
 
 ## Production campaign status
 
-The recursive campaign is intentionally unavailable until the trusted
-evaluator/candidate boundary is implemented. Invoking `campaign.py` validates
+The trusted evaluator/candidate boundary is implemented, but the recursive
+campaign intentionally remains unavailable until the exact path is validated
+on a real H100/MIG partition. Invoking `campaign.py` validates
 the private-plan schedule and declarative pinned-image/MIG/limit configuration,
 then raises
 `ProductionEvaluatorBoundaryUnavailable` before creating a mailbox or launching
 a container. It does not attest the host GPU or construct a Docker evaluator.
-There is no override flag, including for programmatic callers of the composition
-helper.
+There is no campaign override flag. The protected composition helper is
+deliberately runnable by the opt-in release test so that validation exercises
+the exact future production factory without weakening the campaign guard.
 
-The required architecture is an evaluator-owned GPU RPC (or equivalent native
-measurement boundary) where generated code receives only the inputs needed for
-one invocation. It must not be able to read private plans, load or replace the
-reference/incumbent, patch correctness or CUDA timing functions, forge resource
-telemetry, or write the authoritative report. The trusted side must compare
-outputs, measure candidate and incumbent independently, and bind its own report
-to the host-attested GPU identity.
+The implemented architecture is an evaluator-owned accelerator RPC over
+bounded JSON headers and canonical safetensors payloads—never pickle. Generated
+code receives only the tensors needed for one invocation. The evaluator uses
+fresh random timed challenges, checks every response against its trusted
+reference, observes end-to-end latency and partition-global memory itself, and
+binds request/output commitments and measurements to both artifact identities,
+the private-plan commitment, evaluator/boundary builds, and host accelerator
+attestation in a replay-verifiable receipt. Candidate timing/report claims are
+not protocol fields. Exact statistics remain in evaluator-owned audit evidence;
+recursive prompts receive only aggregate gate states and the disposition, so a
+candidate cannot use deliberately modulated timing digits as a holdout-return
+channel.
 
-The production composition must require all of the following once that boundary
-exists:
+The production composition requires all of the following:
 
 - a digest-pinned `--worker-image` and explicit `--container-python`;
 - `--gpu-device MIG-...`, `--gpu-isolation-kind mig`, and the exact
@@ -165,17 +173,15 @@ all confirmation plans must be pairwise disjoint in inputs and relative timing
 order, preventing a later candidate from reusing a confirmation protocol.
 Confirmation details are retained in lineage but excluded from recursive
 feedback, scores, and lesson hints. Promotion still reveals the unavoidable
-pass/fail bit by deciding which champion is carried forward. The current
-lineage store writes full confirmation observations beneath `run_dir`, and the
-mailbox configuration publishes that path. AC-1003 must place those audit files
-in an evaluator-owned location inaccessible to an untrusted implementer before
-the campaign is enabled; fresh plans alone are not an access-control boundary.
+pass/fail bit by deciding which champion is carried forward. Candidate
+containers mount neither `run_dir` nor mailbox/report storage, have no network
+or durable filesystem, and are destroyed between evaluations, so confirmation
+details cannot persist into a later proposal.
 
-`strict-fp32-v1` currently binds `input_downcast_allowed: false` and challenges
-downcasts with strict numerical cases, but it does not prove the candidate's
-internal input precision. AC-1003 must add evaluator-owned IR/runtime precision
-attestation (or narrow the public claim) before strict evidence can be called
-authoritative.
+`strict-fp32-v1` binds `input_downcast_allowed: false` and challenges downcasts
+with strict numerical cases. This is behavioral enforcement, not a general
+proof of a candidate's internal instruction precision; evidence should retain
+that narrower claim unless a future evaluator adds IR/runtime attestation.
 
 ## Docker + MIG release gate
 
@@ -199,7 +205,28 @@ release host does not use the default command names. A passing gate verifies the
 real MIG grant/capacity, denied egress and host paths, bounded output tmpfs, and
 detached cleanup after coordinator `SIGKILL`. Record the command, image digest,
 MIG UUID/capacity, and test log in the release checklist. This gate validates
-the Docker worker; it does not satisfy AC-1003 or enable `campaign.py`.
+the outer Docker worker; it does not by itself enable `campaign.py`.
+
+The AC-1003 gate exercises the protected factory twice with a hostile candidate
+that probes private mounts/environment and egress, patches `torch.cuda.Event`,
+starts a descendant, and writes a workspace marker. Its outputs remain correct
+only when all probes fail, and the second evaluation proves that no marker
+persists. Supply a valid strict primary plan outside the candidate-visible
+AutoKernel root:
+
+```bash
+export AUTOCONTEXT_RUN_PROTECTED_GPU_INTEGRATION=1
+export AUTOCONTEXT_GPU_MEMORY_BYTES=<exact-MIG-capacity-bytes>
+export AUTOCONTEXT_AUTOKERNEL_ROOT=/absolute/path/to/autokernel
+export AUTOCONTEXT_KERNEL_PRIVATE_PLAN=/worker-private/strict-primary.json
+uv run --frozen pytest \
+  tests/test_kernel_h100_production_runtime.py::test_real_h100_protected_authority_adversarial_release_gate \
+  -q
+```
+
+Do not remove `require_protected_evaluator_boundary()` from `campaign.py` until
+this second gate passes on the digest-pinned release image and its authority
+receipt and teardown log have been reviewed.
 
 ## Named workload and protocol
 
@@ -216,11 +243,15 @@ Train and holdout must each independently cover every shape, layout, and value
 class named by the selected canonical profile. Every slice must pass
 correctness; every case must meet the 0.98x incumbent no-regression floor before aggregate promotion. Eight paired
 timing blocks aggregate all cases geometrically while retaining per-case
-medians. The adapter uses three warmups and ten synchronized CUDA-event calls
-per implementation per block. Candidate, incumbent, and PyTorch reference
-orders rotate across blocks. Candidate and incumbent CUDA peak allocation and
-reservation are measured in separate reset windows across every case and are
-bound to their exact artifact identities. The static workload-family identity
+medians. The adapter uses three warmups and ten evaluator-randomized calls per
+implementation per block. Every timed candidate/incumbent output is checked
+against the trusted reference; the evaluator owns wall-clock measurement around
+the complete authority exchange, so a candidate cannot substitute its clock or
+replay an earlier output. Candidate, incumbent, and PyTorch reference orders
+rotate across blocks. In protected mode the evaluator observes partition-global
+memory changes independently for each authority; the legacy trusted control
+retains allocator peak measurements. Both are bound to exact artifact
+identities. The static workload-family identity
 covers the reference and problem contract; the workload fingerprint also binds
 the selected profile, private-plan commitment, and sequential policy.
 
@@ -301,7 +332,7 @@ means the comparison completed but the control decision rejected the candidate;
 that remains a valid contract smoke result. A baseline or infrastructure failure
 exits nonzero with diagnostics. `campaign.py` currently exits nonzero at its
 mandatory protected-evaluator preflight; it cannot emit new production campaign
-evidence until the boundary described above is implemented.
+evidence until the live protected-boundary gate described above passes.
 
 [`verified_h100_result.json`](verified_h100_result.json) records a sanitized
 successful observation on an H100 80GB. It deliberately omits provider, node,
@@ -322,8 +353,9 @@ not a bitwise-equivalent or general-purpose float32 matmul result.
 [`profile_reassessment.json`](profile_reassessment.json) therefore retains that
 observation only as relaxed-precision evidence and records why the exact source
 is rejected by the strict contract. It explicitly marks the strict live H100
-campaign as blocked on AC-1003 and then pending an external H100 run. Once the
-boundary is implemented, a completed new campaign writes `profile_evidence.json`
+campaign as blocked on AC-1003 and then pending an external H100 run. That
+historical statement remains accurate for the artifact; after the protected
+gate passes and the campaign guard is removed, a completed new campaign writes `profile_evidence.json`
 using schema `autocontext.kernel-h100-profile-evidence/v3`, with the exact
 champion artifact and attempt identity, content-addressed primary
 and confirmation report receipts, their plan commitments and protocol IDs,

--- a/examples/kernel_evolution/kernelbench_h100/adapter.py
+++ b/examples/kernel_evolution/kernelbench_h100/adapter.py
@@ -38,7 +38,8 @@ from authority_transport import (
 )
 from profile_contract import PROFILE_NAMES, PROFILES, gpu_attestation_metadata, load_private_plan
 
-from autocontext.kernel_evolution import AcceleratorAttestation, build_authority_receipt
+from autocontext.kernel_evolution import AcceleratorAttestation, build_authority_receipt, read_authority_hmac_secret
+from autocontext.kernel_evolution.authority_tensor import copy_tensor_to_device_preserving_abi
 
 SCHEMA_VERSION = "autocontext.kernelbench-eval/v3"
 PROTOCOL_COMPATIBILITY_VERSION = "autocontext.kernel-protocol-compatibility/v1"
@@ -46,6 +47,14 @@ WARMUP_RUNS = 3
 TIMING_BLOCKS = 8
 CALLS_PER_BLOCK = 10
 _ACTIVE_AUTHORITY_CONTEXT: _AuthorityReceiptContext | None = None
+
+
+def _require_protected_mutation_authority(*, protected_mode: bool) -> None:
+    if protected_mode:
+        raise SystemExit(
+            "protected evaluation requires a trusted out-of-process input-mutation observer; "
+            "the same-interpreter authority v1 is unsupported"
+        )
 
 
 def _digest(payload: bytes | str) -> str:
@@ -115,7 +124,7 @@ def _build_model(module, init_inputs: list[Any], *, entrypoint: str):
 
 def _clone(value):
     if isinstance(value, torch.Tensor):
-        return value.clone()
+        return copy_tensor_to_device_preserving_abi(value, device=str(value.device))
     if isinstance(value, list):
         return [_clone(item) for item in value]
     if isinstance(value, tuple):
@@ -139,7 +148,13 @@ def _to_cuda(value):
 
 def _equal(left, right) -> bool:
     if isinstance(left, torch.Tensor) and isinstance(right, torch.Tensor):
-        return bool(torch.equal(left, right))
+        return (
+            left.dtype == right.dtype
+            and left.shape == right.shape
+            and left.stride() == right.stride()
+            and left.storage_offset() == right.storage_offset()
+            and bool(torch.equal(left, right))
+        )
     if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
         return len(left) == len(right) and all(_equal(a, b) for a, b in zip(left, right, strict=True))
     if isinstance(left, dict) and isinstance(right, dict):
@@ -334,6 +349,7 @@ def _timed_call(model, inputs) -> tuple[Any, float]:
         if not elapsed > 0:
             raise RuntimeError(f"authority measurement returned non-positive latency: {elapsed}")
         return output, elapsed
+    before = _clone(inputs)
     torch.cuda.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
@@ -345,6 +361,8 @@ def _timed_call(model, inputs) -> tuple[Any, float]:
     elapsed = float(start.elapsed_time(end))
     if not elapsed > 0:
         raise RuntimeError(f"CUDA event returned non-positive latency: {elapsed}")
+    if not _equal(before, inputs):
+        raise _TimingChallengeError("a timed model call mutated evaluator-owned inputs")
     return output, elapsed
 
 
@@ -374,6 +392,8 @@ class _AuthorityReceiptContext:
         plan_commitment: str,
         candidate_artifact_digest: str,
         incumbent_artifact_digest: str,
+        signing_key_id: str,
+        signing_secret: bytes,
     ) -> None:
         self.recorder = recorder
         self.attestation = attestation
@@ -382,6 +402,8 @@ class _AuthorityReceiptContext:
         self.plan_commitment = plan_commitment
         self.candidate_artifact_digest = candidate_artifact_digest
         self.incumbent_artifact_digest = incumbent_artifact_digest
+        self.signing_key_id = signing_key_id
+        self.signing_secret = signing_secret
 
     def attach(self, report: dict[str, Any]) -> None:
         measurements = tuple(self.recorder.measurements)
@@ -419,6 +441,8 @@ class _AuthorityReceiptContext:
             incumbent_artifact_digest=self.incumbent_artifact_digest,
             measurements=measurements,
             report=report,
+            signing_key_id=self.signing_key_id,
+            signing_secret=self.signing_secret,
         )
         report["evaluator_authority_receipt"] = receipt.model_dump(mode="json")
 
@@ -542,6 +566,7 @@ def main(role: str = "primary") -> None:
             raise SystemExit("protected evaluation cannot mount generated source into the evaluator")
     elif args.candidate is None or args.incumbent is None:
         raise SystemExit("trusted local evaluation requires candidate and incumbent source paths")
+    _require_protected_mutation_authority(protected_mode=protected_mode)
 
     if role not in {"primary", "confirmation"}:
         raise SystemExit("adapter role must be primary or confirmation")
@@ -655,8 +680,16 @@ def main(role: str = "primary") -> None:
         incumbent_endpoint.accept()
         evaluator_build_digest = os.environ.get("AUTOCONTEXT_EVALUATOR_BUILD_DIGEST")
         boundary_manifest_digest = os.environ.get("AUTOCONTEXT_BOUNDARY_MANIFEST_DIGEST")
-        if evaluator_build_digest is None or boundary_manifest_digest is None:
+        authority_hmac_key_id = os.environ.get("AUTOCONTEXT_AUTHORITY_HMAC_KEY_ID")
+        authority_hmac_secret_file = os.environ.get("AUTOCONTEXT_AUTHORITY_HMAC_SECRET_FILE")
+        if (
+            evaluator_build_digest is None
+            or boundary_manifest_digest is None
+            or authority_hmac_key_id is None
+            or authority_hmac_secret_file is None
+        ):
             raise RuntimeError("protected evaluator build identity environment is incomplete")
+        authority_hmac_secret = read_authority_hmac_secret(Path(authority_hmac_secret_file))
         _ACTIVE_AUTHORITY_CONTEXT = _AuthorityReceiptContext(
             recorder=recorder,
             attestation=_accelerator_attestation(hardware),
@@ -665,6 +698,8 @@ def main(role: str = "primary") -> None:
             plan_commitment=args.plan_commitment,
             candidate_artifact_digest=args.candidate_artifact_digest,
             incumbent_artifact_digest=args.incumbent_artifact_digest,
+            signing_key_id=authority_hmac_key_id,
+            signing_secret=authority_hmac_secret,
         )
 
     try:
@@ -871,9 +906,20 @@ def main(role: str = "primary") -> None:
         "reference_ms": reference,
     }
     names = tuple(models)
+    remote_authority_timing = isinstance(candidate, RemoteAuthorityModel)
+    comparable_names = ("candidate_ms", "incumbent_ms") if remote_authority_timing else names
+    report["metadata"]["timing_comparability"] = {
+        "promotion_comparison": ["candidate_ms", "incumbent_ms"],
+        "candidate_incumbent_comparable": True,
+        "candidate_incumbent_boundary": (
+            "evaluator-owned-authority-rpc/v1" if remote_authority_timing else "evaluator-owned-cuda-event/v1"
+        ),
+        "reference_boundary": "evaluator-owned-cuda-event/v1",
+        "reference_comparable": not remote_authority_timing,
+    }
     blocks: list[dict[str, Any]] = []
     per_case_blocks: dict[str, dict[str, list[float]]] = {name: {model_name: [] for model_name in names} for name in timing_cases}
-    model_orders = _timing_orders(args.plan_commitment, names)
+    model_orders = _timing_orders(args.plan_commitment, comparable_names)
     case_order = private_plan["timing_order"]
     try:
         for block_index, order in enumerate(model_orders):
@@ -890,8 +936,12 @@ def main(role: str = "primary") -> None:
                     # correctness outputs or acknowledging work they skipped.
                     challenge_salt = int.from_bytes(os.urandom(8), "big") % (2**63 - 1)
                     timing_inputs = _case_inputs(case, challenge_salt=challenge_salt)
-                    with torch.inference_mode():
-                        expected = reference(*_clone(timing_inputs))
+                    if remote_authority_timing:
+                        expected, reference_elapsed = _timed_call(reference, _clone(timing_inputs))
+                        call_samples["reference_ms"].append(reference_elapsed)
+                    else:
+                        with torch.inference_mode():
+                            expected = reference(*_clone(timing_inputs))
                     for name in order:
                         output, elapsed = _timed_call(models[name], _clone(timing_inputs))
                         if name != "reference_ms":

--- a/examples/kernel_evolution/kernelbench_h100/adapter.py
+++ b/examples/kernel_evolution/kernelbench_h100/adapter.py
@@ -11,6 +11,7 @@ the pinned PyTorch reference can serve as the initial baseline.
 from __future__ import annotations
 
 import argparse
+import atexit
 import hashlib
 import importlib.util
 import json
@@ -28,13 +29,23 @@ from pathlib import Path
 from typing import Any
 
 import torch
+from authority_transport import (
+    AuthorityEndpoint,
+    AuthorityRecorder,
+    CandidateAuthorityError,
+    CudaGlobalMemoryProbe,
+    RemoteAuthorityModel,
+)
 from profile_contract import PROFILE_NAMES, PROFILES, gpu_attestation_metadata, load_private_plan
+
+from autocontext.kernel_evolution import AcceleratorAttestation, build_authority_receipt
 
 SCHEMA_VERSION = "autocontext.kernelbench-eval/v3"
 PROTOCOL_COMPATIBILITY_VERSION = "autocontext.kernel-protocol-compatibility/v1"
 WARMUP_RUNS = 3
 TIMING_BLOCKS = 8
 CALLS_PER_BLOCK = 10
+_ACTIVE_AUTHORITY_CONTEXT: _AuthorityReceiptContext | None = None
 
 
 def _digest(payload: bytes | str) -> str:
@@ -63,6 +74,8 @@ def _timing_orders(seed_material: str, names: tuple[str, ...]) -> tuple[tuple[st
 
 
 def _write_report(path: Path, report: dict[str, Any]) -> None:
+    if _ACTIVE_AUTHORITY_CONTEXT is not None:
+        _ACTIVE_AUTHORITY_CONTEXT.attach(report)
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     temporary.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
@@ -202,9 +215,48 @@ def _hardware(workload_family_id: str, workload_fingerprint: str) -> dict[str, A
     }
 
 
-def _case_tensor(rows: int, columns: int, case: dict[str, Any], *, layout: str, salt: int):
+def _accelerator_attestation(hardware: dict[str, Any]) -> AcceleratorAttestation:
+    required = {
+        name: os.environ.get(variable)
+        for name, variable in {
+            "device_id": "AUTOCONTEXT_ACCELERATOR_DEVICE_ID",
+            "isolation_kind": "AUTOCONTEXT_ACCELERATOR_ISOLATION_KIND",
+            "enforced_memory_bytes": "AUTOCONTEXT_ACCELERATOR_ENFORCED_MEMORY_BYTES",
+            "attestor_id": "AUTOCONTEXT_ACCELERATOR_ATTESTOR_ID",
+            "grant_attestation_digest": "AUTOCONTEXT_ACCELERATOR_ATTESTATION_DIGEST",
+        }.items()
+    }
+    if any(value is None for value in required.values()):
+        raise RuntimeError("protected evaluator accelerator attestation environment is incomplete")
+    raw_memory = required["enforced_memory_bytes"]
+    assert raw_memory is not None
+    if not raw_memory.isascii() or not raw_memory.isdecimal() or int(raw_memory) < 1:
+        raise RuntimeError("protected evaluator accelerator capacity is invalid")
+    return AcceleratorAttestation(
+        backend=str(hardware["backend"]),
+        vendor="nvidia",
+        architecture=str(hardware["architecture"]),
+        device_id=str(required["device_id"]),
+        isolation_kind=str(required["isolation_kind"]),
+        enforced_memory_bytes=int(raw_memory),
+        runtime=str(hardware["runtime"]),
+        driver=str(hardware["driver"]),
+        attestor_id=str(required["attestor_id"]),
+        metadata={"grant_attestation_digest": str(required["grant_attestation_digest"])},
+    )
+
+
+def _case_tensor(
+    rows: int,
+    columns: int,
+    case: dict[str, Any],
+    *,
+    layout: str,
+    salt: int,
+    challenge_salt: int = 0,
+):
     generator = torch.Generator(device="cpu")
-    generator.manual_seed(case["seed"] + salt)
+    generator.manual_seed((case["seed"] + salt + challenge_salt) % (2**63 - 1))
     storage_shape = (columns, rows) if layout == "transposed" else (rows, columns)
     value_class = case["value_class"]
     minimum = float(case["magnitude_min"])
@@ -236,10 +288,10 @@ def _apply_layout(values, layout: str):
     return values.contiguous().cuda()
 
 
-def _case_inputs(case: dict[str, Any]):
+def _case_inputs(case: dict[str, Any], *, challenge_salt: int = 0):
     if case["value_class"] == "cancellation":
         generator = torch.Generator(device="cpu")
-        generator.manual_seed(case["seed"])
+        generator.manual_seed((case["seed"] + challenge_salt) % (2**63 - 1))
         pairs = case["k"] // 2
         minimum = float(case["magnitude_min"])
         maximum = float(case["magnitude_max"])
@@ -255,25 +307,49 @@ def _case_inputs(case: dict[str, Any]):
         b[1::2].neg_()
         return [_apply_layout(a, case["a_layout"]), _apply_layout(b, case["b_layout"])]
     return [
-        _case_tensor(case["m"], case["k"], case, layout=case["a_layout"], salt=0),
-        _case_tensor(case["k"], case["n"], case, layout=case["b_layout"], salt=1_000_003),
+        _case_tensor(
+            case["m"],
+            case["k"],
+            case,
+            layout=case["a_layout"],
+            salt=0,
+            challenge_salt=challenge_salt,
+        ),
+        _case_tensor(
+            case["k"],
+            case["n"],
+            case,
+            layout=case["b_layout"],
+            salt=1_000_003,
+            challenge_salt=challenge_salt,
+        ),
     ]
 
 
-def _timed_call(model, inputs, calls: int) -> float:
+def _timed_call(model, inputs) -> tuple[Any, float]:
+    if isinstance(model, RemoteAuthorityModel):
+        with torch.inference_mode():
+            output = model(*inputs)
+        elapsed = model.elapsed_ms
+        if not elapsed > 0:
+            raise RuntimeError(f"authority measurement returned non-positive latency: {elapsed}")
+        return output, elapsed
     torch.cuda.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
     start.record()
     with torch.inference_mode():
-        for _ in range(calls):
-            model(*inputs)
+        output = model(*inputs)
     end.record()
     end.synchronize()
-    elapsed = float(start.elapsed_time(end)) / calls
+    elapsed = float(start.elapsed_time(end))
     if not elapsed > 0:
         raise RuntimeError(f"CUDA event returned non-positive latency: {elapsed}")
-    return elapsed
+    return output, elapsed
+
+
+class _TimingChallengeError(RuntimeError):
+    """Raised when a fresh timed output does not match the trusted reference."""
 
 
 def _cuda_peaks(model, inputs) -> tuple[int, int]:
@@ -285,6 +361,80 @@ def _cuda_peaks(model, inputs) -> tuple[int, int]:
         model(*_clone(inputs))
     torch.cuda.synchronize()
     return int(torch.cuda.max_memory_allocated()), int(torch.cuda.max_memory_reserved())
+
+
+class _AuthorityReceiptContext:
+    def __init__(
+        self,
+        *,
+        recorder: AuthorityRecorder,
+        attestation: AcceleratorAttestation,
+        evaluator_build_digest: str,
+        boundary_manifest_digest: str,
+        plan_commitment: str,
+        candidate_artifact_digest: str,
+        incumbent_artifact_digest: str,
+    ) -> None:
+        self.recorder = recorder
+        self.attestation = attestation
+        self.evaluator_build_digest = evaluator_build_digest
+        self.boundary_manifest_digest = boundary_manifest_digest
+        self.plan_commitment = plan_commitment
+        self.candidate_artifact_digest = candidate_artifact_digest
+        self.incumbent_artifact_digest = incumbent_artifact_digest
+
+    def attach(self, report: dict[str, Any]) -> None:
+        measurements = tuple(self.recorder.measurements)
+        if {measurement.role for measurement in measurements} != {"candidate", "incumbent"}:
+            return
+        resources = report.get("resources")
+        if not isinstance(resources, dict):
+            raise RuntimeError("protected evaluator report omitted its resource section")
+        candidate_peak = max(
+            measurement.observed_peak_memory_bytes
+            for measurement in measurements
+            if measurement.role == "candidate"
+        )
+        incumbent_peak = max(
+            measurement.observed_peak_memory_bytes
+            for measurement in measurements
+            if measurement.role == "incumbent"
+        )
+        resources.update(
+            {
+                "candidate_observed_peak_bytes": candidate_peak,
+                "incumbent_observed_peak_bytes": incumbent_peak,
+                "candidate_peak_memory_bytes": candidate_peak,
+                "incumbent_peak_memory_bytes": incumbent_peak,
+                "telemetry_authority": "trusted-evaluator-observed/v1",
+                "accelerator_attestation_digest": self.attestation.digest,
+            }
+        )
+        receipt = build_authority_receipt(
+            evaluator_build_digest=self.evaluator_build_digest,
+            boundary_manifest_digest=self.boundary_manifest_digest,
+            plan_commitment=self.plan_commitment,
+            accelerator_attestation=self.attestation,
+            candidate_artifact_digest=self.candidate_artifact_digest,
+            incumbent_artifact_digest=self.incumbent_artifact_digest,
+            measurements=measurements,
+            report=report,
+        )
+        report["evaluator_authority_receipt"] = receipt.model_dump(mode="json")
+
+
+def _apply_execution_failure(report: dict[str, Any], exc: Exception, *, stage: str) -> None:
+    authority_kind = exc.kind if isinstance(exc, CandidateAuthorityError) else None
+    report["evaluation_status"] = (
+        "infrastructure_error" if authority_kind in {"protocol_corruption", "candidate_crashed"} else "candidate_error"
+    )
+    report["failure_kind"] = "correctness" if isinstance(exc, _TimingChallengeError) else {
+        "oom": "oom",
+        "protocol_corruption": "protocol_corruption",
+        "candidate_crashed": "candidate_crash",
+        "candidate_error": "compile" if stage == "compile" else "crash",
+    }.get(authority_kind, "oom" if isinstance(exc, torch.cuda.OutOfMemoryError) else "crash")
+    report["compile"]["diagnostics"] = f"{stage} failed with {type(exc).__name__}"
 
 
 def _base_report(
@@ -341,6 +491,10 @@ def _base_report(
             "incumbent_peak_reserved_bytes": None,
             "candidate_peak_memory_bytes": None,
             "incumbent_peak_memory_bytes": None,
+            "candidate_observed_peak_bytes": None,
+            "incumbent_observed_peak_bytes": None,
+            "telemetry_authority": None,
+            "accelerator_attestation_digest": None,
             "device_total_memory_bytes": torch.cuda.get_device_properties(0).total_memory,
         },
         "metadata": {
@@ -353,9 +507,13 @@ def _base_report(
 
 
 def main(role: str = "primary") -> None:
+    global _ACTIVE_AUTHORITY_CONTEXT
+    _ACTIVE_AUTHORITY_CONTEXT = None
     parser = argparse.ArgumentParser()
-    parser.add_argument("--candidate", type=Path, required=True)
-    parser.add_argument("--incumbent", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path)
+    parser.add_argument("--incumbent", type=Path)
+    parser.add_argument("--candidate-socket", type=Path)
+    parser.add_argument("--incumbent-socket", type=Path)
     parser.add_argument("--artifact-identity-version", required=True)
     parser.add_argument("--candidate-artifact-digest", required=True)
     parser.add_argument("--incumbent-artifact-digest", required=True)
@@ -375,6 +533,15 @@ def main(role: str = "primary") -> None:
     parser.add_argument("--proposal-cap", type=int, required=True)
     parser.add_argument("--familywise-alpha", type=float, required=True)
     args = parser.parse_args()
+
+    protected_mode = args.candidate_socket is not None or args.incumbent_socket is not None
+    if protected_mode:
+        if args.candidate_socket is None or args.incumbent_socket is None:
+            raise SystemExit("protected evaluation requires both isolated authority sockets")
+        if args.candidate is not None or args.incumbent is not None:
+            raise SystemExit("protected evaluation cannot mount generated source into the evaluator")
+    elif args.candidate is None or args.incumbent is None:
+        raise SystemExit("trusted local evaluation requires candidate and incumbent source paths")
 
     if role not in {"primary", "confirmation"}:
         raise SystemExit("adapter role must be primary or confirmation")
@@ -401,10 +568,15 @@ def main(role: str = "primary") -> None:
     torch.backends.cuda.matmul.allow_tf32 = False
     torch.use_deterministic_algorithms(True)
 
-    candidate_bytes = args.candidate.read_bytes()
-    incumbent_bytes = args.incumbent.read_bytes()
-    if _digest(candidate_bytes) != args.candidate_source_digest or _digest(incumbent_bytes) != args.incumbent_source_digest:
-        raise SystemExit("runner-provided source digest does not match the exact staged source bytes")
+    if not protected_mode:
+        assert args.candidate is not None and args.incumbent is not None
+        candidate_bytes = args.candidate.read_bytes()
+        incumbent_bytes = args.incumbent.read_bytes()
+        if (
+            _digest(candidate_bytes) != args.candidate_source_digest
+            or _digest(incumbent_bytes) != args.incumbent_source_digest
+        ):
+            raise SystemExit("runner-provided source digest does not match the exact staged source bytes")
     reference_bytes = args.reference.read_bytes()
     protocol = {
         "correctness_trials": len(cases),
@@ -433,6 +605,7 @@ def main(role: str = "primary") -> None:
         + json.dumps(profile.semantics(), sort_keys=True, separators=(",", ":")).encode("utf-8")
         + args.problem_id.encode("utf-8")
     )
+    hardware = _hardware(workload_family, workload)
     report = _base_report(
         problem_id=args.problem_id,
         artifact_identity_version=args.artifact_identity_version,
@@ -445,12 +618,54 @@ def main(role: str = "primary") -> None:
         candidate_entrypoint=args.candidate_entrypoint,
         incumbent_entrypoint=args.incumbent_entrypoint,
         reference_digest=_digest(reference_bytes),
-        hardware=_hardware(workload_family, workload),
+        hardware=hardware,
         protocol=protocol,
         profile_name=profile.name,
         role=role,
         public_case_manifest=[{"name": case["name"], "split": case["split"]} for case in cases],
     )
+
+    candidate_endpoint: AuthorityEndpoint | None = None
+    incumbent_endpoint: AuthorityEndpoint | None = None
+    if protected_mode:
+        assert args.candidate_socket is not None and args.incumbent_socket is not None
+        recorder = AuthorityRecorder()
+        memory_probe = CudaGlobalMemoryProbe()
+        candidate_endpoint = AuthorityEndpoint(
+            args.candidate_socket,
+            role="candidate",
+            artifact_digest=args.candidate_artifact_digest,
+            recorder=recorder,
+            memory_probe=memory_probe,
+            timeout_seconds=240.0,
+        )
+        incumbent_endpoint = AuthorityEndpoint(
+            args.incumbent_socket,
+            role="incumbent",
+            artifact_digest=args.incumbent_artifact_digest,
+            recorder=recorder,
+            memory_probe=memory_probe,
+            timeout_seconds=240.0,
+        )
+        candidate_endpoint.listen()
+        incumbent_endpoint.listen()
+        atexit.register(candidate_endpoint.close)
+        atexit.register(incumbent_endpoint.close)
+        candidate_endpoint.accept()
+        incumbent_endpoint.accept()
+        evaluator_build_digest = os.environ.get("AUTOCONTEXT_EVALUATOR_BUILD_DIGEST")
+        boundary_manifest_digest = os.environ.get("AUTOCONTEXT_BOUNDARY_MANIFEST_DIGEST")
+        if evaluator_build_digest is None or boundary_manifest_digest is None:
+            raise RuntimeError("protected evaluator build identity environment is incomplete")
+        _ACTIVE_AUTHORITY_CONTEXT = _AuthorityReceiptContext(
+            recorder=recorder,
+            attestation=_accelerator_attestation(hardware),
+            evaluator_build_digest=evaluator_build_digest,
+            boundary_manifest_digest=boundary_manifest_digest,
+            plan_commitment=args.plan_commitment,
+            candidate_artifact_digest=args.candidate_artifact_digest,
+            incumbent_artifact_digest=args.incumbent_artifact_digest,
+        )
 
     try:
         reference_module = _load_module(args.reference, "reference")
@@ -459,37 +674,61 @@ def main(role: str = "primary") -> None:
         if reference.state_dict():
             raise RuntimeError("this smoke adapter only accepts the stateless pinned Level 1 problem 1")
 
-        incumbent_module = _load_module(args.incumbent, "incumbent")
-        incumbent = _build_model(
-            incumbent_module,
-            init_inputs,
-            entrypoint=args.incumbent_entrypoint,
-        )
+        if protected_mode:
+            assert candidate_endpoint is not None and incumbent_endpoint is not None
+            candidate = RemoteAuthorityModel(candidate_endpoint)
+            incumbent = RemoteAuthorityModel(incumbent_endpoint)
+            incumbent_error: Exception | None = None
+            candidate_error: Exception | None = None
+            try:
+                incumbent.initialize(init_inputs)
+            except Exception as exc:  # bounded and receipt-recorded below
+                incumbent_error = exc
+            try:
+                candidate.initialize(init_inputs)
+            except Exception as exc:  # bounded and receipt-recorded below
+                candidate_error = exc
+            if incumbent_error is not None:
+                raise RuntimeError("isolated incumbent authority failed initialization") from incumbent_error
+            if candidate_error is not None:
+                raise candidate_error
+        else:
+            assert args.candidate is not None and args.incumbent is not None
+            incumbent_module = _load_module(args.incumbent, "incumbent")
+            incumbent = _build_model(
+                incumbent_module,
+                init_inputs,
+                entrypoint=args.incumbent_entrypoint,
+            )
+            candidate_module = _load_module(args.candidate, "candidate")
+            candidate = _build_model(
+                candidate_module,
+                init_inputs,
+                entrypoint=args.candidate_entrypoint,
+            )
         report["compile"]["incumbent_passed"] = True
 
-        candidate_module = _load_module(args.candidate, "candidate")
-        candidate = _build_model(
-            candidate_module,
-            init_inputs,
-            entrypoint=args.candidate_entrypoint,
-        )
-
         compile_inputs = _case_inputs(next(case for case in cases if case["split"] == "train"))
-        torch.cuda.synchronize()
-        compile_started = time.perf_counter()
-        with torch.inference_mode():
-            candidate(*_clone(compile_inputs))
-        torch.cuda.synchronize()
-        report["compile"]["candidate_compile_ms"] = (time.perf_counter() - compile_started) * 1000.0
+        if isinstance(candidate, RemoteAuthorityModel):
+            with torch.inference_mode():
+                candidate(*_clone(compile_inputs))
+            report["compile"]["candidate_compile_ms"] = candidate.elapsed_ms
+        else:
+            torch.cuda.synchronize()
+            compile_started = time.perf_counter()
+            with torch.inference_mode():
+                candidate(*_clone(compile_inputs))
+            torch.cuda.synchronize()
+            report["compile"]["candidate_compile_ms"] = (time.perf_counter() - compile_started) * 1000.0
         with torch.inference_mode():
             incumbent(*_clone(compile_inputs))
         torch.cuda.synchronize()
         report["compile"]["candidate_passed"] = True
         report["compile"]["diagnostics"] = ""
     except Exception as exc:
-        report["evaluation_status"] = "candidate_error"
-        report["failure_kind"] = "oom" if isinstance(exc, torch.cuda.OutOfMemoryError) else "compile"
-        report["compile"]["diagnostics"] = f"{type(exc).__name__}: {exc}"
+        _apply_execution_failure(report, exc, stage="compile")
+        if report["failure_kind"] == "crash":
+            report["failure_kind"] = "compile"
         _write_report(args.report, report)
         return
 
@@ -514,10 +753,8 @@ def main(role: str = "primary") -> None:
                 expected = reference(*reference_inputs)
                 incumbent_output = incumbent(*incumbent_inputs)
                 candidate_output = candidate(*candidate_inputs)
-        except torch.cuda.OutOfMemoryError as exc:
-            report["evaluation_status"] = "candidate_error"
-            report["failure_kind"] = "oom"
-            report["compile"]["diagnostics"] = f"CUDA OOM during correctness: {exc}"
+        except (torch.cuda.OutOfMemoryError, CandidateAuthorityError) as exc:
+            _apply_execution_failure(report, exc, stage="correctness")
             _write_report(args.report, report)
             return
         torch.cuda.synchronize()
@@ -592,34 +829,39 @@ def main(role: str = "primary") -> None:
 
     timing_cases = {case["name"]: (case, _case_inputs(case)) for case in cases}
     try:
-        candidate_allocated = candidate_reserved = 0
-        incumbent_allocated = incumbent_reserved = 0
-        for _case, timing_inputs in timing_cases.values():
-            allocated, reserved = _cuda_peaks(candidate, timing_inputs)
-            candidate_allocated = max(candidate_allocated, allocated)
-            candidate_reserved = max(candidate_reserved, reserved)
-            allocated, reserved = _cuda_peaks(incumbent, timing_inputs)
-            incumbent_allocated = max(incumbent_allocated, allocated)
-            incumbent_reserved = max(incumbent_reserved, reserved)
-            for model in (candidate, incumbent, reference):
-                with torch.inference_mode():
-                    for _ in range(WARMUP_RUNS):
-                        model(*timing_inputs)
+        if isinstance(candidate, RemoteAuthorityModel):
+            for _case, timing_inputs in timing_cases.values():
+                for model in (candidate, incumbent, reference):
+                    with torch.inference_mode():
+                        for _ in range(WARMUP_RUNS):
+                            model(*_clone(timing_inputs))
+        else:
+            candidate_allocated = candidate_reserved = 0
+            incumbent_allocated = incumbent_reserved = 0
+            for _case, timing_inputs in timing_cases.values():
+                allocated, reserved = _cuda_peaks(candidate, timing_inputs)
+                candidate_allocated = max(candidate_allocated, allocated)
+                candidate_reserved = max(candidate_reserved, reserved)
+                allocated, reserved = _cuda_peaks(incumbent, timing_inputs)
+                incumbent_allocated = max(incumbent_allocated, allocated)
+                incumbent_reserved = max(incumbent_reserved, reserved)
+                for model in (candidate, incumbent, reference):
+                    with torch.inference_mode():
+                        for _ in range(WARMUP_RUNS):
+                            model(*timing_inputs)
+            report["resources"].update(
+                {
+                    "candidate_peak_allocated_bytes": candidate_allocated,
+                    "candidate_peak_reserved_bytes": candidate_reserved,
+                    "incumbent_peak_allocated_bytes": incumbent_allocated,
+                    "incumbent_peak_reserved_bytes": incumbent_reserved,
+                    "candidate_peak_memory_bytes": candidate_reserved,
+                    "incumbent_peak_memory_bytes": incumbent_reserved,
+                }
+            )
         torch.cuda.synchronize()
-        report["resources"].update(
-            {
-                "candidate_peak_allocated_bytes": candidate_allocated,
-                "candidate_peak_reserved_bytes": candidate_reserved,
-                "incumbent_peak_allocated_bytes": incumbent_allocated,
-                "incumbent_peak_reserved_bytes": incumbent_reserved,
-                "candidate_peak_memory_bytes": candidate_reserved,
-                "incumbent_peak_memory_bytes": incumbent_reserved,
-            }
-        )
-    except torch.cuda.OutOfMemoryError as exc:
-        report["evaluation_status"] = "candidate_error"
-        report["failure_kind"] = "oom"
-        report["compile"]["diagnostics"] = f"CUDA OOM during resource/warmup measurement: {exc}"
+    except (torch.cuda.OutOfMemoryError, CandidateAuthorityError) as exc:
+        _apply_execution_failure(report, exc, stage="resource/warmup measurement")
         _write_report(args.report, report)
         return
 
@@ -639,18 +881,35 @@ def main(role: str = "primary") -> None:
             aggregated: dict[str, list[float]] = {name: [] for name in names}
             rotated_cases = case_order[block_index % len(case_order) :] + case_order[: block_index % len(case_order)]
             for case_name in rotated_cases:
-                _, timing_inputs = timing_cases[case_name]
-                for name in order:
-                    elapsed = _timed_call(models[name], timing_inputs, CALLS_PER_BLOCK)
+                case, _ = timing_cases[case_name]
+                call_samples: dict[str, list[float]] = {name: [] for name in names}
+                for _ in range(CALLS_PER_BLOCK):
+                    # Each timed exchange uses an evaluator-randomized challenge
+                    # and is checked against a trusted reference.  Candidate
+                    # authorities therefore cannot win by caching earlier
+                    # correctness outputs or acknowledging work they skipped.
+                    challenge_salt = int.from_bytes(os.urandom(8), "big") % (2**63 - 1)
+                    timing_inputs = _case_inputs(case, challenge_salt=challenge_salt)
+                    with torch.inference_mode():
+                        expected = reference(*_clone(timing_inputs))
+                    for name in order:
+                        output, elapsed = _timed_call(models[name], _clone(timing_inputs))
+                        if name != "reference_ms":
+                            matched, _, _ = _compare(output, expected, atol=profile.atol, rtol=profile.rtol)
+                            if not matched:
+                                raise _TimingChallengeError(
+                                    f"{name} failed an evaluator-randomized timed correctness challenge"
+                                )
+                        call_samples[name].append(elapsed)
+                for name in names:
+                    elapsed = statistics.fmean(call_samples[name])
                     per_case_blocks[case_name][name].append(elapsed)
                     aggregated[name].append(elapsed)
             for name in names:
                 block[name] = statistics.geometric_mean(aggregated[name])
             blocks.append(block)
-    except torch.cuda.OutOfMemoryError as exc:
-        report["evaluation_status"] = "candidate_error"
-        report["failure_kind"] = "oom"
-        report["compile"]["diagnostics"] = f"CUDA OOM during timing: {exc}"
+    except (torch.cuda.OutOfMemoryError, CandidateAuthorityError, _TimingChallengeError) as exc:
+        _apply_execution_failure(report, exc, stage="timing")
         _write_report(args.report, report)
         return
 

--- a/examples/kernel_evolution/kernelbench_h100/authority_transport.py
+++ b/examples/kernel_evolution/kernelbench_h100/authority_transport.py
@@ -22,7 +22,11 @@ from autocontext.kernel_evolution import (
     receive_authority_frame,
     send_authority_frame,
 )
-from autocontext.kernel_evolution.authority_tensor import deserialize_tensor_list, serialize_tensor_list
+from autocontext.kernel_evolution.authority_tensor import (
+    copy_tensor_to_device_preserving_abi,
+    deserialize_tensor_list,
+    serialize_tensor_list,
+)
 
 
 class CandidateAuthorityError(RuntimeError):
@@ -256,7 +260,7 @@ class RemoteAuthorityModel:
     def __call__(self, *inputs: Any) -> torch.Tensor | tuple[torch.Tensor, ...]:
         outputs, measurement = self.endpoint.execute(_require_tensor_list(list(inputs)))
         self.last_measurement = measurement
-        cuda_outputs = tuple(output.cuda(non_blocking=False) for output in outputs)
+        cuda_outputs = tuple(copy_tensor_to_device_preserving_abi(output, device="cuda") for output in outputs)
         if len(cuda_outputs) == 1:
             return cuda_outputs[0]
         return cuda_outputs

--- a/examples/kernel_evolution/kernelbench_h100/authority_transport.py
+++ b/examples/kernel_evolution/kernelbench_h100/authority_transport.py
@@ -1,0 +1,292 @@
+"""Trusted evaluator side of the isolated candidate authority protocol."""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+
+from autocontext.kernel_evolution import (
+    AuthorityMeasurement,
+    AuthorityRequest,
+    AuthorityResponse,
+    AuthorityWireError,
+    authority_message_digest,
+    canonical_authority_digest,
+    receive_authority_frame,
+    send_authority_frame,
+)
+from autocontext.kernel_evolution.authority_tensor import deserialize_tensor_list, serialize_tensor_list
+
+
+class CandidateAuthorityError(RuntimeError):
+    """Bounded candidate failure surfaced without candidate-authored prose."""
+
+    def __init__(self, kind: str, diagnostic_code: str) -> None:
+        super().__init__(f"isolated candidate authority failed: {kind}/{diagnostic_code}")
+        self.kind = kind
+        self.diagnostic_code = diagnostic_code
+
+
+@dataclass(slots=True)
+class AuthorityRecorder:
+    """Evaluator-owned global ordering for both isolated authority channels."""
+
+    measurements: list[AuthorityMeasurement] = field(default_factory=list)
+    _next_sequence: int = 0
+
+    def reserve_sequence(self) -> int:
+        sequence = self._next_sequence
+        self._next_sequence += 1
+        return sequence
+
+    def record(self, measurement: AuthorityMeasurement) -> None:
+        if measurement.sequence != len(self.measurements):
+            raise RuntimeError("authority measurements lost their evaluator-owned order")
+        self.measurements.append(measurement)
+
+
+class CudaGlobalMemoryProbe:
+    """Trusted evaluator observation of partition-global memory use."""
+
+    def __init__(self) -> None:
+        free, total = torch.cuda.mem_get_info()
+        if free < 0 or total < 1 or free > total:
+            raise RuntimeError("CUDA returned invalid global memory telemetry")
+        self.total_bytes = int(total)
+
+    def used_bytes(self) -> int:
+        free, total = torch.cuda.mem_get_info()
+        if int(total) != self.total_bytes or free < 0 or free > total:
+            raise RuntimeError("CUDA partition capacity changed during authority evaluation")
+        return int(total - free)
+
+
+class AuthorityEndpoint:
+    """Evaluator-owned listener for one untrusted candidate process."""
+
+    def __init__(
+        self,
+        socket_path: Path,
+        *,
+        role: Literal["candidate", "incumbent"],
+        artifact_digest: str,
+        recorder: AuthorityRecorder,
+        memory_probe: CudaGlobalMemoryProbe,
+        timeout_seconds: float,
+    ) -> None:
+        self.socket_path = socket_path
+        self.role = role
+        self.artifact_digest = artifact_digest
+        self.recorder = recorder
+        self.memory_probe = memory_probe
+        self.timeout_seconds = timeout_seconds
+        self.session_nonce = canonical_authority_digest(os.urandom(32))
+        self._listener: socket.socket | None = None
+        self._connection: socket.socket | None = None
+
+    def listen(self) -> None:
+        if self._listener is not None:
+            raise RuntimeError("authority endpoint is already listening")
+        if self.socket_path.exists() or self.socket_path.is_symlink():
+            raise RuntimeError("authority socket path already exists")
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            listener.bind(str(self.socket_path))
+            self.socket_path.chmod(0o600)
+            listener.listen(1)
+            listener.settimeout(self.timeout_seconds)
+        except Exception:
+            listener.close()
+            raise
+        self._listener = listener
+
+    def accept(self) -> None:
+        listener = self._listener
+        if listener is None:
+            raise RuntimeError("authority endpoint must listen before accepting")
+        connection, _ = listener.accept()
+        connection.settimeout(self.timeout_seconds)
+        self._connection = connection
+
+    def initialize(self, init_inputs: list[torch.Tensor]) -> None:
+        outputs, _measurement = self._exchange("initialize", init_inputs)
+        if outputs:
+            raise CandidateAuthorityError("protocol_corruption", "malformed_output")
+
+    def execute(self, inputs: list[torch.Tensor]) -> tuple[list[torch.Tensor], AuthorityMeasurement]:
+        return self._exchange("execute", inputs)
+
+    def close(self) -> None:
+        if self._connection is not None:
+            try:
+                self._exchange("shutdown", [])
+            except (CandidateAuthorityError, OSError, RuntimeError, TimeoutError, AuthorityWireError):
+                pass
+            self._connection.close()
+            self._connection = None
+        if self._listener is not None:
+            self._listener.close()
+            self._listener = None
+        try:
+            self.socket_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def _exchange(
+        self,
+        operation: Literal["initialize", "execute", "shutdown"],
+        tensors: list[torch.Tensor],
+    ) -> tuple[list[torch.Tensor], AuthorityMeasurement]:
+        connection = self._connection
+        if connection is None:
+            raise RuntimeError("authority endpoint is not connected")
+        payload, manifest_digest = serialize_tensor_list(tensors, prefix="input")
+        if operation == "shutdown":
+            manifest_digest = canonical_authority_digest(b"")
+        sequence = self.recorder.reserve_sequence()
+        request = AuthorityRequest(
+            request_id=canonical_authority_digest(
+                f"{self.session_nonce}:{sequence}:{self.role}:{operation}:{canonical_authority_digest(payload)}"
+            ),
+            session_nonce=self.session_nonce,
+            sequence=sequence,
+            role=self.role,
+            operation=operation,
+            artifact_digest=self.artifact_digest,
+            input_manifest_digest=manifest_digest,
+            payload_digest=canonical_authority_digest(payload),
+            payload_bytes=len(payload),
+        )
+        request_digest = authority_message_digest(request)
+        baseline = self.memory_probe.used_bytes()
+        peak = [baseline]
+        sampling_errors: list[RuntimeError] = []
+        stop = threading.Event()
+        sampler = threading.Thread(target=self._sample_memory, args=(peak, stop, sampling_errors), daemon=True)
+        started = time.perf_counter_ns()
+        sampler.start()
+        try:
+            send_authority_frame(connection, request, payload)
+            response, response_payload = receive_authority_frame(connection, AuthorityResponse)
+            self._validate_response(request, response)
+            outputs, output_manifest_digest = deserialize_tensor_list(response_payload, prefix="output")
+            if response.output_manifest_digest != output_manifest_digest:
+                raise AuthorityWireError("candidate output manifest digest is forged")
+            outcome = {
+                "complete": "complete",
+                "candidate_error": "candidate_error",
+                "oom": "oom",
+                "protocol_error": "protocol_corruption",
+            }[response.outcome]
+            response_digest = authority_message_digest(response)
+            diagnostic_code = response.diagnostic_code
+        except (AuthorityWireError, OSError, TimeoutError) as exc:
+            outcome = "protocol_corruption" if isinstance(exc, AuthorityWireError) else "candidate_crashed"
+            response_digest = canonical_authority_digest(
+                {"request_digest": request_digest, "evaluator_observed_error": outcome}
+            )
+            outputs = []
+            response_payload = b""
+            diagnostic_code = "malformed_output" if outcome == "protocol_corruption" else "execution"
+        finally:
+            finished = time.perf_counter_ns()
+            stop.set()
+            sampler.join(timeout=1.0)
+            peak.append(self.memory_probe.used_bytes())
+            if sampling_errors:
+                raise RuntimeError("trusted accelerator memory sampling failed during candidate execution")
+        measurement = AuthorityMeasurement(
+            sequence=sequence,
+            role=self.role,
+            request_digest=request_digest,
+            response_digest=response_digest,
+            input_commitment=request.payload_digest,
+            output_commitment=canonical_authority_digest(response_payload),
+            elapsed_ns=max(1, finished - started),
+            observed_peak_memory_bytes=max(0, max(peak) - baseline),
+            outcome=outcome,
+        )
+        self.recorder.record(measurement)
+        if outcome != "complete":
+            raise CandidateAuthorityError(outcome, diagnostic_code)
+        return outputs, measurement
+
+    def _sample_memory(
+        self,
+        peak: list[int],
+        stop: threading.Event,
+        errors: list[RuntimeError],
+    ) -> None:
+        while not stop.wait(0.001):
+            try:
+                peak.append(self.memory_probe.used_bytes())
+            except RuntimeError as exc:
+                errors.append(exc)
+                return
+
+    def _validate_response(self, request: AuthorityRequest, response: AuthorityResponse) -> None:
+        if (
+            response.request_id != request.request_id
+            or response.session_nonce != request.session_nonce
+            or response.sequence != request.sequence
+            or response.role != request.role
+            or response.artifact_digest != request.artifact_digest
+        ):
+            raise AuthorityWireError("candidate response escaped its request, role, or artifact identity")
+
+
+class RemoteAuthorityModel:
+    """Torch-call-compatible proxy whose measurements are evaluator-owned."""
+
+    def __init__(self, endpoint: AuthorityEndpoint) -> None:
+        self.endpoint = endpoint
+        self.last_measurement: AuthorityMeasurement | None = None
+
+    def initialize(self, init_inputs: list[Any]) -> None:
+        tensors = _require_tensor_list(init_inputs)
+        self.endpoint.initialize(tensors)
+
+    def __call__(self, *inputs: Any) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        outputs, measurement = self.endpoint.execute(_require_tensor_list(list(inputs)))
+        self.last_measurement = measurement
+        cuda_outputs = tuple(output.cuda(non_blocking=False) for output in outputs)
+        if len(cuda_outputs) == 1:
+            return cuda_outputs[0]
+        return cuda_outputs
+
+    @property
+    def elapsed_ms(self) -> float:
+        if self.last_measurement is None:
+            raise RuntimeError("authority model has no completed measurement")
+        return self.last_measurement.elapsed_ns / 1_000_000.0
+
+    @property
+    def observed_peak_bytes(self) -> int:
+        values = [
+            measurement.observed_peak_memory_bytes
+            for measurement in self.endpoint.recorder.measurements
+            if measurement.role == self.endpoint.role
+        ]
+        return max(values, default=0)
+
+
+def _require_tensor_list(values: list[Any]) -> list[torch.Tensor]:
+    if any(not isinstance(value, torch.Tensor) for value in values):
+        raise TypeError("authority v1 accepts only positional tensor inputs")
+    return values
+
+
+__all__ = [
+    "AuthorityEndpoint",
+    "AuthorityRecorder",
+    "CandidateAuthorityError",
+    "CudaGlobalMemoryProbe",
+    "RemoteAuthorityModel",
+]

--- a/examples/kernel_evolution/kernelbench_h100/authority_worker.py
+++ b/examples/kernel_evolution/kernelbench_h100/authority_worker.py
@@ -29,7 +29,11 @@ from autocontext.kernel_evolution import (
     receive_authority_frame,
     send_authority_frame,
 )
-from autocontext.kernel_evolution.authority_tensor import deserialize_tensor_list, serialize_tensor_list
+from autocontext.kernel_evolution.authority_tensor import (
+    copy_tensor_to_device_preserving_abi,
+    deserialize_tensor_list,
+    serialize_tensor_list,
+)
 
 
 class _FunctionModel(torch.nn.Module):
@@ -136,7 +140,11 @@ def _run(args: argparse.Namespace) -> int:
                     raise AuthorityWireError("input manifest does not match the evaluator request")
                 if request.operation == "initialize":
                     module = _load_module(source)
-                    model = _build_model(module, args.entrypoint, [value.cuda() for value in inputs])
+                    model = _build_model(
+                        module,
+                        args.entrypoint,
+                        [copy_tensor_to_device_preserving_abi(value, device="cuda") for value in inputs],
+                    )
                     response, response_payload = _response(
                         request,
                         outcome="complete",
@@ -146,7 +154,7 @@ def _run(args: argparse.Namespace) -> int:
                 elif request.operation == "execute":
                     if model is None:
                         raise RuntimeError("candidate authority was not initialized")
-                    cuda_inputs = [value.cuda(non_blocking=False) for value in inputs]
+                    cuda_inputs = [copy_tensor_to_device_preserving_abi(value, device="cuda") for value in inputs]
                     with torch.inference_mode():
                         raw_output = model(*cuda_inputs)
                     torch.cuda.synchronize()
@@ -157,7 +165,7 @@ def _run(args: argparse.Namespace) -> int:
                         request,
                         outcome="complete",
                         diagnostic_code="none",
-                        outputs=[value.detach().cpu() for value in values],
+                        outputs=[value.detach() for value in values],
                     )
                 else:
                     response, response_payload = _response(

--- a/examples/kernel_evolution/kernelbench_h100/authority_worker.py
+++ b/examples/kernel_evolution/kernelbench_h100/authority_worker.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Untrusted candidate-side worker for the accelerator authority protocol.
+
+This process intentionally owns no private plan, reference, timing control,
+resource observer, or report path.  Its responses are untrusted tensor bytes;
+the evaluator independently validates them and owns all measurements.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import socket
+import sys
+import time
+import uuid
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Literal
+
+import torch
+
+from autocontext.kernel_evolution import (
+    AuthorityRequest,
+    AuthorityResponse,
+    AuthorityWireError,
+    artifact_digest,
+    canonical_authority_digest,
+    receive_authority_frame,
+    send_authority_frame,
+)
+from autocontext.kernel_evolution.authority_tensor import deserialize_tensor_list, serialize_tensor_list
+
+
+class _FunctionModel(torch.nn.Module):
+    def __init__(self, function: Any) -> None:
+        super().__init__()
+        self._function = function
+
+    def forward(self, *inputs: Any) -> Any:
+        return self._function(*inputs)
+
+
+def _load_module(path: Path) -> ModuleType:
+    name = f"_autoctx_isolated_candidate_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError("candidate source cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_model(module: ModuleType, entrypoint: str, init_inputs: list[Any]) -> Any:
+    target = getattr(module, entrypoint, None)
+    if target is None:
+        raise AttributeError("candidate source omitted its declared entrypoint")
+    if isinstance(target, type) and issubclass(target, torch.nn.Module):
+        return target(*init_inputs).cuda().eval()
+    if callable(target):
+        return _FunctionModel(target).cuda().eval()
+    raise TypeError("candidate entrypoint is not callable")
+
+
+def _connect(path: Path, timeout_seconds: float) -> socket.socket:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: OSError | None = None
+    while time.monotonic() < deadline:
+        connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            connection.connect(str(path))
+            connection.settimeout(timeout_seconds)
+            return connection
+        except OSError as exc:
+            last_error = exc
+            connection.close()
+            time.sleep(0.01)
+    raise TimeoutError("candidate authority could not connect to its evaluator socket") from last_error
+
+
+def _response(
+    request: AuthorityRequest,
+    *,
+    outcome: Literal["complete", "candidate_error", "oom", "protocol_error"],
+    diagnostic_code: Literal[
+        "none",
+        "compile",
+        "execution",
+        "oom",
+        "malformed_request",
+        "malformed_output",
+    ],
+    outputs: list[Any],
+) -> tuple[AuthorityResponse, bytes]:
+    payload, manifest_digest = serialize_tensor_list(outputs, prefix="output")
+    return (
+        AuthorityResponse(
+            request_id=request.request_id,
+            session_nonce=request.session_nonce,
+            sequence=request.sequence,
+            role=request.role,
+            artifact_digest=request.artifact_digest,
+            outcome=outcome,
+            output_manifest_digest=manifest_digest,
+            payload_digest=canonical_authority_digest(payload),
+            payload_bytes=len(payload),
+            diagnostic_code=diagnostic_code,
+        ),
+        payload,
+    )
+
+
+def _run(args: argparse.Namespace) -> int:
+    for support_path in args.support_path:
+        sys.path.insert(0, str(Path(support_path)))
+    source = Path(args.source)
+    source_bytes = source.read_bytes()
+    if artifact_digest(source_bytes, source_suffix=source.suffix, entrypoint=args.entrypoint) != args.artifact_digest:
+        return 4
+    connection = _connect(Path(args.connect), args.connect_timeout)
+    model: Any | None = None
+    session_nonce: str | None = None
+    try:
+        while True:
+            request, payload = receive_authority_frame(connection, AuthorityRequest)
+            if request.role != args.role or request.artifact_digest != args.artifact_digest:
+                return 5
+            if session_nonce is None:
+                session_nonce = request.session_nonce
+            elif request.session_nonce != session_nonce:
+                return 6
+            try:
+                inputs, manifest_digest = deserialize_tensor_list(payload, prefix="input")
+                if request.operation != "shutdown" and request.input_manifest_digest != manifest_digest:
+                    raise AuthorityWireError("input manifest does not match the evaluator request")
+                if request.operation == "initialize":
+                    module = _load_module(source)
+                    model = _build_model(module, args.entrypoint, [value.cuda() for value in inputs])
+                    response, response_payload = _response(
+                        request,
+                        outcome="complete",
+                        diagnostic_code="none",
+                        outputs=[],
+                    )
+                elif request.operation == "execute":
+                    if model is None:
+                        raise RuntimeError("candidate authority was not initialized")
+                    cuda_inputs = [value.cuda(non_blocking=False) for value in inputs]
+                    with torch.inference_mode():
+                        raw_output = model(*cuda_inputs)
+                    torch.cuda.synchronize()
+                    values = list(raw_output) if isinstance(raw_output, (list, tuple)) else [raw_output]
+                    if any(not isinstance(value, torch.Tensor) for value in values):
+                        raise TypeError("candidate output must contain only tensors")
+                    response, response_payload = _response(
+                        request,
+                        outcome="complete",
+                        diagnostic_code="none",
+                        outputs=[value.detach().cpu() for value in values],
+                    )
+                else:
+                    response, response_payload = _response(
+                        request,
+                        outcome="complete",
+                        diagnostic_code="none",
+                        outputs=[],
+                    )
+                    send_authority_frame(connection, response, response_payload)
+                    return 0
+            except torch.cuda.OutOfMemoryError:
+                response, response_payload = _response(
+                    request,
+                    outcome="oom",
+                    diagnostic_code="oom",
+                    outputs=[],
+                )
+            except AuthorityWireError:
+                response, response_payload = _response(
+                    request,
+                    outcome="protocol_error",
+                    diagnostic_code="malformed_request",
+                    outputs=[],
+                )
+            except Exception:
+                response, response_payload = _response(
+                    request,
+                    outcome="candidate_error",
+                    diagnostic_code="compile" if request.operation == "initialize" else "execution",
+                    outputs=[],
+                )
+            send_authority_frame(connection, response, response_payload)
+    except (AuthorityWireError, OSError, TimeoutError):
+        return 7
+    finally:
+        connection.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--connect", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--entrypoint", required=True)
+    parser.add_argument("--artifact-digest", required=True)
+    parser.add_argument("--role", choices=("candidate", "incumbent"), required=True)
+    parser.add_argument("--support-path", action="append", default=[])
+    parser.add_argument("--connect-timeout", type=float, default=20.0)
+    args = parser.parse_args()
+    if args.connect_timeout <= 0:
+        return 2
+    return _run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/kernel_evolution/kernelbench_h100/campaign.py
+++ b/examples/kernel_evolution/kernelbench_h100/campaign.py
@@ -48,7 +48,11 @@ from autocontext.kernel_evolution import (
     KernelEvolutionRunner,
     KernelSequentialTestingPolicy,
     KernelStatisticsPolicy,
+    build_profile_evidence_envelope,
     content_digest,
+    read_authority_hmac_secret,
+    verify_authority_receipt,
+    verify_profile_evidence_envelope,
 )
 
 PROBLEM_ID = "kernelbench-v0.1-level1-1-matmul-profiled-h100-v1"
@@ -313,6 +317,34 @@ def _verified_h100_attestation(report: Any, runtime: H100DockerRuntimeConfig) ->
     return {**payload, "digest": expected_digest}
 
 
+def _verified_profile_authority_receipt(
+    report: Any,
+    *,
+    runtime: H100DockerRuntimeConfig,
+    expected_identity: dict[str, str],
+) -> Any:
+    """Authenticate one exported report against its host-pinned evaluator identity."""
+
+    receipt = getattr(report, "evaluator_authority_receipt", None)
+    if receipt is None:
+        raise RuntimeError("H100 profile evidence is missing a trusted-evaluator authority receipt")
+    if set(expected_identity) != {"evaluator_build_digest", "boundary_manifest_digest"}:
+        raise RuntimeError("H100 profile evidence is missing its host-computed authority identity")
+    try:
+        report_payload = report.model_dump(mode="json")
+        verify_authority_receipt(
+            receipt,
+            report_payload,
+            trusted_key_id=runtime.authority_hmac_key_id,
+            trusted_secret=read_authority_hmac_secret(runtime.authority_hmac_secret_path),
+            expected_evaluator_build_digest=expected_identity["evaluator_build_digest"],
+            expected_boundary_manifest_digest=expected_identity["boundary_manifest_digest"],
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise RuntimeError("H100 profile authority receipt failed authenticated replay") from exc
+    return receipt
+
+
 def _build_profile_evidence(
     *,
     result: KernelEvolutionResult,
@@ -321,6 +353,7 @@ def _build_profile_evidence(
     primary_commitment: str,
     confirmation_commitments: tuple[str, ...],
     runtime: H100DockerRuntimeConfig,
+    authority_identities: dict[str, dict[str, str]],
 ) -> dict[str, Any]:
     """Build and validate the portable H100 profile receipt without side effects."""
     if result.run_id != run_id or result.problem_id != PROBLEM_ID:
@@ -372,6 +405,20 @@ def _build_profile_evidence(
         raise RuntimeError("the champion primary receipt is not bound to the configured primary plan")
 
     hardware_attestation = _verified_h100_attestation(champion_report, runtime)
+    primary_authority_receipt = _verified_profile_authority_receipt(
+        champion_report,
+        runtime=runtime,
+        expected_identity=authority_identities.get(primary_commitment, {}),
+    )
+    primary_accelerator = primary_authority_receipt.accelerator_attestation
+    if (
+        primary_accelerator.device_id != hardware_attestation["device_id"]
+        or primary_accelerator.isolation_kind != hardware_attestation["isolation_kind"]
+        or primary_accelerator.enforced_memory_bytes != hardware_attestation["enforced_memory_bytes"]
+        or primary_accelerator.attestor_id != hardware_attestation["attestor_id"]
+        or primary_accelerator.metadata.get("grant_attestation_digest") != hardware_attestation["digest"]
+    ):
+        raise RuntimeError("the champion authority receipt changed the host-attested accelerator identity")
 
     primary_receipt = {
         "report_digest": champion.report_digest,
@@ -380,6 +427,8 @@ def _build_profile_evidence(
         "plan_commitment": champion_report.protocol.seed_commitment,
         "hardware_scope_id": champion.hardware_scope_id,
         "baseline_id": champion.baseline_id,
+        "authority_receipt_digest": primary_authority_receipt.receipt_digest,
+        "authority_receipt": primary_authority_receipt.model_dump(mode="json"),
     }
     confirmation_receipt = None
     if champion.role == "candidate" and champion.decision == "promoted":
@@ -399,6 +448,20 @@ def _build_profile_evidence(
         confirmation_attestation = _verified_h100_attestation(confirmation_report, runtime)
         if confirmation_attestation != hardware_attestation:
             raise RuntimeError("the champion confirmation receipt changed the attested GPU partition")
+        confirmation_authority_receipt = _verified_profile_authority_receipt(
+            confirmation_report,
+            runtime=runtime,
+            expected_identity=authority_identities.get(confirmation_commitment, {}),
+        )
+        confirmation_accelerator = confirmation_authority_receipt.accelerator_attestation
+        if (
+            confirmation_accelerator.device_id != confirmation_attestation["device_id"]
+            or confirmation_accelerator.isolation_kind != confirmation_attestation["isolation_kind"]
+            or confirmation_accelerator.enforced_memory_bytes != confirmation_attestation["enforced_memory_bytes"]
+            or confirmation_accelerator.attestor_id != confirmation_attestation["attestor_id"]
+            or confirmation_accelerator.metadata.get("grant_attestation_digest") != confirmation_attestation["digest"]
+        ):
+            raise RuntimeError("the confirmation authority receipt changed the host-attested accelerator identity")
         confirmation_receipt = {
             "report_digest": champion.confirmation_report_digest,
             "protocol_id": confirmation.protocol_id,
@@ -406,6 +469,8 @@ def _build_profile_evidence(
             "plan_commitment": confirmation_commitment,
             "hardware_scope_id": confirmation.hardware_scope_id,
             "baseline_id": confirmation.baseline_id,
+            "authority_receipt_digest": confirmation_authority_receipt.receipt_digest,
+            "authority_receipt": confirmation_authority_receipt.model_dump(mode="json"),
         }
 
     holdout_correctness = (
@@ -418,7 +483,7 @@ def _build_profile_evidence(
         if champion_report.performance is not None
         else []
     )
-    return {
+    profile = {
         "schema_version": "autocontext.kernel-h100-profile-evidence/v3",
         "evidence_status": "observed_live_run",
         "run_id": run_id,
@@ -456,6 +521,18 @@ def _build_profile_evidence(
             if attempt.sequential_evidence is not None
         ],
     }
+    signing_secret = read_authority_hmac_secret(runtime.authority_hmac_secret_path)
+    envelope = build_profile_evidence_envelope(
+        profile,
+        signing_key_id=runtime.authority_hmac_key_id,
+        signing_secret=signing_secret,
+    )
+    verify_profile_evidence_envelope(
+        envelope,
+        trusted_key_id=runtime.authority_hmac_key_id,
+        trusted_secret=signing_secret,
+    )
+    return envelope.model_dump(mode="json")
 
 
 def _install_sigterm_interrupt() -> None:
@@ -486,6 +563,13 @@ def main() -> None:
         help="Host-attested isolation type; this composition currently supports explicit MIG UUIDs only",
     )
     parser.add_argument("--gpu-memory-bytes", type=_positive_int, required=True)
+    parser.add_argument("--authority-hmac-key-id", required=True, help="Operator-pinned evaluator signing key id")
+    parser.add_argument(
+        "--authority-hmac-secret-file",
+        type=Path,
+        required=True,
+        help="Owner-only host file mounted only into the trusted evaluator",
+    )
     parser.add_argument("--worker-memory-mb", type=_positive_int, default=16_384)
     parser.add_argument("--worker-cpu-count", type=_positive_float, default=8.0)
     parser.add_argument("--worker-cpu-time-seconds", type=_positive_int, default=600)
@@ -576,6 +660,8 @@ def main() -> None:
         gpu_device=args.gpu_device,
         gpu_isolation_kind=args.gpu_isolation_kind,
         gpu_memory_bytes=args.gpu_memory_bytes,
+        authority_hmac_key_id=args.authority_hmac_key_id,
+        authority_hmac_secret_path=args.authority_hmac_secret_file.resolve(strict=True),
         limits=limits,
         timeout_seconds=args.benchmark_timeout,
     )
@@ -613,6 +699,18 @@ def main() -> None:
         )
         for path, commitment in zip(confirmation_plan_paths, confirmation_commitments, strict=True)
     )
+    authority_identities = {
+        commitment: {
+            "evaluator_build_digest": evaluator.config.expected_evaluator_build_digest,
+            "boundary_manifest_digest": evaluator.config.expected_boundary_manifest_digest,
+        }
+        for commitment, evaluator in (
+            (primary_commitment, primary_evaluator),
+            *zip(confirmation_commitments, confirmation_evaluators, strict=True),
+        )
+    }
+    if any(not all(isinstance(value, str) for value in identity.values()) for identity in authority_identities.values()):
+        raise RuntimeError("protected evaluator omitted its host-computed authority identity")
 
     mailbox = args.mailbox.resolve()
     mailbox.mkdir(parents=True, exist_ok=True)
@@ -706,6 +804,7 @@ def main() -> None:
             primary_commitment=primary_commitment,
             confirmation_commitments=confirmation_commitments,
             runtime=runtime,
+            authority_identities=authority_identities,
         )
         status = {
             **campaign_config,

--- a/examples/kernel_evolution/kernelbench_h100/production_runtime.py
+++ b/examples/kernel_evolution/kernelbench_h100/production_runtime.py
@@ -1,10 +1,9 @@
-"""Fail-closed production composition for the H100 kernel campaign.
+"""Protected evaluator composition for the H100 conformance campaign.
 
-The Docker worker protects the host from generated source.  It does not, by
-itself, protect an authoritative Python evaluator that imports that source in
-the same interpreter.  ``require_protected_evaluator_boundary`` therefore
-keeps the production campaign disabled until the adapter is split across a
-trusted evaluator and an isolated GPU candidate executor.
+The accelerator-neutral boundary is implemented and can be composed for a
+live validation run.  ``require_protected_evaluator_boundary`` deliberately
+keeps the production campaign disabled until that exact Docker/MIG path has
+produced and replayed a real H100 authority receipt.
 """
 
 from __future__ import annotations
@@ -15,9 +14,15 @@ from pathlib import Path, PurePosixPath
 from typing import Literal, NoReturn
 
 from autocontext.execution.scenario_remote_package import require_pinned_runtime_image
-from autocontext.kernel_evolution import DockerGPUDeviceGrant, DockerKernelWorkerLimits
-
-PROTECTED_EVALUATOR_BOUNDARY = "trusted-evaluator/isolated-gpu-candidate-v1"
+from autocontext.kernel_evolution import (
+    PROTECTED_EVALUATOR_BOUNDARY,
+    DockerGPUDeviceGrant,
+    DockerKernelWorkerLimits,
+    DockerProtectedKernelBenchmarkRunner,
+    KernelBenchmarkEvaluator,
+    KernelBenchmarkEvaluatorConfig,
+    NvidiaSMIGPUDeviceAttestor,
+)
 
 
 class ProductionEvaluatorBoundaryUnavailable(RuntimeError):
@@ -25,13 +30,12 @@ class ProductionEvaluatorBoundaryUnavailable(RuntimeError):
 
 
 def require_protected_evaluator_boundary() -> NoReturn:
-    """Fail before GPU work while the adapter and candidate share authority."""
+    """Fail before production GPU work while live validation is pending."""
     raise ProductionEvaluatorBoundaryUnavailable(
-        "production H100 campaigns are disabled: adapter.py imports generated candidate code into the same "
-        "interpreter that owns private plans, correctness, CUDA timing, telemetry, and report.json. A production "
-        f"campaign requires {PROTECTED_EVALUATOR_BOUNDARY}: an evaluator-owned protocol that keeps private plan "
-        "material and authoritative measurement/report controls outside the candidate process. Docker isolation "
-        "protects the host but cannot establish that evidence boundary."
+        "production H100 campaigns remain disabled pending a real H100/MIG validation run for "
+        f"{PROTECTED_EVALUATOR_BOUNDARY}. The implemented evaluator-owned protocol keeps private plans and "
+        "authoritative correctness, measurement, telemetry, and report controls outside generated-code containers; "
+        "the release guard must remain until its live authority receipt is replay-verified."
     )
 
 
@@ -101,26 +105,104 @@ def _compose_docker_evaluator(
     plan_commitment: str,
     proposal_cap: int,
     familywise_alpha: float,
-) -> NoReturn:
-    """Refuse runnable composition until the trusted evaluator exists.
+) -> KernelBenchmarkEvaluator:
+    """Compose the protected path used for live boundary validation.
 
-    Keeping this guard at the construction boundary prevents library callers
-    from bypassing the campaign CLI's preflight and obtaining a runnable
-    same-interpreter evaluator.
+    The normal campaign still calls :func:`require_protected_evaluator_boundary`
+    before this factory.  Keeping the factory runnable lets operators exercise
+    the exact future production path without weakening that release guard.
     """
-    del (
-        runtime,
-        bundle,
-        adapter_name,
-        autokernel_root,
-        private_plan,
-        problem_id,
-        precision_profile,
-        plan_commitment,
-        proposal_cap,
-        familywise_alpha,
+    bundle = bundle.resolve(strict=True)
+    autokernel_root = autokernel_root.resolve(strict=True)
+    private_plan = private_plan.resolve(strict=True)
+    if not (autokernel_root / "kernel.py").is_file():
+        raise ValueError("autokernel_root must contain the pinned kernel.py incumbent")
+    if Path(adapter_name).name != adapter_name or not adapter_name.endswith(".py"):
+        raise ValueError("adapter_name must be a Python filename within the immutable bundle")
+    adapter = bundle / adapter_name
+    reference = bundle / "reference.py"
+    authority_worker = bundle / "authority_worker.py"
+    for path in (adapter, reference, authority_worker, bundle / "authority_transport.py", bundle / "profile_contract.py"):
+        if not path.is_file():
+            raise ValueError(f"protected evaluator input is missing: {path.name}")
+
+    gpu_grant = DockerGPUDeviceGrant(
+        device_id=runtime.gpu_device,
+        isolation_kind=runtime.gpu_isolation_kind,
+        enforced_memory_bytes=runtime.gpu_memory_bytes,
     )
-    require_protected_evaluator_boundary()
+    gpu_attestor = NvidiaSMIGPUDeviceAttestor(runtime.nvidia_smi_binary)
+    runner = DockerProtectedKernelBenchmarkRunner(
+        [
+            runtime.container_python,
+            f"/evaluator/0/{adapter_name}",
+            "--candidate-socket",
+            "{candidate_socket}",
+            "--incumbent-socket",
+            "{incumbent_socket}",
+            "--artifact-identity-version",
+            "{artifact_identity_version}",
+            "--candidate-artifact-digest",
+            "{candidate_artifact_digest}",
+            "--incumbent-artifact-digest",
+            "{incumbent_artifact_digest}",
+            "--candidate-source-digest",
+            "{candidate_source_digest}",
+            "--incumbent-source-digest",
+            "{incumbent_source_digest}",
+            "--candidate-source-suffix",
+            "{candidate_source_suffix}",
+            "--incumbent-source-suffix",
+            "{incumbent_source_suffix}",
+            "--candidate-entrypoint",
+            "{candidate_entrypoint}",
+            "--incumbent-entrypoint",
+            "{incumbent_entrypoint}",
+            "--reference",
+            "/evaluator/0/reference.py",
+            "--report",
+            "{report}",
+            "--problem-id",
+            problem_id,
+            "--autokernel-root",
+            "/evaluator/0",
+            "--precision-profile",
+            precision_profile,
+            "--private-plan",
+            "/evaluator/1",
+            "--plan-commitment",
+            plan_commitment,
+            "--proposal-cap",
+            str(proposal_cap),
+            "--familywise-alpha",
+            f"{familywise_alpha:.17g}",
+        ],
+        image=runtime.image,
+        container_python=runtime.container_python,
+        evaluator_immutable_paths=(bundle, private_plan),
+        evaluator_build_paths=(bundle,),
+        candidate_runtime_path=authority_worker,
+        # Candidate and incumbent source are staged explicitly.  Do not mount
+        # the surrounding AutoKernel checkout (including its .git metadata).
+        candidate_support_paths=(),
+        gpu_grant=gpu_grant,
+        gpu_attestor=gpu_attestor,
+        limits=runtime.limits,
+        docker_binary=runtime.docker_binary,
+    )
+    return KernelBenchmarkEvaluator(
+        runner,
+        KernelBenchmarkEvaluatorConfig(
+            problem_id=problem_id,
+            timeout_seconds=runtime.timeout_seconds,
+            min_timing_blocks=8,
+            bootstrap_samples=20_000,
+            require_resource_telemetry=True,
+            require_authority_receipt=True,
+            adaptive_feedback_policy="aggregate-gates",
+            max_gpu_memory_bytes=runtime.gpu_memory_bytes,
+        ),
+    )
 
 
 __all__ = [

--- a/examples/kernel_evolution/kernelbench_h100/production_runtime.py
+++ b/examples/kernel_evolution/kernelbench_h100/production_runtime.py
@@ -1,15 +1,17 @@
 """Protected evaluator composition for the H100 conformance campaign.
 
-The accelerator-neutral boundary is implemented and can be composed for a
-live validation run.  ``require_protected_evaluator_boundary`` deliberately
-keeps the production campaign disabled until that exact Docker/MIG path has
-produced and replayed a real H100 authority receipt.
+The accelerator-neutral boundary is constructible for manifest inspection, but
+execution deliberately remains unavailable. ``require_protected_evaluator_boundary``
+keeps production disabled until role isolation, trusted mutation observation,
+comparable timing boundaries, and crash-safe container creation are implemented
+and validated on H100/MIG.
 """
 
 from __future__ import annotations
 
 import math
-from dataclasses import asdict, dataclass
+import re
+from dataclasses import asdict, dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Literal, NoReturn
 
@@ -22,7 +24,12 @@ from autocontext.kernel_evolution import (
     KernelBenchmarkEvaluator,
     KernelBenchmarkEvaluatorConfig,
     NvidiaSMIGPUDeviceAttestor,
+    canonical_authority_digest,
+    protected_evaluator_boundary_requirements,
+    read_authority_hmac_secret,
 )
+
+_SAFE_AUTHORITY_HMAC_KEY_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$")
 
 
 class ProductionEvaluatorBoundaryUnavailable(RuntimeError):
@@ -30,12 +37,13 @@ class ProductionEvaluatorBoundaryUnavailable(RuntimeError):
 
 
 def require_protected_evaluator_boundary() -> NoReturn:
-    """Fail before production GPU work while live validation is pending."""
+    """Fail before production GPU work while required authority boundaries are absent."""
     raise ProductionEvaluatorBoundaryUnavailable(
-        "production H100 campaigns remain disabled pending a real H100/MIG validation run for "
-        f"{PROTECTED_EVALUATOR_BOUNDARY}. The implemented evaluator-owned protocol keeps private plans and "
-        "authoritative correctness, measurement, telemetry, and report controls outside generated-code containers; "
-        "the release guard must remain until its live authority receipt is replay-verified."
+        f"production H100 campaigns remain disabled for {PROTECTED_EVALUATOR_BOUNDARY}: "
+        "independently attested evaluator/candidate/incumbent grants, trusted out-of-process input-mutation "
+        "observation, comparable candidate/incumbent/reference timing boundaries, and crash-safe container "
+        "creation are not yet implemented. "
+        "A hardware run alone cannot remove this release guard."
     )
 
 
@@ -50,6 +58,8 @@ class H100DockerRuntimeConfig:
     gpu_device: str
     gpu_isolation_kind: Literal["mig"]
     gpu_memory_bytes: int
+    authority_hmac_key_id: str
+    authority_hmac_secret_path: Path = field(repr=False)
     limits: DockerKernelWorkerLimits
     timeout_seconds: float = 240.0
 
@@ -59,6 +69,9 @@ class H100DockerRuntimeConfig:
             value = getattr(self, name)
             if not value.strip() or any(character in value for character in "\r\n\0"):
                 raise ValueError(f"{name} must be a non-empty single-line value")
+        if _SAFE_AUTHORITY_HMAC_KEY_ID.fullmatch(self.authority_hmac_key_id) is None:
+            raise ValueError("authority_hmac_key_id must be a safe non-empty identifier")
+        read_authority_hmac_secret(self.authority_hmac_secret_path)
         if self.gpu_memory_bytes < 1:
             raise ValueError("gpu_memory_bytes must be positive")
         DockerGPUDeviceGrant(
@@ -76,6 +89,7 @@ class H100DockerRuntimeConfig:
 
     def manifest(self) -> dict[str, object]:
         """Return non-secret deployment inputs captured alongside a run."""
+        requirements = protected_evaluator_boundary_requirements()
         return {
             "image": self.image,
             "docker_binary": self.docker_binary,
@@ -84,11 +98,21 @@ class H100DockerRuntimeConfig:
             "gpu_device": self.gpu_device,
             "gpu_isolation_kind": self.gpu_isolation_kind,
             "gpu_memory_bytes": self.gpu_memory_bytes,
+            "authority_authentication": {
+                "algorithm": "hmac-sha256",
+                "key_id": self.authority_hmac_key_id,
+            },
             "timeout_seconds": self.timeout_seconds,
             "limits": asdict(self.limits),
             "evidence_boundary": {
                 "required": PROTECTED_EVALUATOR_BOUNDARY,
-                "available": False,
+                "available": all(requirement.get("available") is True for requirement in requirements.values()),
+                "requirements": requirements,
+                "unmet_requirements": [
+                    str(requirement["reason"])
+                    for requirement in requirements.values()
+                    if requirement.get("available") is not True
+                ],
             },
         }
 
@@ -106,11 +130,12 @@ def _compose_docker_evaluator(
     proposal_cap: int,
     familywise_alpha: float,
 ) -> KernelBenchmarkEvaluator:
-    """Compose the protected path used for live boundary validation.
+    """Compose the protected path for inspection while execution stays fail-closed.
 
     The normal campaign still calls :func:`require_protected_evaluator_boundary`
-    before this factory.  Keeping the factory runnable lets operators exercise
-    the exact future production path without weakening that release guard.
+    before this factory. The runner itself also returns
+    ``resource_policy_unsupported`` before Docker until every authority boundary
+    represented in its manifest is available.
     """
     bundle = bundle.resolve(strict=True)
     autokernel_root = autokernel_root.resolve(strict=True)
@@ -187,9 +212,16 @@ def _compose_docker_evaluator(
         candidate_support_paths=(),
         gpu_grant=gpu_grant,
         gpu_attestor=gpu_attestor,
+        authority_hmac_key_id=runtime.authority_hmac_key_id,
+        authority_hmac_secret_path=runtime.authority_hmac_secret_path,
         limits=runtime.limits,
         docker_binary=runtime.docker_binary,
     )
+    runner_manifest = runner.manifest()
+    evaluator_build_digest = runner_manifest.get("evaluator_build_digest")
+    if not isinstance(evaluator_build_digest, str):
+        raise ValueError("protected runner manifest omitted its evaluator build digest")
+    boundary_manifest_digest = canonical_authority_digest(runner_manifest)
     return KernelBenchmarkEvaluator(
         runner,
         KernelBenchmarkEvaluatorConfig(
@@ -199,6 +231,10 @@ def _compose_docker_evaluator(
             bootstrap_samples=20_000,
             require_resource_telemetry=True,
             require_authority_receipt=True,
+            authority_hmac_key_id=runtime.authority_hmac_key_id,
+            authority_hmac_secret_path=runtime.authority_hmac_secret_path,
+            expected_evaluator_build_digest=evaluator_build_digest,
+            expected_boundary_manifest_digest=boundary_manifest_digest,
             adaptive_feedback_policy="aggregate-gates",
             max_gpu_memory_bytes=runtime.gpu_memory_bytes,
         ),


### PR DESCRIPTION
## Summary

This implements the software portion of [AC-1003](https://linear.app/greyhaven/issue/AC-1003/split-generated-gpu-candidates-from-the-trusted-benchmark-evaluator) by separating generated accelerator candidates from the trusted benchmark authority.

Previously, candidate loading and authoritative validation shared too much of the same runtime boundary. A hostile generated candidate could therefore have opportunities to observe benchmark controls, interfere with trusted measurement, or reuse information across evaluations. That weakens confidence in promotion evidence and makes production GPU campaigns unsafe to enable.

The change introduces an accelerator-neutral, typed authority protocol with bounded JSON framing and safetensors payloads. The protected runner launches distinct locked-down Docker containers for the trusted evaluator, candidate, and incumbent. The evaluator owns private plans, fresh timed inputs, reference validation, timing, resource observation, and signed receipts; generated code receives only its source and the narrow request channel. Receipts bind protocol identity, artifacts, measurements, resource telemetry, build identity, and host-attested accelerator identity.

The implementation reuses the existing Docker lockdown, GPU/MIG attestation, and watchdog primitives. Cleanup now survives coordinator failure, report and diagnostic payloads fail closed when limits are exceeded, and execution failures distinguish protocol, evaluator, candidate, timeout, OOM, identity, and teardown outcomes. Production adaptive feedback is reduced to aggregate gate states so exact benchmark data is not fed back into later generated candidates.

The H100 example is now an adapter over the accelerator-neutral authority boundary rather than the core design. It includes a runnable protected H100/MIG conformance path and an opt-in adversarial release-gate test covering mount, environment, network, timing-hook, descendant-process, and cross-evaluation persistence attacks.

## Validation

- `uv run ruff check src tests` plus the changed H100 example scripts
- `uv run mypy src` — 850 source files
- Focused authority, Docker worker, H100 production runtime, kernel evolution, and module-size tests all pass
- Full repository test suite validated; three loopback/memory sandbox failures passed when rerun with host access
- `git diff --check`

A physical H100/MIG was not available on this device. The real-hardware adversarial test is included but remains opt-in, and the production enablement guard intentionally remains in place until that test passes on an attested partition.