### PR TITLE
Handle non-object JSON from the Pi CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Pi CLI output containing JSON arrays, scalars or null uses the existing text
+  fallback instead of failing object-envelope parsing. Thanks to @Ftgn-dpA for
+  reporting the issue and proposing a fix in
+  [#1321](https://github.com/greyhaven-ai/autocontext/pull/1321).
 - Interactive runs tolerate bursts of valid worker events before a controller
   request without aborting. Event queues remain bounded, and terminal-result,
   process-exit and controller-token checks still reject invalid requests.

--- a/autocontext/src/autocontext/runtimes/pi_cli.py
+++ b/autocontext/src/autocontext/runtimes/pi_cli.py
@@ -265,19 +265,20 @@ class PiCLIRuntime(AgentRuntime):
         if self._config.json_output:
             try:
                 data = json.loads(raw)
-                text = data.get("result", data.get("output", ""))
-                if not isinstance(text, str) or not text.strip():
-                    text = json.dumps(data)
-                return AgentOutput(
-                    text=text,
-                    cost_usd=data.get("cost_usd", 0.0),
-                    model=data.get("model", "pi"),
-                    session_id=data.get("session_id"),
-                    metadata={
-                        "exit_code": exit_code,
-                        "raw_json": data,
-                    },
-                )
+                if isinstance(data, dict):
+                    text = data.get("result", data.get("output", ""))
+                    if not isinstance(text, str) or not text.strip():
+                        text = json.dumps(data)
+                    return AgentOutput(
+                        text=text,
+                        cost_usd=data.get("cost_usd", 0.0),
+                        model=data.get("model", "pi"),
+                        session_id=data.get("session_id"),
+                        metadata={
+                            "exit_code": exit_code,
+                            "raw_json": data,
+                        },
+                    )
             except (json.JSONDecodeError, TypeError):
                 logger.debug("runtimes.pi_cli: suppressed json.JSONDecodeError), TypeError", exc_info=True)
 

--- a/autocontext/tests/test_pi_cli_runtime.py
+++ b/autocontext/tests/test_pi_cli_runtime.py
@@ -92,6 +92,57 @@ def test_generate_raw_text_fallback() -> None:
     assert output.model == "pi"
 
 
+@pytest.mark.parametrize("exit_code", [0, 3])
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param(' \n[1,  {"result": "nested"}]\t', id="array"),
+        pytest.param("\n[]\n", id="empty-array"),
+        pytest.param(' \t"hello\\nworld"\n', id="string"),
+        pytest.param(' ""\n', id="empty-string"),
+        pytest.param(" 42\n", id="integer"),
+        pytest.param(" -2.50e+3\n", id="float"),
+        pytest.param(" true\n", id="true"),
+        pytest.param(" false\t", id="false"),
+        pytest.param(" null\n", id="null"),
+    ],
+)
+def test_parse_non_object_json_uses_raw_text_fallback(raw: str, exit_code: int) -> None:
+    runtime = PiCLIRuntime(PiCLIConfig(json_output=True, model="configured-model"))
+
+    output = runtime._parse_output(raw, exit_code)
+
+    assert output == AgentOutput(
+        text=raw.strip(),
+        cost_usd=0.0,
+        model="pi",
+        metadata={"exit_code": exit_code},
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_text"),
+    [
+        pytest.param(" {}\n", "{}", id="empty-object"),
+        pytest.param('{"output": "alternate"}', "alternate", id="output-envelope"),
+        pytest.param('{"result": "preferred", "output": "alternate"}', "preferred", id="result-precedence"),
+        pytest.param('{"result": []}', '{"result": []}', id="non-text-result"),
+        pytest.param('{"result": "  "}', '{"result": "  "}', id="blank-result"),
+    ],
+)
+def test_parse_object_json_preserves_envelope_behavior(raw: str, expected_text: str) -> None:
+    runtime = PiCLIRuntime(PiCLIConfig())
+
+    output = runtime._parse_output(raw, 3)
+
+    assert output == AgentOutput(
+        text=expected_text,
+        cost_usd=0.0,
+        model="pi",
+        metadata={"exit_code": 3, "raw_json": json.loads(raw)},
+    )
+
+
 def test_generate_json_object_without_result_serializes_full_payload() -> None:
     runtime = PiCLIRuntime(PiCLIConfig())
     raw_payload = {


### PR DESCRIPTION
## Summary

Valid Pi CLI JSON output could crash when its top-level value was an array, scalar or null: the adapter called dictionary methods on every decoded value. Restrict object-envelope parsing to dictionaries and route other JSON values through the existing text fallback.

Preserve the existing outer-whitespace trimming, JSON spelling and interior whitespace, fallback defaults, exit-code metadata, object-envelope fields, and process execution behavior.

Thanks to @Ftgn-dpA for reporting the issue and proposing a fix in #1321. This is an independently written maintainer implementation based on the reported behavior; it does not import that PR's commits. The changelog includes the acknowledgement.

## Surfaces Touched

- [x] Parity decision: Python's Pi CLI adapter only; no TypeScript runtime or protocol change
- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [x] Docs or examples: changelog acknowledgement
- [ ] CI or release metadata

## Verification

- [x] 18 new non-object JSON regression cases fail with AttributeError on unchanged main
- [x] Five additional object-envelope cases pass on both the original and corrected implementation
- [x] 73 focused tests pass across the Pi runtime, timeout cleanup, runtime artifacts and protocol alignment
- [x] Targeted Ruff and whitespace checks pass
- [x] Independent review reran all 73 focused tests and compared object/plain/malformed output behavior against main
- Full repository CI and normal protected-main review are required before merge.

## Docs And Release Impact

- [x] CHANGELOG.md updated
- No command, configuration key, dependency, permission, release version or subprocess behavior changes.
- No live Pi/provider execution was used for validation.
