### PR TITLE
fix(ci): publish npm artifacts using explicit local paths

### DIFF
--- a/.github/workflows/publish-pi-autocontext.yml
+++ b/.github/workflows/publish-pi-autocontext.yml
@@ -115,4 +115,4 @@ jobs:
           name: pi-package
           path: dist
       - name: Publish to npm with provenance
-        run: npm publish dist/*.tgz --ignore-scripts --access public --provenance
+        run: npm publish ./dist/*.tgz --ignore-scripts --access public --provenance

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -111,4 +111,4 @@ jobs:
           name: ts-package
           path: dist
       - name: Publish to npm with provenance
-        run: npm publish dist/*.tgz --ignore-scripts --access public --provenance
+        run: npm publish ./dist/*.tgz --ignore-scripts --access public --provenance


### PR DESCRIPTION
The npm publishing jobs passed package preparation but treated `dist/pi-autocontext-0.10.1.tgz` as GitHub shorthand and attempted an SSH fetch instead of publishing the downloaded tarball. The TypeScript publisher uses the same path form.

Prefix both artifact paths with `./` so npm resolves them as local tarballs. Publishing flags, OIDC permissions, protected environments, and package versions remain unchanged.

Validation: both workflows pass actionlint; all 21 release-source guard tests and 11 workflow-security tests pass; npm's installed package parser reproduces the old paths as GitHub Git specs and the corrected paths as local file specs.

CI is currently blocked by the baseline optional CUDA dependency `accelerate==1.14.0`, reported by pip-audit under CVE-2026-69112 / GHSA-4j2p-28q2-5m79. The advisory lists no patched release. This PR does not change that dependency or suppress the audit; the blocker must be resolved before the corrected main can satisfy the release source guard.

Failed release: https://github.com/greyhaven-ai/autocontext/actions/runs/34260698163/job/102177903157

After merge and successful CI on the new main commit, rerun the unpublished npm releases through workflow_dispatch on main. Existing immutable release tags stay in place; Python 0.17.1 is already published.
