### PR TITLE
Defer controller admission while worker events drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Interactive runs tolerate bursts of valid worker events before a controller
+  request without aborting. Event queues remain bounded, and terminal-result,
+  process-exit and controller-token checks still reject invalid requests.
+
 ### Security
 
 - Release workflows validate protected-main ancestry and successful CI for the

--- a/autocontext/src/autocontext/server/_run_process_monitor.py
+++ b/autocontext/src/autocontext/server/_run_process_monitor.py
@@ -331,7 +331,7 @@ def _monitor_run_process(
                         break
 
             waitables: list[Any] = []
-            if control_open:
+            if control_open and len(pending_events) < _MAX_PENDING_EVENTS:
                 waitables.append(control_connection)
             if event_open and len(pending_events) < _MAX_PENDING_EVENTS:
                 waitables.append(event_connection)
@@ -339,7 +339,11 @@ def _monitor_run_process(
                 waitables.append(process.sentinel)
 
             buffered_ready: list[Any] = []
-            if control_open and control_reader.has_buffered_frame:
+            if (
+                control_open
+                and len(pending_events) < _MAX_PENDING_EVENTS
+                and control_reader.has_buffered_frame
+            ):
                 buffered_ready.append(control_connection)
             if (
                 event_open
@@ -403,7 +407,10 @@ def _monitor_run_process(
                     )
 
             requests: list[dict[str, Any]] = []
-            if control_ready:
+            # Ordinary event bursts can temporarily fill the bounded queue.
+            # Leave control unread until we scan the earlier events, including
+            # any terminal result; the relay supplies backpressure meanwhile.
+            if control_ready and not event_backlog_unscanned:
                 requests, control_open = control_reader.receive_available(
                     read_from_fd=(
                         not idle_expired
@@ -416,10 +423,6 @@ def _monitor_run_process(
                 observe_leader()
 
             if requests:
-                if event_backlog_unscanned:
-                    raise _RunProcessProtocolError(
-                        "interactive run event backlog hid controller ordering"
-                    )
                 if process_exited:
                     raise _RunProcessProtocolError(
                         "interactive run sent controller data after process exit"

--- a/autocontext/tests/test_run_process_monitor_backpressure.py
+++ b/autocontext/tests/test_run_process_monitor_backpressure.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import threading
+import time
+from multiprocessing.connection import wait
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from autocontext.server._run_process_ipc import _send_json_message
+from autocontext.server._run_process_monitor import _monitor_run_process
+
+
+@pytest.mark.parametrize("event_count", [5, 65])
+@pytest.mark.parametrize("control_case", ["valid", "terminal", "missing-token", "stale-token", "exited"])
+def test_monitor_scans_event_burst_before_admitting_control(
+    event_count: int,
+    control_case: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A queued burst must drain, while a terminal result still bars control."""
+    parent_control, child_control = multiprocessing.Pipe(duplex=True)
+    parent_events, child_events = multiprocessing.Pipe(duplex=False)
+    sentinel, sentinel_writer = multiprocessing.Pipe(duplex=False)
+    process = SimpleNamespace(sentinel=sentinel, exitcode=0)
+    exited = threading.Event()
+    manager = Mock()
+    result = {"type": "result", "run_id": "burst-run", "ok": True, "best_score": 1.0}
+
+    def finish_child(*_args: object, **_kwargs: object) -> None:
+        _send_json_message(child_events, result)
+        child_control.close()
+        child_events.close()
+        exited.set()
+
+    manager._dispatch_control_request.side_effect = finish_child
+    deadline = time.monotonic() + 5.0
+    observations = 0
+
+    def observe_process(_process: object) -> str:
+        nonlocal observations
+        observations += 1
+        if time.monotonic() >= deadline:
+            raise TimeoutError("monitor did not finish the preloaded event burst")
+        if control_case == "exited" and observations > 1:
+            return "exited"
+        return "exited" if exited.is_set() else "running"
+
+    try:
+        # Both channels are ready before monitoring starts, without depending on
+        # child-process scheduling or the host's process-ownership primitives.
+        for index in range(event_count):
+            _send_json_message(
+                child_events,
+                {"type": "event", "event": "burst", "payload": {"index": index}, "channel": "generation"},
+            )
+        if control_case == "terminal":
+            _send_json_message(child_events, result)
+        request: dict[str, object] = {"type": "control", "operation": "is_paused", "args": [], "token": None}
+        if control_case == "missing-token":
+            request.pop("token")
+        elif control_case == "stale-token":
+            request["token"] = "stale"
+        _send_json_message(child_control, request)
+
+        _monitor_run_process(
+            manager,
+            process,
+            parent_control,
+            parent_events,
+            "burst-run",
+            1,
+            observe_process=observe_process,
+            terminate_process=lambda _process: True,
+            close_connection=lambda connection: connection.close(),
+            wait_for_connections=wait,
+            ownership_lost_error=RuntimeError,
+            cleanup_lock=threading.Lock(),
+            result_exit_grace_seconds=1.0,
+            post_exit_idle_drain_seconds=0.2,
+            post_exit_max_drain_seconds=2.0,
+            logger=logging.getLogger(__name__),
+        )
+    finally:
+        for connection in (parent_control, child_control, parent_events, child_events, sentinel, sentinel_writer):
+            connection.close()
+
+    if control_case != "valid":
+        manager._dispatch_control_request.assert_not_called()
+        expected_error = {
+            "terminal": "after its terminal result",
+            "missing-token": "invalid controller sequence token",
+            "stale-token": "invalid controller sequence token",
+            "exited": "after process exit",
+        }[control_case]
+        assert expected_error in caplog.text
+    else:
+        manager._dispatch_control_request.assert_called_once()
+        assert [call.args[1]["index"] for call in manager.events.emit.call_args_list] == list(range(event_count))
+        assert "monitor failed" not in caplog.text


### PR DESCRIPTION
## Summary

A valid burst of five worker events followed by a controller request could abort an interactive run with `interactive run event backlog hid controller ordering`. The monitor's bounded event queue holds four entries; it treated unread ordinary events as a protocol violation when control was also ready.

Defer reading control while earlier events remain unscanned, and let the existing event relay apply backpressure. Retain the queue limits, terminal-result ordering, process-exit checks, single-request admission and sequence-token validation. No events are discarded and no admission limit is raised.

## Surfaces Touched

- [x] Parity decision: Python worker IPC implementation only; no wire contract or TypeScript behavior change
- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [x] Docs or examples: changelog
- [ ] CI or release metadata

## Verification

- [x] Deterministic preloaded-pipe regression: valid bursts of 5 and 65 events fail on the original source and pass with this change
- [x] 10 regression cases cover valid bursts, hidden terminal results, missing/stale controller tokens and exit during deferral
- [x] 62 existing run lifecycle tests pass
- [x] Changed-file Ruff and whitespace checks pass
- [x] Independent source/security review and independent execution of the new regression cases
- Full repository CI is required before merge.

## Docs And Release Impact

- [x] CHANGELOG.md updated
- No public command, environment variable, protocol or release-version change.

## Notes

The runtime issue predates #1326. This small draft made the monitor fix independently reviewable. After its targeted tests and independent security review passed, commit c155e7b8083236a4f7da7af029043a3ef7fed1ca was incorporated into the #1326 feature branch so that foundation's full CI also exercises the corrected monitor.

This draft is closed as incorporated into #1326. The change is not on main yet. #1326 still requires full current-base CI and independent maintainer approval under the protected-main rules; no main-branch review or check was bypassed.
