### PR TITLE
Fix Pi CLI parsing for non-object JSON responses

### DIFF
--- a/autocontext/src/autocontext/runtimes/pi_cli.py
+++ b/autocontext/src/autocontext/runtimes/pi_cli.py
@@ -265,21 +265,23 @@ class PiCLIRuntime(AgentRuntime):
         if self._config.json_output:
             try:
                 data = json.loads(raw)
-                text = data.get("result", data.get("output", ""))
-                if not isinstance(text, str) or not text.strip():
-                    text = json.dumps(data)
-                return AgentOutput(
-                    text=text,
-                    cost_usd=data.get("cost_usd", 0.0),
-                    model=data.get("model", "pi"),
-                    session_id=data.get("session_id"),
-                    metadata={
-                        "exit_code": exit_code,
-                        "raw_json": data,
-                    },
-                )
             except (json.JSONDecodeError, TypeError):
-                logger.debug("runtimes.pi_cli: suppressed json.JSONDecodeError), TypeError", exc_info=True)
+                logger.debug("Pi CLI output is not valid JSON; using raw text", exc_info=True)
+            else:
+                if isinstance(data, dict):
+                    text = data.get("result", data.get("output", ""))
+                    if not isinstance(text, str) or not text.strip():
+                        text = json.dumps(data)
+                    return AgentOutput(
+                        text=text,
+                        cost_usd=data.get("cost_usd", 0.0),
+                        model=data.get("model", "pi"),
+                        session_id=data.get("session_id"),
+                        metadata={
+                            "exit_code": exit_code,
+                            "raw_json": data,
+                        },
+                    )
 
         # Raw text fallback
         return AgentOutput(

--- a/autocontext/tests/test_pi_cli_runtime.py
+++ b/autocontext/tests/test_pi_cli_runtime.py
@@ -116,6 +116,18 @@ def test_generate_json_object_without_result_serializes_full_payload() -> None:
     assert output.metadata["raw_json"] == raw_payload
 
 
+@pytest.mark.parametrize("raw", ['["first", "second"]', '"quoted answer"', "42", "null"])
+def test_generate_non_object_json_falls_back_to_raw_text(raw: str) -> None:
+    runtime = PiCLIRuntime(PiCLIConfig())
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=raw, stderr="")
+
+    with patch("autocontext.runtimes.pi_cli._run_with_group_kill", return_value=mock_result):
+        output = runtime.generate("test prompt")
+
+    assert output.text == raw
+    assert output.model == "pi"
+
+
 def test_generate_json_output_disabled() -> None:
     runtime = PiCLIRuntime(PiCLIConfig(json_output=False))
     mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="raw output\n", stderr="")


### PR DESCRIPTION
## Summary

- guard Pi CLI JSON envelope parsing to dictionary payloads
- fall back to the raw assistant text for valid JSON arrays, strings, numbers, and null
- add regression coverage for each non-object JSON shape

## Why

`PiCLIRuntime` attempts to decode print-mode output as JSON by default. When a Pi answer is itself valid non-object JSON, such as a requested JSON array, `json.loads()` succeeds but the runtime then calls `.get()` on a list or scalar and raises `AttributeError`, aborting the agent run.

JSON object envelopes keep their existing parsing behavior.

## Verification

- `uv run pytest tests/test_pi_cli_runtime.py -q` — 26 passed
- Pi-related runtime suite — 59 passed, 4 skipped
- `uv run ruff check src tests`
- `uv run ruff format --check src/autocontext/runtimes/pi_cli.py tests/test_pi_cli_runtime.py`
- `uv run mypy src/autocontext/runtimes/pi_cli.py`
