### PR TITLE
Harden CI and releases while preserving worker event ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ jobs:
         working-directory: autocontext
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install
         run: uv sync --locked --group dev
@@ -42,6 +45,9 @@ jobs:
         run: uv run ruff check src tests
       - name: Mypy
         run: uv run mypy src
+      - name: Release source guard tests
+        working-directory: .
+        run: python -m unittest discover -s scripts -p "test_release_source.py"
       - name: Protocol parity check
         run: uv run python ../scripts/generate_protocol.py --check
       - name: Markdown link integrity
@@ -54,12 +60,15 @@ jobs:
         working-directory: autocontext
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install
         run: uv sync --locked --group dev
@@ -81,12 +90,15 @@ jobs:
         working-directory: autocontext
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install
         run: uv sync --locked --group dev
@@ -107,12 +119,15 @@ jobs:
         working-directory: autocontext
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install
         run: uv sync --locked --group dev
@@ -144,15 +159,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
+          package-manager-cache: false
           node-version: "24"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install Python deps
         working-directory: autocontext
@@ -182,18 +201,23 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
+          package-manager-cache: false
           node-version: "24"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.4.0"
+          no-cache: true
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install pinned Python audit tool
         working-directory: autocontext
@@ -225,8 +249,11 @@ jobs:
         working-directory: ts
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
+          package-manager-cache: false
           node-version-file: ts/.nvmrc
       - name: Install TypeScript deps
         run: npm ci --ignore-scripts
@@ -247,11 +274,14 @@ jobs:
         working-directory: ts
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
+          package-manager-cache: false
           node-version-file: ts/.nvmrc
       - name: Reuse setup-node headers for native addons
         shell: bash
@@ -262,9 +292,11 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.4.0"
+          no-cache: true
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install Python parity deps
         working-directory: autocontext
@@ -310,12 +342,15 @@ jobs:
         working-directory: autocontext
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install
         run: uv sync --locked --group dev
@@ -361,12 +396,15 @@ jobs:
       OPENAI_VERSION: ${{ matrix.openai-version }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install base deps
         run: uv sync --locked --group dev
@@ -388,11 +426,14 @@ jobs:
       OPENAI_VERSION: ${{ matrix.openai-version }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
+          package-manager-cache: false
           node-version: "24"
       - name: Reuse setup-node headers for native addons
         shell: bash
@@ -401,8 +442,9 @@ jobs:
           test -d "$nodedir/include/node"
           echo "npm_config_nodedir=$nodedir" >> "$GITHUB_ENV"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install Python parity deps
         working-directory: autocontext
@@ -435,12 +477,15 @@ jobs:
       ANTHROPIC_VERSION: ${{ matrix.anthropic-version }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install base deps
         run: uv sync --locked --group dev
@@ -462,15 +507,19 @@ jobs:
       ANTHROPIC_VERSION: ${{ matrix.anthropic-version }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
+          package-manager-cache: false
           node-version: "24"
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install Python parity deps
         working-directory: autocontext
@@ -481,54 +530,3 @@ jobs:
         run: npm install --ignore-scripts --no-save "@anthropic-ai/sdk@$ANTHROPIC_VERSION"
       - name: Run Anthropic integration tests
         run: npm test -- --run --reporter=verbose tests/integrations/ tests/control-plane/instrument/
-
-  primeintellect-live:
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: autocontext
-    env:
-      AUTOCONTEXT_PRIMEINTELLECT_API_KEY: ${{ secrets.AUTOCONTEXT_PRIMEINTELLECT_API_KEY }}
-      AUTOCONTEXT_ANTHROPIC_API_KEY: ${{ secrets.AUTOCONTEXT_ANTHROPIC_API_KEY }}
-    steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-        with:
-          python-version: "3.11"
-      - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
-        with:
-          enable-cache: false
-      - name: Install
-        run: uv sync --locked --group dev
-      - name: Live PrimeIntellect verification
-        if: ${{ env.AUTOCONTEXT_PRIMEINTELLECT_API_KEY != '' && env.AUTOCONTEXT_ANTHROPIC_API_KEY != '' }}
-        env:
-          AUTOCONTEXT_EXECUTOR_MODE: primeintellect
-          AUTOCONTEXT_PRIMEINTELLECT_API_BASE: https://api.primeintellect.ai
-          AUTOCONTEXT_AGENT_PROVIDER: anthropic
-        run: uv run autoctx run --scenario grid_ctf --gens 1 --run-id ci_prime_live
-      - name: Live PrimeIntellect accelerator verification
-        if: >-
-          ${{ env.AUTOCONTEXT_PRIMEINTELLECT_API_KEY != '' &&
-              env.AUTOCONTEXT_ANTHROPIC_API_KEY != '' &&
-              vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_KIND != '' &&
-              vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_COUNT != '' &&
-              vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_REGION != '' &&
-              vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_IMAGE != '' }}
-        env:
-          AUTOCONTEXT_EXECUTOR_MODE: primeintellect
-          AUTOCONTEXT_PRIMEINTELLECT_API_BASE: https://api.primeintellect.ai
-          AUTOCONTEXT_AGENT_PROVIDER: anthropic
-          AUTOCONTEXT_PRIMEINTELLECT_ACCELERATOR_KIND: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_KIND }}
-          AUTOCONTEXT_PRIMEINTELLECT_ACCELERATOR_COUNT: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_COUNT }}
-          AUTOCONTEXT_PRIMEINTELLECT_REGION: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_REGION }}
-          AUTOCONTEXT_PRIMEINTELLECT_SUPPORTED_ACCELERATOR_KINDS: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_KIND }}
-          AUTOCONTEXT_PRIMEINTELLECT_MAX_ACCELERATOR_COUNT: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_COUNT }}
-          AUTOCONTEXT_PRIMEINTELLECT_SUPPORTED_REGIONS: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_REGION }}
-          AUTOCONTEXT_PRIMEINTELLECT_SUPPORTED_IMAGES: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_IMAGE }}
-          AUTOCONTEXT_PRIMEINTELLECT_DOCKER_IMAGE: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_IMAGE }}
-          AUTOCONTEXT_PRIMEINTELLECT_REQUIRED_TELEMETRY: hardware_identity
-          AUTOCONTEXT_PRIMEINTELLECT_AVAILABLE_TELEMETRY: hardware_identity
-        run: uv run autoctx run --scenario grid_ctf --gens 1 --run-id ci_prime_accelerator_live

--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -1,0 +1,76 @@
+name: live-integration
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: live-integration
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  primeintellect-live:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: live-integration
+    defaults:
+      run:
+        working-directory: autocontext
+    steps:
+      # Review the dispatched main commit before approving this environment.
+      # Step-scoped secrets reduce exposure; they do not isolate background
+      # processes started by earlier steps. All code and dependencies here
+      # must be trusted. No artifact from a pull-request run is consumed.
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.12.7"
+          enable-cache: false
+      - name: Install dependencies without service credentials
+        run: uv sync --locked --group dev
+      - name: Live PrimeIntellect verification
+        env:
+          AUTOCONTEXT_PRIMEINTELLECT_API_KEY: ${{ secrets.AUTOCONTEXT_PRIMEINTELLECT_API_KEY }}
+          AUTOCONTEXT_ANTHROPIC_API_KEY: ${{ secrets.AUTOCONTEXT_ANTHROPIC_API_KEY }}
+          AUTOCONTEXT_EXECUTOR_MODE: primeintellect
+          AUTOCONTEXT_PRIMEINTELLECT_API_BASE: https://api.primeintellect.ai
+          AUTOCONTEXT_AGENT_PROVIDER: anthropic
+        run: |
+          if [ -z "$AUTOCONTEXT_PRIMEINTELLECT_API_KEY" ] || [ -z "$AUTOCONTEXT_ANTHROPIC_API_KEY" ]; then
+            echo "Configure both service API keys in the live-integration environment before running this workflow." >&2
+            exit 1
+          fi
+          uv run --no-sync autoctx run --scenario grid_ctf --gens 1 --run-id ci_prime_live
+      - name: Live PrimeIntellect accelerator verification
+        if: >-
+          ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_KIND != '' &&
+              vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_COUNT != '' &&
+              vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_REGION != '' &&
+              vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_IMAGE != '' }}
+        env:
+          AUTOCONTEXT_PRIMEINTELLECT_API_KEY: ${{ secrets.AUTOCONTEXT_PRIMEINTELLECT_API_KEY }}
+          AUTOCONTEXT_ANTHROPIC_API_KEY: ${{ secrets.AUTOCONTEXT_ANTHROPIC_API_KEY }}
+          AUTOCONTEXT_EXECUTOR_MODE: primeintellect
+          AUTOCONTEXT_PRIMEINTELLECT_API_BASE: https://api.primeintellect.ai
+          AUTOCONTEXT_AGENT_PROVIDER: anthropic
+          AUTOCONTEXT_PRIMEINTELLECT_ACCELERATOR_KIND: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_KIND }}
+          AUTOCONTEXT_PRIMEINTELLECT_ACCELERATOR_COUNT: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_COUNT }}
+          AUTOCONTEXT_PRIMEINTELLECT_REGION: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_REGION }}
+          AUTOCONTEXT_PRIMEINTELLECT_SUPPORTED_ACCELERATOR_KINDS: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_KIND }}
+          AUTOCONTEXT_PRIMEINTELLECT_MAX_ACCELERATOR_COUNT: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_ACCELERATOR_COUNT }}
+          AUTOCONTEXT_PRIMEINTELLECT_SUPPORTED_REGIONS: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_REGION }}
+          AUTOCONTEXT_PRIMEINTELLECT_SUPPORTED_IMAGES: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_IMAGE }}
+          AUTOCONTEXT_PRIMEINTELLECT_DOCKER_IMAGE: ${{ vars.AUTOCONTEXT_PRIMEINTELLECT_LIVE_IMAGE }}
+          AUTOCONTEXT_PRIMEINTELLECT_REQUIRED_TELEMETRY: hardware_identity
+          AUTOCONTEXT_PRIMEINTELLECT_AVAILABLE_TELEMETRY: hardware_identity
+        run: uv run --no-sync autoctx run --scenario grid_ctf --gens 1 --run-id ci_prime_accelerator_live

--- a/.github/workflows/publish-pi-autocontext.yml
+++ b/.github/workflows/publish-pi-autocontext.yml
@@ -14,7 +14,31 @@ permissions:
   contents: read
 
 jobs:
+  validate-source:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      checks: read
+    outputs:
+      sha: ${{ steps.authorize.outputs.sha }}
+    steps:
+      # Load policy from protected main, before executing any release source.
+      # Tag rules and registry environment binding must also protect this workflow.
+      - name: Check out trusted release policy
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: main
+          path: release-policy
+          persist-credentials: false
+      - name: Authorize release source and exact-commit CI
+        id: authorize
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 release-policy/scripts/check_release_source.py --tag-prefix pi-v
+
   build-npm:
+    needs: validate-source
     runs-on: ubuntu-latest
     env:
       # Delay fresh npm versions during publish workflow dependency installs.
@@ -24,9 +48,13 @@ jobs:
         working-directory: pi
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.validate-source.outputs.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
       - name: Install npm with release-age exclusions
         run: npm install --global npm@12.0.1
@@ -79,6 +107,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
       - name: Download verified package artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -14,13 +14,40 @@ permissions:
   contents: read
 
 jobs:
+  validate-source:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      checks: read
+    outputs:
+      sha: ${{ steps.authorize.outputs.sha }}
+    steps:
+      # Load policy from protected main, before executing any release source.
+      # Tag rules and registry environment binding must also protect this workflow.
+      - name: Check out trusted release policy
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: main
+          path: release-policy
+          persist-credentials: false
+      - name: Authorize release source and exact-commit CI
+        id: authorize
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 release-policy/scripts/check_release_source.py --tag-prefix py-v
+
   build-python:
+    needs: validate-source
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: autocontext
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.validate-source.outputs.sha }}
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
@@ -45,8 +72,9 @@ jobs:
               sys.exit(1)
           PY
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
+          version: "0.12.7"
           enable-cache: false
       - name: Install pinned audit dependencies
         run: uv sync --locked --group dev

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -14,7 +14,31 @@ permissions:
   contents: read
 
 jobs:
+  validate-source:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      checks: read
+    outputs:
+      sha: ${{ steps.authorize.outputs.sha }}
+    steps:
+      # Load policy from protected main, before executing any release source.
+      # Tag rules and registry environment binding must also protect this workflow.
+      - name: Check out trusted release policy
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: main
+          path: release-policy
+          persist-credentials: false
+      - name: Authorize release source and exact-commit CI
+        id: authorize
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 release-policy/scripts/check_release_source.py --tag-prefix ts-v
+
   build-npm:
+    needs: validate-source
     runs-on: ubuntu-latest
     env:
       # Delay fresh npm versions during publish workflow dependency installs.
@@ -24,13 +48,18 @@ jobs:
         working-directory: ts
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.validate-source.outputs.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.4.0"
+          no-cache: true
       - name: Validate tag matches TypeScript package version
         if: startsWith(github.ref, 'refs/tags/ts-v')
         run: |
@@ -74,6 +103,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
       - name: Download verified package artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+- Release workflows validate protected-main ancestry and successful CI for the
+  exact release commit before building or publishing. Live service checks move
+  to a manual, main-only workflow behind independent environment approval.
+  Workflow credentials and caches are restricted, and the uv installer and
+  tool version are pinned.
+- TypeScript and Pi dependency locks update fast-uri and qs to resolve the
+  current high/moderate production audit findings without changing the sandbox
+  runtime API or weakening the audit threshold.
 - Control-plane WebSockets no longer accept bearer credentials in query strings;
   browser clients use an authenticated, echoed subprotocol, native clients may
   use the Authorization header, and the TUI authenticates both HTTP and WebSocket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Interactive runs tolerate bursts of valid worker events before a controller
+  request without aborting. Event queues remain bounded, and terminal-result,
+  process-exit and controller-token checks still reject invalid requests.
+
 ### Security
 
 - Release workflows validate protected-main ancestry and successful CI for the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,9 +115,36 @@ Publishing is split by package and uses GitHub OIDC trusted publishing rather th
 Release notes:
 
 - Keep the GitHub environment branch/tag policy restricted to `main` and the matching tag namespace.
+- Merge release preparation into protected `main` and wait for CI on that exact
+  commit before creating a release tag. The release guard is loaded from `main`,
+  verifies that the release commit belongs to its history, and requires a
+  successful main-push CI run with `lint`, `test`, `smoke`,
+  `dependency-security`, `ts-lint`, and `ts-test` from GitHub Actions.
+- Release tags are immutable and may be created only by the configured release
+  maintainers. A different configured reviewer must approve publication;
+  publishing environments prohibit self-approval and administrator bypass.
 - The trusted publisher registration in PyPI and npm must match the repo, workflow filename, and environment name exactly.
 - No `NPM_TOKEN`, `NODE_AUTH_TOKEN`, or PyPI API token should be required for the publish jobs.
 - After cutover, remove the old combined `.github/workflows/publish.yml` publisher registration from PyPI and npm.
+
+## Live Service Verification
+
+Live PrimeIntellect checks run through the manual `live-integration` workflow
+from `main`. They do not run on pull requests or automatically after merges.
+Review the dispatched commit and approve the `live-integration` environment
+using a different configured reviewer from the person who started the run.
+
+Before enabling live checks, configure `AUTOCONTEXT_PRIMEINTELLECT_API_KEY` and
+`AUTOCONTEXT_ANTHROPIC_API_KEY` as secrets of that environment. Do not expose
+these keys as repository-wide or inherited organization secrets. Missing keys
+fail the manual run. The optional accelerator check uses the existing
+`AUTOCONTEXT_PRIMEINTELLECT_LIVE_*` environment variables.
+
+Dependency setup receives no service-key environment variables. Only the live
+commands receive the keys, and `uv run --no-sync` avoids reinstalling packages
+while they are present. This limits accidental exposure; all reviewed code in
+the job is still trusted, because step boundaries do not isolate malicious
+background processes.
 
 ## Type System Conventions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,29 @@ We will aim to:
 ## Supported Versions
 
 This project is pre-1.0 and moving quickly. Security fixes, when available, are expected to land on the latest mainline version rather than through long-lived backport branches.
+
+## CI and Release Trust Boundaries
+
+External contributors require workflow approval even after an earlier PR has
+been merged. Review the exact head before approving a run, and review new
+commits again. Main requires fresh review and the Python, TypeScript, smoke,
+and dependency-security checks from GitHub Actions.
+
+Pull-request CI runs with read-only repository permissions on GitHub-hosted
+runners. Keep privileged PR triggers, service secrets, publishing credentials,
+and untrusted artifact promotion out of those jobs. Pin action commits and
+tool versions, disable unnecessary caches, and avoid persisting checkout
+credentials.
+
+Release builds validate their source against protected main and successful CI
+before producing artifacts. Publication uses a separate job, the artifact from
+that same workflow run, and a protected environment with independent approval.
+Release tag creation is restricted, and existing release tags are immutable.
+The corresponding PyPI/npm trusted publisher must require the exact repository,
+workflow filename, and protected environment. These GitHub and registry settings
+must be maintained together; workflow files alone cannot enforce registry trust.
+
+Live service credentials belong only in the protected `live-integration`
+environment. The main-only manual workflow scopes them to live command steps.
+Reviewers must still trust all code and dependencies in that job: separate
+steps are not a process-isolation boundary.

--- a/autocontext/src/autocontext/server/_run_process_monitor.py
+++ b/autocontext/src/autocontext/server/_run_process_monitor.py
@@ -331,7 +331,7 @@ def _monitor_run_process(
                         break
 
             waitables: list[Any] = []
-            if control_open:
+            if control_open and len(pending_events) < _MAX_PENDING_EVENTS:
                 waitables.append(control_connection)
             if event_open and len(pending_events) < _MAX_PENDING_EVENTS:
                 waitables.append(event_connection)
@@ -339,7 +339,11 @@ def _monitor_run_process(
                 waitables.append(process.sentinel)
 
             buffered_ready: list[Any] = []
-            if control_open and control_reader.has_buffered_frame:
+            if (
+                control_open
+                and len(pending_events) < _MAX_PENDING_EVENTS
+                and control_reader.has_buffered_frame
+            ):
                 buffered_ready.append(control_connection)
             if (
                 event_open
@@ -403,7 +407,10 @@ def _monitor_run_process(
                     )
 
             requests: list[dict[str, Any]] = []
-            if control_ready:
+            # Ordinary event bursts can temporarily fill the bounded queue.
+            # Leave control unread until we scan the earlier events, including
+            # any terminal result; the relay supplies backpressure meanwhile.
+            if control_ready and not event_backlog_unscanned:
                 requests, control_open = control_reader.receive_available(
                     read_from_fd=(
                         not idle_expired
@@ -416,10 +423,6 @@ def _monitor_run_process(
                 observe_leader()
 
             if requests:
-                if event_backlog_unscanned:
-                    raise _RunProcessProtocolError(
-                        "interactive run event backlog hid controller ordering"
-                    )
                 if process_exited:
                     raise _RunProcessProtocolError(
                         "interactive run sent controller data after process exit"

--- a/autocontext/tests/test_run_process_monitor_backpressure.py
+++ b/autocontext/tests/test_run_process_monitor_backpressure.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import threading
+import time
+from multiprocessing.connection import wait
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from autocontext.server._run_process_ipc import _send_json_message
+from autocontext.server._run_process_monitor import _monitor_run_process
+
+
+@pytest.mark.parametrize("event_count", [5, 65])
+@pytest.mark.parametrize("control_case", ["valid", "terminal", "missing-token", "stale-token", "exited"])
+def test_monitor_scans_event_burst_before_admitting_control(
+    event_count: int,
+    control_case: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A queued burst must drain, while a terminal result still bars control."""
+    parent_control, child_control = multiprocessing.Pipe(duplex=True)
+    parent_events, child_events = multiprocessing.Pipe(duplex=False)
+    sentinel, sentinel_writer = multiprocessing.Pipe(duplex=False)
+    process = SimpleNamespace(sentinel=sentinel, exitcode=0)
+    exited = threading.Event()
+    manager = Mock()
+    result = {"type": "result", "run_id": "burst-run", "ok": True, "best_score": 1.0}
+
+    def finish_child(*_args: object, **_kwargs: object) -> None:
+        _send_json_message(child_events, result)
+        child_control.close()
+        child_events.close()
+        exited.set()
+
+    manager._dispatch_control_request.side_effect = finish_child
+    deadline = time.monotonic() + 5.0
+    observations = 0
+
+    def observe_process(_process: object) -> str:
+        nonlocal observations
+        observations += 1
+        if time.monotonic() >= deadline:
+            raise TimeoutError("monitor did not finish the preloaded event burst")
+        if control_case == "exited" and observations > 1:
+            return "exited"
+        return "exited" if exited.is_set() else "running"
+
+    try:
+        # Both channels are ready before monitoring starts, without depending on
+        # child-process scheduling or the host's process-ownership primitives.
+        for index in range(event_count):
+            _send_json_message(
+                child_events,
+                {"type": "event", "event": "burst", "payload": {"index": index}, "channel": "generation"},
+            )
+        if control_case == "terminal":
+            _send_json_message(child_events, result)
+        request: dict[str, object] = {"type": "control", "operation": "is_paused", "args": [], "token": None}
+        if control_case == "missing-token":
+            request.pop("token")
+        elif control_case == "stale-token":
+            request["token"] = "stale"
+        _send_json_message(child_control, request)
+
+        _monitor_run_process(
+            manager,
+            process,
+            parent_control,
+            parent_events,
+            "burst-run",
+            1,
+            observe_process=observe_process,
+            terminate_process=lambda _process: True,
+            close_connection=lambda connection: connection.close(),
+            wait_for_connections=wait,
+            ownership_lost_error=RuntimeError,
+            cleanup_lock=threading.Lock(),
+            result_exit_grace_seconds=1.0,
+            post_exit_idle_drain_seconds=0.2,
+            post_exit_max_drain_seconds=2.0,
+            logger=logging.getLogger(__name__),
+        )
+    finally:
+        for connection in (parent_control, child_control, parent_events, child_events, sentinel, sentinel_writer):
+            connection.close()
+
+    if control_case != "valid":
+        manager._dispatch_control_request.assert_not_called()
+        expected_error = {
+            "terminal": "after its terminal result",
+            "missing-token": "invalid controller sequence token",
+            "stale-token": "invalid controller sequence token",
+            "exited": "after process exit",
+        }[control_case]
+        assert expected_error in caplog.text
+    else:
+        manager._dispatch_control_request.assert_called_once()
+        assert [call.args[1]["index"] for call in manager.events.emit.call_args_list] == list(range(event_count))
+        assert "monitor failed" not in caplog.text

--- a/autocontext/tests/test_workflow_security.py
+++ b/autocontext/tests/test_workflow_security.py
@@ -87,8 +87,83 @@ def test_publish_oidc_is_limited_to_artifact_only_jobs() -> None:
 
 def test_live_provider_secrets_are_not_available_to_pull_requests() -> None:
     workflow = (_WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
-    live_job = workflow.split("  primeintellect-live:\n", maxsplit=1)[1]
-    assert live_job.startswith("    if: github.event_name != 'pull_request'\n")
+    # BaseLoader preserves YAML's `on` key rather than treating it as a boolean.
+    document = yaml.load(workflow, Loader=yaml.BaseLoader)
+    assert set(document["on"]) == {"push", "pull_request"}
+    assert "secrets." not in workflow
+    assert document["permissions"] == {"contents": "read"}
+    for job in document["jobs"].values():
+        assert job.get("permissions", {"contents": "read"}) == {"contents": "read"}
+        assert "environment" not in job
+        assert job["runs-on"] in {"ubuntu-latest", "windows-latest"}
+
+
+def test_live_service_execution_requires_manual_main_environment_approval() -> None:
+    document = yaml.load((_WORKFLOWS / "live-integration.yml").read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert set(document["on"]) == {"workflow_dispatch"}
+    assert document["permissions"] == {"contents": "read"}
+    assert document["jobs"], "The manual workflow must retain live verification"
+    for job in document["jobs"].values():
+        assert job["if"] == "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'"
+        assert job["environment"] == "live-integration"
+        assert job.get("permissions", {"contents": "read"}) == {"contents": "read"}
+        assert job["runs-on"] == "ubuntu-latest"
+        for step in job["steps"]:
+            action = step.get("uses", "").split("@", maxsplit=1)[0]
+            assert action not in {"actions/upload-artifact", "actions/download-artifact"}
+            if action == "actions/checkout":
+                assert step["with"]["ref"] == "${{ github.sha }}"
+
+
+def test_live_service_credentials_are_scoped_to_no_sync_execution_steps() -> None:
+    document = yaml.load((_WORKFLOWS / "live-integration.yml").read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert "secrets." not in str(document.get("env", {}))
+    credential_steps = 0
+    for job in document["jobs"].values():
+        assert "secrets." not in str({key: value for key, value in job.items() if key != "steps"})
+        installed = False
+        for step in job["steps"]:
+            run = step.get("run", "")
+            if "uv sync --locked" in run:
+                assert "secrets." not in str(step)
+                installed = True
+            if "secrets." not in str(step):
+                continue
+            credential_steps += 1
+            assert installed, "Install dependencies before exposing service credentials"
+            assert "uses" not in step
+            assert "uv run --no-sync autoctx run" in run
+            assert "uv sync" not in run
+            assert "secrets." not in str({key: value for key, value in step.items() if key != "env"})
+            assert step["env"]["AUTOCONTEXT_PRIMEINTELLECT_API_KEY"] == (
+                "${{ secrets.AUTOCONTEXT_PRIMEINTELLECT_API_KEY }}"
+            )
+            assert step["env"]["AUTOCONTEXT_ANTHROPIC_API_KEY"] == "${{ secrets.AUTOCONTEXT_ANTHROPIC_API_KEY }}"
+    assert credential_steps == 2, "Retain the ordinary and optional accelerator live checks"
+
+
+def test_ci_and_live_setup_do_not_persist_credentials_or_executable_caches() -> None:
+    for name in ("ci.yml", "live-integration.yml"):
+        document = yaml.load((_WORKFLOWS / name).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+        for job_name, job in document["jobs"].items():
+            for step in job["steps"]:
+                action = step.get("uses", "").split("@", maxsplit=1)[0]
+                inputs = step.get("with", {})
+                context = f"{name}:{job_name}:{action}"
+                if action == "actions/checkout":
+                    assert inputs.get("persist-credentials") == "false", context
+                elif action == "actions/setup-node":
+                    assert inputs.get("package-manager-cache") == "false", context
+                    assert not inputs.get("cache"), context
+                elif action == "actions/setup-python":
+                    assert not inputs.get("cache"), context
+                elif action == "oven-sh/setup-bun":
+                    assert inputs.get("no-cache") == "true", context
+                elif action == "astral-sh/setup-uv":
+                    assert inputs.get("enable-cache") == "false", context
+                    assert re.fullmatch(r"\d+\.\d+\.\d+", inputs.get("version", "")), context
+                    # The old ref is an annotated tag object, not a commit.
+                    assert "94527f2e458b27549849d47d273a16bec83a01e9" not in step["uses"], context
 
 
 def test_compose_enforces_runtime_hardening_defaults() -> None:

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -83,13 +83,25 @@ npm pack --dry-run
 - Confirm `python scripts/sync_release_surfaces.py --check` passes.
 - Confirm `python scripts/check_markdown_links.py` passes.
 - Confirm any install commands in the READMEs still match the package names and binaries.
+- Confirm the registry's trusted publisher requires the exact package workflow
+  and protected environment. A matching environment name in YAML alone does
+  not establish the registry's authentication constraints.
+- Confirm the release guard changes, if any, have already landed on protected
+  `main`; publishing loads this policy from `main` before executing release
+  source code.
 
 ## 6. Publish
 
-- Merge the release prep to the intended branch.
-- Create and push package-specific tags in the format `py-vX.Y.Z`, `ts-vX.Y.Z`, and `pi-vX.Y.Z`.
+- Merge the release prep to protected `main` and wait for a successful main-push
+  CI run on the exact release commit, including security and TypeScript checks.
+- A configured release maintainer creates package-specific tags in the format
+  `py-vX.Y.Z`, `ts-vX.Y.Z`, and `pi-vX.Y.Z` at that tested commit. Tags cannot be
+  updated or deleted; correct a release with a new version instead of moving
+  an existing tag.
 - Watch the tag-triggered GitHub Actions `publish-python`, `publish-ts`, and `publish-pi-autocontext` workflows for PyPI and npm.
-- Approve the package-specific publish environment when the trusted publish jobs pause for deployment review.
+- A different configured reviewer approves the package-specific publish
+  environment when the trusted publish jobs pause for deployment review.
+  Self-approval and administrator bypass are disabled.
 - If releasing `pi-autocontext` with a dependency on a new `autoctx` version, publish and verify `autoctx` first, then push the `pi-vX.Y.Z` tag.
 
 ## 7. Post-Release

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -5173,9 +5173,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -6910,9 +6910,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/pi/package.json
+++ b/pi/package.json
@@ -32,7 +32,7 @@
   "overrides": {
     "@hono/node-server": "1.19.15",
     "brace-expansion": "5.0.9",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
     "nanoid": "3.3.18",

--- a/scripts/check_release_source.py
+++ b/scripts/check_release_source.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Authorize a release SHA using protected main and a successful same-SHA CI run.
+
+Run this copy from protected main, before checking out/building release source.
+Tag creation rules and registry OIDC environment restrictions remain necessary:
+a guard in workflow YAML cannot stop a writer who can replace that YAML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+REPOSITORY = "greyhaven-ai/autocontext"
+API_ROOT = f"https://api.github.com/repos/{REPOSITORY}"
+ACTIONS_APP_ID = 15368
+REQUIRED_JOBS = ("lint", "test", "smoke", "dependency-security", "ts-lint", "ts-test")
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
+TAG_PREFIXES = ("py-v", "ts-v", "pi-v")
+JsonObject = dict[str, Any]
+Reader = Callable[[str], JsonObject]
+
+
+class ReleasePolicyError(Exception):
+    """The release did not satisfy the policy, including unavailable evidence."""
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        raise ReleasePolicyError("GitHub API redirected; refusing to forward credentials")
+
+
+class GitHubReader:
+    def __init__(self, token: str) -> None:
+        self.token = token
+        self.opener = urllib.request.build_opener(NoRedirect)
+
+    def __call__(self, path: str) -> JsonObject:
+        if not path.startswith("/") or path.startswith("//"):
+            raise ReleasePolicyError("Invalid GitHub API path")
+        request = urllib.request.Request(
+            API_ROOT + path,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with self.opener.open(request, timeout=30) as response:
+                result = json.load(response)
+        except urllib.error.HTTPError as exc:
+            raise ReleasePolicyError(f"GitHub API request failed (HTTP {exc.code})") from exc
+        except (OSError, ValueError) as exc:
+            raise ReleasePolicyError("GitHub API evidence is unavailable or invalid") from exc
+        if not isinstance(result, dict):
+            raise ReleasePolicyError("GitHub API returned an unexpected response")
+        return result
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ReleasePolicyError(message)
+
+
+def valid_sha(value: Any) -> bool:
+    return isinstance(value, str) and SHA_PATTERN.fullmatch(value) is not None
+
+
+def validate_ref(repository: str, event: str, ref: str, sha: str, tag_prefix: str) -> bool:
+    require(repository == REPOSITORY, "Release must run in the expected repository")
+    require(tag_prefix in TAG_PREFIXES, "Unknown package tag prefix")
+    require(valid_sha(sha), "Release SHA must be a full commit SHA")
+    require(event in ("push", "workflow_dispatch"), "Release event is not allowed")
+    if ref == "refs/heads/main":
+        require(event == "workflow_dispatch", "Only manual releases may target main directly")
+        return False
+    pattern = rf"refs/tags/{re.escape(tag_prefix)}[0-9][A-Za-z0-9.+_-]*\Z"
+    require(re.fullmatch(pattern, ref) is not None, "Release ref is not main or a package release tag")
+    return True
+
+
+def resolve_tag(read: Reader, ref: str) -> str:
+    tag_name = urllib.parse.quote(ref.removeprefix("refs/tags/"), safe="")
+    value = read(f"/git/ref/tags/{tag_name}")
+    require(value.get("ref") == ref, "GitHub returned a different release ref")
+    obj = value.get("object", {})
+    for _ in range(8):
+        require(isinstance(obj, dict) and valid_sha(obj.get("sha")), "Invalid release tag target")
+        if obj.get("type") == "commit":
+            return obj["sha"]
+        require(obj.get("type") == "tag", "Release tag does not resolve to a commit")
+        obj = read(f"/git/tags/{obj['sha']}").get("object", {})
+    raise ReleasePolicyError("Release tag indirection exceeds the policy limit")
+
+
+def latest_ci_run(read: Reader, sha: str) -> JsonObject:
+    query = urllib.parse.urlencode({"event": "push", "branch": "main", "head_sha": sha, "per_page": 100})
+    data = read(f"/actions/workflows/ci.yml/runs?{query}")
+    runs = data.get("workflow_runs")
+    require(isinstance(runs, list) and bool(runs), "No trusted main CI run exists for the release SHA")
+    # The API filter is not the trust decision: independently check each field.
+    candidates = [
+        run for run in runs
+        if isinstance(run, dict)
+        and run.get("head_sha") == sha
+        and run.get("event") == "push"
+        and run.get("head_branch") == "main"
+        and run.get("path") == ".github/workflows/ci.yml"
+        and run.get("repository", {}).get("full_name") == REPOSITORY
+        and run.get("head_repository", {}).get("full_name") == REPOSITORY
+        and isinstance(run.get("id"), int)
+    ]
+    require(bool(candidates), "No trusted main CI run matches the release SHA and workflow")
+    run = max(candidates, key=lambda item: item["id"])
+    require(run.get("status") == "completed" and run.get("conclusion") == "success",
+            "Latest trusted CI run is not successfully completed")
+    require(isinstance(run.get("run_attempt"), int) and run["run_attempt"] > 0,
+            "Trusted CI run has no valid attempt")
+    require(isinstance(run.get("check_suite_id"), int), "Trusted CI run has no check suite")
+    return run
+
+
+def validate_jobs(read: Reader, run: JsonObject, sha: str) -> None:
+    jobs: list[JsonObject] = []
+    run_id, attempt = run["id"], run["run_attempt"]
+    for page in range(1, 101):
+        data = read(f"/actions/runs/{run_id}/jobs?filter=latest&per_page=100&page={page}")
+        batch = data.get("jobs")
+        require(isinstance(batch, list), "GitHub returned invalid CI jobs")
+        jobs.extend(batch)
+        if len(batch) < 100:
+            break
+    else:
+        raise ReleasePolicyError("CI job pagination exceeds the policy limit")
+    for name in REQUIRED_JOBS:
+        matches = [job for job in jobs if isinstance(job, dict) and job.get("name") == name]
+        require(len(matches) == 1, f"CI must have exactly one required job: {name}")
+        job = matches[0]
+        require(job.get("run_id") == run_id
+                and isinstance(job.get("run_attempt"), int)
+                and 0 < job["run_attempt"] <= attempt,
+                f"Required job is from a different CI run or attempt: {name}")
+        require(job.get("head_sha") == sha, f"Required job targets a different commit: {name}")
+        require(job.get("status") == "completed" and job.get("conclusion") == "success",
+                f"Required CI job did not succeed: {name}")
+        check_url = job.get("check_run_url", "")
+        require(isinstance(check_url, str), f"Required job has no check run: {name}")
+        match = re.fullmatch(re.escape(API_ROOT) + r"/check-runs/([0-9]+)", check_url)
+        require(match is not None, f"Required job has an untrusted check URL: {name}")
+        check = read(f"/check-runs/{match[1]}")
+        app = check.get("app", {})
+        require(app.get("id") == ACTIONS_APP_ID and app.get("slug") == "github-actions",
+                f"Required check was not created by GitHub Actions: {name}")
+        require(check.get("head_sha") == sha and check.get("name") == name,
+                f"Required check does not match the release job: {name}")
+        require(check.get("check_suite", {}).get("id") == run["check_suite_id"],
+                f"Required check belongs to a different CI suite: {name}")
+        require(check.get("status") == "completed" and check.get("conclusion") == "success",
+                f"Required GitHub Actions check did not succeed: {name}")
+
+
+def authorize_release(read: Reader, *, repository: str, event: str, ref: str,
+                      sha: str, tag_prefix: str) -> JsonObject:
+    is_tag = validate_ref(repository, event, ref, sha, tag_prefix)
+    if is_tag:
+        require(resolve_tag(read, ref) == sha, "Release tag no longer resolves to the event commit")
+    main = read("/branches/main")
+    require(main.get("name") == "main" and main.get("protected") is True,
+            "Release policy requires protected main")
+    main_sha = main.get("commit", {}).get("sha")
+    require(valid_sha(main_sha), "Protected main has no valid commit SHA")
+    comparison = read(f"/compare/{sha}...{main_sha}")
+    require(comparison.get("status") in ("ahead", "identical")
+            and comparison.get("merge_base_commit", {}).get("sha") == sha,
+            "Release commit is not part of protected main history")
+    run = latest_ci_run(read, sha)
+    validate_jobs(read, run, sha)
+    return {"sha": sha, "ci_run_id": run["id"]}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag-prefix", choices=TAG_PREFIXES, required=True)
+    args = parser.parse_args()
+    try:
+        token = os.environ.get("GH_TOKEN", "")
+        require(bool(token), "GitHub read token is required")
+        result = authorize_release(
+            GitHubReader(token), repository=os.environ.get("GITHUB_REPOSITORY", ""),
+            event=os.environ.get("GITHUB_EVENT_NAME", ""), ref=os.environ.get("GITHUB_REF", ""),
+            sha=os.environ.get("GITHUB_SHA", ""), tag_prefix=args.tag_prefix,
+        )
+        output = os.environ.get("GITHUB_OUTPUT")
+        require(bool(output), "GitHub output file is required")
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"sha={result['sha']}\nci-run-id={result['ci_run_id']}\n")
+        print(f"Authorized release {result['sha']} using successful CI run {result['ci_run_id']}")
+        return 0
+    except ReleasePolicyError as exc:
+        print(f"Release denied: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_source.py
+++ b/scripts/test_release_source.py
@@ -1,0 +1,216 @@
+"""Security boundary tests use synthetic GitHub responses; no network or tokens."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+from urllib.parse import urlencode
+
+from check_release_source import (
+    ACTIONS_APP_ID,
+    API_ROOT,
+    REPOSITORY,
+    REQUIRED_JOBS,
+    ReleasePolicyError,
+    authorize_release,
+)
+
+RELEASE_SHA = "a" * 40
+MAIN_SHA = "b" * 40
+TAG_SHA = "c" * 40
+RUN_ID = 101
+SUITE_ID = 202
+RUNS_PATH = "/actions/workflows/ci.yml/runs?" + urlencode({
+    "event": "push", "branch": "main", "head_sha": RELEASE_SHA, "per_page": 100,
+})
+JOBS_PATH = f"/actions/runs/{RUN_ID}/jobs?filter=latest&per_page=100&page=1"
+COMPARE_PATH = f"/compare/{RELEASE_SHA}...{MAIN_SHA}"
+
+
+def evidence():
+    jobs = []
+    responses = {
+        "/git/ref/tags/ts-v1.2.3": {
+            "ref": "refs/tags/ts-v1.2.3", "object": {"type": "commit", "sha": RELEASE_SHA},
+        },
+        "/branches/main": {"name": "main", "protected": True, "commit": {"sha": MAIN_SHA}},
+        COMPARE_PATH: {"status": "ahead", "merge_base_commit": {"sha": RELEASE_SHA}},
+        RUNS_PATH: {"workflow_runs": [{
+            "id": RUN_ID, "head_sha": RELEASE_SHA, "event": "push", "head_branch": "main",
+            "path": ".github/workflows/ci.yml", "repository": {"full_name": REPOSITORY},
+            "head_repository": {"full_name": REPOSITORY}, "status": "completed",
+            "conclusion": "success", "run_attempt": 2, "check_suite_id": SUITE_ID,
+        }]},
+        JOBS_PATH: {"jobs": jobs},
+    }
+    for check_id, name in enumerate(REQUIRED_JOBS, start=300):
+        jobs.append({
+            "name": name, "run_id": RUN_ID, "run_attempt": 2, "head_sha": RELEASE_SHA,
+            "status": "completed", "conclusion": "success",
+            "check_run_url": f"{API_ROOT}/check-runs/{check_id}",
+        })
+        responses[f"/check-runs/{check_id}"] = {
+            "app": {"id": ACTIONS_APP_ID, "slug": "github-actions"},
+            "name": name, "head_sha": RELEASE_SHA, "status": "completed", "conclusion": "success",
+            "check_suite": {"id": SUITE_ID},
+        }
+    return responses
+
+
+class ReleaseSourceTests(unittest.TestCase):
+    def setUp(self):
+        self.responses = evidence()
+        self.calls = []
+        self.args = {
+            "repository": REPOSITORY, "event": "push", "ref": "refs/tags/ts-v1.2.3",
+            "sha": RELEASE_SHA, "tag_prefix": "ts-v",
+        }
+
+    def read(self, path):
+        self.calls.append(path)
+        if path not in self.responses:
+            raise ReleasePolicyError("Evidence unavailable")
+        return self.responses[path]
+
+    def authorize(self):
+        return authorize_release(self.read, **self.args)
+
+    def deny(self):
+        with self.assertRaises(ReleasePolicyError):
+            self.authorize()
+
+    def test_release_tag_with_main_ancestry_and_exact_ci_is_allowed(self):
+        self.assertEqual(self.authorize(), {"sha": RELEASE_SHA, "ci_run_id": RUN_ID})
+
+    def test_manual_main_release_with_older_reviewed_sha_is_allowed(self):
+        self.args.update(event="workflow_dispatch", ref="refs/heads/main")
+        self.authorize()
+        self.assertNotIn("/git/ref/tags/ts-v1.2.3", self.calls)
+
+    def test_annotated_release_tag_is_resolved_to_commit(self):
+        self.responses["/git/ref/tags/ts-v1.2.3"]["object"] = {"type": "tag", "sha": TAG_SHA}
+        self.responses[f"/git/tags/{TAG_SHA}"] = {"object": {"type": "commit", "sha": RELEASE_SHA}}
+        self.authorize()
+
+    def test_identical_main_commit_is_allowed(self):
+        self.responses[COMPARE_PATH]["status"] = "identical"
+        self.authorize()
+
+    def test_untrusted_refs_events_repositories_and_sha_fail_before_api(self):
+        changes = [
+            {"repository": "attacker/autocontext"}, {"event": "pull_request"},
+            {"event": "pull_request_target"}, {"event": "workflow_run"},
+            {"event": "workflow_dispatch", "ref": "refs/heads/feature"},
+            {"ref": "refs/heads/main"}, {"ref": "refs/tags/py-v1.2.3"},
+            {"ref": "refs/tags/ts-v"}, {"ref": "refs/tags/ts-v1;echo-bad"},
+            {"ref": "refs/tags/ts-v1/../../main"}, {"sha": "a" * 7},
+            {"sha": RELEASE_SHA + "\n"}, {"tag_prefix": "ts-v.*"},
+        ]
+        for change in changes:
+            with self.subTest(change=change):
+                args = self.args | change
+                with self.assertRaises(ReleasePolicyError):
+                    authorize_release(self.read, **args)
+        self.assertEqual(self.calls, [])
+
+    def test_moved_tag_cannot_change_build_source(self):
+        self.responses["/git/ref/tags/ts-v1.2.3"]["object"]["sha"] = MAIN_SHA
+        self.deny()
+
+    def test_wrong_ref_response_is_rejected(self):
+        self.responses["/git/ref/tags/ts-v1.2.3"]["ref"] = "refs/tags/ts-v9"
+        self.deny()
+
+    def test_cyclic_annotated_tag_fails(self):
+        self.responses["/git/ref/tags/ts-v1.2.3"]["object"] = {"type": "tag", "sha": TAG_SHA}
+        self.responses[f"/git/tags/{TAG_SHA}"] = {"object": {"type": "tag", "sha": TAG_SHA}}
+        self.deny()
+
+    def test_non_commit_tag_target_fails(self):
+        self.responses["/git/ref/tags/ts-v1.2.3"]["object"]["type"] = "tree"
+        self.deny()
+
+    def test_unprotected_main_is_rejected(self):
+        self.responses["/branches/main"]["protected"] = False
+        self.deny()
+
+    def test_divergent_or_ahead_of_main_release_is_rejected(self):
+        for value in [{"status": "diverged"}, {"status": "behind"},
+                      {"merge_base_commit": {"sha": MAIN_SHA}}]:
+            with self.subTest(value=value):
+                self.responses[COMPARE_PATH] = {"status": "ahead", "merge_base_commit": {"sha": RELEASE_SHA}} | value
+                self.deny()
+
+    def test_ci_run_must_match_workflow_repo_event_branch_and_sha(self):
+        original = copy.deepcopy(self.responses[RUNS_PATH]["workflow_runs"][0])
+        for change in [{"head_sha": MAIN_SHA}, {"event": "pull_request"}, {"head_branch": "feature"},
+                       {"path": ".github/workflows/spoof.yml"},
+                       {"repository": {"full_name": "attacker/autocontext"}},
+                       {"head_repository": {"full_name": "attacker/autocontext"}}]:
+            with self.subTest(change=change):
+                self.responses[RUNS_PATH]["workflow_runs"] = [original | change]
+                self.deny()
+
+    def test_old_success_cannot_mask_latest_failed_or_in_progress_run(self):
+        original = self.responses[RUNS_PATH]["workflow_runs"][0]
+        for change in [{"conclusion": "failure"}, {"status": "in_progress", "conclusion": None}]:
+            with self.subTest(change=change):
+                self.responses[RUNS_PATH]["workflow_runs"] = [original, original | {"id": RUN_ID + 1} | change]
+                self.deny()
+
+    def test_missing_and_duplicate_required_job_are_rejected(self):
+        original = copy.deepcopy(self.responses[JOBS_PATH]["jobs"])
+        for jobs in [original[:-1], original + [original[0]]]:
+            with self.subTest(count=len(jobs)):
+                self.responses[JOBS_PATH]["jobs"] = jobs
+                self.deny()
+
+    def test_required_job_must_be_successful_and_same_sha_run(self):
+        original = copy.deepcopy(self.responses[JOBS_PATH]["jobs"][0])
+        for change in [{"conclusion": "skipped"}, {"conclusion": "failure"},
+                       {"status": "in_progress"}, {"head_sha": MAIN_SHA},
+                       {"run_id": RUN_ID + 1}, {"run_attempt": 3}]:
+            with self.subTest(change=change):
+                self.responses[JOBS_PATH]["jobs"][0] = original | change
+                self.deny()
+
+    def test_successful_previous_attempt_job_in_successful_partial_rerun_is_allowed(self):
+        self.responses[JOBS_PATH]["jobs"][0]["run_attempt"] = 1
+        self.authorize()
+
+    def test_check_url_cannot_send_token_to_other_host_or_repository(self):
+        for url in ["https://attacker.example/check-runs/1", "https://api.github.com/repos/attacker/x/check-runs/1",
+                    API_ROOT + "/check-runs/300?token=bad", API_ROOT + "/check-runs/300/../secret"]:
+            with self.subTest(url=url):
+                self.responses[JOBS_PATH]["jobs"][0]["check_run_url"] = url
+                self.deny()
+                self.assertNotIn(url, self.calls)
+
+    def test_forged_check_name_other_app_suite_or_sha_is_rejected(self):
+        original = copy.deepcopy(self.responses["/check-runs/300"])
+        for change in [{"app": {"id": 123, "slug": "github-actions"}},
+                       {"app": {"id": ACTIONS_APP_ID, "slug": "spoof"}},
+                       {"head_sha": MAIN_SHA}, {"name": "spoof"},
+                       {"check_suite": {"id": SUITE_ID + 1}},
+                       {"conclusion": "neutral"}, {"status": "in_progress"}]:
+            with self.subTest(change=change):
+                self.responses["/check-runs/300"] = original | change
+                self.deny()
+
+    def test_api_failure_denies_release(self):
+        del self.responses["/check-runs/300"]
+        self.deny()
+
+    def test_missing_ci_denies_release(self):
+        self.responses[RUNS_PATH]["workflow_runs"] = []
+        self.deny()
+
+    def test_jobs_are_paginated(self):
+        jobs = self.responses[JOBS_PATH]["jobs"]
+        self.responses[JOBS_PATH]["jobs"] = [{"name": "other"}] * 100
+        self.responses[JOBS_PATH.removesuffix("page=1") + "page=2"] = {"jobs": jobs}
+        self.authorize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ts/bun.lock
+++ b/ts/bun.lock
@@ -48,7 +48,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.15",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
     "js-yaml": "4.3.1",
@@ -460,7 +460,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -716,7 +716,7 @@
 
     "pyodide": ["pyodide@0.28.3", "", { "dependencies": { "ws": "^8.5.0" } }, "sha512-rtCsyTU55oNGpLzSVuAd55ZvruJDEX8o6keSdWKN9jPeBVSNlynaKFG7eRqkiIgU7i2M6HEgYtm0atCEQX3u4A=="],
 
-    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "querystring-es3": ["querystring-es3@0.2.1", "", {}, "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="],
 
@@ -772,9 +772,9 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -3068,9 +3068,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -4652,9 +4652,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -215,7 +215,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.15",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
     "js-yaml": "4.3.1",


### PR DESCRIPTION
## Summary

Gate live service verification behind a manual main-only workflow and independent environment approval. Ordinary CI no longer includes the live job; service keys are supplied only to the actual live commands. Checkout credentials and caches are disabled where unnecessary, and the uv installer commit and tool version are pinned.

Before a release builds, load policy from protected main and validate the immutable release SHA against main history and a successful same-SHA main CI run. Require six successful jobs from the GitHub Actions app and the matching check suite. Keep publishing in separate environment-protected jobs that consume only their own run's packaged artifacts.

Update fast-uri to 3.1.6 and qs to 6.16.0 in the TypeScript/Pi locks so the existing moderate-severity audit gate passes. Synchronize Bun's supporting side-channel patches. No sandbox API migration or audit-threshold reduction is included.

Fix a pre-existing worker-event ordering race exposed by full CI: a legitimate burst of five events could abort an interactive run when control was also ready. Defer controller reads while the bounded event backlog drains, retaining terminal-result ordering, process-exit and sequence-token checks. This narrow fix was independently reviewed in #1327 and is included here so the foundation's required CI exercises the correction.

## Surfaces Touched

- [x] Parity decision: repository-wide CI/release policy applies to Python, TypeScript and Pi; no runtime feature parity change
- [x] Python package (workflow security tests and bounded worker-event admission)
- [x] TypeScript package (dependency override and locks)
- [ ] TUI
- [x] Docs or examples
- [x] CI or release metadata

## Verification

- [x] 21 release-source guard unit tests, including wrong refs/SHAs/events, stale or spoofed CI, moved tags, missing/duplicate jobs, and unavailable evidence
- [x] 11 workflow security tests
- [x] 10 worker-event regression cases (including baseline red checks) and 62 existing run lifecycle tests; independent source/security review
- [x] actionlint 1.7.12: all five workflows pass
- [x] Ruff on changed Python scripts/tests; Markdown links; git diff checks
- [x] Guard read-only API smoke against current main: recognizes its trusted exact-SHA CI evidence without triggering a release
- [x] Clean TypeScript and Pi npm installs with lifecycle scripts disabled; Ajv URI-reference and qs parsing compatibility checks
- [x] Frozen Bun lock validation; npm and Bun production audits pass the unchanged moderate threshold
- Full package CI will run on this PR. Live service calls and publication were not triggered.
- The reviewed checkout 7.0.1 upgrade from merged #1308 is integrated without restoring the automatic live job or weakening any guard.

## Docs And Release Impact

- [x] Updated CONTRIBUTING.md, SECURITY.md and release checklist
- [x] Updated CHANGELOG.md
- No package release/version bump in this change.

## Notes

Companion GitHub settings have already been applied: all external contributors require workflow approval; main dismisses stale reviews and requires latest-push approval plus the six checks from GitHub Actions; release tags are immutable with creation limited to the existing release reviewers; publishing and live-integration environments require independent approval without administrator bypass; action sources are allowlisted and SHA pinning is required.

The new live-integration environment accepts main only. Its two service keys must be configured as environment secrets before a manual run; missing credentials fail the run. Step-scoped keys do not isolate malicious processes inside an already approved job.

The guard must land on protected main before these publisher definitions are used. Release candidates must already have completed main CI; unavailable or pending evidence fails closed. Tag restrictions and registry environment binding remain necessary because arbitrary replacement of a workflow definition cannot be prevented by a check inside that definition.

npm/PyPI trusted-publisher environment bindings still need authenticated registry verification; this PR does not claim to configure them. Remaining low-severity dependency advisories are not suppressed or forced through a breaking dependency upgrade.
