### PR TITLE
fix: default dataclass metadata to a dict, not a pydantic FieldInfo

### DIFF
--- a/autocontext/src/autocontext/loop/exploration.py
+++ b/autocontext/src/autocontext/loop/exploration.py
@@ -13,7 +13,7 @@ Key types:
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -160,7 +160,7 @@ class BasinCandidate:
     playbook: str
     lessons: str
     temperature: float
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 def _strip_specific_tactics(playbook: str) -> str:

--- a/autocontext/src/autocontext/providers/scenario_routing.py
+++ b/autocontext/src/autocontext/providers/scenario_routing.py
@@ -10,7 +10,7 @@ AC-290: PiModelHandoff, resolve_pi_model, PiExecutionTrace
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -28,7 +28,7 @@ class ScenarioRoutingContext:
     backend: str = ""
     runtime_type: str = "provider"
     manual_model_override: str = ""
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class RoutingDecision(BaseModel):

--- a/autocontext/tests/test_exploration_mechanisms.py
+++ b/autocontext/tests/test_exploration_mechanisms.py
@@ -249,6 +249,19 @@ class TestBasinCandidates:
         assert experimental.playbook != ""
         assert experimental.playbook != divergent.playbook
 
+    def test_default_metadata_is_an_empty_per_instance_dict(self) -> None:
+        from autocontext.loop.exploration import BasinCandidate
+
+        first = BasinCandidate(branch_type="divergent", playbook="", lessons="Lessons", temperature=0.7)
+        second = BasinCandidate(branch_type="divergent", playbook="", lessons="Lessons", temperature=0.7)
+
+        assert first.metadata == {}
+        assert first.metadata.get("note", "") == ""
+        assert first.metadata is not second.metadata
+
+        first.metadata["note"] = "branch note"
+        assert second.metadata == {}
+
     def test_disabled_returns_empty(self) -> None:
         from autocontext.loop.exploration import (
             MultiBasinConfig,

--- a/autocontext/tests/test_scenario_routing.py
+++ b/autocontext/tests/test_scenario_routing.py
@@ -82,6 +82,18 @@ class TestScenarioRoutingContext:
         assert ctx.role == ""
         assert ctx.runtime_type == "provider"
 
+    def test_default_metadata_is_an_empty_per_instance_dict(self) -> None:
+        from autocontext.providers.scenario_routing import ScenarioRoutingContext
+
+        first = ScenarioRoutingContext(scenario="grid_ctf")
+        second = ScenarioRoutingContext(scenario="othello")
+
+        assert first.metadata == {}
+        assert first.metadata is not second.metadata
+
+        first.metadata["attempt"] = 1
+        assert second.metadata == {}
+
 
 # ===========================================================================
 # AC-289: RoutingDecision


### PR DESCRIPTION
## Summary

- `BasinCandidate` and `ScenarioRoutingContext` are stdlib `@dataclass(slots=True)` classes, but both declared their `metadata` field as `dict[str, Any] = Field(default_factory=dict)` using pydantic's `Field`. Pydantic only interprets `Field` inside a `BaseModel`. A stdlib dataclass keeps whatever the expression returns as the literal default, so every instance built without an explicit `metadata` argument got the `FieldInfo` object itself, the same one shared across all instances, where the annotation promises a dict.
- Both now use `dataclasses.field(default_factory=dict)`. Nothing else changes.

## The bug

`autocontext/src/autocontext/loop/exploration.py:163` and `autocontext/src/autocontext/providers/scenario_routing.py:31`. On `main`:

```
>>> BasinCandidate(branch_type="divergent", playbook="", lessons="L", temperature=0.7).metadata
FieldInfo(annotation=NoneType, required=False, default_factory=dict)
>>> ScenarioRoutingContext(scenario="grid_ctf").metadata is ScenarioRoutingContext(scenario="othello").metadata
True
```

That default has no mapping API. `autocontext/src/autocontext/loop/stage_helpers/exploration.py:269` calls `branch.metadata.get("note", "")` and line 296 calls `dict(branch.metadata)` on every non-conservative basin branch, so a `BasinCandidate` that reaches those lines without an explicit `metadata` raises `AttributeError: 'FieldInfo' object has no attribute 'get'` instead of reading an absent note. `ScenarioRoutingContext.metadata` is not read by `resolve_provider_for_context`, so nothing in tree touches that one yet.

The two in-tree sites that build a non-conservative `BasinCandidate` both pass `metadata` explicitly, so this is a wrong default and a latent crash rather than a live one. mypy is blind to it because `Field()` is typed `Any`, which is why `mypy src` has been clean over both lines.

## The fix

Both modules already import `BaseModel` and `Field` for the pydantic models next door (`BranchRecord`, `RoutingDecision`, `PiModelHandoff`, `PiExecutionTrace`), so only the two dataclass defaults change and both imports stay. Five modules in the package already import `dataclasses.field` and `pydantic.Field` side by side: `training/model_registry.py`, `harness/scoring/backends.py`, `execution/trajectory_harness.py`, `execution/agent_task_evolution.py`, `scenarios/custom/spec.py`.

An AST sweep over all 916 files in `autocontext/src` found these two classes and no others mixing the two APIs, so this is the whole of it.

## Surfaces Touched

- [x] Parity decision: nothing here is user-visible and `ts/` has no pydantic, so there is no cross-runtime parity work to do or defer
- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src tests` gives `All checks passed!`
- [x] `cd autocontext && uv run mypy src` gives `Success: no issues found in 916 source files`
- [x] `cd autocontext && uv run pytest tests/test_exploration_mechanisms.py tests/test_scenario_routing.py tests/test_training_backend.py` gives `60 passed`
- [x] `cd autocontext && uv run pytest tests -m "not live" -k "explor or routing or basin"` gives `212 passed, 3 skipped, 10867 deselected`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Both new tests fail on unmodified `main` with `AssertionError: assert FieldInfo(annotation=NoneType, required=False, default_factory=dict) == {}` and pass with the change. They assert the default is `{}`, answers `.get("note", "")`, and is a fresh object per instance, so a shared mutable default would fail them too.

The other two lint-job steps also pass: `uv run python ../scripts/generate_protocol.py --check` gives `Protocol artifacts are in sync.` and `uv run python ../scripts/check_markdown_links.py` gives `Markdown link check passed: 257 local link(s) across 130 Markdown files.`

Everything above ran on CPython 3.11.15, the version the `ci` workflow pins. One test in `tests/test_model_router_integration.py` is excluded from the count above because it fails on this machine for an unrelated reason, and fails the same way on `14641042c0fbf09464ab88819571ee74554dada0` without this change: `test_orchestrator_resolve_model_uses_harness_coverage`, which logs `skipping harness 'preflight_synthesized': isolation unavailable` and then resolves to the wrong model tier. Local sandboxing is not available here.

TypeScript was not run: no file under `ts/` is touched.

## Docs And Release Impact

- [x] no user-facing docs changes needed

No public command, environment variable, package path, or agent-facing workflow changes, so none of the documentation touch points in `CONTRIBUTING.md` apply.

## Notes

Behaviour is unchanged for every caller that already passes `metadata`, which is both in-tree construction sites that reach the consuming code. Python only.

