### PR TITLE
Reduce Python generation overhead and shard CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,13 @@ jobs:
       - name: Markdown link integrity
         run: uv run python ../scripts/check_markdown_links.py
 
-  test:
+  python-test-shards:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     defaults:
       run:
         working-directory: autocontext
@@ -64,9 +69,59 @@ jobs:
       - name: Install
         run: uv sync --locked --group dev
       - name: Tests
-        run: uv run pytest --cov=src/autocontext --cov-report=html:htmlcov -m "not live"
+        env:
+          COVERAGE_FILE: .coverage.shard-${{ matrix.shard }}
+        run: >-
+          uv run python scripts/pytest_shard.py ${{ matrix.shard }}/4
+          --cov=src/autocontext --cov-report=
+          --junitxml=junit-shard-${{ matrix.shard }}.xml -m "not live"
       - name: Upload coverage
         if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: python-test-data-${{ matrix.shard }}
+          include-hidden-files: true
+          path: |
+            autocontext/.coverage.shard-${{ matrix.shard }}
+            autocontext/junit-shard-${{ matrix.shard }}.xml
+          retention-days: 14
+
+  # Preserve the required status name and combine coverage from every shard.
+  test:
+    if: always()
+    needs: [python-test-shards]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: autocontext
+    steps:
+      - name: Verify all Python test shards passed
+        working-directory: .
+        run: |
+          if [ "${{ needs.python-test-shards.result }}" != "success" ]; then
+            echo "one or more Python test shards failed"
+            exit 1
+          fi
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        with:
+          enable-cache: false
+      - name: Install
+        run: uv sync --locked --group dev
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          pattern: python-test-data-*
+          path: autocontext
+          merge-multiple: true
+      - name: Combine coverage
+        run: |
+          uv run coverage combine
+          uv run coverage html -d htmlcov
+      - name: Upload coverage
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-report
@@ -303,7 +358,6 @@ jobs:
           echo "all ts-test shards passed"
 
   smoke:
-    needs: [lint, test, package-boundaries]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
           merge-multiple: true
       - name: Combine coverage
         run: |
+          for shard in 1 2 3 4; do
+            test -s ".coverage.shard-$shard"
+          done
           uv run coverage combine
           uv run coverage html -d htmlcov
       - name: Upload coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Performance
+
+- Python generation paths now skip architect provider calls between scheduled
+  generations, retaining zero-token `skipped` execution records. With the default
+  cadence of three, architect calls occur on generations 3, 6, 9, and so on;
+  set `AUTOCONTEXT_ARCHITECT_EVERY_N_GENS=1` to run the architect every generation.
+- Direct and pipeline role execution share dependency scheduling: architect can
+  overlap analyst and coach, and coach starts when analyst finishes. Role runtime
+  bindings are independent. RLM retains serial sessions and shares the skip policy.
+- Strategy search batches database reads and caches unchanged knowledge contents
+  and tokenized fields, with filesystem revision checks for external edits.
+- Python CI runs four test shards with combined coverage; smoke checks start
+  independently. Dependency caching remains disabled.
+
+These runtime optimizations land in Python first; TypeScript execution behavior
+is unchanged.
+
 ### Security
 
 - Control-plane WebSockets no longer accept bearer credentials in query strings;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ uv run pytest
 uv run python ../scripts/check_markdown_links.py
 ```
 
+Python CI runs four module-preserving shards, balanced by collected test count.
+To reproduce one shard from `autocontext/`, run
+`uv run python scripts/pytest_shard.py 1/4 -m "not live"`.
+Each shard retains JUnit timings and coverage data; the required `test` job
+checks all shards and combines their coverage into the existing report.
+Dependency caches remain disabled in public workflows.
+
 TypeScript:
 
 ```bash

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -278,3 +278,16 @@ uv run pytest
 
 Keep this README concise. Add deep reference prose to `docs/` or the repo-level
 docs index instead.
+
+### Architect cadence and search efficiency
+
+Python runs the architect on generations divisible by
+`AUTOCONTEXT_ARCHITECT_EVERY_N_GENS` (default `3`). Other generations retain a
+`skipped` architect execution with zero token usage and no tool or harness
+changes. Set the value to `1` for an architect call every generation. This
+applies to direct, pipeline, and RLM generation paths.
+
+Direct and pipeline execution overlap the independent architect with the analyst
+and coach; the coach still receives the current analyst's findings. RLM sessions
+remain serial. Strategy search reuses unchanged knowledge-file contents while
+checking file revisions and current database summaries on every query.

--- a/autocontext/scripts/pytest_shard.py
+++ b/autocontext/scripts/pytest_shard.py
@@ -1,0 +1,58 @@
+"""Run a deterministic, module-preserving shard of the collected pytest suite.
+
+Usage (from autocontext/): python scripts/pytest_shard.py 1/4 [pytest arguments]
+Modules are balanced by collected test count; no timing cache is required.
+"""
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from collections.abc import Sequence
+
+import pytest
+
+
+def partition_modules(modules: dict[str, int], count: int) -> list[set[str]]:
+    if count < 1:
+        raise ValueError("shard count must be positive")
+    shards: list[set[str]] = [set() for _ in range(count)]
+    sizes = [0] * count
+    for module in sorted(modules, key=lambda name: (-modules[name], name)):
+        index = min(range(count), key=lambda candidate: (sizes[candidate], candidate))
+        shards[index].add(module)
+        sizes[index] += modules[module]
+    return shards
+
+
+class ShardPlugin:
+    def __init__(self, index: int, count: int) -> None:
+        self.index = index
+        self.count = count
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_collection_modifyitems(self, config: pytest.Config, items: list[pytest.Item]) -> None:
+        modules: dict[str, int] = defaultdict(int)
+        for item in items:
+            modules[item.nodeid.split("::", 1)[0]] += 1
+        selected = partition_modules(modules, self.count)[self.index - 1]
+        kept, removed = [], []
+        for item in items:
+            (kept if item.nodeid.split("::", 1)[0] in selected else removed).append(item)
+        items[:] = kept
+        config.hook.pytest_deselected(items=removed)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    try:
+        index, count = map(int, args[0].split("/"))
+        if not 1 <= index <= count:
+            raise ValueError
+    except (IndexError, ValueError):
+        print("usage: pytest_shard.py INDEX/COUNT [pytest arguments] (1 <= INDEX <= COUNT)", file=sys.stderr)
+        return 2
+    return int(pytest.main(args[1:], plugins=[ShardPlugin(index, count)]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/autocontext/src/autocontext/agents/execution_policy.py
+++ b/autocontext/src/autocontext/agents/execution_policy.py
@@ -1,0 +1,36 @@
+"""Shared role cadence and dependency policy for generation execution."""
+
+from __future__ import annotations
+
+import uuid
+
+from autocontext.harness.core.types import RoleExecution, RoleUsage
+from autocontext.harness.orchestration.dag import RoleDAG
+from autocontext.harness.orchestration.types import RoleSpec
+
+
+def architect_due(generation: int, every_n_generations: int) -> bool:
+    return generation % every_n_generations == 0
+
+
+def skipped_architect(generation: int, every_n_generations: int) -> RoleExecution:
+    return RoleExecution(
+        role="architect",
+        content='Architect skipped by cadence; no infrastructure changes.\n```json\n{"tools": []}\n```',
+        usage=RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model=""),
+        subagent_id=uuid.uuid4().hex,
+        status="skipped",
+        metadata={"reason": "architect_cadence", "generation": generation, "every_n_generations": every_n_generations},
+    )
+
+
+def feedback_roles(*, depends_on: tuple[str, ...] = ()) -> list[RoleSpec]:
+    return [
+        RoleSpec(name="analyst", depends_on=depends_on),
+        RoleSpec(name="architect", depends_on=depends_on),
+        RoleSpec(name="coach", depends_on=("analyst",)),
+    ]
+
+
+def feedback_dag() -> RoleDAG:
+    return RoleDAG(feedback_roles())

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from threading import RLock
 from typing import TYPE_CHECKING, Any
 
 from autocontext.agents import role_runtime_overrides
@@ -14,6 +15,7 @@ from autocontext.agents.competitor import CompetitorRunner
 from autocontext.agents.context_evaluation_isolation import isolate_context_bundle_client
 from autocontext.agents.context_routing_activation import resolve_active_context_settings
 from autocontext.agents.curator import KnowledgeCurator
+from autocontext.agents.execution_policy import architect_due, skipped_architect
 from autocontext.agents.llm_client import DeferredMLXClient, LanguageModelClient, build_client_from_settings
 from autocontext.agents.model_router import ModelRouter, TierConfig
 from autocontext.agents.orchestrator_helpers import (
@@ -22,7 +24,6 @@ from autocontext.agents.orchestrator_helpers import (
     _run_competitor_phase,
     _run_translator_phase,
 )
-from autocontext.agents.parsers import parse_analyst_exec, parse_architect_exec, parse_coach_exec, parse_competitor_output
 from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext, available_local_models
 from autocontext.agents.runtime_session_wiring import runtime_session_client_for_role
 from autocontext.agents.skeptic import SkepticAgent
@@ -42,7 +43,6 @@ if TYPE_CHECKING:
     from autocontext.agents.role_router import ProviderConfig
 
 logger = logging.getLogger(__name__)
-_ARCHITECT_CADENCE_SKIP = "\n\nArchitect cadence note: no major intervention; return minimal status + empty tools array."
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,16 +155,20 @@ class AgentOrchestrator:
         # so the key is a variable-length tuple of optional strings.
         self._routed_clients: dict[tuple[str | None, ...], LanguageModelClient] = {}
         self._disposable_client_ids: set[int] = set()
-        runtime = SubagentRuntime(client=self.client, constrained_output=settings.constrained_output)
-        self.competitor = CompetitorRunner(runtime, settings.model_competitor, settings.competitor_max_tokens)
-        self.translator = StrategyTranslator(runtime, settings.model_translator, settings.translator_max_tokens)
-        self.analyst = AnalystRunner(runtime, settings.model_analyst, settings.analyst_max_tokens)
-        self.coach = CoachRunner(runtime, settings.model_coach, settings.coach_max_tokens)
-        self.architect = ArchitectRunner(runtime, settings.model_architect, settings.architect_max_tokens)
+        self._role_resolution_lock = RLock()
+
+        def runtime() -> SubagentRuntime:
+            return SubagentRuntime(client=self.client, constrained_output=settings.constrained_output)
+
+        self.competitor = CompetitorRunner(runtime(), settings.model_competitor, settings.competitor_max_tokens)
+        self.translator = StrategyTranslator(runtime(), settings.model_translator, settings.translator_max_tokens)
+        self.analyst = AnalystRunner(runtime(), settings.model_analyst, settings.analyst_max_tokens)
+        self.coach = CoachRunner(runtime(), settings.model_coach, settings.coach_max_tokens)
+        self.architect = ArchitectRunner(runtime(), settings.model_architect, settings.architect_max_tokens)
         self.curator: KnowledgeCurator | None = None
         if settings.curator_enabled:
             self.curator = KnowledgeCurator(
-                runtime,
+                runtime(),
                 settings.model_curator,
                 max_tokens=settings.curator_max_tokens,
                 rating_max_tokens=settings.curator_rating_max_tokens,
@@ -172,7 +176,7 @@ class AgentOrchestrator:
             )
         self.skeptic: SkepticAgent | None = None
         if settings.skeptic_enabled:
-            self.skeptic = SkepticAgent(runtime, settings.model_skeptic, settings.skeptic_max_tokens)
+            self.skeptic = SkepticAgent(runtime(), settings.model_skeptic, settings.skeptic_max_tokens)
         self._role_clients: dict[str, LanguageModelClient] = {}
         self._active_generation_deadline: float | None = None
         self._context_bundle_evaluation_isolation_depth = 0
@@ -493,19 +497,20 @@ class AgentOrchestrator:
     ) -> Any:
         original_client = runner.runtime.client
         original_model = runner.model
-        previous_deadline = self._active_generation_deadline
-        self._active_generation_deadline = generation_deadline
-        resolved_client: LanguageModelClient | None = None
-        try:
-            resolved_client, model = self._resolve_role_execution(
-                role,
-                generation=generation,
-                retry_count=retry_count,
-                is_plateau=is_plateau,
-                scenario_name=scenario_name,
-            )
-        finally:
-            self._active_generation_deadline = previous_deadline
+        with self._role_resolution_lock:
+            previous_deadline = self._active_generation_deadline
+            self._active_generation_deadline = generation_deadline
+            resolved_client: LanguageModelClient | None = None
+            try:
+                resolved_client, model = self._resolve_role_execution(
+                    role,
+                    generation=generation,
+                    retry_count=retry_count,
+                    is_plateau=is_plateau,
+                    scenario_name=scenario_name,
+                )
+            finally:
+                self._active_generation_deadline = previous_deadline
         from autocontext.agents.panel_runtime import panel_client_for_role
 
         def wrap_panel_client(wrapped: LanguageModelClient, provider_name: str) -> LanguageModelClient:
@@ -590,8 +595,7 @@ class AgentOrchestrator:
             _notify,
         )
 
-        architect_cadence = _ARCHITECT_CADENCE_SKIP if generation_index % self.settings.architect_every_n_gens != 0 else ""
-        architect_prompt = prompts.architect + architect_cadence
+        architect_prompt = prompts.architect
 
         analyst_exec, coach_exec, architect_exec = _run_analyst_coach_architect(
             self,
@@ -605,7 +609,6 @@ class AgentOrchestrator:
             generation_deadline,
             _notify,
             parts=parts,
-            architect_cadence=architect_cadence,
         )
 
         return _assemble_agent_outputs(
@@ -636,8 +639,7 @@ class AgentOrchestrator:
 
         dag = build_mts_dag()
 
-        cadence_skip = _ARCHITECT_CADENCE_SKIP if generation_index % self.settings.architect_every_n_gens != 0 else ""
-        architect_prompt = prompts.architect + cadence_skip
+        architect_prompt = prompts.architect
 
         prompt_map = {
             "competitor": prompts.competitor,
@@ -666,9 +668,8 @@ class AgentOrchestrator:
             for role, rp in role_parts.items():
                 if not rp.isolation_safe:
                     continue
-                suffix = cadence_skip if role == "architect" else ""
-                system_map[role] = rp.system + suffix
-                flat_map[role] = rp.flat + suffix
+                system_map[role] = rp.system
+                flat_map[role] = rp.flat
                 prompt_map[role] = rp.untrusted_reference
 
         handler = build_role_handler(
@@ -730,30 +731,15 @@ class AgentOrchestrator:
         # under `python -O`; nothing below depends on this one executing.
         assert strategy is not None
 
-        competitor_typed = parse_competitor_output(
+        return _assemble_agent_outputs(
+            self,
             results["competitor"].content,
             strategy,
-            is_code_strategy=self.settings.code_strategies_enabled,
-        )
-        analyst_typed = parse_analyst_exec(results["analyst"])
-        coach_typed = parse_coach_exec(results["coach"])
-        architect_typed = parse_architect_exec(results["architect"])
-
-        return AgentOutputs(
-            strategy=strategy,
-            analysis_markdown=analyst_typed.raw_markdown,
-            coach_markdown=coach_typed.raw_markdown,
-            coach_playbook=coach_typed.playbook,
-            coach_lessons=coach_typed.lessons,
-            coach_competitor_hints=coach_typed.hints,
-            architect_markdown=architect_typed.raw_markdown,
-            architect_tools=architect_typed.tool_specs,
-            architect_harness_specs=architect_typed.harness_specs,
-            role_executions=[results[r] for r in ["competitor", "translator", "analyst", "coach", "architect"]],
-            competitor_output=competitor_typed,
-            analyst_output=analyst_typed,
-            coach_output=coach_typed,
-            architect_output=architect_typed,
+            results["competitor"],
+            results["translator"],
+            results["analyst"],
+            results["coach"],
+            results["architect"],
         )
 
     def resolve_model(
@@ -970,6 +956,9 @@ class AgentOrchestrator:
             worker_cls=backend.worker_cls,
             client=analyst_client,
         )
+
+        if not architect_due(generation_index, self.settings.architect_every_n_gens):
+            return analyst_exec, skipped_architect(generation_index, self.settings.architect_every_n_gens)
 
         # Reset turn counter between roles for deterministic client
         architect_client, architect_model = self._resolve_role_execution(

--- a/autocontext/src/autocontext/agents/orchestrator_helpers.py
+++ b/autocontext/src/autocontext/agents/orchestrator_helpers.py
@@ -14,9 +14,11 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, nullcontext
 from typing import TYPE_CHECKING, Any
 
+from autocontext.agents.execution_policy import architect_due, feedback_dag, skipped_architect
 from autocontext.agents.parsers import parse_analyst_exec, parse_architect_exec, parse_coach_exec, parse_competitor_output
 from autocontext.agents.role_isolation import resolve_role_turn
 from autocontext.agents.types import AgentOutputs, RoleExecution
+from autocontext.harness.orchestration.engine import PipelineEngine
 
 if TYPE_CHECKING:
     from autocontext.agents.orchestrator import AgentOrchestrator
@@ -217,58 +219,35 @@ def _run_analyst_coach_architect(
                 coach_exec = coach_future.result()
         notify("coach", "completed")
     else:
-        # Analyst runs first; its output enriches the coach prompt
-        notify("analyst", "started")
-        with orchestrator._use_role_runtime(
-            "analyst",
-            orchestrator.analyst,
-            generation=generation_index,
-            scenario_name=scenario_name,
-            generation_deadline=generation_deadline,
-        ):
-            analyst_user, analyst_system = _direct_turn(
-                orchestrator, parts.analyst if parts else None, orchestrator.analyst, prompts.analyst
-            )
-            if analyst_system:
-                analyst_exec = orchestrator.analyst.run(analyst_user, system=analyst_system)
-            else:
-                analyst_exec = orchestrator.analyst.run(analyst_user)
-        notify("analyst", "completed")
-        notify("coach", "started")
-        notify("architect", "started")
-        with (
-            orchestrator._use_role_runtime(
-                "coach",
-                orchestrator.coach,
+        def run_role(role: str, prompt: str, completed: dict[str, RoleExecution]) -> RoleExecution:
+            if role == "architect" and not architect_due(generation_index, settings.architect_every_n_gens):
+                return skipped_architect(generation_index, settings.architect_every_n_gens)
+            runner = getattr(orchestrator, role)
+            with orchestrator._use_role_runtime(
+                role,
+                runner,
                 generation=generation_index,
                 scenario_name=scenario_name,
                 generation_deadline=generation_deadline,
-            ),
-            orchestrator._use_role_runtime(
-                "architect",
-                orchestrator.architect,
-                generation=generation_index,
-                scenario_name=scenario_name,
-                generation_deadline=generation_deadline,
-            ),
-        ):
-            enriched_coach_prompt, coach_system = _coach_turn(prompts.coach, analyst_exec.content)
-            architect_user, architect_system = _direct_turn(
-                orchestrator,
-                parts.architect if parts else None,
-                orchestrator.architect,
-                architect_prompt,
-                suffix=architect_cadence,
-            )
-            coach_kwargs = {"system": coach_system} if coach_system else {}
-            architect_kwargs = {"system": architect_system} if architect_system else {}
-            with ThreadPoolExecutor(max_workers=2) as pool:
-                coach_future = pool.submit(orchestrator.coach.run, enriched_coach_prompt, **coach_kwargs)
-                architect_future = pool.submit(orchestrator.architect.run, architect_user, **architect_kwargs)
-                coach_exec = coach_future.result()
-                notify("coach", "completed")
-                architect_exec = architect_future.result()
-                notify("architect", "completed")
+            ):
+                if role == "coach":
+                    user, system = _coach_turn(prompt, completed["analyst"].content)
+                else:
+                    user, system = _direct_turn(
+                        orchestrator,
+                        getattr(parts, role) if parts else None,
+                        runner,
+                        prompt,
+                        suffix=architect_cadence if role == "architect" else "",
+                    )
+                execution: RoleExecution = runner.run(user, **({"system": system} if system else {}))
+                return execution
+
+        results = PipelineEngine(feedback_dag(), run_role, max_workers=2).execute(
+            {"analyst": prompts.analyst, "coach": prompts.coach, "architect": architect_prompt},
+            on_role_event=notify,
+        )
+        analyst_exec, coach_exec, architect_exec = (results[role] for role in ("analyst", "coach", "architect"))
 
     return analyst_exec, coach_exec, architect_exec
 

--- a/autocontext/src/autocontext/agents/pipeline_adapter.py
+++ b/autocontext/src/autocontext/agents/pipeline_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from autocontext.agents.execution_policy import architect_due, feedback_roles, skipped_architect
 from autocontext.harness.core.types import RoleExecution
 from autocontext.harness.orchestration.dag import RoleDAG
 from autocontext.harness.orchestration.types import RoleSpec
@@ -25,9 +26,7 @@ def build_mts_dag() -> RoleDAG:
         [
             RoleSpec(name="competitor"),
             RoleSpec(name="translator", depends_on=("competitor",)),
-            RoleSpec(name="analyst", depends_on=("translator",)),
-            RoleSpec(name="architect", depends_on=("translator",)),
-            RoleSpec(name="coach", depends_on=("analyst",)),
+            *feedback_roles(depends_on=("translator",)),
         ]
     )
 
@@ -114,6 +113,8 @@ def build_role_handler(
                     return orch.analyst.run(user_prompt, system=system)
                 return orch.analyst.run(user_prompt)
         elif name == "architect":
+            if not architect_due(generation, orch.settings.architect_every_n_gens):
+                return skipped_architect(generation, orch.settings.architect_every_n_gens)
             with orch._use_role_runtime(
                 "architect",
                 orch.architect,

--- a/autocontext/src/autocontext/harness/orchestration/engine.py
+++ b/autocontext/src/autocontext/harness/orchestration/engine.py
@@ -1,9 +1,9 @@
-"""PipelineEngine — execute roles in DAG order with parallel batches."""
+"""Execute ready roles as soon as their dependencies complete."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 
 from autocontext.harness.core.types import RoleExecution
 from autocontext.harness.orchestration.dag import RoleDAG
@@ -13,6 +13,8 @@ RoleHandler = Callable[[str, str, dict[str, RoleExecution]], RoleExecution]
 
 class PipelineEngine:
     def __init__(self, dag: RoleDAG, handler: RoleHandler, max_workers: int = 4) -> None:
+        if max_workers < 1:
+            raise ValueError("max_workers must be positive")
         self._dag = dag
         self._handler = handler
         self._max_workers = max_workers
@@ -22,33 +24,36 @@ class PipelineEngine:
         prompts: dict[str, str],
         on_role_event: Callable[[str, str], None] | None = None,
     ) -> dict[str, RoleExecution]:
+        self._dag.validate()
+        roles = self._dag.roles
+        pending = set(roles)
         completed: dict[str, RoleExecution] = {}
-        batches = self._dag.execution_batches()
+        running: dict[Future[RoleExecution], str] = {}
 
-        for batch in batches:
-            if len(batch) == 1:
-                name = batch[0]
-                if on_role_event:
-                    on_role_event(name, "started")
-                completed[name] = self._handler(name, prompts.get(name, ""), completed)
-                if on_role_event:
-                    on_role_event(name, "completed")
-            else:
-                workers = min(len(batch), self._max_workers)
-                snapshot = dict(completed)
+        def run(name: str, snapshot: dict[str, RoleExecution]) -> RoleExecution:
+            return self._handler(name, prompts.get(name, ""), snapshot)
 
-                def _run(role_name: str, snap: dict[str, RoleExecution] = snapshot) -> tuple[str, RoleExecution]:
-                    if on_role_event:
-                        on_role_event(role_name, "started")
-                    result = self._handler(role_name, prompts.get(role_name, ""), snap)
-                    if on_role_event:
-                        on_role_event(role_name, "completed")
-                    return role_name, result
-
-                with ThreadPoolExecutor(max_workers=workers) as pool:
-                    futures = [pool.submit(_run, name) for name in batch]
-                    for future in futures:
-                        name, execution = future.result()
-                        completed[name] = execution
-
+        with ThreadPoolExecutor(max_workers=self._max_workers) as pool:
+            try:
+                while pending or running:
+                    ready = sorted(name for name in pending if all(dep in completed for dep in roles[name].depends_on))
+                    for name in ready[:self._max_workers - len(running)]:
+                        if on_role_event:
+                            on_role_event(name, "started")
+                        running[pool.submit(run, name, dict(completed))] = name
+                        pending.remove(name)
+                    done, _ = wait(running, return_when=FIRST_COMPLETED)
+                    # Resolve all finished futures before dispatching dependents;
+                    # any failure prevents new work from being submitted.
+                    results = [(running[future], future.result()) for future in done]
+                    for name, result in sorted(results):
+                        completed[name] = result
+                        if on_role_event:
+                            on_role_event(name, "completed")
+                    for future in done:
+                        del running[future]
+            except BaseException:
+                for future in running:
+                    future.cancel()
+                raise
         return completed

--- a/autocontext/src/autocontext/knowledge/search.py
+++ b/autocontext/src/autocontext/knowledge/search.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import re
+from collections import OrderedDict
 from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from threading import RLock
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
@@ -16,6 +21,7 @@ from autocontext.scenarios.capabilities import (
     get_task_prompt_safe,
     resolve_capabilities,
 )
+from autocontext.storage.artifacts import ArtifactStore
 
 # Common English stopwords to ignore during search
 _STOPWORDS = frozenset({
@@ -48,12 +54,11 @@ class SearchResult:
 
 def search_strategies(ctx: MtsToolContext, query: str, top_k: int = 5) -> list[SearchResult]:
     """Search solved scenarios by natural language query, ranked by keyword relevance."""
+    terms = _tokenize(query)
+    if not terms or top_k <= 0:
+        return []
     index = _build_search_index(ctx)
     if not index:
-        return []
-
-    terms = _tokenize(query)
-    if not terms:
         return []
 
     scored: list[tuple[float, dict[str, Any]]] = []
@@ -106,7 +111,7 @@ def _keyword_score(terms: list[str], entry: dict[str, Any]) -> tuple[float, list
         text = str(entry.get(field_name, "")).lower()
         if not text:
             continue
-        text_tokens = set(re.findall(r"[a-z0-9]+", text))
+        text_tokens = _field_tokens(text)
         for term in terms:
             if term in text_tokens:
                 total += weight
@@ -132,24 +137,73 @@ def _scenario_description(scenario: object) -> str:
     return get_description(scenario)
 
 
+@lru_cache(maxsize=1024)
+def _field_tokens(text: str) -> frozenset[str]:
+    return frozenset(re.findall(r"[a-z0-9]+", text))
+
+
+@dataclass(frozen=True)
+class _KnowledgeEntry:
+    revision: tuple[tuple[object, ...], ...]
+    playbook_excerpt: str
+    lessons: str
+    hints: str
+
+
+# Scope cached contents to the artifact store lifetime and cap each store's
+# entries. Check filesystem revisions on every query, including external edits.
+_KNOWLEDGE_CACHE: WeakKeyDictionary[ArtifactStore, OrderedDict[str, _KnowledgeEntry]] = WeakKeyDictionary()
+_CACHE_LOCK = RLock()
+
+
+def _file_revision(path: Path) -> tuple[object, ...]:
+    try:
+        info = path.stat()
+    except FileNotFoundError:
+        return (str(path), None)
+    return (str(path), info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, info.st_ctime_ns)
+
+
+def _read_search_knowledge(artifacts: ArtifactStore, name: str) -> _KnowledgeEntry:
+    scenario_dir = artifacts._scenario_dir(name)
+    paths = (
+        scenario_dir / "playbook.md",
+        artifacts._skill_dir(name) / "SKILL.md",
+        scenario_dir / "hints.md",
+        scenario_dir / "hint_state.json",
+    )
+    revision = tuple(_file_revision(path) for path in paths)
+    with _CACHE_LOCK:
+        cache = _KNOWLEDGE_CACHE.setdefault(artifacts, OrderedDict())
+        cached = cache.get(name)
+        if cached is not None and cached.revision == revision:
+            cache.move_to_end(name)
+            return cached
+        entry = _KnowledgeEntry(
+            revision=revision,
+            playbook_excerpt=artifacts.read_playbook(name)[:500],
+            lessons=" ".join(artifacts.read_skill_lessons_raw(name)),
+            hints=artifacts.read_hints(name),
+        )
+        # Never retain a mixed revision if another process wrote during reads.
+        if revision == tuple(_file_revision(path) for path in paths):
+            cache[name] = entry
+            cache.move_to_end(name)
+            while len(cache) > 128:
+                cache.popitem(last=False)
+        else:
+            cache.pop(name, None)
+        return entry
+
+
 def _build_search_index(ctx: MtsToolContext) -> list[dict[str, Any]]:
     """Build searchable entries for all scenarios with completed runs."""
     entries: list[dict[str, Any]] = []
-    for name in sorted(SCENARIO_REGISTRY.keys()):
-        completed = ctx.sqlite.count_completed_runs(name)
-        if completed == 0:
-            continue
-
+    summary = ctx.sqlite.get_search_knowledge_summary()
+    for name in sorted(SCENARIO_REGISTRY.keys() & summary.keys()):
         scenario = SCENARIO_REGISTRY[name]()
-        snapshot = ctx.sqlite.get_best_knowledge_snapshot(name)
-
-        playbook = ctx.artifacts.read_playbook(name)
-        playbook_excerpt = playbook[:500] if len(playbook) > 500 else playbook
-
-        raw_lessons = ctx.artifacts.read_skill_lessons_raw(name)
-        lessons_text = " ".join(raw_lessons)
-
-        hints = ctx.artifacts.read_hints(name)
+        snapshot = summary[name]
+        knowledge = _read_search_knowledge(ctx.artifacts, name)
 
         caps = resolve_capabilities(scenario)
         strategy_interface = get_strategy_interface_safe(scenario) or ""
@@ -163,13 +217,13 @@ def _build_search_index(ctx: MtsToolContext) -> list[dict[str, Any]]:
             "description": _scenario_description(scenario),
             "strategy_interface": strategy_interface,
             "evaluation_criteria": evaluation_criteria,
-            "lessons": lessons_text,
-            "playbook_excerpt": playbook_excerpt,
-            "hints": hints,
+            "lessons": knowledge.lessons,
+            "playbook_excerpt": knowledge.playbook_excerpt,
+            "hints": knowledge.hints,
             "task_prompt": task_prompt,
             "judge_rubric": judge_rubric,
-            "best_score": snapshot["best_score"] if snapshot else 0.0,
-            "best_elo": snapshot["best_elo"] if snapshot else 1500.0,
-            "completed_runs": completed,
+            "best_score": snapshot["best_score"],
+            "best_elo": snapshot["best_elo"],
+            "completed_runs": snapshot["completed_runs"],
         })
     return entries

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -746,6 +746,31 @@ class SQLiteStore(
                 ),
             )
 
+    def get_search_knowledge_summary(self) -> dict[str, dict[str, Any]]:
+        """Read completed counts and best snapshots in one connection/snapshot."""
+        with self.connection() as conn:
+            rows = conn.execute(
+                """
+                WITH completed AS (
+                    SELECT scenario, COUNT(*) AS completed_runs
+                    FROM runs WHERE status = 'completed' GROUP BY scenario
+                ), ranked AS (
+                    SELECT scenario, best_score, best_elo,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY scenario ORDER BY best_score DESC, id ASC
+                        ) AS rank
+                    FROM knowledge_snapshots
+                    WHERE scenario IN (SELECT scenario FROM completed)
+                )
+                SELECT completed.scenario, completed.completed_runs,
+                    COALESCE(ranked.best_score, 0.0) AS best_score,
+                    COALESCE(ranked.best_elo, 1500.0) AS best_elo
+                FROM completed LEFT JOIN ranked
+                    ON completed.scenario = ranked.scenario AND ranked.rank = 1
+                """
+            ).fetchall()
+            return {row["scenario"]: dict(row) for row in rows}
+
     def get_best_knowledge_snapshot(self, scenario: str) -> dict[str, Any] | None:
         with self.connection() as conn:
             row = conn.execute(

--- a/autocontext/tests/test_generation_efficiency.py
+++ b/autocontext/tests/test_generation_efficiency.py
@@ -1,0 +1,144 @@
+"""Call-count, dependency scheduling, and role isolation regressions."""
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from autocontext.agents.llm_client import DeterministicDevClient
+from autocontext.agents.orchestrator import AgentOrchestrator
+from autocontext.agents.types import RoleExecution, RoleUsage
+from autocontext.config.settings import AppSettings
+from autocontext.prompts.templates import PromptBundle
+
+
+def execution(role: str) -> RoleExecution:
+    return RoleExecution(role, f"{role} result", RoleUsage(1, 1, 1, role), "test", "ok")
+
+
+def prompts() -> PromptBundle:
+    return PromptBundle(
+        competitor="Describe your strategy reasoning and recommend specific parameter values.",
+        analyst="Analyze strengths/failures and return Findings, Root Causes, Actionable Recommendations.",
+        coach="Update the playbook.",
+        architect="Propose infrastructure/tooling improvements.",
+    )
+
+
+@pytest.mark.parametrize("pipeline", [False, True])
+def test_cadence_eliminates_calls_but_retains_zero_cost_records(pipeline: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    orch = AgentOrchestrator(DeterministicDevClient(), AppSettings(agent_provider="deterministic", use_pipeline_engine=pipeline))
+    calls = MagicMock(wraps=orch.architect.run)
+    monkeypatch.setattr(orch.architect, "run", calls)
+    for generation in (1, 2, 3):
+        output = orch.run_generation(prompts(), generation)
+        architect = next(result for result in output.role_executions if result.role == "architect")
+        if generation < 3:
+            assert architect.status == "skipped"
+            assert architect.usage.input_tokens == architect.usage.output_tokens == architect.usage.latency_ms == 0
+            assert architect.metadata["reason"] == "architect_cadence"
+            assert output.architect_tools == []
+            assert output.architect_harness_specs == []
+        else:
+            assert architect.status != "skipped"
+    assert calls.call_count == 1
+
+
+@pytest.mark.parametrize("pipeline", [False, True])
+def test_architect_overlaps_analyst_and_coach_does_not_wait_for_architect(
+    pipeline: bool, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orch = AgentOrchestrator(DeterministicDevClient(), AppSettings(agent_provider="deterministic", use_pipeline_engine=pipeline))
+    both_started = threading.Barrier(2)
+    coach_started = threading.Event()
+
+    def analyst(prompt: str, **kwargs: object) -> RoleExecution:
+        both_started.wait(timeout=5)
+        return execution("analyst")
+
+    def architect(prompt: str, **kwargs: object) -> RoleExecution:
+        both_started.wait(timeout=5)
+        assert coach_started.wait(timeout=5), "coach waited for independent architect"
+        return execution("architect")
+
+    def coach(prompt: str, **kwargs: object) -> RoleExecution:
+        assert "analyst result" in prompt
+        coach_started.set()
+        return execution("coach")
+
+    monkeypatch.setattr(orch.analyst, "run", analyst)
+    monkeypatch.setattr(orch.architect, "run", architect)
+    monkeypatch.setattr(orch.coach, "run", coach)
+    orch.run_generation(prompts(), 3)
+
+
+@pytest.mark.parametrize("pipeline", [False, True])
+def test_parallel_roles_keep_their_resolved_clients(pipeline: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    orch = AgentOrchestrator(DeterministicDevClient(), AppSettings(agent_provider="deterministic", use_pipeline_engine=pipeline))
+    clients = {role: DeterministicDevClient() for role in ("competitor", "translator", "analyst", "architect", "coach")}
+    barrier = threading.Barrier(2)
+
+    def resolve(role: str, **kwargs: object) -> tuple[DeterministicDevClient, None]:
+        return clients[role], None
+
+    def role_call(role: str):
+        def run(prompt: str, **kwargs: object) -> RoleExecution:
+            barrier.wait(timeout=5)
+            assert getattr(orch, role).runtime.client is clients[role]
+            return execution(role)
+        return run
+
+    monkeypatch.setattr(orch, "_resolve_role_execution", resolve)
+    monkeypatch.setattr(orch.analyst, "run", role_call("analyst"))
+    monkeypatch.setattr(orch.architect, "run", role_call("architect"))
+    orch.run_generation(prompts(), 3)
+    assert orch.analyst.runtime.client is orch.client
+    assert orch.architect.runtime.client is orch.client
+
+
+@pytest.mark.parametrize("generation, expected_roles", [(1, ["analyst"]), (3, ["analyst", "architect"])])
+def test_rlm_cadence_skips_session_and_context_loading(
+    generation: int, expected_roles: list[str], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orch = AgentOrchestrator(DeterministicDevClient(), AppSettings(agent_provider="deterministic"))
+    loader = MagicMock()
+    orch._rlm_loader = loader
+    calls: list[str] = []
+
+    def session(*, role: str, **kwargs: object) -> tuple[RoleExecution, list[object]]:
+        calls.append(role)
+        return execution(role), []
+
+    monkeypatch.setattr(orch, "_run_single_rlm_session", session)
+    _, architect = orch._run_rlm_roles("run", "grid_ctf", generation, {}, "architect prompt")
+    assert calls == expected_roles
+    assert loader.load_for_architect.call_count == (generation == 3)
+    if generation == 1:
+        assert architect.status == "skipped"
+
+
+@pytest.mark.parametrize("pipeline", [False, True])
+def test_failed_analyst_does_not_start_coach_and_restores_bindings(
+    pipeline: bool, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orch = AgentOrchestrator(DeterministicDevClient(), AppSettings(agent_provider="deterministic", use_pipeline_engine=pipeline))
+    both_started = threading.Barrier(2)
+    coach = MagicMock(side_effect=AssertionError("coach must not run after failed analyst"))
+
+    def analyst(prompt: str, **kwargs: object) -> RoleExecution:
+        both_started.wait(timeout=5)
+        raise ValueError("analyst failed")
+
+    def architect(prompt: str, **kwargs: object) -> RoleExecution:
+        both_started.wait(timeout=5)
+        return execution("architect")
+
+    monkeypatch.setattr(orch.analyst, "run", analyst)
+    monkeypatch.setattr(orch.architect, "run", architect)
+    monkeypatch.setattr(orch.coach, "run", coach)
+    with pytest.raises(ValueError, match="analyst failed"):
+        orch.run_generation(prompts(), 3)
+    coach.assert_not_called()
+    assert orch.analyst.runtime.client is orch.client
+    assert orch.architect.runtime.client is orch.client

--- a/autocontext/tests/test_orchestrator_feedback.py
+++ b/autocontext/tests/test_orchestrator_feedback.py
@@ -121,7 +121,7 @@ def test_architect_independent_of_analyst() -> None:
     orch = AgentOrchestrator(client=client, settings=settings)
     prompts = _make_prompt_bundle()
 
-    orch.run_generation(prompts, generation_index=1)
+    orch.run_generation(prompts, generation_index=3)
 
     architect_calls = [(role, prompt) for role, prompt in client.calls if role == "architect"]
     assert len(architect_calls) == 1, f"Expected 1 architect call, got {len(architect_calls)}"

--- a/autocontext/tests/test_pipeline_adapter.py
+++ b/autocontext/tests/test_pipeline_adapter.py
@@ -189,7 +189,7 @@ class TestPipelineOrchestratorIntegration:
         settings = _make_settings(use_pipeline=True)
         orch = AgentOrchestrator(client=client, settings=settings)
         prompts = _make_prompt_bundle()
-        outputs = orch.run_generation(prompts, generation_index=1)
+        outputs = orch.run_generation(prompts, generation_index=3)
         # DeterministicDevClient architect response has tools JSON
         assert isinstance(outputs.architect_tools, list)
         assert len(outputs.architect_tools) >= 1

--- a/autocontext/tests/test_prompt_injection_isolation.py
+++ b/autocontext/tests/test_prompt_injection_isolation.py
@@ -117,6 +117,7 @@ def _run(client: LanguageModelClient, *, use_pipeline: bool) -> _RecordingCapabl
     settings = AppSettings(
         agent_provider="deterministic",
         structural_role_isolation=True,
+        architect_every_n_gens=1,
         use_pipeline_engine=use_pipeline,
     )
     orch = AgentOrchestrator(client=client, settings=settings)
@@ -156,7 +157,7 @@ def test_isolation_survives_the_hook_wrapper() -> None:
     # client still isolates end-to-end rather than silently flattening.
     recorder = _RecordingCapableClient()
     wrapped = HookedLanguageModelClient(recorder, HookBus())
-    settings = AppSettings(agent_provider="deterministic", structural_role_isolation=True)
+    settings = AppSettings(agent_provider="deterministic", structural_role_isolation=True, architect_every_n_gens=1)
     orch = AgentOrchestrator(client=wrapped, settings=settings)
     prompts, parts = _build()
     orch.run_generation(prompts, generation_index=1, parts=parts)

--- a/autocontext/tests/test_pytest_sharding.py
+++ b/autocontext/tests/test_pytest_sharding.py
@@ -1,0 +1,29 @@
+"""The CI shard partition must preserve every test and module exactly once."""
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "pytest_shard.py"
+partition_modules = runpy.run_path(str(_SCRIPT))["partition_modules"]
+
+
+def test_shards_cover_modules_once_and_ignore_input_order() -> None:
+    modules = {"large.py": 100, "medium.py": 80, "small.py": 20, "tiny.py": 10, "other.py": 30}
+    shards = partition_modules(modules, 4)
+    assert set.union(*shards) == set(modules)
+    assert sum(map(len, shards)) == len(modules)
+    assert shards == partition_modules(dict(reversed(list(modules.items()))), 4)
+    sizes = [sum(modules[name] for name in shard) for shard in shards]
+    assert max(sizes) - min(sizes) <= max(modules.values())
+
+
+def test_single_shard_keeps_every_module() -> None:
+    assert partition_modules({"a": 1, "b": 3}, 1) == [{"a", "b"}]
+
+
+def test_invalid_shard_count_is_rejected() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        partition_modules({"a": 1}, 0)

--- a/autocontext/tests/test_rlm_competitor.py
+++ b/autocontext/tests/test_rlm_competitor.py
@@ -560,6 +560,7 @@ class TestOrchestratorCompetitorRlm:
         settings = AppSettings(
             agent_provider="deterministic",
             rlm_enabled=True,
+            architect_every_n_gens=1,
             rlm_competitor_enabled=False,  # Use normal competitor path
             rlm_max_turns=5,
             curator_enabled=False,

--- a/autocontext/tests/test_role_isolation_wiring.py
+++ b/autocontext/tests/test_role_isolation_wiring.py
@@ -16,6 +16,7 @@ from autocontext.agents.architect import ArchitectRunner
 from autocontext.agents.coach import CoachRunner
 from autocontext.agents.competitor import CompetitorRunner
 from autocontext.agents.subagent_runtime import SubagentRuntime
+from autocontext.config.settings import AppSettings
 from autocontext.extensions.hooks import HookBus
 from autocontext.extensions.llm import HookedLanguageModelClient
 from autocontext.harness.core.llm_client import LanguageModelClient
@@ -89,6 +90,7 @@ class _FakeOrch:
     """Minimal orchestrator surface build_role_handler needs."""
 
     def __init__(self, client: LanguageModelClient) -> None:
+        self.settings = AppSettings(architect_every_n_gens=1)
         runtime = SubagentRuntime(client)
         self.competitor = CompetitorRunner(runtime, "m")
         self.analyst = AnalystRunner(runtime, "m")

--- a/autocontext/tests/test_run_manager_stop_lifecycle.py
+++ b/autocontext/tests/test_run_manager_stop_lifecycle.py
@@ -520,6 +520,7 @@ def test_rlm_run_uses_spawned_main_thread_isolation_and_relays_events(tmp_path: 
     settings = _make_settings(tmp_path).model_copy(
         update={
             "rlm_enabled": True,
+            "architect_every_n_gens": 1,
             "rlm_max_turns": 5,
         }
     )

--- a/autocontext/tests/test_runtime_session_run_wiring.py
+++ b/autocontext/tests/test_runtime_session_run_wiring.py
@@ -82,7 +82,7 @@ def _prompts():
 
 
 def test_orchestrator_records_run_scoped_runtime_session_for_runtime_bridge(tmp_path: Path) -> None:
-    settings = AppSettings(agent_provider="deterministic", db_path=tmp_path / "events.db")
+    settings = AppSettings(agent_provider="deterministic", db_path=tmp_path / "events.db", architect_every_n_gens=1)
     orchestrator = AgentOrchestrator(
         client=RuntimeBridgeClient(_DeterministicAgentRuntime()),
         settings=settings,

--- a/autocontext/tests/test_search_efficiency.py
+++ b/autocontext/tests/test_search_efficiency.py
@@ -1,0 +1,104 @@
+"""Search stays fresh while avoiding per-scenario SQL and repeated file reads."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from autocontext.config import AppSettings
+from autocontext.knowledge.search import _build_search_index, search_strategies
+from autocontext.mcp.tools import MtsToolContext
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> MtsToolContext:
+    context = MtsToolContext(AppSettings(
+        db_path=tmp_path / "runs.db", knowledge_root=tmp_path / "knowledge", skills_root=tmp_path / "skills",
+        runs_root=tmp_path / "runs", claude_skills_path=tmp_path / "claude",
+    ))
+    context.sqlite.create_run("run", "grid_ctf", 3, "local")
+    context.sqlite.mark_run_completed("run")
+    return context
+
+
+def test_search_opens_one_connection_and_reuses_files(ctx: MtsToolContext, monkeypatch: pytest.MonkeyPatch) -> None:
+    connect = MagicMock(wraps=ctx.sqlite.connect)
+    read = MagicMock(wraps=ctx.artifacts.read_playbook)
+    monkeypatch.setattr(ctx.sqlite, "connect", connect)
+    monkeypatch.setattr(ctx.artifacts, "read_playbook", read)
+    first = search_strategies(ctx, "capture flag")
+    assert first
+    assert connect.call_count == read.call_count == 1
+    assert search_strategies(ctx, "capture flag") == first
+    assert connect.call_count == 2
+    assert read.call_count == 1
+    ctx.artifacts.write_playbook("grid_ctf", "quasar tactics")
+    assert search_strategies(ctx, "quasar")
+    assert read.call_count == 2
+
+
+def test_external_edits_deletions_and_skill_lessons_invalidate(ctx: MtsToolContext) -> None:
+    directory = ctx.artifacts._scenario_dir("grid_ctf")
+    directory.mkdir(parents=True)
+    hints = directory / "hints.md"
+    hints.write_text("quasar")
+    assert search_strategies(ctx, "quasar")
+    hints.write_text("nebula")
+    assert not search_strategies(ctx, "quasar")
+    assert search_strategies(ctx, "nebula")
+    hints.unlink()
+    assert not search_strategies(ctx, "nebula")
+    skill = ctx.artifacts._skill_dir("grid_ctf") / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("## Operational Lessons\n- quasar\n")
+    assert search_strategies(ctx, "quasar")
+    skill.write_text("## Operational Lessons\n- nebula\n")
+    assert not search_strategies(ctx, "quasar")
+    assert search_strategies(ctx, "nebula")
+
+
+def test_database_changes_are_visible_after_warming_cache(ctx: MtsToolContext) -> None:
+    assert _build_search_index(ctx)[0]["completed_runs"] == 1
+    ctx.sqlite.create_run("run2", "grid_ctf", 3, "local")
+    ctx.sqlite.mark_run_completed("run2")
+    with ctx.sqlite.connection() as conn:
+        conn.execute(
+            "INSERT INTO knowledge_snapshots(scenario, run_id, best_score, best_elo, playbook_hash) VALUES (?, ?, ?, ?, ?)",
+            ("grid_ctf", "run2", 0.9, 1700.0, "hash"),
+        )
+    entry = _build_search_index(ctx)[0]
+    assert entry["completed_runs"] == 2
+    assert entry["best_score"] == 0.9
+    assert entry["best_elo"] == 1700.0
+    with ctx.sqlite.connection() as conn:
+        conn.execute("UPDATE runs SET status = 'running'")
+    assert _build_search_index(ctx) == []
+
+
+def test_empty_query_does_no_io(ctx: MtsToolContext, monkeypatch: pytest.MonkeyPatch) -> None:
+    connect = MagicMock(side_effect=AssertionError("unexpected SQL"))
+    monkeypatch.setattr(ctx.sqlite, "connect", connect)
+    assert search_strategies(ctx, "the and") == []
+    assert search_strategies(ctx, "flag", top_k=0) == []
+
+
+def test_cache_does_not_cross_artifact_stores(ctx: MtsToolContext, tmp_path: Path) -> None:
+    ctx.artifacts.write_playbook("grid_ctf", "quasar")
+    assert search_strategies(ctx, "quasar")
+    other = MtsToolContext(ctx.settings.model_copy(update={"knowledge_root": tmp_path / "other"}))
+    assert not search_strategies(other, "quasar")
+
+
+def test_structured_hint_state_changes_invalidate_cached_search(ctx: MtsToolContext) -> None:
+    import json
+
+    from autocontext.domain.hints import HintManager, HintVolumePolicy
+
+    ctx.artifacts.write_hint_manager("grid_ctf", HintManager.from_hint_text("- quasar", policy=HintVolumePolicy()))
+    assert search_strategies(ctx, "quasar")
+    # Change only structured state; leave the old flat hints snapshot in place.
+    state = ctx.artifacts._scenario_dir("grid_ctf") / "hint_state.json"
+    state.write_text(json.dumps(HintManager.from_hint_text("- nebula", policy=HintVolumePolicy()).to_dict()))
+    assert not search_strategies(ctx, "quasar")
+    assert search_strategies(ctx, "nebula")


### PR DESCRIPTION
Python generations currently call the architect even between scheduled interventions, and role scheduling waits on independent work. This change skips architect provider calls outside the configured cadence, preserves zero-token skipped execution records, and shares dependency-based scheduling between direct and pipeline execution. With the default cadence, architect calls occur on generations 3, 6, 9, etc.; setting the cadence to 1 retains an architect call every generation. RLM sessions retain serial execution and use the same cadence policy.

Strategy search batches completed-run counts and best snapshots into one database lookup and caches unchanged knowledge contents and tokenized fields, checking file revisions for external edits. Python CI runs four module-preserving shards, combines coverage under the existing required `test` status, and starts smoke checks independently. The aggregator requires every shard to succeed and every coverage file to be present.

Updated against current main, including the CI/release hardening and dataclass fixes. The new aggregation job retains read-only permissions, disabled checkout credentials/caches, and the pinned uv installer and version. The ordinary CI workflow has no service secrets or publishing permissions.

Validation:
- Original implementation: 198 focused tests covering cadence, concurrency, provider isolation, failure handling, search invalidation, RLM/runtime integration, and shard partitioning; Ruff, mypy, protocol parity, Markdown links, and shard/coverage smoke checks passed.
- Current-main update: 59 focused runtime/search/sharding/workflow tests and 21 release-source guard tests passed. Full Python Ruff, actionlint, Markdown links and whitespace checks passed. Workflow security tests and actionlint passed again after adding the coverage completeness check. Full current-head CI remains required.
- Independent workflow review confirmed that shard failures cannot satisfy the required `test` check and that the release/live safeguards remain intact.

Python-first change; TypeScript runtime parity is deferred. The existing scenario discovery API on main is preserved, keeping this PR independent of the separate authorization and scenario-isolation work.
